### PR TITLE
Host the Zen App Server from ZenX

### DIFF
--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -1,8 +1,18 @@
 import { defineConfig } from "electron-vite";
 import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
 
 export default defineConfig({
-  main: {},
+  main: {
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve(__dirname, "src/main/index.ts"),
+          "app-server-host": resolve(__dirname, "src/main/app-server-host.ts"),
+        },
+      },
+    },
+  },
   preload: {},
   renderer: {
     plugins: [react()],

--- a/apps/zenx/src/main/app-server-host.ts
+++ b/apps/zenx/src/main/app-server-host.ts
@@ -1,0 +1,59 @@
+import { createHostedAppServer } from "../../../../apps/cli/src/host.js";
+import {
+  serveCodexWebSocket,
+  type CodexWebSocketServer,
+} from "../../../../src/protocol/codex/websocket.js";
+import {
+  isHostCommand,
+  type HostCommand,
+  type HostEvent,
+} from "./host-messages.js";
+
+let server: CodexWebSocketServer | undefined;
+let shuttingDown = false;
+
+process.on("message", (message: unknown) => {
+  if (!isHostCommand(message)) return;
+  void handleCommand(message).catch((error: unknown) => {
+    send({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+    process.exitCode = 1;
+    void shutdown();
+  });
+});
+
+process.once("disconnect", () => void shutdown());
+process.once("SIGINT", () => void shutdown());
+process.once("SIGTERM", () => void shutdown());
+
+async function handleCommand(command: HostCommand): Promise<void> {
+  if (command.type === "shutdown") {
+    await shutdown();
+    return;
+  }
+  if (server !== undefined) {
+    throw new Error("ZenX App Server host already started");
+  }
+  server = await serveCodexWebSocket({
+    appServer: createHostedAppServer(command.config),
+    zenHome: command.config.dataDirectory,
+    listen: "ws://127.0.0.1:0",
+    bearerToken: command.bearerToken,
+  });
+  send({ type: "ready", url: server.url });
+}
+
+async function shutdown(): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  await server?.close();
+  server = undefined;
+  if (process.connected) process.disconnect();
+  process.exit(process.exitCode ?? 0);
+}
+
+function send(event: HostEvent): void {
+  if (process.connected) process.send?.(event);
+}

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -1,0 +1,285 @@
+import { fork, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { chmod, mkdir, open, unlink } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  ZenXProtocolClient,
+  type ClientRequestMethod,
+  type ClientRequestParams,
+  type ClientRequestResults,
+  type ServerNotificationMethod,
+  type ServerNotificationParams,
+} from "../protocol-client/index.js";
+import {
+  isHostEvent,
+  type HostCommand,
+  type ZenXHostConfig,
+} from "./host-messages.js";
+
+export type AppServerHostStatus =
+  | { type: "starting" }
+  | { type: "ready" }
+  | { type: "error"; message: string }
+  | { type: "stopped" };
+
+export interface AppServerManagerOptions {
+  entryPath: string;
+  tokenFile: string;
+  hostConfig: ZenXHostConfig;
+  execPath?: string;
+  execArgv?: string[];
+  environment?: NodeJS.ProcessEnv;
+  startupTimeoutMs?: number;
+}
+
+type NotificationListener = (
+  method: ServerNotificationMethod,
+  params: ServerNotificationParams[ServerNotificationMethod],
+) => void;
+
+export class AppServerManager {
+  readonly #options: AppServerManagerOptions;
+  readonly #statusListeners = new Set<(status: AppServerHostStatus) => void>();
+  readonly #notificationListeners = new Set<NotificationListener>();
+  #status: AppServerHostStatus = { type: "stopped" };
+  #child: ChildProcess | undefined;
+  #client: ZenXProtocolClient | undefined;
+  #stopping = false;
+
+  constructor(options: AppServerManagerOptions) {
+    this.#options = options;
+  }
+
+  get status(): AppServerHostStatus {
+    return this.#status;
+  }
+
+  get processId(): number | undefined {
+    return this.#child?.pid;
+  }
+
+  async start(): Promise<void> {
+    if (this.#child !== undefined) {
+      throw new Error("ZenX App Server host is already running");
+    }
+    this.#stopping = false;
+    this.#setStatus({ type: "starting" });
+    const bearerToken = await createPrivateTokenFile(this.#options.tokenFile);
+    const child = fork(this.#options.entryPath, [], {
+      cwd: process.cwd(),
+      env: {
+        ...(this.#options.environment ?? process.env),
+        ...(this.#options.execPath === undefined
+          ? {}
+          : { ELECTRON_RUN_AS_NODE: "1" }),
+      },
+      execPath: this.#options.execPath,
+      execArgv: this.#options.execArgv,
+      silent: true,
+    });
+    this.#child = child;
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      console.error(`[ZenX App Server] ${chunk.toString().trimEnd()}`);
+    });
+    child.once("exit", (code, signal) => {
+      this.#handleChildExit(child, code, signal);
+    });
+
+    try {
+      const url = await waitForReady(
+        child,
+        this.#options.startupTimeoutMs ?? 10_000,
+        {
+          type: "start",
+          config: this.#options.hostConfig,
+          bearerToken,
+        },
+      );
+      this.#client = await ZenXProtocolClient.connect({
+        url,
+        clientInfo: { name: "zenx", title: "ZenX", version: "0.1.0" },
+        bearerTokenFile: this.#options.tokenFile,
+      });
+      this.#forwardNotifications(this.#client);
+      this.#setStatus({ type: "ready" });
+    } catch (error) {
+      const message = asError(error).message;
+      this.#setStatus({ type: "error", message });
+      child.kill("SIGTERM");
+      throw new Error(message);
+    }
+  }
+
+  async request<M extends ClientRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]> {
+    if (this.#status.type !== "ready" || this.#client === undefined) {
+      const detail =
+        this.#status.type === "error" ? `: ${this.#status.message}` : "";
+      throw new Error(`Zen App Server is not ready${detail}`);
+    }
+    return await this.#client.request(method, params);
+  }
+
+  onStatus(listener: (status: AppServerHostStatus) => void): () => void {
+    this.#statusListeners.add(listener);
+    return () => this.#statusListeners.delete(listener);
+  }
+
+  onNotification(listener: NotificationListener): () => void {
+    this.#notificationListeners.add(listener);
+    return () => this.#notificationListeners.delete(listener);
+  }
+
+  async stop(): Promise<void> {
+    if (this.#stopping) return;
+    this.#stopping = true;
+    this.#client?.close();
+    this.#client = undefined;
+    const child = this.#child;
+    if (child !== undefined && child.exitCode === null) {
+      child.send({ type: "shutdown" } satisfies HostCommand);
+      await waitForExit(child, 3_000);
+      if (child.exitCode === null) child.kill("SIGTERM");
+    }
+    this.#child = undefined;
+    await removeTokenFile(this.#options.tokenFile);
+    this.#setStatus({ type: "stopped" });
+  }
+
+  #forwardNotifications(client: ZenXProtocolClient): void {
+    for (const method of [
+      "thread/started",
+      "thread/name/updated",
+      "thread/settings/updated",
+      "turn/started",
+      "item/started",
+      "item/agentMessage/delta",
+      "item/commandExecution/outputDelta",
+      "item/completed",
+      "serverRequest/resolved",
+      "turn/completed",
+      "error",
+    ] as const) {
+      client.onNotification(method, (params) => {
+        for (const listener of this.#notificationListeners) {
+          listener(method, params);
+        }
+      });
+    }
+  }
+
+  #handleChildExit(
+    child: ChildProcess,
+    code: number | null,
+    signal: NodeJS.Signals | null,
+  ): void {
+    if (this.#child !== child) return;
+    this.#child = undefined;
+    this.#client?.close();
+    this.#client = undefined;
+    if (!this.#stopping) {
+      const reason =
+        signal === null ? `exit code ${String(code)}` : `signal ${signal}`;
+      this.#setStatus({
+        type: "error",
+        message: `Zen App Server stopped unexpectedly (${reason})`,
+      });
+    }
+  }
+
+  #setStatus(status: AppServerHostStatus): void {
+    this.#status = status;
+    for (const listener of this.#statusListeners) listener(status);
+  }
+}
+
+async function createPrivateTokenFile(filePath: string): Promise<string> {
+  await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
+  const token = randomBytes(32).toString("hex");
+  const handle = await open(filePath, "w", 0o600);
+  try {
+    await handle.writeFile(`${token}\n`, "utf8");
+    await handle.chmod(0o600);
+  } finally {
+    await handle.close();
+  }
+  if (process.platform !== "win32") await chmod(filePath, 0o600);
+  return token;
+}
+
+async function removeTokenFile(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+}
+
+async function waitForReady(
+  child: ChildProcess,
+  timeoutMs: number,
+  command: HostCommand,
+): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("Timed out starting Zen App Server")),
+      timeoutMs,
+    );
+    const cleanup = (): void => {
+      clearTimeout(timer);
+      child.off("message", onMessage);
+      child.off("exit", onExit);
+      child.off("error", onError);
+    };
+    const onMessage = (message: unknown): void => {
+      if (!isHostEvent(message)) return;
+      cleanup();
+      if (message.type === "ready") resolve(message.url);
+      else reject(new Error(message.message));
+    };
+    const onExit = (
+      code: number | null,
+      signal: NodeJS.Signals | null,
+    ): void => {
+      cleanup();
+      reject(
+        new Error(
+          `Zen App Server exited during startup (${signal ?? String(code)})`,
+        ),
+      );
+    };
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+    child.on("message", onMessage);
+    child.once("exit", onExit);
+    child.once("error", onError);
+    child.send(command);
+  });
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      child.off("exit", exited);
+      resolve();
+    }, timeoutMs);
+    const exited = (): void => {
+      clearTimeout(timer);
+      resolve();
+    };
+    child.once("exit", exited);
+  });
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/zenx/src/main/host-config.ts
+++ b/apps/zenx/src/main/host-config.ts
@@ -1,0 +1,70 @@
+import os from "node:os";
+import path from "node:path";
+
+import type { HostProvider } from "../../../../apps/cli/src/host.js";
+import { DEFAULT_OPENAI_SUBSCRIPTION_MODEL } from "../../../../src/model/openai-subscription.js";
+import type { ZenXHostConfig } from "./host-messages.js";
+
+export function resolveZenXHostConfig(
+  environment: NodeJS.ProcessEnv = process.env,
+): ZenXHostConfig {
+  const providerName = environment["ZENX_PROVIDER"] ?? "fake";
+  const dataDirectory = path.resolve(
+    environment["ZENX_DATA_DIR"] ?? path.join(os.homedir(), ".zen"),
+  );
+  const model =
+    environment["ZENX_MODEL"] ??
+    (providerName === "openai-subscription"
+      ? DEFAULT_OPENAI_SUBSCRIPTION_MODEL
+      : "fake");
+  const models = (environment["ZENX_MODELS"] ?? model)
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (models.length === 0 || !models.includes(model)) {
+    throw new Error("ZENX_MODELS must include the configured ZENX_MODEL");
+  }
+  const approvalPolicy = environment["ZENX_APPROVAL_POLICY"] ?? "never";
+  if (approvalPolicy !== "always" && approvalPolicy !== "never") {
+    throw new Error("ZENX_APPROVAL_POLICY must be always or never");
+  }
+
+  let provider: HostProvider;
+  let secretEnvironmentVariables: readonly string[] = [];
+  if (providerName === "fake") {
+    provider = { type: "fake" };
+  } else if (providerName === "openai-subscription") {
+    provider = {
+      type: "openai-subscription",
+      profilePath:
+        environment["ZENX_SUBSCRIPTION_PROFILE"] ??
+        path.join(dataDirectory, "openai-subscription-auth.json"),
+    };
+  } else if (providerName === "openai-compatible") {
+    const keyName = environment["ZENX_API_KEY_ENV"] ?? "OPENAI_API_KEY";
+    const apiKey = environment[keyName];
+    if (apiKey === undefined || apiKey.length === 0) {
+      throw new Error(`API key environment variable ${keyName} is not set`);
+    }
+    delete environment[keyName];
+    provider = {
+      type: "openai-compatible",
+      baseUrl: environment["ZENX_BASE_URL"] ?? "https://api.openai.com/v1",
+      apiKey,
+      name: environment["ZENX_PROVIDER_NAME"] ?? "openai",
+    };
+    secretEnvironmentVariables = [keyName];
+  } else {
+    throw new Error(`Unsupported ZENX_PROVIDER: ${providerName}`);
+  }
+
+  return {
+    cwd: path.resolve(environment["ZENX_CWD"] ?? process.cwd()),
+    dataDirectory,
+    model,
+    models,
+    approvalPolicy,
+    provider,
+    secretEnvironmentVariables,
+  };
+}

--- a/apps/zenx/src/main/host-messages.ts
+++ b/apps/zenx/src/main/host-messages.ts
@@ -1,0 +1,33 @@
+import type { ZenHostOptions } from "../../../../apps/cli/src/host.js";
+
+export type ZenXHostConfig = Omit<ZenHostOptions, "journal" | "threadMetadata">;
+
+export type HostCommand =
+  | {
+      type: "start";
+      config: ZenXHostConfig;
+      bearerToken: string;
+    }
+  | { type: "shutdown" };
+
+export type HostEvent =
+  { type: "ready"; url: string } | { type: "error"; message: string };
+
+export function isHostCommand(value: unknown): value is HostCommand {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    return false;
+  }
+  const type = (value as { type?: unknown }).type;
+  return type === "start" || type === "shutdown";
+}
+
+export function isHostEvent(value: unknown): value is HostEvent {
+  if (typeof value !== "object" || value === null || !("type" in value)) {
+    return false;
+  }
+  const event = value as { type?: unknown; url?: unknown; message?: unknown };
+  return (
+    (event.type === "ready" && typeof event.url === "string") ||
+    (event.type === "error" && typeof event.message === "string")
+  );
+}

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -1,5 +1,13 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, ipcMain, shell } from "electron";
 import { join } from "node:path";
+
+import { isClientRequestMethod } from "../protocol-client/index.js";
+import { ipcChannels } from "../preload/ipc.js";
+import { AppServerManager } from "./app-server-manager.js";
+import { resolveZenXHostConfig } from "./host-config.js";
+
+let appServerManager: AppServerManager | undefined;
+let quitting = false;
 
 function createWindow(): BrowserWindow {
   const window = new BrowserWindow({
@@ -32,7 +40,24 @@ function createWindow(): BrowserWindow {
   return window;
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
+  try {
+    appServerManager = new AppServerManager({
+      entryPath: join(__dirname, "app-server-host.js"),
+      tokenFile: join(app.getPath("userData"), "runtime", "app-server.token"),
+      hostConfig: resolveZenXHostConfig(),
+      execPath: process.execPath,
+    });
+    installProtocolIpc(appServerManager);
+    await appServerManager.start();
+  } catch (error) {
+    console.error("Could not start Zen App Server", error);
+    if (appServerManager === undefined) {
+      installFailedProtocolIpc(
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
   createWindow();
 
   app.on("activate", () => {
@@ -40,6 +65,43 @@ app.whenReady().then(() => {
   });
 });
 
+app.on("before-quit", (event) => {
+  if (quitting || appServerManager === undefined) return;
+  event.preventDefault();
+  quitting = true;
+  void appServerManager.stop().finally(() => app.quit());
+});
+
 app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
 });
+
+function installProtocolIpc(manager: AppServerManager): void {
+  ipcMain.handle(ipcChannels.getStatus, () => manager.status);
+  ipcMain.handle(
+    ipcChannels.request,
+    async (_event, method: unknown, params: unknown) => {
+      if (!isClientRequestMethod(method)) {
+        throw new Error(`Unsupported ZenX protocol method: ${String(method)}`);
+      }
+      return await manager.request(method, params as never);
+    },
+  );
+  manager.onStatus((status) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(ipcChannels.status, status);
+    }
+  });
+  manager.onNotification((method, params) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(ipcChannels.notification, method, params);
+    }
+  });
+}
+
+function installFailedProtocolIpc(message: string): void {
+  ipcMain.handle(ipcChannels.getStatus, () => ({ type: "error", message }));
+  ipcMain.handle(ipcChannels.request, () => {
+    throw new Error(`Zen App Server is not ready: ${message}`);
+  });
+}

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -1,5 +1,47 @@
-import { contextBridge } from "electron";
+import { contextBridge, ipcRenderer } from "electron";
+
+import type { AppServerHostStatus } from "../main/app-server-manager.js";
+import type {
+  ClientRequestMethod,
+  ClientRequestParams,
+  ClientRequestResults,
+  ServerNotificationMethod,
+  ServerNotificationParams,
+} from "../protocol-client/index.js";
+import { ipcChannels } from "./ipc.js";
 
 contextBridge.exposeInMainWorld("zenx", {
   platform: process.platform,
+  protocol: {
+    getStatus: async (): Promise<AppServerHostStatus> =>
+      await ipcRenderer.invoke(ipcChannels.getStatus),
+    request: async <M extends ClientRequestMethod>(
+      method: M,
+      params: ClientRequestParams[M],
+    ): Promise<ClientRequestResults[M]> =>
+      await ipcRenderer.invoke(ipcChannels.request, method, params),
+    onStatus: (
+      listener: (status: AppServerHostStatus) => void,
+    ): (() => void) => {
+      const wrapped = (_event: Electron.IpcRendererEvent, status: unknown) => {
+        listener(status as AppServerHostStatus);
+      };
+      ipcRenderer.on(ipcChannels.status, wrapped);
+      return () => ipcRenderer.off(ipcChannels.status, wrapped);
+    },
+    onNotification: (
+      listener: <M extends ServerNotificationMethod>(
+        method: M,
+        params: ServerNotificationParams[M],
+      ) => void,
+    ): (() => void) => {
+      const wrapped = (
+        _event: Electron.IpcRendererEvent,
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ) => listener(method, params);
+      ipcRenderer.on(ipcChannels.notification, wrapped);
+      return () => ipcRenderer.off(ipcChannels.notification, wrapped);
+    },
+  },
 });

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -1,0 +1,6 @@
+export const ipcChannels = {
+  getStatus: "zenx:app-server:get-status",
+  request: "zenx:protocol:request",
+  status: "zenx:app-server:status",
+  notification: "zenx:protocol:notification",
+} as const;

--- a/apps/zenx/src/protocol-client/index.ts
+++ b/apps/zenx/src/protocol-client/index.ts
@@ -1,3 +1,4 @@
 export { readBearerTokenFile } from "./auth.js";
+export { clientRequestMethods, isClientRequestMethod } from "./methods.js";
 export { ZenXProtocolClient, ZenXProtocolError } from "./protocol-client.js";
 export type * from "./types.js";

--- a/apps/zenx/src/protocol-client/methods.ts
+++ b/apps/zenx/src/protocol-client/methods.ts
@@ -1,0 +1,25 @@
+import type { ClientRequestMethod } from "./types.js";
+
+export const clientRequestMethods = [
+  "account/read",
+  "skills/list",
+  "model/list",
+  "thread/start",
+  "thread/resume",
+  "thread/read",
+  "thread/list",
+  "thread/name/set",
+  "thread/settings/update",
+  "thread/unsubscribe",
+  "turn/start",
+  "turn/interrupt",
+] as const satisfies readonly Exclude<ClientRequestMethod, "initialize">[];
+
+export function isClientRequestMethod(
+  value: unknown,
+): value is (typeof clientRequestMethods)[number] {
+  return (
+    typeof value === "string" &&
+    (clientRequestMethods as readonly string[]).includes(value)
+  );
+}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,8 +1,56 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import type { AppServerHostStatus } from "../../main/app-server-manager";
 import { Icon } from "./icons";
 
 export function App() {
   const [railOpen, setRailOpen] = useState(true);
+  const [serverStatus, setServerStatus] = useState<AppServerHostStatus>({
+    type: "starting",
+  });
+  const [threadCount, setThreadCount] = useState<number | null>(null);
+  const [requestError, setRequestError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const loadThreads = async () => {
+      try {
+        const result = await window.zenx.protocol.request("thread/list", {});
+        if (active) {
+          setThreadCount(result.data.length);
+          setRequestError(null);
+        }
+      } catch (error) {
+        if (active) {
+          setRequestError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      }
+    };
+    const dispose = window.zenx.protocol.onStatus((status) => {
+      if (!active) return;
+      setServerStatus(status);
+      if (status.type === "ready") void loadThreads();
+    });
+    void window.zenx.protocol
+      .getStatus()
+      .then((status) => {
+        if (!active) return;
+        setServerStatus(status);
+        if (status.type === "ready") void loadThreads();
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setRequestError(
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+      });
+    return () => {
+      active = false;
+      dispose();
+    };
+  }, []);
 
   return (
     <div className="app-shell">
@@ -39,9 +87,13 @@ export function App() {
         </nav>
 
         <section className="thread-list" aria-labelledby="threads-heading">
-          <h2 id="threads-heading">Threads</h2>
+          <h2 id="threads-heading">
+            Threads{threadCount === null ? "" : ` · ${String(threadCount)}`}
+          </h2>
           <div className="sidebar-empty">
-            Your conversations will appear here.
+            {serverStatus.type === "ready"
+              ? "Your conversations will appear here."
+              : "Waiting for the local App Server."}
           </div>
         </section>
       </aside>
@@ -64,17 +116,38 @@ export function App() {
           </button>
         </header>
 
-        <section className="empty-canvas" aria-label="Empty conversation">
-          <div className="empty-glyph" aria-hidden="true">
-            <Icon name="thread" size={22} />
-          </div>
-          <h2>No thread selected</h2>
-          <p>Create a conversation to start working with Zen.</p>
-          <button className="primary-button" type="button">
-            <Icon name="compose" size={15} />
-            New conversation
-          </button>
-        </section>
+        {serverStatus.type === "error" || requestError !== null ? (
+          <section className="empty-canvas server-error" role="alert">
+            <div className="empty-glyph" aria-hidden="true">
+              <Icon name="thread" size={22} />
+            </div>
+            <h2>Zen App Server stopped</h2>
+            <p>
+              {serverStatus.type === "error"
+                ? serverStatus.message
+                : requestError}
+            </p>
+            <span>Restart ZenX after checking the host configuration.</span>
+          </section>
+        ) : serverStatus.type !== "ready" ? (
+          <section className="empty-canvas" aria-live="polite">
+            <div className="loading-ring" aria-hidden="true" />
+            <h2>Starting Zen App Server</h2>
+            <p>Connecting to the local agent runtime…</p>
+          </section>
+        ) : (
+          <section className="empty-canvas" aria-label="Empty conversation">
+            <div className="empty-glyph" aria-hidden="true">
+              <Icon name="thread" size={22} />
+            </div>
+            <h2>No thread selected</h2>
+            <p>Create a conversation to start working with Zen.</p>
+            <button className="primary-button" type="button">
+              <Icon name="compose" size={15} />
+              New conversation
+            </button>
+          </section>
+        )}
       </main>
 
       <aside

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -1,0 +1,32 @@
+import type { AppServerHostStatus } from "../../main/app-server-manager.js";
+import type {
+  ClientRequestMethod,
+  ClientRequestParams,
+  ClientRequestResults,
+  ServerNotificationMethod,
+  ServerNotificationParams,
+} from "../../protocol-client/index.js";
+
+declare global {
+  interface Window {
+    zenx: {
+      platform: NodeJS.Platform;
+      protocol: {
+        getStatus(): Promise<AppServerHostStatus>;
+        request<M extends ClientRequestMethod>(
+          method: M,
+          params: ClientRequestParams[M],
+        ): Promise<ClientRequestResults[M]>;
+        onStatus(listener: (status: AppServerHostStatus) => void): () => void;
+        onNotification(
+          listener: <M extends ServerNotificationMethod>(
+            method: M,
+            params: ServerNotificationParams[M],
+          ) => void,
+        ): () => void;
+      };
+    };
+  }
+}
+
+export {};

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -13,6 +13,7 @@
   --color-blue: #62a8fa;
   --color-blue-strong: #7bb5f8;
   --color-blue-dim: rgba(98, 168, 250, 0.12);
+  --color-red: #f0716f;
   --color-focus: #7bb5f8;
   --space-1: 4px;
   --space-2: 8px;
@@ -284,6 +285,33 @@ button:focus-visible {
   margin: var(--space-1) 0 var(--space-5);
   color: var(--color-text-subtle);
   font-size: var(--font-size-body);
+}
+
+.server-error .empty-glyph {
+  color: var(--color-red);
+  border-color: rgba(240, 113, 111, 0.35);
+  background: rgba(240, 113, 111, 0.1);
+}
+
+.server-error span {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.loading-ring {
+  width: 22px;
+  height: 22px;
+  margin-bottom: var(--space-4);
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-blue);
+  border-radius: 50%;
+  animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .primary-button {

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  AppServerManager,
+  type AppServerHostStatus,
+} from "../src/main/app-server-manager.js";
+
+function managerFor(directory: string): AppServerManager {
+  return new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+}
+
+test("hosts a real App Server and removes its private token on shutdown", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-host-"));
+  const manager = managerFor(directory);
+  const tokenFile = path.join(directory, "runtime", "app-server.token");
+  try {
+    await manager.start();
+    assert.deepEqual(await manager.request("thread/list", {}), {
+      data: [],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+    if (process.platform !== "win32") {
+      assert.equal((await stat(tokenFile)).mode & 0o777, 0o600);
+    }
+    await manager.stop();
+    await assert.rejects(stat(tokenFile), { code: "ENOENT" });
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("reports a killed App Server as a terminal error without restarting", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-crash-"));
+  const manager = managerFor(directory);
+  try {
+    await manager.start();
+    const statuses: AppServerHostStatus[] = [];
+    const failed = deferred<AppServerHostStatus & { type: "error" }>();
+    manager.onStatus((status) => {
+      statuses.push(status);
+      if (status.type === "error") failed.resolve(status);
+    });
+    const processId = manager.processId;
+    assert.notEqual(processId, undefined);
+    process.kill(processId!, "SIGKILL");
+
+    const status = await within(failed.promise);
+    assert.match(status.message, /stopped unexpectedly/u);
+    await assert.rejects(
+      manager.request("thread/list", {}),
+      /Zen App Server is not ready/u,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(manager.processId, undefined);
+    assert.equal(
+      statuses.some((entry) => entry.type === "starting"),
+      false,
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  milliseconds = 10_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Timed out waiting for App Server status")),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/apps/zenx/test/host-config.test.ts
+++ b/apps/zenx/test/host-config.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveZenXHostConfig } from "../src/main/host-config.js";
+
+test("resolves fake and subscription hosts from external ZenX config", () => {
+  const fake = resolveZenXHostConfig({
+    ZENX_CWD: "/tmp/zenx-cwd",
+    ZENX_DATA_DIR: "/tmp/zenx-data",
+  });
+  assert.equal(fake.provider.type, "fake");
+  assert.equal(fake.model, "fake");
+  assert.deepEqual(fake.models, ["fake"]);
+
+  const subscription = resolveZenXHostConfig({
+    ZENX_PROVIDER: "openai-subscription",
+    ZENX_DATA_DIR: "/tmp/zenx-subscription",
+  });
+  assert.equal(subscription.provider.type, "openai-subscription");
+  if (subscription.provider.type === "openai-subscription") {
+    assert.equal(
+      subscription.provider.profilePath,
+      "/tmp/zenx-subscription/openai-subscription-auth.json",
+    );
+  }
+});
+
+test("moves an OpenAI-compatible key into host config and blocks shell inheritance", () => {
+  const environment: NodeJS.ProcessEnv = {
+    ZENX_PROVIDER: "openai-compatible",
+    ZENX_MODEL: "local-model",
+    ZENX_API_KEY_ENV: "ZENX_TEST_KEY",
+    ZENX_TEST_KEY: "private-key",
+  };
+  const config = resolveZenXHostConfig(environment);
+  assert.equal(config.provider.type, "openai-compatible");
+  if (config.provider.type === "openai-compatible") {
+    assert.equal(config.provider.apiKey, "private-key");
+  }
+  assert.deepEqual(config.secretEnvironmentVariables, ["ZENX_TEST_KEY"]);
+  assert.equal(environment["ZENX_TEST_KEY"], undefined);
+});


### PR DESCRIPTION
## Summary

- launch the existing CLI host composition in an Electron-owned child process with a loopback-only WebSocket listener
- generate a fresh 0600 bearer-token file, keep the credential in main/child process scope, and remove it on shutdown
- keep the typed protocol client in main and expose only whitelisted protocol requests/status/events through preload IPC
- load thread/list on renderer startup and render an explicit terminal error when the host exits instead of starting a repair loop
- resolve fake, subscription, and OpenAI-compatible adapters from external ZenX host configuration

## Validation

- npm run check --workspace apps/zenx
- npm run check
- integration test starts the real child host and completes thread/list
- SIGKILL integration test verifies terminal error state and no restart
- npm run dev --workspace apps/zenx starts Electron and its hosted App Server

Implementation note: a child process was selected because the issue explicitly requires kill-process failure acceptance; this remains an apps/zenx-only hosting detail.

Closes #5