### PR TITLE
Add the typed ZenX protocol client

### DIFF
--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -7,12 +7,14 @@
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
-    "typecheck": "tsc -b --pretty false",
-    "check": "npm run typecheck && npm run build"
+    "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
+    "test": "tsx --test test/**/*.test.ts",
+    "check": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "ws": "^8.18.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",
@@ -21,6 +23,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^43.2.0",
     "electron-vite": "^5.0.0",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.2",
     "vite": "^7.3.6"
   }

--- a/apps/zenx/src/protocol-client/auth.ts
+++ b/apps/zenx/src/protocol-client/auth.ts
@@ -1,0 +1,26 @@
+import { open } from "node:fs/promises";
+
+export async function readBearerTokenFile(filePath: string): Promise<string> {
+  const handle = await open(filePath, "r");
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile()) {
+      throw new Error(`Bearer token path is not a regular file: ${filePath}`);
+    }
+    if (process.platform !== "win32" && (metadata.mode & 0o044) !== 0) {
+      throw new Error(
+        `Bearer token file is readable by group or others; run chmod 600 ${filePath}`,
+      );
+    }
+    const token = (await handle.readFile("utf8")).trim();
+    if (token.length === 0) {
+      throw new Error(`Bearer token file is empty: ${filePath}`);
+    }
+    if (token.includes("\n") || token.includes("\r")) {
+      throw new Error("Bearer token file must contain exactly one token");
+    }
+    return token;
+  } finally {
+    await handle.close();
+  }
+}

--- a/apps/zenx/src/protocol-client/index.ts
+++ b/apps/zenx/src/protocol-client/index.ts
@@ -1,0 +1,3 @@
+export { readBearerTokenFile } from "./auth.js";
+export { ZenXProtocolClient, ZenXProtocolError } from "./protocol-client.js";
+export type * from "./types.js";

--- a/apps/zenx/src/protocol-client/protocol-client.ts
+++ b/apps/zenx/src/protocol-client/protocol-client.ts
@@ -1,0 +1,501 @@
+import { WebSocket, type RawData } from "ws";
+
+import {
+  isNotification,
+  isRequest,
+  isResponse,
+  type JsonRpcMessage,
+  type RequestId,
+} from "../../../../src/protocol/codex/wire.js";
+import { readBearerTokenFile } from "./auth.js";
+import type {
+  ClientInfo,
+  ClientRequestMethod,
+  ClientRequestParams,
+  ClientRequestResults,
+  ConnectionStatus,
+  ServerNotificationMethod,
+  ServerNotificationParams,
+  ServerRequestMethod,
+  ServerRequestParams,
+  ServerRequestResults,
+} from "./types.js";
+
+type UnknownNotificationHandler = (params: unknown) => void | Promise<void>;
+type UnknownServerRequestHandler = (
+  params: unknown,
+) => unknown | Promise<unknown>;
+
+export interface ZenXProtocolClientOptions {
+  url: string;
+  clientInfo: ClientInfo;
+  bearerToken?: string;
+  bearerTokenFile?: string;
+  reconnect?: {
+    maxAttempts?: number;
+    minDelayMs?: number;
+    maxDelayMs?: number;
+  };
+}
+
+interface ReconnectPolicy {
+  maxAttempts: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+}
+
+const defaultReconnectPolicy: ReconnectPolicy = {
+  maxAttempts: 8,
+  minDelayMs: 150,
+  maxDelayMs: 3_000,
+};
+
+export class ZenXProtocolClient {
+  readonly #url: string;
+  readonly #clientInfo: ClientInfo;
+  readonly #bearerToken: string | undefined;
+  readonly #reconnectPolicy: ReconnectPolicy;
+  readonly #pending = new Map<
+    RequestId,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+  readonly #notificationHandlers = new Map<
+    string,
+    Set<UnknownNotificationHandler>
+  >();
+  readonly #serverRequestHandlers = new Map<
+    string,
+    UnknownServerRequestHandler
+  >();
+  readonly #statusHandlers = new Set<
+    (status: ConnectionStatus) => void | Promise<void>
+  >();
+  readonly #subscribedThreads = new Set<string>();
+  #socket: WebSocket | undefined;
+  #nextRequestId = 1;
+  #ready = false;
+  #establishedOnce = false;
+  #manualClose = false;
+  #reconnectTask: Promise<void> | undefined;
+
+  private constructor(
+    options: ZenXProtocolClientOptions,
+    bearerToken: string | undefined,
+  ) {
+    this.#url = options.url;
+    this.#clientInfo = options.clientInfo;
+    this.#bearerToken = bearerToken;
+    this.#reconnectPolicy = {
+      ...defaultReconnectPolicy,
+      ...options.reconnect,
+    };
+    validateReconnectPolicy(this.#reconnectPolicy);
+  }
+
+  static async connect(
+    options: ZenXProtocolClientOptions,
+  ): Promise<ZenXProtocolClient> {
+    assertLoopbackWebSocketUrl(options.url);
+    if (
+      options.bearerToken !== undefined &&
+      options.bearerTokenFile !== undefined
+    ) {
+      throw new Error("Provide bearerToken or bearerTokenFile, not both");
+    }
+    const bearerToken =
+      options.bearerTokenFile === undefined
+        ? options.bearerToken
+        : await readBearerTokenFile(options.bearerTokenFile);
+    if (bearerToken !== undefined && bearerToken.length === 0) {
+      throw new Error("WebSocket bearer token must not be empty");
+    }
+    const client = new ZenXProtocolClient(options, bearerToken);
+    await client.#connectInitial();
+    return client;
+  }
+
+  get connected(): boolean {
+    return this.#ready;
+  }
+
+  get subscriptions(): readonly string[] {
+    return [...this.#subscribedThreads];
+  }
+
+  async request<M extends ClientRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]> {
+    if (method === "initialize") {
+      throw new Error(
+        "initialize is managed by ZenXProtocolClient.connect() and cannot be repeated",
+      );
+    }
+    if (!this.#ready) {
+      throw new Error("App Server connection is not ready");
+    }
+    const result = await this.#rawRequest(method, params);
+    this.#recordSubscription(method, params, result);
+    return result;
+  }
+
+  onNotification<M extends ServerNotificationMethod>(
+    method: M,
+    handler: (params: ServerNotificationParams[M]) => void | Promise<void>,
+  ): () => void {
+    const wrapped: UnknownNotificationHandler = async (params) => {
+      await handler(params as ServerNotificationParams[M]);
+    };
+    const handlers = this.#notificationHandlers.get(method) ?? new Set();
+    handlers.add(wrapped);
+    this.#notificationHandlers.set(method, handlers);
+    return () => handlers.delete(wrapped);
+  }
+
+  onServerRequest<M extends ServerRequestMethod>(
+    method: M,
+    handler: (
+      params: ServerRequestParams[M],
+    ) => ServerRequestResults[M] | Promise<ServerRequestResults[M]>,
+  ): () => void {
+    const wrapped: UnknownServerRequestHandler = async (params) =>
+      await handler(params as ServerRequestParams[M]);
+    this.#serverRequestHandlers.set(method, wrapped);
+    return () => {
+      if (this.#serverRequestHandlers.get(method) === wrapped) {
+        this.#serverRequestHandlers.delete(method);
+      }
+    };
+  }
+
+  onStatus(
+    handler: (status: ConnectionStatus) => void | Promise<void>,
+  ): () => void {
+    this.#statusHandlers.add(handler);
+    return () => this.#statusHandlers.delete(handler);
+  }
+
+  close(): void {
+    if (this.#manualClose) return;
+    this.#manualClose = true;
+    this.#ready = false;
+    this.#rejectPending(new Error("App Server connection closed"));
+    const socket = this.#socket;
+    this.#socket = undefined;
+    if (
+      socket !== undefined &&
+      (socket.readyState === WebSocket.OPEN ||
+        socket.readyState === WebSocket.CONNECTING)
+    ) {
+      socket.close(1000, "ZenX client closed");
+    }
+    this.#emitStatus({ type: "closed" });
+  }
+
+  async #connectInitial(): Promise<void> {
+    this.#emitStatus({ type: "connecting" });
+    try {
+      await this.#openAndInitialize();
+      this.#establishedOnce = true;
+      this.#ready = true;
+      this.#emitStatus({ type: "ready", reconnected: false });
+    } catch (error) {
+      this.#manualClose = true;
+      const socket = this.#socket;
+      this.#socket = undefined;
+      if (socket !== undefined && socket.readyState !== WebSocket.CLOSED) {
+        socket.terminate();
+      }
+      this.#rejectPending(asError(error));
+      this.#emitStatus({ type: "closed" });
+      throw asError(error);
+    }
+  }
+
+  async #openAndInitialize(): Promise<void> {
+    const socket = new WebSocket(this.#url, {
+      ...(this.#bearerToken === undefined
+        ? {}
+        : { headers: { Authorization: `Bearer ${this.#bearerToken}` } }),
+    });
+    this.#socket = socket;
+    socket.on("message", (data, isBinary) => {
+      void this.#receive(data, isBinary).catch((error: unknown) => {
+        this.#emitStatus({ type: "protocolError", error: asError(error) });
+      });
+    });
+    socket.on("error", (error) => {
+      if (socket.readyState === WebSocket.OPEN) {
+        this.#emitStatus({ type: "protocolError", error });
+      }
+    });
+    socket.once("close", (code, reason) => {
+      this.#handleSocketClose(socket, code, reason.toString());
+    });
+
+    await waitForOpen(socket);
+    await this.#rawRequest("initialize", {
+      clientInfo: this.#clientInfo,
+      capabilities: null,
+    });
+    this.#send({ method: "initialized" });
+  }
+
+  async #rawRequest<M extends ClientRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]> {
+    const id = this.#nextRequestId++;
+    const response = new Promise<unknown>((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+    });
+    try {
+      this.#send({ id, method, params });
+    } catch (error) {
+      this.#pending.delete(id);
+      throw error;
+    }
+    return (await response) as ClientRequestResults[M];
+  }
+
+  async #receive(data: RawData, isBinary: boolean): Promise<void> {
+    if (isBinary) {
+      this.#socket?.close(1003, "JSON text frames required");
+      throw new Error("App Server sent a binary WebSocket frame");
+    }
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(data.toString()) as JsonRpcMessage;
+    } catch {
+      this.#socket?.close(1003, "Invalid JSON");
+      throw new Error("App Server sent invalid JSON");
+    }
+
+    if (isResponse(message)) {
+      const pending = this.#pending.get(message.id);
+      if (pending === undefined) return;
+      this.#pending.delete(message.id);
+      if ("error" in message) {
+        pending.reject(
+          new ZenXProtocolError(
+            message.error.code,
+            message.error.message,
+            message.error.data,
+          ),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if (isRequest(message)) {
+      const handler = this.#serverRequestHandlers.get(message.method);
+      if (handler === undefined) {
+        this.#send({
+          id: message.id,
+          error: {
+            code: -32601,
+            message: `Method not found: ${message.method}`,
+          },
+        });
+        return;
+      }
+      try {
+        const result = await handler(message.params);
+        this.#send({ id: message.id, result });
+      } catch (error) {
+        this.#send({
+          id: message.id,
+          error: { code: -32603, message: asError(error).message },
+        });
+      }
+      return;
+    }
+
+    if (isNotification(message)) {
+      const handlers = this.#notificationHandlers.get(message.method);
+      if (handlers === undefined) return;
+      for (const handler of handlers) await handler(message.params);
+    }
+  }
+
+  #send(message: JsonRpcMessage): void {
+    if (this.#socket?.readyState !== WebSocket.OPEN) {
+      throw new Error("App Server connection is not open");
+    }
+    this.#socket.send(JSON.stringify(message));
+  }
+
+  #handleSocketClose(socket: WebSocket, code: number, reason: string): void {
+    if (this.#socket !== socket) return;
+    this.#socket = undefined;
+    this.#ready = false;
+    this.#rejectPending(
+      new Error(
+        `App Server connection closed (${String(code)}${reason.length === 0 ? "" : `: ${reason}`})`,
+      ),
+    );
+    if (!this.#manualClose && this.#establishedOnce) {
+      this.#scheduleReconnect();
+    }
+  }
+
+  #scheduleReconnect(): void {
+    if (this.#reconnectTask !== undefined || this.#manualClose) return;
+    this.#reconnectTask = this.#reconnect().finally(() => {
+      this.#reconnectTask = undefined;
+    });
+  }
+
+  async #reconnect(): Promise<void> {
+    let lastError = new Error("App Server reconnect failed");
+    for (
+      let attempt = 1;
+      attempt <= this.#reconnectPolicy.maxAttempts;
+      attempt += 1
+    ) {
+      const delayMs = Math.min(
+        this.#reconnectPolicy.maxDelayMs,
+        this.#reconnectPolicy.minDelayMs * 2 ** (attempt - 1),
+      );
+      this.#emitStatus({ type: "reconnecting", attempt, delayMs });
+      await delay(delayMs);
+      if (this.#manualClose) return;
+      try {
+        await this.#openAndInitialize();
+        await this.#restoreSubscriptions();
+        this.#ready = true;
+        this.#emitStatus({ type: "ready", reconnected: true });
+        return;
+      } catch (error) {
+        lastError = asError(error);
+        const socket = this.#socket;
+        this.#socket = undefined;
+        if (socket !== undefined && socket.readyState !== WebSocket.CLOSED) {
+          socket.terminate();
+        }
+      }
+    }
+    this.#emitStatus({ type: "protocolError", error: lastError });
+    this.close();
+  }
+
+  async #restoreSubscriptions(): Promise<void> {
+    for (const threadId of this.#subscribedThreads) {
+      try {
+        const result = await this.#rawRequest("thread/resume", { threadId });
+        this.#emitStatus({
+          type: "resubscribed",
+          threadId,
+          thread: result.thread,
+        });
+      } catch (error) {
+        if (this.#socket?.readyState !== WebSocket.OPEN) throw error;
+        this.#emitStatus({
+          type: "resubscribeFailed",
+          threadId,
+          error: asError(error),
+        });
+      }
+    }
+  }
+
+  #recordSubscription<M extends ClientRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+    result: ClientRequestResults[M],
+  ): void {
+    if (method === "thread/start") {
+      this.#subscribedThreads.add(
+        (result as ClientRequestResults["thread/start"]).thread.id,
+      );
+      return;
+    }
+    if (method === "thread/resume" || method === "turn/start") {
+      this.#subscribedThreads.add(
+        (params as ClientRequestParams["thread/resume"]).threadId,
+      );
+      return;
+    }
+    if (method === "thread/unsubscribe") {
+      this.#subscribedThreads.delete(
+        (params as ClientRequestParams["thread/unsubscribe"]).threadId,
+      );
+    }
+  }
+
+  #rejectPending(error: Error): void {
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+  }
+
+  #emitStatus(status: ConnectionStatus): void {
+    for (const handler of this.#statusHandlers) {
+      void Promise.resolve(handler(status)).catch(() => undefined);
+    }
+  }
+}
+
+export class ZenXProtocolError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = "ZenXProtocolError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+async function waitForOpen(socket: WebSocket): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const opened = (): void => {
+      socket.off("error", failed);
+      resolve();
+    };
+    const failed = (error: Error): void => {
+      socket.off("open", opened);
+      reject(error);
+    };
+    socket.once("open", opened);
+    socket.once("error", failed);
+  });
+}
+
+function assertLoopbackWebSocketUrl(rawUrl: string): void {
+  const url = new URL(rawUrl);
+  if (url.protocol !== "ws:") {
+    throw new Error("ZenX supports ws:// App Server connections only");
+  }
+  if (
+    url.hostname !== "127.0.0.1" &&
+    url.hostname !== "localhost" &&
+    url.hostname !== "::1" &&
+    url.hostname !== "[::1]"
+  ) {
+    throw new Error(`Refusing non-loopback App Server: ${url.hostname}`);
+  }
+}
+
+function validateReconnectPolicy(policy: ReconnectPolicy): void {
+  if (
+    !Number.isInteger(policy.maxAttempts) ||
+    policy.maxAttempts < 1 ||
+    !Number.isFinite(policy.minDelayMs) ||
+    policy.minDelayMs < 0 ||
+    !Number.isFinite(policy.maxDelayMs) ||
+    policy.maxDelayMs < policy.minDelayMs
+  ) {
+    throw new Error("Invalid App Server reconnect policy");
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/zenx/src/protocol-client/types.ts
+++ b/apps/zenx/src/protocol-client/types.ts
@@ -1,0 +1,222 @@
+import type {
+  CodexCommandItem,
+  CodexThread,
+  CodexThreadItem,
+  CodexTurn,
+} from "../../../../src/protocol/codex/mapper.js";
+
+export type Thread = CodexThread;
+export type Turn = CodexTurn;
+export type ThreadItem = CodexThreadItem;
+export type CommandItem = CodexCommandItem;
+
+export interface ClientInfo {
+  name: string;
+  title: string;
+  version: string;
+}
+
+export interface InitializeParams {
+  clientInfo: ClientInfo;
+  capabilities: null;
+}
+
+export interface InitializeResult {
+  userAgent: string;
+  codexHome: string;
+  platformFamily: "unix" | "windows";
+  platformOs: string;
+}
+
+export interface ThreadConfigurationParams {
+  cwd?: string;
+  model?: string;
+  approvalPolicy?: "on-request" | "never";
+  approvalsReviewer?: "user";
+  sandbox?: "danger-full-access";
+  sandboxPolicy?: { type: "dangerFullAccess" };
+  collaborationMode?: {
+    mode: "default";
+    settings: {
+      model: string;
+      reasoning_effort: "medium";
+      developer_instructions: string;
+    };
+  };
+}
+
+export interface ThreadSettingsSnapshot {
+  model: string;
+  modelProvider: string;
+  serviceTier: null;
+  cwd: string;
+  instructionSources: unknown[];
+  approvalPolicy: "on-request" | "never";
+  approvalsReviewer: "user";
+  sandbox: { type: "dangerFullAccess" };
+  reasoningEffort: null;
+}
+
+export interface UpdatedThreadSettings {
+  approvalPolicy: "on-request" | "never";
+  approvalsReviewer: "user";
+  collaborationMode: {
+    mode: "default";
+    settings: { model: string; reasoning_effort: "medium" };
+  };
+  cwd: string;
+  effort: null;
+  model: string;
+  modelProvider: string;
+  personality: null;
+  sandboxPolicy: { type: "dangerFullAccess" };
+  serviceTier: null;
+  summary: null;
+}
+
+export interface ModelSummary {
+  id: string;
+  model: string;
+  upgrade: null;
+  upgradeInfo: null;
+  availabilityNux: null;
+  displayName: string;
+  description: string;
+  hidden: boolean;
+  supportedReasoningEfforts: unknown[];
+  defaultReasoningEffort: "medium";
+  inputModalities: ["text"];
+  supportsPersonality: false;
+  additionalSpeedTiers: unknown[];
+  serviceTiers: unknown[];
+  defaultServiceTier: null;
+  isDefault: boolean;
+}
+
+export interface ClientRequestParams {
+  initialize: InitializeParams;
+  "account/read": Record<string, never>;
+  "skills/list": { cwds: string[] };
+  "model/list": { cursor?: null };
+  "thread/start": ThreadConfigurationParams;
+  "thread/resume": { threadId: string } & ThreadConfigurationParams;
+  "thread/read": { threadId: string; includeTurns?: boolean };
+  "thread/list": { limit?: number; cursor?: string | null };
+  "thread/name/set": { threadId: string; name: string };
+  "thread/settings/update": { threadId: string; model: string };
+  "thread/unsubscribe": { threadId: string };
+  "turn/start": {
+    threadId: string;
+    input: Array<{ type: "text"; text: string }>;
+    clientUserMessageId?: string;
+  } & ThreadConfigurationParams;
+  "turn/interrupt": { threadId: string; turnId: string };
+}
+
+export interface ClientRequestResults {
+  initialize: InitializeResult;
+  "account/read": { account: null; requiresOpenaiAuth: false };
+  "skills/list": {
+    data: Array<{ cwd: string; skills: unknown[]; errors: unknown[] }>;
+  };
+  "model/list": { data: ModelSummary[]; nextCursor: null };
+  "thread/start": { thread: Thread } & ThreadSettingsSnapshot;
+  "thread/resume": { thread: Thread } & ThreadSettingsSnapshot;
+  "thread/read": { thread: Thread };
+  "thread/list": {
+    data: Thread[];
+    nextCursor: null;
+    backwardsCursor: null;
+  };
+  "thread/name/set": Record<string, never>;
+  "thread/settings/update": Record<string, never>;
+  "thread/unsubscribe": {
+    status: "unsubscribed" | "notSubscribed";
+  };
+  "turn/start": { turn: Turn };
+  "turn/interrupt": Record<string, never>;
+}
+
+export type ClientRequestMethod = keyof ClientRequestParams;
+
+export interface ServerNotificationParams {
+  "thread/started": { thread: Thread };
+  "thread/name/updated": { threadId: string; threadName: string };
+  "thread/settings/updated": {
+    threadId: string;
+    threadSettings: UpdatedThreadSettings;
+  };
+  "turn/started": { threadId: string; turn: Turn };
+  "item/started": {
+    threadId: string;
+    turnId: string;
+    item: ThreadItem;
+    startedAtMs: number;
+  };
+  "item/agentMessage/delta": {
+    threadId: string;
+    turnId: string;
+    itemId: string;
+    delta: string;
+  };
+  "item/commandExecution/outputDelta": {
+    threadId: string;
+    turnId: string;
+    itemId: string;
+    delta: string;
+  };
+  "item/completed": {
+    threadId: string;
+    turnId: string;
+    item: ThreadItem;
+    completedAtMs: number;
+  };
+  "serverRequest/resolved": { threadId: string; requestId: string };
+  "turn/completed": { threadId: string; turn: Turn };
+  error: {
+    error: {
+      message: string;
+      codexErrorInfo: null;
+      additionalDetails: null;
+    };
+    willRetry: boolean;
+    threadId: string;
+    turnId: string;
+  };
+}
+
+export type ServerNotificationMethod = keyof ServerNotificationParams;
+
+export interface ServerRequestParams {
+  "item/commandExecution/requestApproval": {
+    threadId: string;
+    turnId: string;
+    itemId: string;
+    startedAtMs: number;
+    environmentId: null;
+    reason: null;
+    command: string;
+    cwd: string;
+    commandActions: unknown[];
+    proposedExecpolicyAmendment: null;
+    networkApprovalContext: null;
+    proposedNetworkPolicyAmendments: null;
+  };
+}
+
+export interface ServerRequestResults {
+  "item/commandExecution/requestApproval": {
+    decision: "accept" | "acceptForSession" | "decline" | "cancel";
+  };
+}
+
+export type ServerRequestMethod = keyof ServerRequestParams;
+
+export type ConnectionStatus =
+  | { type: "connecting" }
+  | { type: "ready"; reconnected: boolean }
+  | { type: "reconnecting"; attempt: number; delayMs: number }
+  | { type: "resubscribed"; threadId: string; thread: Thread }
+  | { type: "resubscribeFailed"; threadId: string; error: Error }
+  | { type: "protocolError"; error: Error }
+  | { type: "closed" };

--- a/apps/zenx/test/protocol-client.test.ts
+++ b/apps/zenx/test/protocol-client.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createHostedAppServer } from "../../../apps/cli/src/host.js";
+import { InMemoryThreadJournal } from "../../../src/journal.js";
+import { serveCodexWebSocket } from "../../../src/protocol/codex/websocket.js";
+import {
+  readBearerTokenFile,
+  ZenXProtocolClient,
+  type ConnectionStatus,
+  type ServerNotificationMethod,
+} from "../src/protocol-client/index.js";
+
+function testHost() {
+  return createHostedAppServer({
+    cwd: process.cwd(),
+    dataDirectory: path.join(os.tmpdir(), "unused-zenx-test-data"),
+    model: "fake",
+    approvalPolicy: "never",
+    provider: { type: "fake" },
+    journal: new InMemoryThreadJournal(),
+  });
+}
+
+function clientOptions(
+  url: string,
+  name: string,
+  extra: Partial<Parameters<typeof ZenXProtocolClient.connect>[0]> = {},
+) {
+  return {
+    url,
+    clientInfo: { name, title: name, version: "0.1.0" },
+    ...extra,
+  };
+}
+
+test("reads bearer credentials only from a private regular file", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-token-"));
+  const tokenFile = path.join(directory, "app-server.token");
+  try {
+    await writeFile(tokenFile, "  private-token\n", { mode: 0o600 });
+    assert.equal(await readBearerTokenFile(tokenFile), "private-token");
+    if (process.platform !== "win32") {
+      await chmod(tokenFile, 0o644);
+      await assert.rejects(
+        readBearerTokenFile(tokenFile),
+        /readable by group or others/u,
+      );
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("runs a complete typed lifecycle against the real App Server", async () => {
+  const appServer = testHost();
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zenx-home"),
+    listen: "ws://127.0.0.1:0",
+    bearerToken: "integration-token",
+  });
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-auth-"));
+  const tokenFile = path.join(directory, "token");
+  await writeFile(tokenFile, "integration-token\n", { mode: 0o600 });
+  const client = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-integration", {
+      bearerTokenFile: tokenFile,
+    }),
+  );
+  try {
+    assert.deepEqual(await client.request("account/read", {}), {
+      account: null,
+      requiresOpenaiAuth: false,
+    });
+    assert.equal(
+      (await client.request("skills/list", { cwds: [process.cwd()] })).data[0]
+        ?.cwd,
+      process.cwd(),
+    );
+    assert.equal(
+      (await client.request("model/list", {})).data[0]?.isDefault,
+      true,
+    );
+
+    const notifications: ServerNotificationMethod[] = [];
+    const completed = deferred<void>();
+    for (const method of [
+      "thread/started",
+      "turn/started",
+      "item/started",
+      "item/agentMessage/delta",
+      "item/completed",
+      "turn/completed",
+    ] as const) {
+      client.onNotification(method, () => {
+        notifications.push(method);
+        if (method === "turn/completed") completed.resolve();
+      });
+    }
+
+    const started = await client.request("thread/start", {
+      cwd: process.cwd(),
+      model: "fake",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    assert.equal(started.thread.status.type, "idle");
+    assert.deepEqual(client.subscriptions, [started.thread.id]);
+
+    const turn = await client.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "hello from ZenX" }],
+      clientUserMessageId: "zenx-message-1",
+    });
+    assert.equal(turn.turn.status, "inProgress");
+    await within(completed.promise);
+
+    assert(notifications.includes("thread/started"));
+    assert(notifications.includes("turn/started"));
+    assert(notifications.includes("item/agentMessage/delta"));
+    assert.equal(notifications.at(-1), "turn/completed");
+
+    const read = await client.request("thread/read", {
+      threadId: started.thread.id,
+      includeTurns: true,
+    });
+    assert.equal(read.thread.turns[0]?.status, "completed");
+    assert.equal(
+      read.thread.turns[0]?.items.find((item) => item.type === "userMessage")
+        ?.clientId,
+      "zenx-message-1",
+    );
+
+    await assert.rejects(
+      client.request("initialize", {
+        clientInfo: { name: "again", title: "Again", version: "1" },
+        capabilities: null,
+      }),
+      /cannot be repeated/u,
+    );
+  } finally {
+    client.close();
+    await server.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("projects the same turn events to two subscribed ZenX clients", async () => {
+  const appServer = testHost();
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zenx-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-initiating"),
+  );
+  const observing = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-observing"),
+  );
+  try {
+    const started = await initiating.request("thread/start", {
+      cwd: process.cwd(),
+      model: "fake",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    await observing.request("thread/resume", {
+      threadId: started.thread.id,
+    });
+
+    const firstEvents: Array<{ method: string; params: unknown }> = [];
+    const secondEvents: Array<{ method: string; params: unknown }> = [];
+    const firstCompleted = deferred<void>();
+    const secondCompleted = deferred<void>();
+    const methods = [
+      "turn/started",
+      "item/started",
+      "item/agentMessage/delta",
+      "item/completed",
+      "turn/completed",
+    ] as const;
+    for (const method of methods) {
+      initiating.onNotification(method, (params) => {
+        firstEvents.push({ method, params: normalizeEvent(params) });
+        if (method === "turn/completed") firstCompleted.resolve();
+      });
+      observing.onNotification(method, (params) => {
+        secondEvents.push({ method, params: normalizeEvent(params) });
+        if (method === "turn/completed") secondCompleted.resolve();
+      });
+    }
+
+    await initiating.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "same projection" }],
+    });
+    await within(
+      Promise.all([firstCompleted.promise, secondCompleted.promise]),
+    );
+    assert.deepEqual(secondEvents, firstEvents);
+  } finally {
+    initiating.close();
+    observing.close();
+    await server.close();
+  }
+});
+
+test("reconnects and restores subscriptions with thread/resume", async () => {
+  const appServer = testHost();
+  const firstServer = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zenx-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const client = await ZenXProtocolClient.connect(
+    clientOptions(firstServer.url, "zenx-reconnect", {
+      reconnect: { maxAttempts: 20, minDelayMs: 20, maxDelayMs: 50 },
+    }),
+  );
+  let secondServer: Awaited<ReturnType<typeof serveCodexWebSocket>> | undefined;
+  try {
+    const started = await client.request("thread/start", {
+      cwd: process.cwd(),
+      model: "fake",
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const statuses: ConnectionStatus[] = [];
+    const reconnected = deferred<void>();
+    client.onStatus((status) => {
+      statuses.push(status);
+      if (status.type === "ready" && status.reconnected) {
+        reconnected.resolve();
+      }
+    });
+
+    const endpoint = new URL(firstServer.url);
+    await firstServer.close();
+    secondServer = await serveCodexWebSocket({
+      appServer,
+      zenHome: path.join(os.tmpdir(), "zenx-home"),
+      listen: `ws://127.0.0.1:${endpoint.port}`,
+    });
+    await within(reconnected.promise);
+
+    const restored = statuses.find(
+      (status) =>
+        status.type === "resubscribed" && status.threadId === started.thread.id,
+    );
+    assert(restored && restored.type === "resubscribed");
+    assert.equal(restored.thread.id, started.thread.id);
+
+    const turnCompleted = deferred<void>();
+    client.onNotification("turn/completed", () => turnCompleted.resolve());
+    await client.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "after reconnect" }],
+    });
+    await within(turnCompleted.promise);
+  } finally {
+    client.close();
+    if (secondServer !== undefined) await secondServer.close();
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  milliseconds = 5_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Timed out waiting for protocol event")),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function normalizeEvent(value: unknown): unknown {
+  return JSON.parse(
+    JSON.stringify(value, (key, nestedValue: unknown) =>
+      key === "startedAtMs" || key === "completedAtMs"
+        ? undefined
+        : nestedValue,
+    ),
+  ) as unknown;
+}

--- a/apps/zenx/tsconfig.json
+++ b/apps/zenx/tsconfig.json
@@ -1,7 +1,4 @@
 {
-  "files": [],
-  "references": [
-    { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.web.json" }
-  ]
+  "extends": "./tsconfig.web.json",
+  "include": ["src/renderer/src/**/*.ts", "src/renderer/src/**/*.tsx"]
 }

--- a/apps/zenx/tsconfig.node.json
+++ b/apps/zenx/tsconfig.node.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "module": "NodeNext",
@@ -15,6 +14,8 @@
   "include": [
     "electron.vite.config.ts",
     "src/main/**/*.ts",
-    "src/preload/**/*.ts"
+    "src/preload/**/*.ts",
+    "src/protocol-client/**/*.ts",
+    "test/**/*.ts"
   ]
 }

--- a/apps/zenx/tsconfig.web.json
+++ b/apps/zenx/tsconfig.web.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "composite": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react-jsx",
     "lib": ["ES2023", "DOM", "DOM.Iterable"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^19.2.8",
-        "react-dom": "^19.2.8"
+        "react-dom": "^19.2.8",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -40,6 +41,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "electron": "^43.2.0",
         "electron-vite": "^5.0.0",
+        "tsx": "^4.20.6",
         "typescript": "^5.9.2",
         "vite": "^7.3.6"
       }
@@ -1987,6 +1989,509 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/typescript": {


### PR DESCRIPTION
## Summary

- add a typed Codex 0.146.0 request, notification, and approval API using the repository wire types
- enforce initialize then initialized during connect, restrict transport to loopback WebSocket, and validate private bearer-token files
- reconnect with bounded backoff and restore tracked subscriptions through thread/resume without synthesizing wire events
- cover a real App Server lifecycle, identical dual-client projections, authentication, and reconnect/resubscribe behavior

## Validation

- npm run check --workspace apps/zenx
- npm run check

The implementation stays in apps/zenx; src and the wire protocol are unchanged.

Closes #4