### PR TITLE
feat: add thread model switching and metadata

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,11 @@
 - **Turn** — 一次交换：从一条用户输入开始、到 agent 完成响应为止追加的那段连续 Item。
 - **AgentRuntime** — 驱动一个 Thread 的循环：从 ItemList 编译上下文 → 调用模型 → 执行工具，把发生的一切追加为 Item。
 - **AppServer** — 按 threadId 把请求路由到 Thread、驱动 AgentRuntime、向订阅者广播 item 事件的唯一服务入口。
+- **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
+  append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
+  canonical ItemList。
+- **ModelCatalog** — 宿主公开的可选模型与默认模型目录；App Server 只投影和
+  校验它，credential 与 Provider 连接仍由宿主外部配置持有。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并
@@ -41,8 +46,17 @@ Thread 记录实际使用的 cwd；"项目列表"是客户端按 workspace 派�
 或用户理解的执行历史会不会改变？** 会，就是 Item；不会，就放外侧。
 Thread 内可以保留一份不含秘密的生效配置描述（`provider / model / cwd /
 tool_policy`），记录"当时用了什么"；credential 及其引用都不进入 Thread。
+初始配置由 `thread_metadata` 记录；Turn 之间的配置变化由
+`thread_configuration_changed` canonical Item 追加记录。当前生效配置由初始
+metadata 与后续配置 Item 依次归约；每个 Turn 使用其 `turn_started` 之前最后
+一份生效配置。活跃 Turn 期间不得修改配置。
 宿主也不会把完整进程环境交给 shell tool：工具只继承运行命令所需的最小环境，
 Provider credential 即使来自环境变量也会被显式排除。
+
+Thread 的用户展示名称、置顶与归档等产品状态不改变 Agent 下一轮上下文，因此
+不进入 canonical ItemList。ZAS 可以知道、持久化并通过 App Server 同步这些
+状态；客户端当前选中的 Thread 仍是每个客户端或 conversation binding 的状态，
+ZAS 不保存全局 `currentThreadId`。
 
 首版不实现 context compaction。未来若引入，compaction 结果必须作为新的
 canonical Item 追加，已有 Item 不改写、不删除。
@@ -92,6 +106,12 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
   Item 事件流和 command item 审批请求。精确清单见
   `src/protocol/codex/README.md`。
 - `account/read`、`skills/list` 与 `model/list` 只投影宿主公开能力，不向 Zen Core 或 Thread 写入账户、skill、provider 状态。
+- `thread/settings/update` 修改后续 Turn 使用的配置；`turn/start` 携带的模型
+  override 复用同一内部更新路径。成功变更必须先追加
+  `thread_configuration_changed`，再广播 `thread/settings/updated`。
+- `thread/name/set` 修改 ZAS 的 ThreadMetadataStore 并广播
+  `thread/name/updated`；名称不是 Agent Item。`thread/list`、`thread/read` 与
+  `thread/resume` 返回当前名称。
 - 未实现的方法一律返回 JSON-RPC `-32601`；不返回伪造的成功结果。
 - **sandbox 与 approval 分离**：sandbox 限制工具实际上能做什么，approval
   决定何时询问用户。首版只接受明确支持的 sandbox mode，其他 mode 返回

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,9 @@
   append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
   canonical ItemList。
 - **ModelCatalog** — 宿主公开的可选模型与默认模型目录；App Server 只投影和
-  校验它，credential 与 Provider 连接仍由宿主外部配置持有。
+  校验它，credential 与 Provider 连接仍由宿主外部配置持有。目录必须有且仅有
+  一个可见默认模型；`hidden` 只表示不在客户端选择器展示，已知模型 id 仍可由
+  既有 Thread 或显式请求使用。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并
@@ -109,6 +111,10 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
 - `thread/settings/update` 修改后续 Turn 使用的配置；`turn/start` 携带的模型
   override 复用同一内部更新路径。成功变更必须先追加
   `thread_configuration_changed`，再广播 `thread/settings/updated`。
+- ZAS 是 Thread 生效配置的唯一权威。所有接入端通过
+  `thread/settings/updated` 与 `thread/resume` 返回值镜像同一份配置；恢复
+  Thread 时不得用客户端缓存覆盖 ZAS，只有用户明确选择新模型时才提交配置
+  变更。同值更新是空操作，即使 Turn 正在运行也不得阻断跨端恢复。
 - `thread/name/set` 修改 ZAS 的 ThreadMetadataStore 并广播
   `thread/name/updated`；名称不是 Agent Item。`thread/list`、`thread/read` 与
   `thread/resume` 返回当前名称。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,9 @@
 - **AppServer** — 按 threadId 把请求路由到 Thread、驱动 AgentRuntime、向订阅者广播 item 事件的唯一服务入口。
 - **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
   append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
-  canonical ItemList。
+  canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、
+  读取或列表；ZAS 降级为无展示名称并明确记录 warning，而 metadata 写入失败
+  仍须返回错误。
 - **ModelCatalog** — 宿主公开的可选模型与默认模型目录；App Server 只投影和
   校验它，credential 与 Provider 连接仍由宿主外部配置持有。目录必须有且仅有
   一个可见默认模型；`hidden` 只表示不在客户端选择器展示，已知模型 id 仍可由
@@ -115,6 +117,10 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
   `thread/settings/updated` 与 `thread/resume` 返回值镜像同一份配置；恢复
   Thread 时不得用客户端缓存覆盖 ZAS，只有用户明确选择新模型时才提交配置
   变更。同值更新是空操作，即使 Turn 正在运行也不得阻断跨端恢复。
+- Codex 协议投影不把 `thread_configuration_changed` 伪装成 Codex Thread Item；
+  它只通过当前 `threadSettings` 与 settings 通知暴露结果，不承诺展示历史切换点。
+  canonical ItemList 仍保留完整切换点和各 Turn 的生效模型，供 Zen 原生客户端
+  重放。
 - `thread/name/set` 修改 ZAS 的 ThreadMetadataStore 并广播
   `thread/name/updated`；名称不是 Agent Item。`thread/list`、`thread/read` 与
   `thread/resume` 返回当前名称。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,6 +15,9 @@
   canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、
   读取或列表；ZAS 降级为无展示名称并明确记录 warning，而 metadata 写入失败
   仍须返回错误。
+- **UnavailableThreadSnapshot** — ZAS 在列举 Thread 时对无法重放的 canonical
+  journal 生成的只读故障投影；它只暴露 threadId、可用的产品名称和
+  `systemError`，不伪造或跳过权威会话历史。
 - **ModelCatalog** — 宿主公开的可选模型与默认模型目录；App Server 只投影和
   校验它，credential 与 Provider 连接仍由宿主外部配置持有。目录必须有且仅有
   一个可见默认模型；`hidden` 只表示不在客户端选择器展示，已知模型 id 仍可由
@@ -124,6 +127,9 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
 - `thread/name/set` 修改 ZAS 的 ThreadMetadataStore 并广播
   `thread/name/updated`；名称不是 Agent Item。`thread/list`、`thread/read` 与
   `thread/resume` 返回当前名称。
+- `thread/list` 必须隔离单个损坏 journal，并使用 Codex 标准
+  `status: systemError` 显式返回该 threadId；`thread/read` / `thread/resume`
+  仍明确失败，且不得用默认配置伪造可恢复的 Thread snapshot。
 - 未实现的方法一律返回 JSON-RPC `-32601`；不返回伪造的成功结果。
 - **sandbox 与 approval 分离**：sandbox 限制工具实际上能做什么，approval
   决定何时询问用户。首版只接受明确支持的 sandbox mode，其他 mode 返回

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -6,7 +6,8 @@
 ## 第一客户端
 
 **自建薄 Zen CLI** 是首个稳定接入端，只覆盖启动 / 恢复 Thread、发送消息、
-流式显示与审批，不拥有 Agent 或调度语义。
+流式显示、审批与模型选择，不拥有 Agent 或调度语义。交互式 `/model` 只调用
+App Server 的 Thread 设置操作；可用模型来自 ZAS 投影的宿主 ModelCatalog。
 
 原版 `codex --remote` 与固定版本 T3 Code 是机会型兼容目标：Phase 2 用最小
 stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协议子集。能接入

--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ Zen CLI 就只做 JSONL stdio ↔ WebSocket 薄桥；Thread 与模型执行仍�
 自动追加的 `mcp_servers.t3-code` 两项 `-c` 配置只在这个 remote bridge 模式下
 被精确识别并忽略；除此之外，bridge 只接受 `--remote` 与可选的
 `--auth-token-file`。模型、审批、workspace 等宿主配置应在中央 App Server
-启动时传入。Zen 当前不宣称提供 T3 MCP tools。
+启动时传入。用 `--models <model-a,model-b>` 声明完整 ModelCatalog，并用
+`--model <name>` 选择初始模型；T3、Zen CLI 与其他客户端都从同一个 App
+Server 读取目录，并在 Turn 之间切换同一 Thread 的模型。Zen 当前不宣称提供
+T3 MCP tools。
 
 真实模型使用 `--provider openai-compatible`、`--model`、`--base-url` 与
 `--api-key-env`。指定的 key 只由宿主读取，不进入协议、Thread 或 shell tool
@@ -71,6 +74,10 @@ node dist/apps/cli/src/cli.js auth login
 node dist/apps/cli/src/cli.js run --provider openai-subscription "hello"
 node dist/apps/cli/src/cli.js app-server --provider openai-subscription
 ```
+
+交互式 `zen chat` 中，`/model` 列出宿主公开的模型，`/model <name>` 修改当前
+Thread 后续 Turn 使用的模型。活跃 Turn 期间的修改会被 ZAS 拒绝；成功修改会
+进入 append-only Thread journal，而 credential 仍留在宿主外部。
 
 IMZen 的配置与运行方法见 [apps/imzen/README.md](apps/imzen/README.md)。
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -183,11 +183,17 @@ async function chatCommand(args: ParsedArguments): Promise<void> {
           await printModels(session.client);
           continue;
         }
-        await session.client.request("thread/settings/update", {
-          threadId,
-          model,
-        });
-        process.stdout.write(`Model switched to ${model}.\n`);
+        try {
+          await session.client.request("thread/settings/update", {
+            threadId,
+            model,
+          });
+          process.stdout.write(`Model switched to ${model}.\n`);
+        } catch (error) {
+          process.stderr.write(
+            `Could not switch model: ${error instanceof Error ? error.message : String(error)}\n`,
+          );
+        }
         continue;
       }
       await runOneTurn(session.client, threadId, prompt);

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -85,7 +85,6 @@ async function appServerCommand(args: ParsedArguments): Promise<void> {
     serveCodexStdio({
       appServer: host,
       zenHome,
-      configuredModel: hostConfig.model,
     });
     return;
   }
@@ -94,7 +93,6 @@ async function appServerCommand(args: ParsedArguments): Promise<void> {
     appServer: host,
     zenHome,
     listen,
-    configuredModel: hostConfig.model,
     ...(bearerToken === undefined ? {} : { bearerToken }),
   });
   process.stderr.write(`Zen App Server listening on ${server.url}\n`);
@@ -164,7 +162,9 @@ async function chatCommand(args: ParsedArguments): Promise<void> {
       args,
       session.localServer !== undefined,
     );
-    process.stdout.write(`Zen thread ${threadId}. Type /exit to stop.\n`);
+    process.stdout.write(
+      `Zen thread ${threadId}. Type /model to list models, /model <name> to switch, or /exit to stop.\n`,
+    );
     while (true) {
       const prompt = (await terminal.question("> ")).trim();
       if (prompt === "/exit" || prompt === "/quit") {
@@ -173,12 +173,42 @@ async function chatCommand(args: ParsedArguments): Promise<void> {
       if (prompt.length === 0) {
         continue;
       }
+      if (prompt === "/model") {
+        await printModels(session.client);
+        continue;
+      }
+      if (prompt.startsWith("/model ")) {
+        const model = prompt.slice("/model ".length).trim();
+        if (model.length === 0) {
+          await printModels(session.client);
+          continue;
+        }
+        await session.client.request("thread/settings/update", {
+          threadId,
+          model,
+        });
+        process.stdout.write(`Model switched to ${model}.\n`);
+        continue;
+      }
       await runOneTurn(session.client, threadId, prompt);
     }
   } finally {
     terminal.close();
     session.client.close();
     await session.localServer?.close();
+  }
+}
+
+async function printModels(client: CodexClient): Promise<void> {
+  const response = await client.request("model/list", {});
+  if (!isRecord(response) || !Array.isArray(response.data)) {
+    throw new Error("App Server returned an invalid model list");
+  }
+  process.stdout.write("Available models:\n");
+  for (const value of response.data) {
+    if (isRecord(value) && typeof value.id === "string") {
+      process.stdout.write(`  ${value.id}\n`);
+    }
   }
 }
 
@@ -278,7 +308,6 @@ async function connectClient(args: ParsedArguments): Promise<ClientSession> {
       appServer: createHostedAppServer(hostConfig),
       zenHome: dataDirectory(args),
       listen: "ws://127.0.0.1:0",
-      configuredModel: hostConfig.model,
       ...(bearerToken === undefined ? {} : { bearerToken }),
     });
     url = localServer.url;
@@ -482,6 +511,7 @@ function hostOptions(args: ParsedArguments) {
     cwd: workingDirectory(args),
     dataDirectory: dataDirectory(args),
     model: modelName(args, providerName),
+    models: modelNames(args, providerName),
     approvalPolicy: approval,
     provider,
     secretEnvironmentVariables,
@@ -503,6 +533,7 @@ function parseArguments(args: string[]): ParsedArguments {
     "deny",
     "listen",
     "model",
+    "models",
     "provider",
     "provider-name",
     "remote",
@@ -676,6 +707,21 @@ function modelName(args: ParsedArguments, providerName: string): string {
   );
 }
 
+function modelNames(args: ParsedArguments, providerName: string): string[] {
+  const configured = option(args, "models");
+  if (configured === undefined) {
+    return [modelName(args, providerName)];
+  }
+  const models = configured
+    .split(",")
+    .map((model) => model.trim())
+    .filter((model) => model.length > 0);
+  if (models.length === 0) {
+    throw new Error("--models must contain at least one model name");
+  }
+  return models;
+}
+
 function subscriptionProfilePath(args: ParsedArguments): string {
   return path.join(dataDirectory(args), "openai-subscription-auth.json");
 }
@@ -725,6 +771,7 @@ Core options:
   --cwd <path>                 Thread working directory
   --data-dir <path>            Host-owned Zen data directory
   --model <name>               Model name (defaults to fake, or gpt-5.6-terra for subscription)
+  --models <a,b,...>           Complete model catalog exposed by this Zen host
   --approval always|never      Tool approval policy (default: never / Full Access)
   --approve                    Accept one-shot run approvals (implies --approval always)
   --deny                       Decline one-shot run approvals (implies --approval always)

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -5,10 +5,15 @@ import {
   JsonlThreadJournal,
   type ThreadJournal,
 } from "../../../src/journal.js";
+import { StaticModelCatalog } from "../../../src/model-catalog.js";
 import { FakeModel, type ModelAdapter } from "../../../src/model.js";
 import { OpenAiCompatibleModel } from "../../../src/model/openai-compatible.js";
 import { OpenAiSubscriptionModel } from "../../../src/model/openai-subscription.js";
 import { AgentRuntime } from "../../../src/runtime.js";
+import {
+  JsonlThreadMetadataStore,
+  type ThreadMetadataStore,
+} from "../../../src/thread-metadata.js";
 import { ShellToolExecutor } from "../../../src/tool.js";
 import { OpenAiSubscriptionAuthProfile } from "./subscription-auth.js";
 
@@ -30,14 +35,22 @@ export interface ZenHostOptions {
   cwd: string;
   dataDirectory: string;
   model: string;
+  models?: readonly string[];
   approvalPolicy: "always" | "never";
   provider: HostProvider;
   secretEnvironmentVariables?: readonly string[];
   journal?: ThreadJournal;
+  threadMetadata?: ThreadMetadataStore;
 }
 
 export function createHostedAppServer(options: ZenHostOptions): ZenAppServer {
   const model = createModel(options.provider);
+  const modelIds = uniqueModels(options.models ?? [options.model]);
+  if (!modelIds.includes(options.model)) {
+    throw new Error(
+      `Default model ${options.model} is absent from the configured model list`,
+    );
+  }
   return new ZenAppServer({
     journal:
       options.journal ??
@@ -52,6 +65,14 @@ export function createHostedAppServer(options: ZenHostOptions): ZenAppServer {
             : [],
       }),
     }),
+    modelCatalog: new StaticModelCatalog(
+      modelIds.map((id) => ({ id, isDefault: id === options.model })),
+    ),
+    threadMetadata:
+      options.threadMetadata ??
+      new JsonlThreadMetadataStore(
+        path.join(options.dataDirectory, "thread-metadata.jsonl"),
+      ),
     defaults: {
       cwd: path.resolve(options.cwd),
       model: options.model,
@@ -59,6 +80,23 @@ export function createHostedAppServer(options: ZenHostOptions): ZenAppServer {
       approvalPolicy: options.approvalPolicy,
     },
   });
+}
+
+function uniqueModels(models: readonly string[]): string[] {
+  const output: string[] = [];
+  const seen = new Set<string>();
+  for (const rawModel of models) {
+    const model = rawModel.trim();
+    if (model.length === 0 || seen.has(model)) {
+      continue;
+    }
+    seen.add(model);
+    output.push(model);
+  }
+  if (output.length === 0) {
+    throw new Error("At least one configured model is required");
+  }
+  return output;
 }
 
 function createModel(provider: HostProvider): ModelAdapter {

--- a/apps/imzen/README.md
+++ b/apps/imzen/README.md
@@ -62,6 +62,11 @@ created through T3 Code or another App Server client. The binding and the most
 recent list are display state held only in IMZen memory. `/threads` shows at
 most 20 matches; use a query to narrow larger histories.
 
+Use `/model` to list the central Zen host's ModelCatalog and `/model <name>` to
+change the selected Thread for subsequent Turns. IMZen does not keep a separate
+model setting: it calls the same App Server operation used by Zen CLI and T3
+Code, and ZAS rejects changes while a Turn is active.
+
 Supported keys at the top level are `qq`, `telegram`, `feishu`, and `weixin`.
 Feishu additionally requires installing the `feishu` extra. Each IMZen
 deployment owns its channel config and credentials; do not point it at

--- a/apps/imzen/src/imzen/gateway.py
+++ b/apps/imzen/src/imzen/gateway.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
+from imcodex.appserver import AppServerError
 from imcodex.models import InboundMessage, OutboundMessage
 
 from .config import PermissionMode
@@ -461,7 +462,7 @@ class ImZenGateway:
             )
         except Exception as exc:
             text = f"Could not switch model to **{argument}**: {exc}"
-            if "not available" in str(exc).casefold():
+            if _zen_error_code(exc) == "model_unavailable":
                 try:
                     text = f"{text}\n\n{await self._model_catalog_markdown()}"
                 except Exception:
@@ -762,6 +763,13 @@ class ImZenGateway:
         if not items:
             raise ValueError("message text and attachments are empty")
         return items
+
+
+def _zen_error_code(error: Exception) -> str | None:
+    if not isinstance(error, AppServerError) or not isinstance(error.data, dict):
+        return None
+    code = error.data.get("zenCode")
+    return code if isinstance(code, str) else None
 
 
 def _thread_id(result: dict) -> str:

--- a/apps/imzen/src/imzen/gateway.py
+++ b/apps/imzen/src/imzen/gateway.py
@@ -23,6 +23,10 @@ class AppServerClient(Protocol):
 
     async def initialize(self) -> dict: ...
 
+    async def call(self, method: str, params: dict | None = None) -> dict: ...
+
+    async def list_models(self, **params: Any) -> dict: ...
+
     async def start_thread(self, **params: Any) -> dict: ...
 
     async def list_threads(self, **params: Any) -> dict: ...
@@ -149,13 +153,16 @@ class ImZenGateway:
         if command == "/permission":
             await self._set_permission(inbound, argument.strip())
             return
+        if command == "/model":
+            await self._set_model(inbound, argument.strip())
+            return
         if command == "/help":
             await self._send_to_conversation(
                 self._key(inbound),
                 message_type="status",
                 text=(
                     "IMZen commands: /new, /threads [query], /pick <number|id|query>, "
-                    "/status, "
+                    "/status, /model [name], "
                     "/permission [full-access|approval-required], "
                     "/approve [id], /deny [id], /cancel [id], /help"
                 ),
@@ -425,6 +432,65 @@ class ImZenGateway:
                 inbound,
                 f"permission-{permission_mode}",
             ),
+        )
+
+    async def _set_model(self, inbound: InboundMessage, argument: str) -> None:
+        key = self._key(inbound)
+        result = await self.client.list_models()
+        data = result.get("data")
+        if not isinstance(data, list):
+            raise RuntimeError("model/list did not return a model list")
+        models = [
+            model
+            for model in data
+            if isinstance(model, dict)
+            and isinstance(model.get("id"), str)
+            and model["id"]
+            and model.get("hidden") is not True
+        ]
+        if not argument:
+            lines = ["## Zen models"]
+            for model in models:
+                model_id = str(model["id"])
+                display_name = str(model.get("displayName") or model_id)
+                default = " — default" if model.get("isDefault") is True else ""
+                lines.append(f"- **{display_name}** (`{model_id}`){default}")
+            lines.append("Use `/model <name>` to switch the selected thread.")
+            await self._send_to_conversation(
+                key,
+                message_type="status",
+                text="\n".join(lines),
+                delivery_id=self._inbound_delivery_id(inbound, "models"),
+            )
+            return
+
+        thread_id = self._thread_by_conversation.get(key)
+        if thread_id is None:
+            await self._send_to_conversation(
+                key,
+                message_type="error",
+                text="No Zen thread is selected. Send a message or use `/threads` and `/pick`.",
+                delivery_id=self._inbound_delivery_id(inbound, "model-no-thread"),
+            )
+            return
+        matching = next((model for model in models if model["id"] == argument), None)
+        if matching is None:
+            await self._send_to_conversation(
+                key,
+                message_type="error",
+                text=f"Model is not available from this Zen host: {argument}",
+                delivery_id=self._inbound_delivery_id(inbound, "model-unavailable"),
+            )
+            return
+        await self.client.call(
+            "thread/settings/update",
+            {"threadId": thread_id, "model": argument},
+        )
+        await self._send_to_conversation(
+            key,
+            message_type="status",
+            text=f"Model switched to **{argument}** for subsequent turns.",
+            delivery_id=self._inbound_delivery_id(inbound, "model-switched"),
         )
 
     async def _clear_binding(self, key: ConversationKey) -> None:

--- a/apps/imzen/src/imzen/gateway.py
+++ b/apps/imzen/src/imzen/gateway.py
@@ -436,19 +436,19 @@ class ImZenGateway:
 
     async def _set_model(self, inbound: InboundMessage, argument: str) -> None:
         key = self._key(inbound)
-        result = await self.client.list_models()
-        data = result.get("data")
-        if not isinstance(data, list):
-            raise RuntimeError("model/list did not return a model list")
-        models = [
-            model
-            for model in data
-            if isinstance(model, dict)
-            and isinstance(model.get("id"), str)
-            and model["id"]
-            and model.get("hidden") is not True
-        ]
         if not argument:
+            result = await self.client.list_models()
+            data = result.get("data")
+            if not isinstance(data, list):
+                raise RuntimeError("model/list did not return a model list")
+            models = [
+                model
+                for model in data
+                if isinstance(model, dict)
+                and isinstance(model.get("id"), str)
+                and model["id"]
+                and model.get("hidden") is not True
+            ]
             lines = ["## Zen models"]
             for model in models:
                 model_id = str(model["id"])
@@ -471,15 +471,6 @@ class ImZenGateway:
                 message_type="error",
                 text="No Zen thread is selected. Send a message or use `/threads` and `/pick`.",
                 delivery_id=self._inbound_delivery_id(inbound, "model-no-thread"),
-            )
-            return
-        matching = next((model for model in models if model["id"] == argument), None)
-        if matching is None:
-            await self._send_to_conversation(
-                key,
-                message_type="error",
-                text=f"Model is not available from this Zen host: {argument}",
-                delivery_id=self._inbound_delivery_id(inbound, "model-unavailable"),
             )
             return
         await self.client.call(

--- a/apps/imzen/src/imzen/gateway.py
+++ b/apps/imzen/src/imzen/gateway.py
@@ -437,29 +437,10 @@ class ImZenGateway:
     async def _set_model(self, inbound: InboundMessage, argument: str) -> None:
         key = self._key(inbound)
         if not argument:
-            result = await self.client.list_models()
-            data = result.get("data")
-            if not isinstance(data, list):
-                raise RuntimeError("model/list did not return a model list")
-            models = [
-                model
-                for model in data
-                if isinstance(model, dict)
-                and isinstance(model.get("id"), str)
-                and model["id"]
-                and model.get("hidden") is not True
-            ]
-            lines = ["## Zen models"]
-            for model in models:
-                model_id = str(model["id"])
-                display_name = str(model.get("displayName") or model_id)
-                default = " — default" if model.get("isDefault") is True else ""
-                lines.append(f"- **{display_name}** (`{model_id}`){default}")
-            lines.append("Use `/model <name>` to switch the selected thread.")
             await self._send_to_conversation(
                 key,
                 message_type="status",
-                text="\n".join(lines),
+                text=await self._model_catalog_markdown(),
                 delivery_id=self._inbound_delivery_id(inbound, "models"),
             )
             return
@@ -473,16 +454,53 @@ class ImZenGateway:
                 delivery_id=self._inbound_delivery_id(inbound, "model-no-thread"),
             )
             return
-        await self.client.call(
-            "thread/settings/update",
-            {"threadId": thread_id, "model": argument},
-        )
+        try:
+            await self.client.call(
+                "thread/settings/update",
+                {"threadId": thread_id, "model": argument},
+            )
+        except Exception as exc:
+            text = f"Could not switch model to **{argument}**: {exc}"
+            if "not available" in str(exc).casefold():
+                try:
+                    text = f"{text}\n\n{await self._model_catalog_markdown()}"
+                except Exception:
+                    text = f"{text}\n\nUse `/model` to list available models."
+            await self._send_to_conversation(
+                key,
+                message_type="error",
+                text=text,
+                delivery_id=self._inbound_delivery_id(inbound, "model-error"),
+            )
+            return
         await self._send_to_conversation(
             key,
             message_type="status",
             text=f"Model switched to **{argument}** for subsequent turns.",
             delivery_id=self._inbound_delivery_id(inbound, "model-switched"),
         )
+
+    async def _model_catalog_markdown(self) -> str:
+        result = await self.client.list_models()
+        data = result.get("data")
+        if not isinstance(data, list):
+            raise RuntimeError("model/list did not return a model list")
+        models = [
+            model
+            for model in data
+            if isinstance(model, dict)
+            and isinstance(model.get("id"), str)
+            and model["id"]
+            and model.get("hidden") is not True
+        ]
+        lines = ["## Zen models"]
+        for model in models:
+            model_id = str(model["id"])
+            display_name = str(model.get("displayName") or model_id)
+            default = " — default" if model.get("isDefault") is True else ""
+            lines.append(f"- **{display_name}** (`{model_id}`){default}")
+        lines.append("Use `/model <name>` to switch the selected thread.")
+        return "\n".join(lines)
 
     async def _clear_binding(self, key: ConversationKey) -> None:
         old_thread_id = self._thread_by_conversation.get(key)

--- a/apps/imzen/tests/test_gateway.py
+++ b/apps/imzen/tests/test_gateway.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from imcodex.appserver import AppServerError
 from imcodex.models import InboundMessage
 
 from imzen.middleware import ImZenMiddleware
@@ -51,7 +52,11 @@ class FakeAppServer:
         payload = dict(params or {})
         self.calls.append((method, payload))
         if method == "thread/settings/update" and payload.get("model") == "missing":
-            raise RuntimeError("Model is not available from this Zen host: missing")
+            raise AppServerError(
+                "Model is not available from this Zen host: missing",
+                code=-32000,
+                data={"zenCode": "model_unavailable"},
+            )
         if method == "thread/settings/update" and payload.get("model") == "busy":
             raise RuntimeError("Thread thread-1 already has a running turn")
         return {}

--- a/apps/imzen/tests/test_gateway.py
+++ b/apps/imzen/tests/test_gateway.py
@@ -52,6 +52,8 @@ class FakeAppServer:
         self.calls.append((method, payload))
         if method == "thread/settings/update" and payload.get("model") == "missing":
             raise RuntimeError("Model is not available from this Zen host: missing")
+        if method == "thread/settings/update" and payload.get("model") == "busy":
+            raise RuntimeError("Thread thread-1 already has a running turn")
         return {}
 
     async def list_models(self, **_params: Any) -> dict:
@@ -234,16 +236,32 @@ async def test_model_rejects_unavailable_model_and_requires_a_bound_thread(tmp_p
     await middleware.handle_inbound(adapter, inbound("m2", "start work"))
     await middleware.handle_inbound(adapter, inbound("m3", "/model missing"))
     assert adapter.sent[-1].message_type == "error"
-    assert (
-        adapter.sent[-1].text == "Zen could not process this message: "
-        "Model is not available from this Zen host: missing"
-    )
+    assert "Could not switch model to **missing**" in adapter.sent[-1].text
+    assert "Model is not available from this Zen host: missing" in adapter.sent[-1].text
+    assert "**Model One** (`model-one`) — default" in adapter.sent[-1].text
+    assert "**Model Two** (`model-two`)" in adapter.sent[-1].text
     assert client.calls == [
         (
             "thread/settings/update",
             {"threadId": "thread-1", "model": "missing"},
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_model_busy_error_is_reported_as_a_model_command_failure(tmp_path):
+    client = FakeAppServer()
+    adapter = FakeAdapter()
+    middleware = ImZenMiddleware(client=client, default_cwd=str(tmp_path))
+    middleware.register_adapter(adapter)
+
+    await middleware.handle_inbound(adapter, inbound("m1", "start work"))
+    await middleware.handle_inbound(adapter, inbound("m2", "/model busy"))
+
+    assert adapter.sent[-1].message_type == "error"
+    assert adapter.sent[-1].text == (
+        "Could not switch model to **busy**: Thread thread-1 already has a running turn"
+    )
 
 
 @pytest.mark.asyncio

--- a/apps/imzen/tests/test_gateway.py
+++ b/apps/imzen/tests/test_gateway.py
@@ -48,7 +48,10 @@ class FakeAppServer:
         return {}
 
     async def call(self, method: str, params: dict | None = None) -> dict:
-        self.calls.append((method, dict(params or {})))
+        payload = dict(params or {})
+        self.calls.append((method, payload))
+        if method == "thread/settings/update" and payload.get("model") == "missing":
+            raise RuntimeError("Model is not available from this Zen host: missing")
         return {}
 
     async def list_models(self, **_params: Any) -> dict:
@@ -231,8 +234,16 @@ async def test_model_rejects_unavailable_model_and_requires_a_bound_thread(tmp_p
     await middleware.handle_inbound(adapter, inbound("m2", "start work"))
     await middleware.handle_inbound(adapter, inbound("m3", "/model missing"))
     assert adapter.sent[-1].message_type == "error"
-    assert adapter.sent[-1].text == "Model is not available from this Zen host: missing"
-    assert client.calls == []
+    assert (
+        adapter.sent[-1].text == "Zen could not process this message: "
+        "Model is not available from this Zen host: missing"
+    )
+    assert client.calls == [
+        (
+            "thread/settings/update",
+            {"threadId": "thread-1", "model": "missing"},
+        )
+    ]
 
 
 @pytest.mark.asyncio

--- a/apps/imzen/tests/test_gateway.py
+++ b/apps/imzen/tests/test_gateway.py
@@ -15,6 +15,15 @@ class FakeAppServer:
         self.connection_reset_handlers = []
         self.started_threads: list[dict[str, Any]] = []
         self.started_turns: list[tuple[str, dict[str, Any]]] = []
+        self.calls: list[tuple[str, dict]] = []
+        self.models: list[dict[str, Any]] = [
+            {
+                "id": "model-one",
+                "displayName": "Model One",
+                "isDefault": True,
+            },
+            {"id": "model-two", "displayName": "Model Two"},
+        ]
         self.listed_threads: list[dict[str, Any]] = []
         self.list_threads_calls = 0
         self.resumed_threads: list[str] = []
@@ -37,6 +46,13 @@ class FakeAppServer:
     async def initialize(self) -> dict:
         self.initialized = True
         return {}
+
+    async def call(self, method: str, params: dict | None = None) -> dict:
+        self.calls.append((method, dict(params or {})))
+        return {}
+
+    async def list_models(self, **_params: Any) -> dict:
+        return {"data": self.models}
 
     async def start_thread(self, **params: Any) -> dict:
         self.started_threads.append(params)
@@ -175,6 +191,48 @@ async def test_conversation_reuses_one_thread_and_projects_completed_item(tmp_pa
 
     await middleware.stop()
     assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_model_lists_host_catalog_and_switches_the_bound_thread(tmp_path):
+    client = FakeAppServer()
+    adapter = FakeAdapter()
+    middleware = ImZenMiddleware(client=client, default_cwd=str(tmp_path))
+    middleware.register_adapter(adapter)
+
+    await middleware.handle_inbound(adapter, inbound("m1", "/model"))
+    assert adapter.sent[-1].message_type == "status"
+    assert "**Model One** (`model-one`) — default" in adapter.sent[-1].text
+    assert "**Model Two** (`model-two`)" in adapter.sent[-1].text
+
+    await middleware.handle_inbound(adapter, inbound("m2", "start work"))
+    await middleware.handle_inbound(adapter, inbound("m3", "/model model-two"))
+
+    assert client.calls == [
+        (
+            "thread/settings/update",
+            {"threadId": "thread-1", "model": "model-two"},
+        )
+    ]
+    assert adapter.sent[-1].text == "Model switched to **model-two** for subsequent turns."
+
+
+@pytest.mark.asyncio
+async def test_model_rejects_unavailable_model_and_requires_a_bound_thread(tmp_path):
+    client = FakeAppServer()
+    adapter = FakeAdapter()
+    middleware = ImZenMiddleware(client=client, default_cwd=str(tmp_path))
+    middleware.register_adapter(adapter)
+
+    await middleware.handle_inbound(adapter, inbound("m1", "/model model-two"))
+    assert adapter.sent[-1].message_type == "error"
+    assert "No Zen thread is selected" in adapter.sent[-1].text
+
+    await middleware.handle_inbound(adapter, inbound("m2", "start work"))
+    await middleware.handle_inbound(adapter, inbound("m3", "/model missing"))
+    assert adapter.sent[-1].message_type == "error"
+    assert adapter.sent[-1].text == "Model is not available from this Zen host: missing"
+    assert client.calls == []
 
 
 @pytest.mark.asyncio

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -70,7 +70,6 @@ export type AppServerEvent =
 
 export interface UpdateThreadSettingsInput {
   model: string;
-  expectedModel?: string;
 }
 
 export class ZenAppServer {
@@ -174,13 +173,20 @@ export class ZenAppServer {
     input: UpdateThreadSettingsInput,
   ): Promise<ThreadSnapshot> {
     return await this.#withThreadMutation(threadId, async () => {
+      const thread = await this.#requireThread(threadId);
+      if (input.model === thread.effectiveConfiguration().model) {
+        return await this.#snapshot(
+          thread,
+          this.#activeTurns.get(threadId)?.turnId,
+        );
+      }
+      this.#requireAvailableModel(input.model);
       if (this.#activeTurns.has(threadId)) {
         throw new AppServerError(
           "thread_busy",
           `Thread ${threadId} already has a running turn`,
         );
       }
-      const thread = await this.#requireThread(threadId);
       return await this.#updateThreadSettingsUnlocked(thread, input);
     });
   }
@@ -228,6 +234,13 @@ export class ZenAppServer {
       }
 
       const thread = await this.#requireThread(threadId);
+      const initialConfiguration = thread.effectiveConfiguration();
+      if (initialConfiguration.provider !== this.#runtime.provider) {
+        throw new AppServerError(
+          "provider_unavailable",
+          `Thread ${threadId} requires provider ${initialConfiguration.provider}, but this host provides ${this.#runtime.provider}`,
+        );
+      }
       if (options.model !== undefined) {
         await this.#updateThreadSettingsUnlocked(thread, {
           model: options.model,
@@ -333,6 +346,7 @@ export class ZenAppServer {
   }
 
   async #commit(thread: Thread, item: CanonicalItem): Promise<void> {
+    thread.validateAppend(item);
     await this.#journal.append(item);
     thread.append(item);
   }
@@ -366,15 +380,6 @@ export class ZenAppServer {
   ): Promise<ThreadSnapshot> {
     this.#requireAvailableModel(input.model);
     const current = thread.effectiveConfiguration();
-    if (
-      input.expectedModel !== undefined &&
-      input.expectedModel !== current.model
-    ) {
-      throw new AppServerError(
-        "stale_thread_configuration",
-        `Expected model ${input.expectedModel}, but current model is ${current.model}`,
-      );
-    }
     if (input.model === current.model) {
       return await this.#snapshot(thread);
     }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -49,6 +49,15 @@ export interface ThreadSnapshot {
   name?: string;
 }
 
+export interface UnavailableThreadSnapshot {
+  id: string;
+  status: "systemError";
+  error: string;
+  name?: string;
+}
+
+export type ThreadListEntry = ThreadSnapshot | UnavailableThreadSnapshot;
+
 export interface TurnHandle {
   id: string;
   done: Promise<void>;
@@ -147,15 +156,23 @@ export class ZenAppServer {
     return await this.#snapshot(thread);
   }
 
-  async listThreads(): Promise<ThreadSnapshot[]> {
+  async listThreads(): Promise<ThreadListEntry[]> {
     const threadIds = await this.#journal.listThreadIds();
-    const snapshots: ThreadSnapshot[] = [];
+    const snapshots: ThreadListEntry[] = [];
     for (const threadId of threadIds) {
-      const thread = await this.#loadThread(threadId);
-      if (thread !== undefined) {
-        snapshots.push(
-          await this.#snapshot(thread, this.#activeTurns.get(threadId)?.turnId),
-        );
+      try {
+        const thread = await this.#loadThread(threadId);
+        if (thread !== undefined) {
+          snapshots.push(
+            await this.#snapshot(
+              thread,
+              this.#activeTurns.get(threadId)?.turnId,
+            ),
+          );
+        }
+      } catch (error) {
+        console.warn(`Could not load Thread ${threadId}`, error);
+        snapshots.push(await this.#unavailableSnapshot(threadId, error));
       }
     }
     return snapshots;
@@ -371,6 +388,29 @@ export class ZenAppServer {
       provider: configuration.provider,
       sandbox: configuration.sandbox,
       approvalPolicy: configuration.approvalPolicy,
+      ...(productMetadata.name === undefined
+        ? {}
+        : { name: productMetadata.name }),
+    };
+  }
+
+  async #unavailableSnapshot(
+    threadId: string,
+    error: unknown,
+  ): Promise<UnavailableThreadSnapshot> {
+    let productMetadata: ThreadProductMetadata = {};
+    try {
+      productMetadata = await this.#threadMetadata.read(threadId);
+    } catch (metadataError) {
+      console.warn(
+        `Could not read product metadata for unavailable Thread ${threadId}`,
+        metadataError,
+      );
+    }
+    return {
+      id: threadId,
+      status: "systemError",
+      error: error instanceof Error ? error.message : String(error),
       ...(productMetadata.name === undefined
         ? {}
         : { name: productMetadata.name }),

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -18,6 +18,7 @@ import {
 } from "./thread.js";
 import {
   normalizeThreadName,
+  type ThreadProductMetadata,
   type ThreadMetadataStore,
 } from "./thread-metadata.js";
 import type { ApprovalHandler } from "./tool.js";
@@ -247,12 +248,6 @@ export class ZenAppServer {
         });
       }
       const configuration = thread.effectiveConfiguration();
-      if (configuration.provider !== this.#runtime.provider) {
-        throw new AppServerError(
-          "provider_unavailable",
-          `Thread ${threadId} requires provider ${configuration.provider}, but this host provides ${this.#runtime.provider}`,
-        );
-      }
       const turnId = this.#id();
       const controller = new AbortController();
 
@@ -356,7 +351,15 @@ export class ZenAppServer {
     activeTurnId?: string,
   ): Promise<ThreadSnapshot> {
     const configuration = thread.effectiveConfiguration();
-    const productMetadata = await this.#threadMetadata.read(thread.id);
+    let productMetadata: ThreadProductMetadata = {};
+    try {
+      productMetadata = await this.#threadMetadata.read(thread.id);
+    } catch (error) {
+      console.warn(
+        `Could not read product metadata for Thread ${thread.id}`,
+        error,
+      );
+    }
     return {
       id: thread.id,
       items: thread.items,

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -5,11 +5,21 @@ import type {
   ApprovalPolicy,
   CanonicalItem,
   SandboxMode,
+  ThreadConfigurationChangedItem,
   ThreadMetadataItem,
 } from "./item.js";
 import type { ThreadJournal } from "./journal.js";
+import type { ModelCatalog, ModelCatalogEntry } from "./model-catalog.js";
 import { AgentRuntime, type RuntimeEvent } from "./runtime.js";
-import { Thread, type DerivedTurn } from "./thread.js";
+import {
+  Thread,
+  type DerivedTurn,
+  type EffectiveThreadConfiguration,
+} from "./thread.js";
+import {
+  normalizeThreadName,
+  type ThreadMetadataStore,
+} from "./thread-metadata.js";
 import type { ApprovalHandler } from "./tool.js";
 
 export interface AppServerDefaults {
@@ -35,6 +45,7 @@ export interface ThreadSnapshot {
   provider: string;
   sandbox: SandboxMode;
   approvalPolicy: ApprovalPolicy;
+  name?: string;
 }
 
 export interface TurnHandle {
@@ -42,9 +53,31 @@ export interface TurnHandle {
   done: Promise<void>;
 }
 
+export interface ThreadSettingsUpdatedEvent {
+  type: "thread_settings_updated";
+  threadId: string;
+  settings: EffectiveThreadConfiguration;
+}
+
+export interface ThreadNameUpdatedEvent {
+  type: "thread_name_updated";
+  threadId: string;
+  name: string;
+}
+
+export type AppServerEvent =
+  RuntimeEvent | ThreadSettingsUpdatedEvent | ThreadNameUpdatedEvent;
+
+export interface UpdateThreadSettingsInput {
+  model: string;
+  expectedModel?: string;
+}
+
 export class ZenAppServer {
   readonly #journal: ThreadJournal;
   readonly #runtime: AgentRuntime;
+  readonly #modelCatalog: ModelCatalog;
+  readonly #threadMetadata: ThreadMetadataStore;
   readonly #defaults: AppServerDefaults;
   readonly #id: () => string;
   readonly #now: () => string;
@@ -53,49 +86,65 @@ export class ZenAppServer {
     string,
     { turnId: string; controller: AbortController; done: Promise<void> }
   >();
-  readonly #subscribers = new Set<(event: RuntimeEvent) => void>();
+  readonly #subscribers = new Set<(event: AppServerEvent) => void>();
+  readonly #mutationChains = new Map<string, Promise<void>>();
 
   constructor(options: {
     journal: ThreadJournal;
     runtime: AgentRuntime;
+    modelCatalog: ModelCatalog;
+    threadMetadata: ThreadMetadataStore;
     defaults: AppServerDefaults;
     idFactory?: () => string;
     now?: () => string;
   }) {
     this.#journal = options.journal;
     this.#runtime = options.runtime;
+    this.#modelCatalog = options.modelCatalog;
+    this.#threadMetadata = options.threadMetadata;
     this.#defaults = {
       ...options.defaults,
       cwd: path.resolve(options.defaults.cwd),
     };
     this.#id = options.idFactory ?? randomUUID;
     this.#now = options.now ?? (() => new Date().toISOString());
+    if (this.#modelCatalog.get(this.#defaults.model) === undefined) {
+      throw new Error(
+        `Default model ${this.#defaults.model} is absent from the model catalog`,
+      );
+    }
   }
 
-  subscribe(listener: (event: RuntimeEvent) => void): () => void {
+  subscribe(listener: (event: AppServerEvent) => void): () => void {
     this.#subscribers.add(listener);
     return () => {
       this.#subscribers.delete(listener);
     };
   }
 
+  listModels(): readonly ModelCatalogEntry[] {
+    return this.#modelCatalog.list();
+  }
+
   async startThread(input: StartThreadInput = {}): Promise<ThreadSnapshot> {
     const threadId = this.#id();
     const thread = new Thread(threadId);
+    const model = input.model ?? this.#defaults.model;
+    this.#requireAvailableModel(model);
     const metadata: ThreadMetadataItem = {
       id: this.#id(),
       threadId,
       createdAt: this.#now(),
       type: "thread_metadata",
       cwd: path.resolve(input.cwd ?? this.#defaults.cwd),
-      model: input.model ?? this.#defaults.model,
+      model,
       provider: this.#runtime.provider,
       sandbox: input.sandbox ?? this.#defaults.sandbox,
       approvalPolicy: input.approvalPolicy ?? this.#defaults.approvalPolicy,
     };
     await this.#commit(thread, metadata);
     this.#threads.set(threadId, thread);
-    return this.#snapshot(thread);
+    return await this.#snapshot(thread);
   }
 
   async listThreads(): Promise<ThreadSnapshot[]> {
@@ -105,7 +154,7 @@ export class ZenAppServer {
       const thread = await this.#loadThread(threadId);
       if (thread !== undefined) {
         snapshots.push(
-          this.#snapshot(thread, this.#activeTurns.get(threadId)?.turnId),
+          await this.#snapshot(thread, this.#activeTurns.get(threadId)?.turnId),
         );
       }
     }
@@ -114,84 +163,130 @@ export class ZenAppServer {
 
   async readThread(threadId: string): Promise<ThreadSnapshot> {
     const thread = await this.#requireThread(threadId);
-    return this.#snapshot(thread, this.#activeTurns.get(threadId)?.turnId);
+    return await this.#snapshot(
+      thread,
+      this.#activeTurns.get(threadId)?.turnId,
+    );
+  }
+
+  async updateThreadSettings(
+    threadId: string,
+    input: UpdateThreadSettingsInput,
+  ): Promise<ThreadSnapshot> {
+    return await this.#withThreadMutation(threadId, async () => {
+      if (this.#activeTurns.has(threadId)) {
+        throw new AppServerError(
+          "thread_busy",
+          `Thread ${threadId} already has a running turn`,
+        );
+      }
+      const thread = await this.#requireThread(threadId);
+      return await this.#updateThreadSettingsUnlocked(thread, input);
+    });
+  }
+
+  async setThreadName(
+    threadId: string,
+    requestedName: string,
+  ): Promise<ThreadSnapshot> {
+    const thread = await this.#requireThread(threadId);
+    let name: string;
+    try {
+      name = normalizeThreadName(requestedName);
+    } catch (error) {
+      throw new AppServerError(
+        "invalid_request",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    await this.#threadMetadata.setName(threadId, name);
+    this.#emit({ type: "thread_name_updated", threadId, name });
+    return await this.#snapshot(
+      thread,
+      this.#activeTurns.get(threadId)?.turnId,
+    );
   }
 
   async startTurn(
     threadId: string,
     text: string,
-    options: { clientId?: string; requestApproval?: ApprovalHandler } = {},
+    options: {
+      clientId?: string;
+      model?: string;
+      requestApproval?: ApprovalHandler;
+    } = {},
   ): Promise<TurnHandle> {
     if (text.length === 0) {
       throw new AppServerError("invalid_request", "Turn input cannot be empty");
     }
-    if (this.#activeTurns.has(threadId)) {
-      throw new AppServerError(
-        "thread_busy",
-        `Thread ${threadId} already has a running turn`,
-      );
-    }
+    return await this.#withThreadMutation(threadId, async () => {
+      if (this.#activeTurns.has(threadId)) {
+        throw new AppServerError(
+          "thread_busy",
+          `Thread ${threadId} already has a running turn`,
+        );
+      }
 
-    const thread = await this.#requireThread(threadId);
-    if (this.#activeTurns.has(threadId)) {
-      throw new AppServerError(
-        "thread_busy",
-        `Thread ${threadId} already has a running turn`,
-      );
-    }
-    const metadata = requireMetadata(thread);
-    if (metadata.provider !== this.#runtime.provider) {
-      throw new AppServerError(
-        "provider_unavailable",
-        `Thread ${threadId} requires provider ${metadata.provider}, but this host provides ${this.#runtime.provider}`,
-      );
-    }
-    const turnId = this.#id();
-    const controller = new AbortController();
+      const thread = await this.#requireThread(threadId);
+      if (options.model !== undefined) {
+        await this.#updateThreadSettingsUnlocked(thread, {
+          model: options.model,
+        });
+      }
+      const configuration = thread.effectiveConfiguration();
+      if (configuration.provider !== this.#runtime.provider) {
+        throw new AppServerError(
+          "provider_unavailable",
+          `Thread ${threadId} requires provider ${configuration.provider}, but this host provides ${this.#runtime.provider}`,
+        );
+      }
+      const turnId = this.#id();
+      const controller = new AbortController();
 
-    const done = new Promise<void>((resolve, reject) => {
-      setImmediate(() => {
-        void (async () => {
-          try {
-            await this.#runtime.runTurn({
-              thread,
-              turnId,
-              text,
-              ...(options.clientId === undefined
-                ? {}
-                : { clientId: options.clientId }),
-              configuration: {
-                cwd: metadata.cwd,
-                model: metadata.model,
-                sandbox: metadata.sandbox,
-                approvalPolicy: metadata.approvalPolicy,
-              },
-              signal: controller.signal,
-              commit: async (item) => {
-                await this.#commit(thread, item);
-              },
-              emit: (event) => {
-                this.#emit(event);
-              },
-              ...(options.requestApproval === undefined
-                ? {}
-                : { requestApproval: options.requestApproval }),
-            });
-            resolve();
-          } catch (error) {
-            reject(error instanceof Error ? error : new Error(String(error)));
-          } finally {
-            const active = this.#activeTurns.get(threadId);
-            if (active?.turnId === turnId) {
-              this.#activeTurns.delete(threadId);
+      const done = new Promise<void>((resolve, reject) => {
+        setImmediate(() => {
+          void (async () => {
+            try {
+              await this.#runtime.runTurn({
+                thread,
+                turnId,
+                text,
+                ...(options.clientId === undefined
+                  ? {}
+                  : { clientId: options.clientId }),
+                configuration: {
+                  cwd: configuration.cwd,
+                  model: configuration.model,
+                  sandbox: configuration.sandbox,
+                  approvalPolicy: configuration.approvalPolicy,
+                },
+                signal: controller.signal,
+                commit: async (item) => {
+                  await this.#commit(thread, item);
+                },
+                emit: (event) => {
+                  this.#emit(event);
+                },
+                ...(options.requestApproval === undefined
+                  ? {}
+                  : { requestApproval: options.requestApproval }),
+              });
+              resolve();
+            } catch (error) {
+              reject(error instanceof Error ? error : new Error(String(error)));
+            } finally {
+              const active = this.#activeTurns.get(threadId);
+              if (active?.turnId === turnId) {
+                this.#activeTurns.delete(threadId);
+              }
             }
-          }
-        })();
+          })();
+        });
       });
-    });
 
-    this.#activeTurns.set(threadId, { turnId, controller, done });
-    return { id: turnId, done };
+      this.#activeTurns.set(threadId, { turnId, controller, done });
+      return { id: turnId, done };
+    });
   }
 
   async interruptTurn(threadId: string, turnId: string): Promise<void> {
@@ -242,23 +337,98 @@ export class ZenAppServer {
     thread.append(item);
   }
 
-  #snapshot(thread: Thread, activeTurnId?: string): ThreadSnapshot {
-    const metadata = requireMetadata(thread);
+  async #snapshot(
+    thread: Thread,
+    activeTurnId?: string,
+  ): Promise<ThreadSnapshot> {
+    const configuration = thread.effectiveConfiguration();
+    const productMetadata = await this.#threadMetadata.read(thread.id);
     return {
       id: thread.id,
       items: thread.items,
       turns: thread.deriveTurns(
         activeTurnId === undefined ? {} : { activeTurnId },
       ),
-      cwd: metadata.cwd,
-      model: metadata.model,
-      provider: metadata.provider,
-      sandbox: metadata.sandbox,
-      approvalPolicy: metadata.approvalPolicy,
+      cwd: configuration.cwd,
+      model: configuration.model,
+      provider: configuration.provider,
+      sandbox: configuration.sandbox,
+      approvalPolicy: configuration.approvalPolicy,
+      ...(productMetadata.name === undefined
+        ? {}
+        : { name: productMetadata.name }),
     };
   }
 
-  #emit(event: RuntimeEvent): void {
+  async #updateThreadSettingsUnlocked(
+    thread: Thread,
+    input: UpdateThreadSettingsInput,
+  ): Promise<ThreadSnapshot> {
+    this.#requireAvailableModel(input.model);
+    const current = thread.effectiveConfiguration();
+    if (
+      input.expectedModel !== undefined &&
+      input.expectedModel !== current.model
+    ) {
+      throw new AppServerError(
+        "stale_thread_configuration",
+        `Expected model ${input.expectedModel}, but current model is ${current.model}`,
+      );
+    }
+    if (input.model === current.model) {
+      return await this.#snapshot(thread);
+    }
+    const changed: ThreadConfigurationChangedItem = {
+      id: this.#id(),
+      threadId: thread.id,
+      createdAt: this.#now(),
+      type: "thread_configuration_changed",
+      model: { from: current.model, to: input.model },
+    };
+    await this.#commit(thread, changed);
+    const settings = thread.effectiveConfiguration();
+    this.#emit({
+      type: "thread_settings_updated",
+      threadId: thread.id,
+      settings,
+    });
+    return await this.#snapshot(thread);
+  }
+
+  #requireAvailableModel(model: string): void {
+    if (this.#modelCatalog.get(model) === undefined) {
+      throw new AppServerError(
+        "model_unavailable",
+        `Model is not available from this Zen host: ${model}`,
+      );
+    }
+  }
+
+  async #withThreadMutation<T>(
+    threadId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.#mutationChains.get(threadId) ?? Promise.resolve();
+    let release = (): void => undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const chain = previous.then(async () => {
+      await gate;
+    });
+    this.#mutationChains.set(threadId, chain);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.#mutationChains.get(threadId) === chain) {
+        this.#mutationChains.delete(threadId);
+      }
+    }
+  }
+
+  #emit(event: AppServerEvent): void {
     for (const subscriber of this.#subscribers) {
       subscriber(event);
     }
@@ -273,19 +443,4 @@ export class AppServerError extends Error {
     this.name = "AppServerError";
     this.code = code;
   }
-}
-
-function requireMetadata(thread: Thread): ThreadMetadataItem {
-  const metadata = [...thread.items]
-    .reverse()
-    .find(
-      (item): item is ThreadMetadataItem => item.type === "thread_metadata",
-    );
-  if (metadata === undefined) {
-    throw new AppServerError(
-      "invalid_thread",
-      `Thread ${thread.id} has no metadata item`,
-    );
-  }
-  return metadata;
 }

--- a/src/item.ts
+++ b/src/item.ts
@@ -1,5 +1,6 @@
 export type ItemType =
   | "thread_metadata"
+  | "thread_configuration_changed"
   | "turn_started"
   | "turn_completed"
   | "turn_aborted"
@@ -25,6 +26,14 @@ export interface ThreadMetadataItem extends ItemBase {
   provider: string;
   sandbox: SandboxMode;
   approvalPolicy: ApprovalPolicy;
+}
+
+export interface ThreadConfigurationChangedItem extends ItemBase {
+  type: "thread_configuration_changed";
+  model: {
+    from: string;
+    to: string;
+  };
 }
 
 export interface TurnStartedItem extends ItemBase {
@@ -88,6 +97,7 @@ export interface FailureItem extends ItemBase {
 
 export type CanonicalItem =
   | ThreadMetadataItem
+  | ThreadConfigurationChangedItem
   | TurnStartedItem
   | TurnCompletedItem
   | TurnAbortedItem

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,0 +1,87 @@
+export interface ModelCatalogEntry {
+  id: string;
+  displayName?: string;
+  description?: string;
+  hidden?: boolean;
+  isDefault?: boolean;
+}
+
+export interface ModelCatalog {
+  list(): readonly ModelCatalogEntry[];
+  get(model: string): ModelCatalogEntry | undefined;
+  defaultModel(): ModelCatalogEntry;
+}
+
+export class StaticModelCatalog implements ModelCatalog {
+  readonly #entries: readonly ModelCatalogEntry[];
+  readonly #byId: ReadonlyMap<string, ModelCatalogEntry>;
+  readonly #default: ModelCatalogEntry;
+
+  constructor(entries: readonly ModelCatalogEntry[]) {
+    if (entries.length === 0) {
+      throw new Error("Model catalog must contain at least one model");
+    }
+    const normalized = entries.map((entry) => normalizeEntry(entry));
+    const byId = new Map<string, ModelCatalogEntry>();
+    for (const entry of normalized) {
+      if (byId.has(entry.id)) {
+        throw new Error(`Duplicate model catalog entry: ${entry.id}`);
+      }
+      byId.set(entry.id, entry);
+    }
+    const defaults = normalized.filter((entry) => entry.isDefault === true);
+    if (defaults.length > 1) {
+      throw new Error("Model catalog can contain only one default model");
+    }
+    const defaultEntry = defaults[0] ?? normalized[0];
+    if (defaultEntry === undefined) {
+      throw new Error("Model catalog has no default model");
+    }
+    this.#entries = Object.freeze(
+      normalized.map((entry) =>
+        Object.freeze({
+          ...entry,
+          isDefault: entry.id === defaultEntry.id,
+        }),
+      ),
+    );
+    this.#byId = new Map(this.#entries.map((entry) => [entry.id, entry]));
+    const resolvedDefault = this.#byId.get(defaultEntry.id);
+    if (resolvedDefault === undefined) {
+      throw new Error("Model catalog default disappeared");
+    }
+    this.#default = resolvedDefault;
+  }
+
+  list(): readonly ModelCatalogEntry[] {
+    return this.#entries;
+  }
+
+  get(model: string): ModelCatalogEntry | undefined {
+    return this.#byId.get(model);
+  }
+
+  defaultModel(): ModelCatalogEntry {
+    return this.#default;
+  }
+}
+
+function normalizeEntry(entry: ModelCatalogEntry): ModelCatalogEntry {
+  const id = entry.id.trim();
+  if (id.length === 0) {
+    throw new Error("Model catalog ids must not be empty");
+  }
+  const displayName = entry.displayName?.trim();
+  const description = entry.description?.trim();
+  return {
+    id,
+    ...(displayName === undefined || displayName.length === 0
+      ? {}
+      : { displayName }),
+    ...(description === undefined || description.length === 0
+      ? {}
+      : { description }),
+    ...(entry.hidden === undefined ? {} : { hidden: entry.hidden }),
+    ...(entry.isDefault === undefined ? {} : { isDefault: entry.isDefault }),
+  };
+}

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -33,10 +33,7 @@ export class StaticModelCatalog implements ModelCatalog {
     if (defaults.length !== 1) {
       throw new Error("Model catalog must contain exactly one default model");
     }
-    const defaultEntry = defaults[0];
-    if (defaultEntry === undefined) {
-      throw new Error("Model catalog has no default model");
-    }
+    const defaultEntry = defaults[0]!;
     if (defaultEntry.hidden === true) {
       throw new Error("Model catalog default must be visible");
     }
@@ -48,7 +45,7 @@ export class StaticModelCatalog implements ModelCatalog {
     );
     this.#entries = Object.freeze(frozenEntries);
     this.#byId = new Map(this.#entries.map((entry) => [entry.id, entry]));
-    this.#default = frozenEntries[normalized.indexOf(defaultEntry)]!;
+    this.#default = this.#byId.get(defaultEntry.id)!;
   }
 
   list(): readonly ModelCatalogEntry[] {

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -30,27 +30,25 @@ export class StaticModelCatalog implements ModelCatalog {
       byId.set(entry.id, entry);
     }
     const defaults = normalized.filter((entry) => entry.isDefault === true);
-    if (defaults.length > 1) {
-      throw new Error("Model catalog can contain only one default model");
+    if (defaults.length !== 1) {
+      throw new Error("Model catalog must contain exactly one default model");
     }
-    const defaultEntry = defaults[0] ?? normalized[0];
+    const defaultEntry = defaults[0];
     if (defaultEntry === undefined) {
       throw new Error("Model catalog has no default model");
     }
-    this.#entries = Object.freeze(
-      normalized.map((entry) =>
-        Object.freeze({
-          ...entry,
-          isDefault: entry.id === defaultEntry.id,
-        }),
-      ),
-    );
-    this.#byId = new Map(this.#entries.map((entry) => [entry.id, entry]));
-    const resolvedDefault = this.#byId.get(defaultEntry.id);
-    if (resolvedDefault === undefined) {
-      throw new Error("Model catalog default disappeared");
+    if (defaultEntry.hidden === true) {
+      throw new Error("Model catalog default must be visible");
     }
-    this.#default = resolvedDefault;
+    const frozenEntries = normalized.map((entry) =>
+      Object.freeze({
+        ...entry,
+        isDefault: entry.id === defaultEntry.id,
+      }),
+    );
+    this.#entries = Object.freeze(frozenEntries);
+    this.#byId = new Map(this.#entries.map((entry) => [entry.id, entry]));
+    this.#default = frozenEntries[normalized.indexOf(defaultEntry)]!;
   }
 
   list(): readonly ModelCatalogEntry[] {

--- a/src/model.ts
+++ b/src/model.ts
@@ -137,6 +137,7 @@ export function compileModelMessages(
         });
         break;
       case "reasoning":
+      case "thread_configuration_changed":
       case "thread_metadata":
       case "turn_aborted":
       case "turn_completed":

--- a/src/protocol/codex/README.md
+++ b/src/protocol/codex/README.md
@@ -16,6 +16,8 @@ Client requests：
 - `thread/resume`
 - `thread/read`
 - `thread/list`
+- `thread/name/set`
+- `thread/settings/update`
 - `thread/unsubscribe`
 - `turn/start`
 - `turn/interrupt`
@@ -25,6 +27,8 @@ Client notification：`initialized`。
 Server notifications：
 
 - `thread/started`
+- `thread/name/updated`
+- `thread/settings/updated`
 - `turn/started`
 - `item/started`
 - `item/agentMessage/delta`

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -710,6 +710,7 @@ export class CodexConnection {
       event.type === "thread_name_updated" ||
       event.type === "thread_settings_updated"
     ) {
+      console.warn(`Could not project ${event.type} notification`, error);
       return;
     }
     const threadId =

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -20,6 +20,7 @@ import {
   projectThread,
   projectTurn,
   threadSettings,
+  threadSettingsUpdated,
 } from "./mapper.js";
 import {
   isNotification,
@@ -208,7 +209,7 @@ export class CodexConnection {
         ]);
         const sandbox = optionalString(params.sandbox);
         const cwd = optionalString(params.cwd);
-        const model = optionalString(params.model);
+        const model = optionalNonEmptyString(params.model, "model");
         const approvalPolicy = readApprovalPolicy(params.approvalPolicy);
         readApprovalsReviewer(params.approvalsReviewer);
         if (sandbox !== undefined && sandbox !== "danger-full-access") {
@@ -234,12 +235,8 @@ export class CodexConnection {
       case "thread/resume": {
         const threadId = requiredString(params, "threadId");
         let snapshot = await this.#appServer.readThread(threadId);
-        const requestedModel = optionalString(params.model);
-        const validationSnapshot =
-          requestedModel === undefined
-            ? snapshot
-            : { ...snapshot, model: requestedModel };
-        validateMatchingThreadConfiguration(params, validationSnapshot, [
+        const requestedModel = optionalNonEmptyString(params.model, "model");
+        validateMatchingThreadConfiguration(params, snapshot, requestedModel, [
           "threadId",
           "cwd",
           "model",
@@ -328,25 +325,19 @@ export class CodexConnection {
       case "turn/start": {
         const threadId = requiredString(params, "threadId");
         const snapshot = await this.#appServer.readThread(threadId);
-        const requestedModel = optionalString(params.model);
-        validateMatchingThreadConfiguration(
-          params,
-          requestedModel === undefined
-            ? snapshot
-            : { ...snapshot, model: requestedModel },
-          [
-            "threadId",
-            "input",
-            "cwd",
-            "model",
-            "approvalPolicy",
-            "sandbox",
-            "sandboxPolicy",
-            "approvalsReviewer",
-            "collaborationMode",
-            "clientUserMessageId",
-          ],
-        );
+        const requestedModel = optionalNonEmptyString(params.model, "model");
+        validateMatchingThreadConfiguration(params, snapshot, requestedModel, [
+          "threadId",
+          "input",
+          "cwd",
+          "model",
+          "approvalPolicy",
+          "sandbox",
+          "sandboxPolicy",
+          "approvalsReviewer",
+          "collaborationMode",
+          "clientUserMessageId",
+        ]);
         const text = readTextInput(params.input);
         const clientId = optionalNonEmptyString(
           params.clientUserMessageId,
@@ -414,12 +405,11 @@ export class CodexConnection {
     }
     if (event.type === "thread_settings_updated") {
       if (this.#subscribedThreads.has(event.threadId)) {
-        const snapshot = await this.#appServer.readThread(event.threadId);
         this.#send({
           method: "thread/settings/updated",
           params: {
             threadId: event.threadId,
-            threadSettings: threadSettings(snapshot),
+            threadSettings: threadSettingsUpdated(event.settings),
           },
         });
       }
@@ -913,6 +903,7 @@ function readTextInput(value: unknown): string {
 function validateMatchingThreadConfiguration(
   params: Record<string, unknown>,
   snapshot: ThreadSnapshot,
+  requestedModel: string | undefined,
   supportedKeys: string[],
 ): void {
   rejectUnsupportedValues(params, supportedKeys);
@@ -921,13 +912,6 @@ function validateMatchingThreadConfiguration(
   if (cwd !== undefined && path.resolve(cwd) !== snapshot.cwd) {
     throw new InvalidParamsError(
       `cwd does not match thread metadata: ${snapshot.cwd}`,
-    );
-  }
-
-  const model = optionalString(params.model);
-  if (model !== undefined && model !== snapshot.model) {
-    throw new InvalidParamsError(
-      `model does not match thread metadata: ${snapshot.model}`,
     );
   }
 
@@ -957,12 +941,17 @@ function validateMatchingThreadConfiguration(
   }
 
   readApprovalsReviewer(params.approvalsReviewer);
-  readDefaultCollaborationMode(params.collaborationMode, snapshot);
+  readDefaultCollaborationMode(
+    params.collaborationMode,
+    snapshot,
+    requestedModel ?? snapshot.model,
+  );
 }
 
 function readDefaultCollaborationMode(
   value: unknown,
   snapshot: ThreadSnapshot,
+  model: string,
 ): void {
   if (value === undefined || value === null) {
     return;
@@ -978,7 +967,7 @@ function readDefaultCollaborationMode(
         key !== "reasoning_effort" &&
         key !== "developer_instructions",
     ) ||
-    value.settings.model !== snapshot.model ||
+    value.settings.model !== model ||
     value.settings.reasoning_effort !== "medium" ||
     typeof value.settings.developer_instructions !== "string"
   ) {

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import {
   AppServerError,
+  type AppServerEvent,
   type ThreadSnapshot,
   ZenAppServer,
 } from "../../app-server.js";
@@ -11,7 +12,6 @@ import type {
   CanonicalItem,
   ToolCallItem,
 } from "../../item.js";
-import type { RuntimeEvent } from "../../runtime.js";
 import type { ApprovalRequest } from "../../tool.js";
 import {
   projectCommandCompleted,
@@ -37,14 +37,12 @@ export interface CodexConnectionOptions {
   appServer: ZenAppServer;
   send: SendJson;
   zenHome: string;
-  configuredModel?: string;
 }
 
 export class CodexConnection {
   readonly #appServer: ZenAppServer;
   readonly #send: SendJson;
   readonly #zenHome: string;
-  readonly #configuredModel: string;
   readonly #pending = new Map<
     RequestId,
     {
@@ -66,7 +64,6 @@ export class CodexConnection {
     this.#appServer = options.appServer;
     this.#send = options.send;
     this.#zenHome = options.zenHome;
-    this.#configuredModel = options.configuredModel ?? "fake";
     this.#unsubscribe = this.#appServer.subscribe((event) => {
       this.#eventChain = this.#eventChain
         .then(async () => {
@@ -174,30 +171,28 @@ export class CodexConnection {
         if (params.cursor !== undefined && params.cursor !== null) {
           throw new InvalidParamsError("model/list cursor is not supported");
         }
-        const model = this.#configuredModel;
         this.#send({
           id: request.id,
           result: {
-            data: [
-              {
-                id: model,
-                model,
-                upgrade: null,
-                upgradeInfo: null,
-                availabilityNux: null,
-                displayName: model,
-                description: "Model configured by the Zen host",
-                hidden: false,
-                supportedReasoningEfforts: [],
-                defaultReasoningEffort: "medium",
-                inputModalities: ["text"],
-                supportsPersonality: false,
-                additionalSpeedTiers: [],
-                serviceTiers: [],
-                defaultServiceTier: null,
-                isDefault: true,
-              },
-            ],
+            data: this.#appServer.listModels().map((entry) => ({
+              id: entry.id,
+              model: entry.id,
+              upgrade: null,
+              upgradeInfo: null,
+              availabilityNux: null,
+              displayName: entry.displayName ?? entry.id,
+              description:
+                entry.description ?? "Model configured by the Zen host",
+              hidden: entry.hidden ?? false,
+              supportedReasoningEfforts: [],
+              defaultReasoningEffort: "medium",
+              inputModalities: ["text"],
+              supportsPersonality: false,
+              additionalSpeedTiers: [],
+              serviceTiers: [],
+              defaultServiceTier: null,
+              isDefault: entry.isDefault ?? false,
+            })),
             nextCursor: null,
           },
         });
@@ -238,8 +233,13 @@ export class CodexConnection {
       }
       case "thread/resume": {
         const threadId = requiredString(params, "threadId");
-        const snapshot = await this.#appServer.readThread(threadId);
-        validateMatchingThreadConfiguration(params, snapshot, [
+        let snapshot = await this.#appServer.readThread(threadId);
+        const requestedModel = optionalString(params.model);
+        const validationSnapshot =
+          requestedModel === undefined
+            ? snapshot
+            : { ...snapshot, model: requestedModel };
+        validateMatchingThreadConfiguration(params, validationSnapshot, [
           "threadId",
           "cwd",
           "model",
@@ -248,6 +248,11 @@ export class CodexConnection {
           "sandboxPolicy",
           "approvalsReviewer",
         ]);
+        if (requestedModel !== undefined) {
+          snapshot = await this.#appServer.updateThreadSettings(threadId, {
+            model: requestedModel,
+          });
+        }
         this.#subscribedThreads.add(threadId);
         this.#send({
           id: request.id,
@@ -256,6 +261,25 @@ export class CodexConnection {
             ...threadSettings(snapshot),
           },
         });
+        return;
+      }
+      case "thread/name/set": {
+        rejectUnsupportedValues(params, ["threadId", "name"]);
+        const threadId = requiredString(params, "threadId");
+        await this.#appServer.setThreadName(
+          threadId,
+          requiredString(params, "name"),
+        );
+        this.#send({ id: request.id, result: {} });
+        return;
+      }
+      case "thread/settings/update": {
+        rejectUnsupportedValues(params, ["threadId", "model"]);
+        const threadId = requiredString(params, "threadId");
+        await this.#appServer.updateThreadSettings(threadId, {
+          model: requiredString(params, "model"),
+        });
+        this.#send({ id: request.id, result: {} });
         return;
       }
       case "thread/read": {
@@ -304,18 +328,25 @@ export class CodexConnection {
       case "turn/start": {
         const threadId = requiredString(params, "threadId");
         const snapshot = await this.#appServer.readThread(threadId);
-        validateMatchingThreadConfiguration(params, snapshot, [
-          "threadId",
-          "input",
-          "cwd",
-          "model",
-          "approvalPolicy",
-          "sandbox",
-          "sandboxPolicy",
-          "approvalsReviewer",
-          "collaborationMode",
-          "clientUserMessageId",
-        ]);
+        const requestedModel = optionalString(params.model);
+        validateMatchingThreadConfiguration(
+          params,
+          requestedModel === undefined
+            ? snapshot
+            : { ...snapshot, model: requestedModel },
+          [
+            "threadId",
+            "input",
+            "cwd",
+            "model",
+            "approvalPolicy",
+            "sandbox",
+            "sandboxPolicy",
+            "approvalsReviewer",
+            "collaborationMode",
+            "clientUserMessageId",
+          ],
+        );
         const text = readTextInput(params.input);
         const clientId = optionalNonEmptyString(
           params.clientUserMessageId,
@@ -324,6 +355,7 @@ export class CodexConnection {
         this.#subscribedThreads.add(threadId);
         const handle = await this.#appServer.startTurn(threadId, text, {
           ...(clientId === undefined ? {} : { clientId }),
+          ...(requestedModel === undefined ? {} : { model: requestedModel }),
           requestApproval: async (approval) =>
             await this.#requestApproval(approval),
         });
@@ -367,7 +399,32 @@ export class CodexConnection {
     }
   }
 
-  async #projectEvent(event: RuntimeEvent): Promise<void> {
+  async #projectEvent(event: AppServerEvent): Promise<void> {
+    if (event.type === "thread_name_updated") {
+      if (this.#subscribedThreads.has(event.threadId)) {
+        this.#send({
+          method: "thread/name/updated",
+          params: {
+            threadId: event.threadId,
+            threadName: event.name,
+          },
+        });
+      }
+      return;
+    }
+    if (event.type === "thread_settings_updated") {
+      if (this.#subscribedThreads.has(event.threadId)) {
+        const snapshot = await this.#appServer.readThread(event.threadId);
+        this.#send({
+          method: "thread/settings/updated",
+          params: {
+            threadId: event.threadId,
+            threadSettings: threadSettings(snapshot),
+          },
+        });
+      }
+      return;
+    }
     const eventThreadId =
       event.type === "item_completed" ? event.item.threadId : event.threadId;
     if (!this.#subscribedThreads.has(eventThreadId)) {
@@ -658,7 +715,13 @@ export class CodexConnection {
     this.#send({ id, error });
   }
 
-  #sendErrorNotification(error: unknown, event: RuntimeEvent): void {
+  #sendErrorNotification(error: unknown, event: AppServerEvent): void {
+    if (
+      event.type === "thread_name_updated" ||
+      event.type === "thread_settings_updated"
+    ) {
+      return;
+    }
     const threadId =
       event.type === "item_completed" ? event.item.threadId : event.threadId;
     const turnId =

--- a/src/protocol/codex/mapper.ts
+++ b/src/protocol/codex/mapper.ts
@@ -1,4 +1,8 @@
-import type { ThreadSnapshot } from "../../app-server.js";
+import type {
+  ThreadListEntry,
+  ThreadSnapshot,
+  UnavailableThreadSnapshot,
+} from "../../app-server.js";
 import type {
   CanonicalItem,
   ThreadMetadataItem,
@@ -19,7 +23,10 @@ export interface CodexThread {
   createdAt: number;
   updatedAt: number;
   recencyAt: null;
-  status: { type: "idle" } | { type: "active"; activeFlags: [] };
+  status:
+    | { type: "idle" }
+    | { type: "systemError" }
+    | { type: "active"; activeFlags: [] };
   path: null;
   cwd: string;
   cliVersion: string;
@@ -86,9 +93,12 @@ export interface CodexCommandItem {
 }
 
 export function projectThread(
-  snapshot: ThreadSnapshot,
+  snapshot: ThreadListEntry,
   options: { includeTurns: boolean },
 ): CodexThread {
+  if (isUnavailableThread(snapshot)) {
+    return projectUnavailableThread(snapshot);
+  }
   const metadata = metadataFor(snapshot.items);
   const createdAt = seconds(metadata.createdAt);
   const updatedAt = seconds(
@@ -121,6 +131,41 @@ export function projectThread(
     turns: options.includeTurns
       ? snapshot.turns.map((turn) => projectTurn(turn, true, snapshot.cwd))
       : [],
+  };
+}
+
+function isUnavailableThread(
+  snapshot: ThreadListEntry,
+): snapshot is UnavailableThreadSnapshot {
+  return "status" in snapshot && snapshot.status === "systemError";
+}
+
+function projectUnavailableThread(
+  snapshot: UnavailableThreadSnapshot,
+): CodexThread {
+  return {
+    id: snapshot.id,
+    sessionId: snapshot.id,
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "Thread journal could not be loaded.",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "",
+    createdAt: 0,
+    updatedAt: 0,
+    recencyAt: null,
+    status: { type: "systemError" },
+    path: null,
+    cwd: "",
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: snapshot.name ?? null,
+    turns: [],
   };
 }
 

--- a/src/protocol/codex/mapper.ts
+++ b/src/protocol/codex/mapper.ts
@@ -246,7 +246,10 @@ export function projectCommandCompleted(
 }
 
 export function threadSettings(
-  snapshot: ThreadSnapshot,
+  snapshot: Pick<
+    ThreadSnapshot,
+    "model" | "provider" | "cwd" | "approvalPolicy" | "sandbox"
+  >,
 ): Record<string, unknown> {
   return {
     model: snapshot.model,
@@ -259,6 +262,34 @@ export function threadSettings(
     approvalsReviewer: "user",
     sandbox: { type: "dangerFullAccess" },
     reasoningEffort: null,
+  };
+}
+
+export function threadSettingsUpdated(
+  snapshot: Pick<
+    ThreadSnapshot,
+    "model" | "provider" | "cwd" | "approvalPolicy" | "sandbox"
+  >,
+): Record<string, unknown> {
+  return {
+    approvalPolicy:
+      snapshot.approvalPolicy === "never" ? "never" : "on-request",
+    approvalsReviewer: "user",
+    collaborationMode: {
+      mode: "default",
+      settings: {
+        model: snapshot.model,
+        reasoning_effort: "medium",
+      },
+    },
+    cwd: snapshot.cwd,
+    effort: null,
+    model: snapshot.model,
+    modelProvider: snapshot.provider,
+    personality: null,
+    sandboxPolicy: { type: "dangerFullAccess" },
+    serviceTier: null,
+    summary: null,
   };
 }
 

--- a/src/protocol/codex/mapper.ts
+++ b/src/protocol/codex/mapper.ts
@@ -28,7 +28,7 @@ export interface CodexThread {
   agentNickname: null;
   agentRole: null;
   gitInfo: null;
-  name: null;
+  name: string | null;
   turns: CodexTurn[];
 }
 
@@ -117,7 +117,7 @@ export function projectThread(
     agentNickname: null,
     agentRole: null,
     gitInfo: null,
-    name: null,
+    name: snapshot.name ?? null,
     turns: options.includeTurns
       ? snapshot.turns.map((turn) => projectTurn(turn, true, snapshot.cwd))
       : [],
@@ -192,6 +192,7 @@ export function projectCompletedItem(
     case "tool_call":
       return projectCommandStarted(item, "");
     case "failure":
+    case "thread_configuration_changed":
     case "thread_metadata":
     case "tool_result":
     case "turn_aborted":

--- a/src/protocol/codex/stdio.ts
+++ b/src/protocol/codex/stdio.ts
@@ -7,7 +7,6 @@ import type { ZenAppServer } from "../../app-server.js";
 export function serveCodexStdio(options: {
   appServer: ZenAppServer;
   zenHome: string;
-  configuredModel?: string;
 }): () => void {
   const connection = new CodexConnection({
     ...options,

--- a/src/protocol/codex/websocket.ts
+++ b/src/protocol/codex/websocket.ts
@@ -16,7 +16,6 @@ export async function serveCodexWebSocket(options: {
   zenHome: string;
   listen: string;
   bearerToken?: string;
-  configuredModel?: string;
 }): Promise<CodexWebSocketServer> {
   const endpoint = new URL(options.listen);
   if (endpoint.protocol !== "ws:") {
@@ -60,9 +59,6 @@ export async function serveCodexWebSocket(options: {
     const connection = new CodexConnection({
       appServer: options.appServer,
       zenHome: options.zenHome,
-      ...(options.configuredModel === undefined
-        ? {}
-        : { configuredModel: options.configuredModel }),
       send: (message) => {
         if (socket.readyState === WebSocket.OPEN) {
           socket.send(JSON.stringify(message));

--- a/src/thread-metadata.ts
+++ b/src/thread-metadata.ts
@@ -1,0 +1,146 @@
+import { mkdir, open, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface ThreadProductMetadata {
+  name?: string;
+}
+
+export interface ThreadMetadataStore {
+  read(threadId: string): Promise<ThreadProductMetadata>;
+  setName(threadId: string, name: string): Promise<ThreadProductMetadata>;
+}
+
+interface ThreadNameSetEvent {
+  type: "thread_name_set";
+  threadId: string;
+  name: string;
+  updatedAt: string;
+}
+
+export class InMemoryThreadMetadataStore implements ThreadMetadataStore {
+  readonly #metadata = new Map<string, ThreadProductMetadata>();
+
+  async read(threadId: string): Promise<ThreadProductMetadata> {
+    return structuredClone(this.#metadata.get(threadId) ?? {});
+  }
+
+  async setName(
+    threadId: string,
+    name: string,
+  ): Promise<ThreadProductMetadata> {
+    const metadata = { name };
+    this.#metadata.set(threadId, metadata);
+    return structuredClone(metadata);
+  }
+}
+
+export class JsonlThreadMetadataStore implements ThreadMetadataStore {
+  readonly #filename: string;
+  readonly #metadata = new Map<string, ThreadProductMetadata>();
+  #loadPromise: Promise<void> | undefined;
+  #writeChain: Promise<void> = Promise.resolve();
+
+  constructor(filename: string) {
+    this.#filename = path.resolve(filename);
+  }
+
+  async read(threadId: string): Promise<ThreadProductMetadata> {
+    await this.#load();
+    return structuredClone(this.#metadata.get(threadId) ?? {});
+  }
+
+  async setName(
+    threadId: string,
+    name: string,
+  ): Promise<ThreadProductMetadata> {
+    await this.#load();
+    const event: ThreadNameSetEvent = {
+      type: "thread_name_set",
+      threadId,
+      name,
+      updatedAt: new Date().toISOString(),
+    };
+    const write = this.#writeChain.then(async () => {
+      await mkdir(path.dirname(this.#filename), { recursive: true });
+      const file = await open(this.#filename, "a", 0o600);
+      try {
+        await file.write(`${JSON.stringify(event)}\n`);
+        await file.sync();
+      } finally {
+        await file.close();
+      }
+      this.#metadata.set(threadId, { name });
+    });
+    this.#writeChain = write.catch(() => undefined);
+    await write;
+    return { name };
+  }
+
+  async #load(): Promise<void> {
+    this.#loadPromise ??= this.#loadFile();
+    await this.#loadPromise;
+  }
+
+  async #loadFile(): Promise<void> {
+    let contents: string;
+    try {
+      contents = await readFile(this.#filename, "utf8");
+    } catch (error) {
+      if (isNodeError(error) && error.code === "ENOENT") {
+        return;
+      }
+      throw error;
+    }
+    for (const [index, line] of contents.split("\n").entries()) {
+      if (line.length === 0) {
+        continue;
+      }
+      let event: unknown;
+      try {
+        event = JSON.parse(line);
+      } catch {
+        throw new Error(
+          `Invalid JSON in ${this.#filename} at line ${String(index + 1)}`,
+        );
+      }
+      if (!isThreadNameSetEvent(event)) {
+        throw new Error(
+          `Invalid thread metadata in ${this.#filename} at line ${String(index + 1)}`,
+        );
+      }
+      this.#metadata.set(event.threadId, { name: event.name });
+    }
+  }
+}
+
+export function normalizeThreadName(value: string): string {
+  const normalized = value.trim().replace(/\s+/gu, " ");
+  if (normalized.length === 0) {
+    throw new Error("Thread name must not be empty");
+  }
+  if (normalized.length > 200) {
+    throw new Error("Thread name must not exceed 200 characters");
+  }
+  return normalized;
+}
+
+function isThreadNameSetEvent(value: unknown): value is ThreadNameSetEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "thread_name_set" &&
+    "threadId" in value &&
+    typeof value.threadId === "string" &&
+    value.threadId.length > 0 &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    value.name.length > 0 &&
+    "updatedAt" in value &&
+    typeof value.updatedAt === "string"
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
+}

--- a/src/thread-metadata.ts
+++ b/src/thread-metadata.ts
@@ -77,8 +77,16 @@ export class JsonlThreadMetadataStore implements ThreadMetadataStore {
   }
 
   async #load(): Promise<void> {
-    this.#loadPromise ??= this.#loadFile();
-    await this.#loadPromise;
+    const load = this.#loadPromise ?? this.#loadFile();
+    this.#loadPromise = load;
+    try {
+      await load;
+    } catch (error) {
+      if (this.#loadPromise === load) {
+        this.#loadPromise = undefined;
+      }
+      throw error;
+    }
   }
 
   async #loadFile(): Promise<void> {
@@ -99,14 +107,16 @@ export class JsonlThreadMetadataStore implements ThreadMetadataStore {
       try {
         event = JSON.parse(line);
       } catch {
-        throw new Error(
-          `Invalid JSON in ${this.#filename} at line ${String(index + 1)}`,
+        console.warn(
+          `Ignoring invalid JSON in ${this.#filename} at line ${String(index + 1)}`,
         );
+        continue;
       }
       if (!isThreadNameSetEvent(event)) {
-        throw new Error(
-          `Invalid thread metadata in ${this.#filename} at line ${String(index + 1)}`,
+        console.warn(
+          `Ignoring invalid thread metadata in ${this.#filename} at line ${String(index + 1)}`,
         );
+        continue;
       }
       this.#metadata.set(event.threadId, { name: event.name });
     }

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -72,17 +72,8 @@ export class Thread {
     let configuration: EffectiveThreadConfiguration | undefined;
 
     for (const item of this.#items) {
-      if (item.type === "thread_metadata") {
-        configuration = configurationFromMetadata(item);
-        continue;
-      }
-      if (item.type === "thread_configuration_changed") {
-        if (configuration === undefined) {
-          throw new Error(
-            `Thread ${this.id} changed configuration before metadata`,
-          );
-        }
-        configuration = { ...configuration, model: item.model.to };
+      if (isConfigurationItem(item)) {
+        configuration = applyConfigurationItem(this.id, configuration, item);
         continue;
       }
       if (item.turnId === undefined) {
@@ -118,29 +109,11 @@ export class Thread {
     return turns;
   }
 
-  latestMetadata(): CanonicalItem | undefined {
-    return [...this.#items]
-      .reverse()
-      .find((item) => item.type === "thread_metadata");
-  }
-
   effectiveConfiguration(): EffectiveThreadConfiguration {
     let configuration: EffectiveThreadConfiguration | undefined;
     for (const item of this.#items) {
-      if (item.type === "thread_metadata") {
-        configuration = configurationFromMetadata(item);
-      } else if (item.type === "thread_configuration_changed") {
-        if (configuration === undefined) {
-          throw new Error(
-            `Thread ${this.id} changed configuration before metadata`,
-          );
-        }
-        if (configuration.model !== item.model.from) {
-          throw new Error(
-            `Thread ${this.id} has a stale model change from ${item.model.from}`,
-          );
-        }
-        configuration = { ...configuration, model: item.model.to };
+      if (isConfigurationItem(item)) {
+        configuration = applyConfigurationItem(this.id, configuration, item);
       }
     }
     if (configuration === undefined) {
@@ -148,6 +121,37 @@ export class Thread {
     }
     return configuration;
   }
+}
+
+type ConfigurationItem = Extract<
+  CanonicalItem,
+  { type: "thread_metadata" | "thread_configuration_changed" }
+>;
+
+function isConfigurationItem(item: CanonicalItem): item is ConfigurationItem {
+  return (
+    item.type === "thread_metadata" ||
+    item.type === "thread_configuration_changed"
+  );
+}
+
+function applyConfigurationItem(
+  threadId: string,
+  configuration: EffectiveThreadConfiguration | undefined,
+  item: ConfigurationItem,
+): EffectiveThreadConfiguration {
+  if (item.type === "thread_metadata") {
+    return configurationFromMetadata(item);
+  }
+  if (configuration === undefined) {
+    throw new Error(`Thread ${threadId} changed configuration before metadata`);
+  }
+  if (configuration.model !== item.model.from) {
+    throw new Error(
+      `Thread ${threadId} has a stale model change from ${item.model.from}`,
+    );
+  }
+  return { ...configuration, model: item.model.to };
 }
 
 function configurationFromMetadata(

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -39,7 +39,7 @@ export class Thread {
     return Object.freeze([...this.#items]);
   }
 
-  append(item: CanonicalItem): void {
+  validateAppend(item: CanonicalItem): void {
     if (item.threadId !== this.id) {
       throw new Error(
         `Item ${item.id} belongs to ${item.threadId}, not ${this.id}`,
@@ -59,6 +59,10 @@ export class Thread {
         throw new Error("Model change must change the effective model");
       }
     }
+  }
+
+  append(item: CanonicalItem): void {
+    this.validateAppend(item);
     this.#items.push(deepFreeze(structuredClone(item)));
   }
 

--- a/src/thread.ts
+++ b/src/thread.ts
@@ -1,4 +1,9 @@
-import type { CanonicalItem } from "./item.js";
+import type {
+  ApprovalPolicy,
+  CanonicalItem,
+  SandboxMode,
+  ThreadMetadataItem,
+} from "./item.js";
 
 export type DerivedTurnStatus =
   "inProgress" | "completed" | "failed" | "interrupted";
@@ -7,6 +12,15 @@ export interface DerivedTurn {
   id: string;
   items: CanonicalItem[];
   status: DerivedTurnStatus;
+  model: string;
+}
+
+export interface EffectiveThreadConfiguration {
+  cwd: string;
+  model: string;
+  provider: string;
+  sandbox: SandboxMode;
+  approvalPolicy: ApprovalPolicy;
 }
 
 export class Thread {
@@ -34,20 +48,53 @@ export class Thread {
     if (this.#items.some((existing) => existing.id === item.id)) {
       throw new Error(`Duplicate item id ${item.id}`);
     }
+    if (item.type === "thread_configuration_changed") {
+      const current = this.effectiveConfiguration();
+      if (current.model !== item.model.from) {
+        throw new Error(
+          `Stale model change from ${item.model.from}; current model is ${current.model}`,
+        );
+      }
+      if (item.model.from === item.model.to) {
+        throw new Error("Model change must change the effective model");
+      }
+    }
     this.#items.push(deepFreeze(structuredClone(item)));
   }
 
   deriveTurns(options: { activeTurnId?: string } = {}): DerivedTurn[] {
     const turns: DerivedTurn[] = [];
     const byId = new Map<string, DerivedTurn>();
+    let configuration: EffectiveThreadConfiguration | undefined;
 
     for (const item of this.#items) {
+      if (item.type === "thread_metadata") {
+        configuration = configurationFromMetadata(item);
+        continue;
+      }
+      if (item.type === "thread_configuration_changed") {
+        if (configuration === undefined) {
+          throw new Error(
+            `Thread ${this.id} changed configuration before metadata`,
+          );
+        }
+        configuration = { ...configuration, model: item.model.to };
+        continue;
+      }
       if (item.turnId === undefined) {
         continue;
       }
       let turn = byId.get(item.turnId);
       if (turn === undefined) {
-        turn = { id: item.turnId, items: [], status: "inProgress" };
+        if (configuration === undefined) {
+          throw new Error(`Thread ${this.id} has a Turn before metadata`);
+        }
+        turn = {
+          id: item.turnId,
+          items: [],
+          status: "inProgress",
+          model: configuration.model,
+        };
         byId.set(item.turnId, turn);
         turns.push(turn);
       }
@@ -72,6 +119,43 @@ export class Thread {
       .reverse()
       .find((item) => item.type === "thread_metadata");
   }
+
+  effectiveConfiguration(): EffectiveThreadConfiguration {
+    let configuration: EffectiveThreadConfiguration | undefined;
+    for (const item of this.#items) {
+      if (item.type === "thread_metadata") {
+        configuration = configurationFromMetadata(item);
+      } else if (item.type === "thread_configuration_changed") {
+        if (configuration === undefined) {
+          throw new Error(
+            `Thread ${this.id} changed configuration before metadata`,
+          );
+        }
+        if (configuration.model !== item.model.from) {
+          throw new Error(
+            `Thread ${this.id} has a stale model change from ${item.model.from}`,
+          );
+        }
+        configuration = { ...configuration, model: item.model.to };
+      }
+    }
+    if (configuration === undefined) {
+      throw new Error(`Thread ${this.id} has no metadata item`);
+    }
+    return configuration;
+  }
+}
+
+function configurationFromMetadata(
+  item: ThreadMetadataItem,
+): EffectiveThreadConfiguration {
+  return {
+    cwd: item.cwd,
+    model: item.model,
+    provider: item.provider,
+    sandbox: item.sandbox,
+    approvalPolicy: item.approvalPolicy,
+  };
 }
 
 function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -13,16 +13,22 @@ import {
 } from "../src/protocol/codex/client.js";
 import { CodexConnection } from "../src/protocol/codex/connection.js";
 import { serveCodexWebSocket } from "../src/protocol/codex/websocket.js";
+import { InMemoryThreadMetadataStore } from "../src/thread-metadata.js";
 import { isRecord, type JsonRpcMessage } from "../src/protocol/codex/wire.js";
 
-function testHost(approvalPolicy: "always" | "never" = "never") {
+function testHost(
+  approvalPolicy: "always" | "never" = "never",
+  models: readonly string[] = ["fake"],
+) {
   return createHostedAppServer({
     cwd: process.cwd(),
     dataDirectory: path.join(os.tmpdir(), "unused-zen-test-data"),
-    model: "fake",
+    model: models[0] ?? "fake",
+    models,
     approvalPolicy,
     provider: { type: "fake" },
     journal: new InMemoryThreadJournal(),
+    threadMetadata: new InMemoryThreadMetadataStore(),
   });
 }
 
@@ -75,9 +81,8 @@ test("enforces the Codex initialize handshake and method boundary", async () => 
 test("projects the exact T3 Code provider bootstrap from host configuration", async () => {
   const messages: JsonRpcMessage[] = [];
   const connection = new CodexConnection({
-    appServer: testHost(),
+    appServer: testHost("never", ["gpt-5.6-terra", "gpt-5.6-sol"]),
     zenHome: path.join(os.tmpdir(), "zen-home"),
-    configuredModel: "gpt-5.6-terra",
     send: (message) => {
       messages.push(message);
     },
@@ -129,11 +134,186 @@ test("projects the exact T3 Code provider bootstrap from host configuration", as
           defaultServiceTier: null,
           isDefault: true,
         },
+        {
+          id: "gpt-5.6-sol",
+          model: "gpt-5.6-sol",
+          upgrade: null,
+          upgradeInfo: null,
+          availabilityNux: null,
+          displayName: "gpt-5.6-sol",
+          description: "Model configured by the Zen host",
+          hidden: false,
+          supportedReasoningEfforts: [],
+          defaultReasoningEffort: "medium",
+          inputModalities: ["text"],
+          supportsPersonality: false,
+          additionalSpeedTiers: [],
+          serviceTiers: [],
+          defaultServiceTier: null,
+          isDefault: false,
+        },
       ],
       nextCursor: null,
     },
   });
   connection.close();
+});
+
+test("switches models canonically and synchronizes thread settings", async () => {
+  const appServer = testHost("never", ["fake", "other"]);
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await CodexClient.connect(server.url);
+  const observing = await CodexClient.connect(server.url);
+  try {
+    await initiating.initialize({
+      name: "initiating",
+      title: "Initiating",
+      version: "1",
+    });
+    await observing.initialize({
+      name: "observing",
+      title: "Observing",
+      version: "1",
+    });
+    const started = await initiating.request("thread/start", {
+      model: "fake",
+      cwd: process.cwd(),
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    });
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    if (typeof thread.id !== "string") {
+      throw new Error("thread/start omitted id");
+    }
+    await observing.request("thread/resume", { threadId: thread.id });
+
+    const updated = deferred<Record<string, unknown>>();
+    observing.onNotification("thread/settings/updated", (params) => {
+      if (isRecord(params)) {
+        updated.resolve(params);
+      }
+    });
+    const response = await initiating.request("thread/settings/update", {
+      threadId: thread.id,
+      model: "other",
+    });
+    assert.deepEqual(response, {});
+    const notification = await within(updated.promise);
+    assert.equal(notification.threadId, thread.id);
+    assert(
+      isRecord(notification.threadSettings) &&
+        notification.threadSettings.model === "other",
+    );
+
+    const snapshot = await appServer.readThread(thread.id);
+    assert.equal(snapshot.model, "other");
+    assert.equal(
+      snapshot.items.filter(
+        (item) => item.type === "thread_configuration_changed",
+      ).length,
+      1,
+    );
+
+    const completed = deferred<void>();
+    initiating.onNotification("turn/completed", () => {
+      completed.resolve();
+    });
+    await initiating.request("turn/start", {
+      threadId: thread.id,
+      input: [{ type: "text", text: "switch back" }],
+      model: "fake",
+    });
+    await within(completed.promise);
+    const afterTurn = await appServer.readThread(thread.id);
+    assert.equal(afterTurn.model, "fake");
+    assert.equal(
+      afterTurn.items.filter(
+        (item) => item.type === "thread_configuration_changed",
+      ).length,
+      2,
+    );
+  } finally {
+    initiating.close();
+    observing.close();
+    await server.close();
+  }
+});
+
+test("synchronizes ZAS-owned thread names without adding Agent items", async () => {
+  const appServer = testHost();
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await CodexClient.connect(server.url);
+  const observing = await CodexClient.connect(server.url);
+  try {
+    await initiating.initialize({
+      name: "initiating",
+      title: "Initiating",
+      version: "1",
+    });
+    await observing.initialize({
+      name: "observing",
+      title: "Observing",
+      version: "1",
+    });
+    const started = await initiating.request("thread/start", {});
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    if (typeof thread.id !== "string") {
+      throw new Error("thread/start omitted id");
+    }
+    await observing.request("thread/resume", { threadId: thread.id });
+
+    const renamed = deferred<Record<string, unknown>>();
+    observing.onNotification("thread/name/updated", (params) => {
+      if (isRecord(params)) {
+        renamed.resolve(params);
+      }
+    });
+    await initiating.request("thread/name/set", {
+      threadId: thread.id,
+      name: "Shared title",
+    });
+    assert.deepEqual(await within(renamed.promise), {
+      threadId: thread.id,
+      threadName: "Shared title",
+    });
+
+    for (const [method, params] of [
+      ["thread/read", { threadId: thread.id }],
+      ["thread/resume", { threadId: thread.id }],
+      ["thread/list", {}],
+    ] as const) {
+      const result = await observing.request(method, params);
+      if (method === "thread/list") {
+        assert(isRecord(result) && Array.isArray(result.data));
+        const first = result.data[0];
+        assert(isRecord(first));
+        assert.equal(first.name, "Shared title");
+      } else {
+        assert.equal(
+          responseResult<Record<string, unknown>>(result, "thread").name,
+          "Shared title",
+        );
+      }
+    }
+    assert.equal(
+      (await appServer.readThread(thread.id)).items.some(
+        (item) => "name" in item,
+      ),
+      false,
+    );
+  } finally {
+    initiating.close();
+    observing.close();
+    await server.close();
+  }
 });
 
 test("streams the minimal Codex Thread/Turn/Item lifecycle over WebSocket", async () => {
@@ -404,8 +584,16 @@ test("rejects mismatched or unsupported T3 thread configuration", async () => {
     });
     const thread = responseResult<Record<string, unknown>>(start, "thread");
 
+    await assert.rejects(
+      client.request("thread/resume", {
+        threadId: thread.id,
+        model: "a-different-model",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32000,
+    );
+
     for (const params of [
-      { threadId: thread.id, model: "a-different-model" },
       { threadId: thread.id, approvalPolicy: "on-request" },
       { threadId: thread.id, sandbox: "workspace-write" },
       { threadId: thread.id, approvalsReviewer: "auto_review" },
@@ -419,8 +607,16 @@ test("rejects mismatched or unsupported T3 thread configuration", async () => {
     }
 
     const input = [{ type: "text", text: "must not run" }];
+    await assert.rejects(
+      client.request("turn/start", {
+        threadId: thread.id,
+        input,
+        model: "a-different-model",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32000,
+    );
     for (const overrides of [
-      { model: "a-different-model" },
       { approvalPolicy: "on-request" },
       { sandboxPolicy: { type: "workspaceWrite" } },
       { approvalsReviewer: "auto_review" },
@@ -883,7 +1079,6 @@ test("CLI executes one full local protocol turn", async () => {
 
     for (const [options, expected] of [
       [["--approval", "always", "--approve"], /approvalPolicy does not match/u],
-      [["--model", "different-model"], /model does not match/u],
       [["--cwd", os.tmpdir()], /cwd does not match/u],
     ] as const) {
       await assert.rejects(
@@ -899,6 +1094,35 @@ test("CLI executes one full local protocol turn", async () => {
         expected,
       );
     }
+
+    const switchedModel = await executeCli([
+      "run",
+      "--data-dir",
+      temporaryDirectory,
+      "--thread",
+      persistedThreadId,
+      "--model",
+      "different-model",
+      "resume with a different model",
+    ]);
+    assert.match(switchedModel.stdout, /Echo: resume with a different model/u);
+
+    const switchedFromCatalog = await executeCli([
+      "run",
+      "--data-dir",
+      temporaryDirectory,
+      "--thread",
+      persistedThreadId,
+      "--model",
+      "fake",
+      "--models",
+      "fake,different-model",
+      "resume with a host model catalog",
+    ]);
+    assert.match(
+      switchedFromCatalog.stdout,
+      /Echo: resume with a host model catalog/u,
+    );
 
     const matchingResume = await executeCli([
       "run",

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -192,7 +192,7 @@ test("switches models canonically and synchronizes thread settings", async () =>
     await observing.request("thread/resume", { threadId: thread.id });
 
     const updated = deferred<Record<string, unknown>>();
-    observing.onNotification("thread/settings/updated", (params) => {
+    initiating.onNotification("thread/settings/updated", (params) => {
       if (isRecord(params)) {
         updated.resolve(params);
       }
@@ -236,9 +236,114 @@ test("switches models canonically and synchronizes thread settings", async () =>
       ).length,
       2,
     );
+
+    const rapidModels: string[] = [];
+    const rapidUpdates = deferred<void>();
+    initiating.onNotification("thread/settings/updated", (params) => {
+      if (
+        isRecord(params) &&
+        isRecord(params.threadSettings) &&
+        typeof params.threadSettings.model === "string"
+      ) {
+        rapidModels.push(params.threadSettings.model);
+        if (rapidModels.length === 2) {
+          rapidUpdates.resolve();
+        }
+      }
+    });
+    await Promise.all([
+      appServer.updateThreadSettings(String(thread.id), { model: "other" }),
+      appServer.updateThreadSettings(String(thread.id), { model: "fake" }),
+    ]);
+    await within(rapidUpdates.promise);
+    assert.deepEqual(rapidModels, ["other", "fake"]);
   } finally {
     initiating.close();
     observing.close();
+    await server.close();
+  }
+});
+
+test("resumes an active thread when T3 repeats its effective model", async () => {
+  const appServer = testHost("always", ["fake", "other"]);
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const running = await CodexClient.connect(server.url);
+  const resuming = await CodexClient.connect(server.url);
+  const approvalSeen = deferred<void>();
+  const releaseApproval = deferred<{ decision: "decline" }>();
+  try {
+    await running.initialize({
+      name: "imzen",
+      title: "IMZen",
+      version: "1",
+    });
+    await resuming.initialize({
+      name: "t3code_desktop",
+      title: "T3 Code Desktop",
+      version: "0.0.31",
+    });
+    running.onServerRequest(
+      "item/commandExecution/requestApproval",
+      async () => {
+        approvalSeen.resolve();
+        return await releaseApproval.promise;
+      },
+    );
+    const started = await running.request("thread/start", {
+      cwd: process.cwd(),
+      model: "fake",
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+      approvalsReviewer: "user",
+    });
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    const turn = await running.request("turn/start", {
+      threadId: thread.id,
+      input: [{ type: "text", text: "!shell printf active" }],
+      model: "fake",
+      approvalPolicy: "on-request",
+      sandboxPolicy: { type: "dangerFullAccess" },
+      approvalsReviewer: "user",
+    });
+    await within(approvalSeen.promise);
+
+    const resumed = await resuming.request("thread/resume", {
+      threadId: thread.id,
+      cwd: process.cwd(),
+      model: "fake",
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+      approvalsReviewer: "user",
+    });
+    assert.equal(
+      responseResult<Record<string, unknown>>(resumed, "thread").id,
+      thread.id,
+    );
+    assert.equal((await appServer.readThread(String(thread.id))).model, "fake");
+
+    await assert.rejects(
+      resuming.request("thread/resume", {
+        threadId: thread.id,
+        model: "other",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32000,
+    );
+
+    const completed = deferred<void>();
+    running.onNotification("turn/completed", () => {
+      completed.resolve();
+    });
+    releaseApproval.resolve({ decision: "decline" });
+    await within(completed.promise);
+    assert(isRecord(turn) && isRecord(turn.turn));
+  } finally {
+    running.close();
+    resuming.close();
     await server.close();
   }
 });
@@ -515,6 +620,23 @@ test("accepts matching T3 full-access resume and turn configuration", async () =
     });
     const thread = responseResult<Record<string, unknown>>(start, "thread");
 
+    await assert.rejects(
+      client.request("thread/resume", {
+        threadId: thread.id,
+        model: "",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+    await assert.rejects(
+      client.request("thread/settings/update", {
+        threadId: thread.id,
+        model: "",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+
     const resumed = await client.request("thread/resume", {
       threadId: thread.id,
       cwd: process.cwd(),
@@ -607,6 +729,15 @@ test("rejects mismatched or unsupported T3 thread configuration", async () => {
     }
 
     const input = [{ type: "text", text: "must not run" }];
+    await assert.rejects(
+      client.request("turn/start", {
+        threadId: thread.id,
+        input,
+        model: "",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
     await assert.rejects(
       client.request("turn/start", {
         threadId: thread.id,

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -24,6 +24,7 @@ import {
   type ModelRequest,
 } from "../src/model.js";
 import { OpenAiCompatibleModel } from "../src/model/openai-compatible.js";
+import { projectThread } from "../src/protocol/codex/mapper.js";
 import { AgentRuntime } from "../src/runtime.js";
 import {
   InMemoryThreadMetadataStore,
@@ -295,6 +296,42 @@ test("product metadata load failures degrade and retry", async (t) => {
       "utf8",
     );
     assert.equal((await server.readThread(thread.id)).name, "Retried name");
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("isolates a corrupt journal and lists it as a system error", async (t) => {
+  t.mock.method(console, "warn", () => undefined);
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zen-corrupt-journal-"),
+  );
+  const journalDirectory = path.join(temporaryDirectory, "threads");
+  const metadata = new InMemoryThreadMetadataStore();
+  const journal = new JsonlThreadJournal(journalDirectory);
+  try {
+    const server = createServer({ journal, threadMetadata: metadata });
+    const healthy = await server.startThread();
+    await writeFile(
+      path.join(journalDirectory, "corrupt-thread.jsonl"),
+      "not-json\n",
+      "utf8",
+    );
+    await metadata.setName("corrupt-thread", "Damaged work");
+
+    const listed = await server.listThreads();
+    assert.equal(listed.length, 2);
+    assert(listed.some((entry) => entry.id === healthy.id));
+    const unavailable = listed.find((entry) => entry.id === "corrupt-thread");
+    assert(unavailable !== undefined && "status" in unavailable);
+    assert.equal(unavailable.status, "systemError");
+    assert.equal(unavailable.name, "Damaged work");
+    assert.match(unavailable.error, /Invalid JSON/u);
+    assert.deepEqual(
+      projectThread(unavailable, { includeTurns: false }).status,
+      { type: "systemError" },
+    );
+    await assert.rejects(server.readThread("corrupt-thread"), /Invalid JSON/u);
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
@@ -672,6 +709,7 @@ test("keeps stale open turns interrupted while only the current turn is active",
     await server.readThread(threadId),
     ...(await server.listThreads()),
   ]) {
+    assert(!("status" in snapshot));
     assert.deepEqual(
       snapshot.turns.map((turn) => [turn.id, turn.status]),
       [

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { ZenAppServer } from "../src/app-server.js";
+import { type AppServerEvent, ZenAppServer } from "../src/app-server.js";
 import type {
   CanonicalItem,
   ThreadMetadataItem,
@@ -15,6 +15,7 @@ import {
   JsonlThreadJournal,
   type ThreadJournal,
 } from "../src/journal.js";
+import { StaticModelCatalog, type ModelCatalog } from "../src/model-catalog.js";
 import {
   FakeModel,
   type ModelAdapter,
@@ -23,7 +24,12 @@ import {
   type ModelRequest,
 } from "../src/model.js";
 import { OpenAiCompatibleModel } from "../src/model/openai-compatible.js";
-import { AgentRuntime, type RuntimeEvent } from "../src/runtime.js";
+import { AgentRuntime } from "../src/runtime.js";
+import {
+  InMemoryThreadMetadataStore,
+  JsonlThreadMetadataStore,
+  type ThreadMetadataStore,
+} from "../src/thread-metadata.js";
 import { ShellToolExecutor, type ToolExecutor } from "../src/tool.js";
 
 function createServer(
@@ -31,6 +37,8 @@ function createServer(
     journal?: ThreadJournal;
     approvalPolicy?: "always" | "never";
     model?: ModelAdapter;
+    modelCatalog?: ModelCatalog;
+    threadMetadata?: ThreadMetadataStore;
     tools?: ToolExecutor;
   } = {},
 ): ZenAppServer {
@@ -40,14 +48,165 @@ function createServer(
       model: options.model ?? new FakeModel(),
       tools: options.tools ?? new ShellToolExecutor(),
     }),
+    modelCatalog:
+      options.modelCatalog ??
+      new StaticModelCatalog([{ id: "fake", isDefault: true }]),
+    threadMetadata: options.threadMetadata ?? new InMemoryThreadMetadataStore(),
     defaults: {
       cwd: process.cwd(),
-      model: "fake",
+      model: options.modelCatalog?.defaultModel().id ?? "fake",
       sandbox: "danger-full-access",
       approvalPolicy: options.approvalPolicy ?? "never",
     },
   });
 }
+
+test("derives each turn model from append-only configuration changes", async () => {
+  const journal = new InMemoryThreadJournal();
+  const requestedModels: string[] = [];
+  const model: ModelAdapter = {
+    provider: "recording",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      requestedModels.push(request.model);
+      yield { type: "text_delta", delta: request.model };
+    },
+  };
+  const catalog = new StaticModelCatalog([
+    { id: "model-one", isDefault: true },
+    { id: "model-two" },
+  ]);
+  const server = createServer({ journal, model, modelCatalog: catalog });
+  const thread = await server.startThread({ model: "model-one" });
+  await (
+    await server.startTurn(thread.id, "first")
+  ).done;
+
+  const changed = await server.updateThreadSettings(thread.id, {
+    model: "model-two",
+    expectedModel: "model-one",
+  });
+  assert.equal(changed.model, "model-two");
+  await (
+    await server.startTurn(thread.id, "second")
+  ).done;
+
+  assert.deepEqual(requestedModels, ["model-one", "model-two"]);
+  assert.deepEqual(
+    changed.items
+      .filter((item) => item.type === "thread_configuration_changed")
+      .map((item) => item.model),
+    [{ from: "model-one", to: "model-two" }],
+  );
+
+  const replayed = createServer({ journal, model, modelCatalog: catalog });
+  const replayedSnapshot = await replayed.readThread(thread.id);
+  assert.equal(replayedSnapshot.model, "model-two");
+  assert.deepEqual(
+    replayedSnapshot.turns.map((turn) => turn.model),
+    ["model-one", "model-two"],
+  );
+});
+
+test("rejects unavailable, stale, and active-turn model changes", async () => {
+  let releaseModel: (() => void) | undefined;
+  const waiting = new Promise<void>((resolve) => {
+    releaseModel = resolve;
+  });
+  const slowModel: ModelAdapter = {
+    provider: "slow",
+    async *stream(): AsyncIterable<ModelEvent> {
+      await waiting;
+      yield { type: "text_delta", delta: "done" };
+    },
+  };
+  const server = createServer({
+    model: slowModel,
+    modelCatalog: new StaticModelCatalog([
+      { id: "fake", isDefault: true },
+      { id: "other" },
+    ]),
+  });
+  const thread = await server.startThread();
+
+  await assert.rejects(
+    server.updateThreadSettings(thread.id, { model: "missing" }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "model_unavailable",
+  );
+  await assert.rejects(
+    server.updateThreadSettings(thread.id, {
+      model: "other",
+      expectedModel: "stale",
+    }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "stale_thread_configuration",
+  );
+
+  const active = await server.startTurn(thread.id, "wait");
+  await assert.rejects(
+    server.updateThreadSettings(thread.id, { model: "other" }),
+    (error: unknown) =>
+      error instanceof Error && "code" in error && error.code === "thread_busy",
+  );
+  releaseModel?.();
+  await active.done;
+  assert.equal((await server.readThread(thread.id)).model, "fake");
+});
+
+test("persists user-facing names outside the canonical ItemList", async () => {
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zen-thread-metadata-test-"),
+  );
+  try {
+    const journal = new InMemoryThreadJournal();
+    const filename = path.join(temporaryDirectory, "thread-metadata.jsonl");
+    const server = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    const thread = await server.startThread();
+
+    const named = await server.setThreadName(thread.id, "  Model routing  ");
+    assert.equal(named.name, "Model routing");
+    assert.equal(
+      named.items.some((item) => "name" in item),
+      false,
+    );
+
+    const replayed = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    assert.equal((await replayed.readThread(thread.id)).name, "Model routing");
+    assert.equal((await replayed.listThreads())[0]?.name, "Model routing");
+    const events = (await readFile(filename, "utf8"))
+      .trim()
+      .split("\n")
+      .map(
+        (line) =>
+          JSON.parse(line) as {
+            type: string;
+            threadId: string;
+            name: string;
+            updatedAt: string;
+          },
+      );
+    assert.deepEqual(events, [
+      {
+        type: "thread_name_set",
+        threadId: thread.id,
+        name: "Model routing",
+        updatedAt: events[0]?.updatedAt,
+      },
+    ]);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
 
 function createTwoCallModel(): ModelAdapter {
   return {
@@ -165,7 +324,7 @@ async function waitForProcessExit(
 
 test("runs a deterministic in-memory turn from append-only items", async () => {
   const server = createServer();
-  const events: RuntimeEvent[] = [];
+  const events: AppServerEvent[] = [];
   server.subscribe((event) => {
     events.push(event);
   });
@@ -242,7 +401,7 @@ test("partial model deltas are not canonicalized when the model ends incomplete"
     },
   };
   const server = createServer({ model: incompleteModel });
-  const events: RuntimeEvent[] = [];
+  const events: AppServerEvent[] = [];
   server.subscribe((event) => {
     events.push(event);
   });
@@ -751,10 +910,6 @@ test("deduplicates concurrent cold thread loads before starting a turn", async (
   });
 
   let readCount = 0;
-  let releaseReads!: () => void;
-  const bothReadsStarted = new Promise<void>((resolve) => {
-    releaseReads = resolve;
-  });
   const journal: ThreadJournal = {
     append: async (item) => {
       await backing.append(item);
@@ -762,10 +917,9 @@ test("deduplicates concurrent cold thread loads before starting a turn", async (
     listThreadIds: async () => await backing.listThreadIds(),
     read: async (requestedThreadId) => {
       readCount += 1;
-      if (readCount === 2) {
-        releaseReads();
-      }
-      await bothReadsStarted;
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       return await backing.read(requestedThreadId);
     },
   };
@@ -795,6 +949,7 @@ test("deduplicates concurrent cold thread loads before starting a turn", async (
   const snapshot = await server.readThread(threadId);
   assert.equal(snapshot.turns.length, 1);
   assert.equal(snapshot.turns[0]?.status, "completed");
+  assert.equal(readCount, 1);
   assert(snapshot.items.some((item) => item.type === "agent_message"));
 });
 
@@ -898,7 +1053,13 @@ test("runs an OpenAI-compatible tool round through the same Runtime and ItemList
       );
     },
   });
-  const server = createServer({ model });
+  const server = createServer({
+    model,
+    modelCatalog: new StaticModelCatalog([
+      { id: "fake", isDefault: true },
+      { id: "provider-model" },
+    ]),
+  });
   const thread = await server.startThread({ model: "provider-model" });
   const turn = await server.startTurn(thread.id, "use the tool");
   await turn.done;

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -92,10 +92,12 @@ test("requires one visible default while hidden models remain addressable", () =
 test("derives each turn model from append-only configuration changes", async () => {
   const journal = new InMemoryThreadJournal();
   const requestedModels: string[] = [];
+  const requestedMessages: ModelMessage[][] = [];
   const model: ModelAdapter = {
     provider: "recording",
     async *stream(request): AsyncIterable<ModelEvent> {
       requestedModels.push(request.model);
+      requestedMessages.push(structuredClone(request.messages));
       yield { type: "text_delta", delta: request.model };
     },
   };
@@ -118,6 +120,11 @@ test("derives each turn model from append-only configuration changes", async () 
   ).done;
 
   assert.deepEqual(requestedModels, ["model-one", "model-two"]);
+  assert.deepEqual(requestedMessages[1], [
+    { role: "user", text: "first" },
+    { role: "assistant", text: "model-one" },
+    { role: "user", text: "second" },
+  ]);
   assert.deepEqual(
     changed.items
       .filter((item) => item.type === "thread_configuration_changed")
@@ -215,14 +222,79 @@ test("persists user-facing names outside the canonical ItemList", async () => {
             updatedAt: string;
           },
       );
-    assert.deepEqual(events, [
+    assert.equal(events.length, 1);
+    assert.deepEqual(
+      { ...events[0], updatedAt: undefined },
       {
         type: "thread_name_set",
         threadId: thread.id,
         name: "Model routing",
-        updatedAt: events[0]?.updatedAt,
+        updatedAt: undefined,
       },
-    ]);
+    );
+    assert.equal(Number.isNaN(Date.parse(events[0]!.updatedAt)), false);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("product metadata corruption never blocks canonical threads", async (t) => {
+  t.mock.method(console, "warn", () => undefined);
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zen-thread-metadata-corrupt-"),
+  );
+  const filename = path.join(temporaryDirectory, "thread-metadata.jsonl");
+  const journal = new InMemoryThreadJournal();
+  try {
+    await writeFile(filename, "not-json\n", "utf8");
+    const server = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    const thread = await server.startThread();
+    assert.equal((await server.listThreads()).length, 1);
+    assert.deepEqual(await journal.listThreadIds(), [thread.id]);
+
+    const named = await server.setThreadName(thread.id, "Recovered name");
+    assert.equal(named.name, "Recovered name");
+    const replayed = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    assert.equal((await replayed.readThread(thread.id)).name, "Recovered name");
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
+test("product metadata load failures degrade and retry", async (t) => {
+  t.mock.method(console, "warn", () => undefined);
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zen-thread-metadata-retry-"),
+  );
+  const filename = path.join(temporaryDirectory, "thread-metadata.jsonl");
+  const journal = new InMemoryThreadJournal();
+  try {
+    await mkdir(filename);
+    const server = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    const thread = await server.startThread();
+    assert.equal(thread.name, undefined);
+
+    await rm(filename, { recursive: true });
+    await writeFile(
+      filename,
+      `${JSON.stringify({
+        type: "thread_name_set",
+        threadId: thread.id,
+        name: "Retried name",
+        updatedAt: new Date().toISOString(),
+      })}\n`,
+      "utf8",
+    );
+    assert.equal((await server.readThread(thread.id)).name, "Retried name");
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -40,6 +40,8 @@ function createServer(
     modelCatalog?: ModelCatalog;
     threadMetadata?: ThreadMetadataStore;
     tools?: ToolExecutor;
+    idFactory?: () => string;
+    runtimeIdFactory?: () => string;
   } = {},
 ): ZenAppServer {
   return new ZenAppServer({
@@ -47,6 +49,9 @@ function createServer(
     runtime: new AgentRuntime({
       model: options.model ?? new FakeModel(),
       tools: options.tools ?? new ShellToolExecutor(),
+      ...(options.runtimeIdFactory === undefined
+        ? {}
+        : { idFactory: options.runtimeIdFactory }),
     }),
     modelCatalog:
       options.modelCatalog ??
@@ -58,8 +63,31 @@ function createServer(
       sandbox: "danger-full-access",
       approvalPolicy: options.approvalPolicy ?? "never",
     },
+    ...(options.idFactory === undefined
+      ? {}
+      : { idFactory: options.idFactory }),
   });
 }
+
+test("requires one visible default while hidden models remain addressable", () => {
+  assert.throws(
+    () => new StaticModelCatalog([{ id: "model-one" }]),
+    /exactly one default model/u,
+  );
+  assert.throws(
+    () =>
+      new StaticModelCatalog([
+        { id: "model-one", isDefault: true, hidden: true },
+      ]),
+    /default must be visible/u,
+  );
+  const catalog = new StaticModelCatalog([
+    { id: "model-one", isDefault: true },
+    { id: "model-hidden", hidden: true },
+  ]);
+  assert.equal(catalog.defaultModel().id, "model-one");
+  assert.equal(catalog.get("model-hidden")?.hidden, true);
+});
 
 test("derives each turn model from append-only configuration changes", async () => {
   const journal = new InMemoryThreadJournal();
@@ -83,7 +111,6 @@ test("derives each turn model from append-only configuration changes", async () 
 
   const changed = await server.updateThreadSettings(thread.id, {
     model: "model-two",
-    expectedModel: "model-one",
   });
   assert.equal(changed.model, "model-two");
   await (
@@ -107,7 +134,7 @@ test("derives each turn model from append-only configuration changes", async () 
   );
 });
 
-test("rejects unavailable, stale, and active-turn model changes", async () => {
+test("allows active-turn model no-ops but rejects real changes", async () => {
   let releaseModel: (() => void) | undefined;
   const waiting = new Promise<void>((resolve) => {
     releaseModel = resolve;
@@ -135,18 +162,11 @@ test("rejects unavailable, stale, and active-turn model changes", async () => {
       "code" in error &&
       error.code === "model_unavailable",
   );
-  await assert.rejects(
-    server.updateThreadSettings(thread.id, {
-      model: "other",
-      expectedModel: "stale",
-    }),
-    (error: unknown) =>
-      error instanceof Error &&
-      "code" in error &&
-      error.code === "stale_thread_configuration",
-  );
-
   const active = await server.startTurn(thread.id, "wait");
+  const resumed = await server.updateThreadSettings(thread.id, {
+    model: "fake",
+  });
+  assert.equal(resumed.model, "fake");
   await assert.rejects(
     server.updateThreadSettings(thread.id, { model: "other" }),
     (error: unknown) =>
@@ -206,6 +226,23 @@ test("persists user-facing names outside the canonical ItemList", async () => {
   } finally {
     await rm(temporaryDirectory, { recursive: true, force: true });
   }
+});
+
+test("validates canonical items before appending them to the journal", async () => {
+  const journal = new InMemoryThreadJournal();
+  const server = createServer({
+    journal,
+    idFactory: () => "duplicate-id",
+    runtimeIdFactory: () => "duplicate-id",
+  });
+  const thread = await server.startThread();
+  const turn = await server.startTurn(thread.id, "must not persist");
+
+  await assert.rejects(turn.done, /Duplicate item id duplicate-id/u);
+  assert.deepEqual(
+    (await journal.read(thread.id)).map((item) => item.type),
+    ["thread_metadata"],
+  );
 });
 
 function createTwoCallModel(): ModelAdapter {
@@ -967,10 +1004,18 @@ test("refuses to run a persisted thread through a different provider", async () 
     sandbox: "danger-full-access",
     approvalPolicy: "never",
   });
-  const server = createServer({ journal });
+  const server = createServer({
+    journal,
+    modelCatalog: new StaticModelCatalog([
+      { id: "original-model", isDefault: true },
+      { id: "other-model" },
+    ]),
+  });
 
   await assert.rejects(
-    server.startTurn(threadId, "must not silently switch providers"),
+    server.startTurn(threadId, "must not silently switch providers", {
+      model: "other-model",
+    }),
     /requires provider original-provider, but this host provides fake/u,
   );
   const snapshot = await server.readThread(threadId);


### PR DESCRIPTION
Closes #1.

Adds a host-owned ModelCatalog, append-only Thread model configuration changes, Codex-compatible settings/name operations, and multi-client notifications. Zen CLI and IMZen now use the same App Server model operation, while user-facing Thread names stay in a separate ZAS-owned append-only metadata stream.

Validation: `npm run check` (73 Node tests, 41 IMZen tests).

Generated with Codex (GPT-5.6). 