### PR TITLE
Build the ZenX dual-view sidebar

### DIFF
--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,13 +1,30 @@
 import { useEffect, useState } from "react";
-import type { AppServerHostStatus } from "../../main/app-server-manager";
+import type { AppServerHostStatus } from "../../main/app-server-manager.js";
+import type { Thread } from "../../protocol-client/index.js";
 import { Icon } from "./icons";
+import { Sidebar } from "./Sidebar";
+import {
+  applyThreadNotification,
+  readSidebarMode,
+  threadTitle,
+  writeSidebarMode,
+  type SidebarMode,
+} from "./thread-list";
 
 export function App() {
   const [railOpen, setRailOpen] = useState(true);
   const [serverStatus, setServerStatus] = useState<AppServerHostStatus>({
     type: "starting",
   });
-  const [threadCount, setThreadCount] = useState<number | null>(null);
+  const [threads, setThreads] = useState<Thread[]>([]);
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>(() => {
+    try {
+      return readSidebarMode(window.localStorage);
+    } catch {
+      return "inbox";
+    }
+  });
   const [requestError, setRequestError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -16,7 +33,7 @@ export function App() {
       try {
         const result = await window.zenx.protocol.request("thread/list", {});
         if (active) {
-          setThreadCount(result.data.length);
+          setThreads(result.data);
           setRequestError(null);
         }
       } catch (error) {
@@ -32,6 +49,15 @@ export function App() {
       setServerStatus(status);
       if (status.type === "ready") void loadThreads();
     });
+    const disposeNotifications = window.zenx.protocol.onNotification(
+      (method, params) => {
+        if (active) {
+          setThreads((current) =>
+            applyThreadNotification(current, method, params),
+          );
+        }
+      },
+    );
     void window.zenx.protocol
       .getStatus()
       .then((status) => {
@@ -49,60 +75,45 @@ export function App() {
     return () => {
       active = false;
       dispose();
+      disposeNotifications();
     };
   }, []);
 
+  const selectedThread =
+    threads.find((thread) => thread.id === selectedThreadId) ?? null;
+  const changeSidebarMode = (mode: SidebarMode) => {
+    setSidebarMode(mode);
+    try {
+      writeSidebarMode(window.localStorage, mode);
+    } catch {
+      // A disabled localStorage keeps the in-memory preference for this window.
+    }
+  };
+
   return (
     <div className="app-shell">
-      <aside className="sidebar" aria-label="Thread navigation">
-        <header className="sidebar-header">
-          <div className="brand-mark" aria-hidden="true">
-            Z
-          </div>
-          <div className="brand-name">
-            ZenX <Icon name="chevron-down" size={11} />
-          </div>
-          <button
-            className="icon-button"
-            type="button"
-            aria-label="Search threads"
-          >
-            <Icon name="search" />
-          </button>
-        </header>
-
-        <nav className="sidebar-nav" aria-label="Primary">
-          <button className="nav-item" type="button">
-            <Icon name="compose" />
-            New conversation
-          </button>
-          <button
-            className="nav-item selected"
-            type="button"
-            aria-current="page"
-          >
-            <Icon name="inbox" />
-            Inbox
-          </button>
-        </nav>
-
-        <section className="thread-list" aria-labelledby="threads-heading">
-          <h2 id="threads-heading">
-            Threads{threadCount === null ? "" : ` · ${String(threadCount)}`}
-          </h2>
-          <div className="sidebar-empty">
-            {serverStatus.type === "ready"
-              ? "Your conversations will appear here."
-              : "Waiting for the local App Server."}
-          </div>
-        </section>
-      </aside>
+      <Sidebar
+        mode={sidebarMode}
+        onModeChange={changeSidebarMode}
+        onSelectThread={setSelectedThreadId}
+        selectedThreadId={selectedThreadId}
+        serverReady={serverStatus.type === "ready"}
+        threads={threads}
+      />
 
       <main className="workspace">
         <header className="workspace-header">
           <div>
-            <h1>Start a conversation</h1>
-            <p>Select a thread or create a new one.</p>
+            <h1>
+              {selectedThread === null
+                ? "Start a conversation"
+                : threadTitle(selectedThread)}
+            </h1>
+            <p>
+              {selectedThread === null
+                ? "Select a thread or create a new one."
+                : `${selectedThread.cwd} · ${selectedThread.modelProvider}`}
+            </p>
           </div>
           <button
             className={`toolbar-button${railOpen ? " active" : ""}`}
@@ -135,7 +146,7 @@ export function App() {
             <h2>Starting Zen App Server</h2>
             <p>Connecting to the local agent runtime…</p>
           </section>
-        ) : (
+        ) : selectedThread === null ? (
           <section className="empty-canvas" aria-label="Empty conversation">
             <div className="empty-glyph" aria-hidden="true">
               <Icon name="thread" size={22} />
@@ -146,6 +157,14 @@ export function App() {
               <Icon name="compose" size={15} />
               New conversation
             </button>
+          </section>
+        ) : (
+          <section className="empty-canvas" aria-label="Selected thread">
+            <div className="empty-glyph" aria-hidden="true">
+              <Icon name="thread" size={22} />
+            </div>
+            <h2>Thread selected</h2>
+            <p>Conversation history will appear here in the thread view.</p>
           </section>
         )}
       </main>

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -1,0 +1,331 @@
+import { useMemo, useState } from "react";
+
+import type { Thread } from "../../protocol-client/index.js";
+import { Icon } from "./icons";
+import {
+  deriveInboxSections,
+  deriveProjectGroups,
+  threadTitle,
+  type SidebarMode,
+} from "./thread-list";
+
+interface SidebarProps {
+  mode: SidebarMode;
+  onModeChange(mode: SidebarMode): void;
+  onSelectThread(threadId: string): void;
+  selectedThreadId: string | null;
+  serverReady: boolean;
+  threads: readonly Thread[];
+}
+
+export function Sidebar({
+  mode,
+  onModeChange,
+  onSelectThread,
+  selectedThreadId,
+  serverReady,
+  threads,
+}: SidebarProps) {
+  return (
+    <aside className="sidebar" aria-label="Thread navigation">
+      <header className="sidebar-header">
+        <div className="brand-mark" aria-hidden="true">
+          Z
+        </div>
+        <div className="brand-name">
+          ZenX <Icon name="chevron-down" size={11} />
+        </div>
+        <button
+          className="icon-button"
+          type="button"
+          aria-label="Search threads"
+        >
+          <Icon name="search" />
+        </button>
+        <button
+          className="icon-button"
+          type="button"
+          aria-label={
+            mode === "inbox" ? "Switch to project view" : "Switch to inbox view"
+          }
+          aria-pressed={mode === "projects"}
+          onClick={() => onModeChange(mode === "inbox" ? "projects" : "inbox")}
+        >
+          <Icon name={mode === "inbox" ? "tree" : "inbox"} />
+        </button>
+      </header>
+
+      <nav className="sidebar-nav" aria-label="Primary">
+        <button className="nav-item" type="button">
+          <Icon name="compose" />
+          New conversation
+        </button>
+      </nav>
+
+      <div className="sidebar-mode-label" aria-live="polite">
+        <span>{mode === "inbox" ? "Inbox" : "Projects"}</span>
+        <span>{threads.length}</span>
+      </div>
+
+      <div className="thread-list">
+        {!serverReady ? (
+          <p className="sidebar-empty">Waiting for the local App Server.</p>
+        ) : threads.length === 0 ? (
+          <p className="sidebar-empty">Your conversations will appear here.</p>
+        ) : mode === "inbox" ? (
+          <InboxView
+            onSelectThread={onSelectThread}
+            selectedThreadId={selectedThreadId}
+            threads={threads}
+          />
+        ) : (
+          <ProjectsView
+            onSelectThread={onSelectThread}
+            selectedThreadId={selectedThreadId}
+            threads={threads}
+          />
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function InboxView({
+  threads,
+  selectedThreadId,
+  onSelectThread,
+}: Pick<SidebarProps, "threads" | "selectedThreadId" | "onSelectThread">) {
+  const sections = deriveInboxSections(threads);
+  return (
+    <>
+      {sections.map((section) =>
+        section.threads.length === 0 ? null : (
+          <section className="thread-section" key={section.key}>
+            <h2>
+              {section.label} <span>{section.threads.length}</span>
+            </h2>
+            {section.threads.map((thread) => (
+              <ThreadCard
+                key={thread.id}
+                onSelectThread={onSelectThread}
+                selected={thread.id === selectedThreadId}
+                thread={thread}
+              />
+            ))}
+          </section>
+        ),
+      )}
+      <section
+        className="thread-section watching-placeholder"
+        aria-disabled="true"
+      >
+        <h2>
+          Watching <span>v1</span>
+        </h2>
+      </section>
+    </>
+  );
+}
+
+function ProjectsView({
+  threads,
+  selectedThreadId,
+  onSelectThread,
+}: Pick<SidebarProps, "threads" | "selectedThreadId" | "onSelectThread">) {
+  const groups = deriveProjectGroups(threads);
+  const pinned = threads.filter((thread) => thread.isPinned);
+  return (
+    <>
+      {pinned.length > 0 ? (
+        <section className="thread-section compact-section">
+          <h2>Pinned</h2>
+          {pinned.map((thread) => (
+            <CompactThreadRow
+              key={thread.id}
+              onSelectThread={onSelectThread}
+              selected={thread.id === selectedThreadId}
+              thread={thread}
+            />
+          ))}
+        </section>
+      ) : null}
+      <section className="thread-section compact-section">
+        <h2>Projects</h2>
+        {groups.map((group) => (
+          <ProjectRows
+            group={group}
+            key={group.key}
+            onSelectThread={onSelectThread}
+            selectedThreadId={selectedThreadId}
+          />
+        ))}
+      </section>
+    </>
+  );
+}
+
+function ProjectRows({
+  group,
+  selectedThreadId,
+  onSelectThread,
+}: {
+  group: ReturnType<typeof deriveProjectGroups>[number];
+  selectedThreadId: string | null;
+  onSelectThread(threadId: string): void;
+}) {
+  const [open, setOpen] = useState(true);
+  const activeCount = useMemo(
+    () =>
+      group.threads.filter((thread) => thread.status.type === "active").length,
+    [group.threads],
+  );
+  return (
+    <div className="project-group">
+      <button
+        className="project-header"
+        type="button"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <Icon
+          className={open ? "rotated" : undefined}
+          name="chevron-right"
+          size={11}
+        />
+        <Icon name="folder" size={14} />
+        <span>{group.label}</span>
+        <small>
+          {activeCount > 0 ? `${activeCount} active` : group.threads.length}
+        </small>
+      </button>
+      {open
+        ? group.threads.map((thread) => (
+            <CompactThreadRow
+              key={thread.id}
+              onSelectThread={onSelectThread}
+              selected={thread.id === selectedThreadId}
+              thread={thread}
+            />
+          ))
+        : null}
+    </div>
+  );
+}
+
+function ThreadCard({
+  thread,
+  selected,
+  onSelectThread,
+}: {
+  thread: Thread;
+  selected: boolean;
+  onSelectThread(threadId: string): void;
+}) {
+  const content = (
+    <>
+      <div className="thread-card-title-row">
+        <StatusDot thread={thread} />
+        <strong>{threadTitle(thread)}</strong>
+        <time>{formatRecency(thread.updatedAt)}</time>
+      </div>
+      <div className="thread-card-meta">
+        <StatusPill thread={thread} />
+        {thread.cwd.length > 0 ? <span>{projectName(thread.cwd)}</span> : null}
+        {thread.modelProvider.length > 0 ? (
+          <span>{thread.modelProvider}</span>
+        ) : null}
+      </div>
+      <p>{thread.preview || "Thread journal could not be loaded."}</p>
+    </>
+  );
+  return thread.status.type === "systemError" ? (
+    <div className="thread-card system-error" role="status">
+      {content}
+    </div>
+  ) : (
+    <button
+      className={`thread-card${selected ? " selected" : ""}`}
+      type="button"
+      onClick={() => onSelectThread(thread.id)}
+    >
+      {content}
+    </button>
+  );
+}
+
+function CompactThreadRow({
+  thread,
+  selected,
+  onSelectThread,
+}: {
+  thread: Thread;
+  selected: boolean;
+  onSelectThread(threadId: string): void;
+}) {
+  const contents = (
+    <>
+      <span>{threadTitle(thread)}</span>
+      <StatusGlyph thread={thread} />
+    </>
+  );
+  return thread.status.type === "systemError" ? (
+    <div className="compact-thread system-error" role="status">
+      {contents}
+    </div>
+  ) : (
+    <button
+      className={`compact-thread${selected ? " selected" : ""}`}
+      type="button"
+      onClick={() => onSelectThread(thread.id)}
+    >
+      {contents}
+    </button>
+  );
+}
+
+function StatusDot({ thread }: { thread: Thread }) {
+  return (
+    <span className={`status-dot ${statusClass(thread)}`} aria-hidden="true" />
+  );
+}
+
+function StatusPill({ thread }: { thread: Thread }) {
+  const label =
+    thread.status.type === "active"
+      ? "Running"
+      : thread.status.type === "systemError"
+        ? "Unavailable"
+        : "Complete";
+  return <span className={`status-pill ${statusClass(thread)}`}>{label}</span>;
+}
+
+function StatusGlyph({ thread }: { thread: Thread }) {
+  return thread.status.type === "active" ? (
+    <span className="mini-spinner" aria-label="Running" />
+  ) : thread.status.type === "systemError" ? (
+    <span className="status-warning" aria-label="Unavailable">
+      <Icon name="warning" size={13} />
+    </span>
+  ) : null;
+}
+
+function statusClass(thread: Thread): string {
+  return thread.status.type === "active"
+    ? "active"
+    : thread.status.type === "systemError"
+      ? "error"
+      : "settled";
+}
+
+function projectName(cwd: string): string {
+  const parts = cwd.split(/[\\/]/u).filter(Boolean);
+  return parts.at(-1) ?? cwd;
+}
+
+function formatRecency(seconds: number): string {
+  const elapsed = Math.max(0, Math.floor(Date.now() / 1_000) - seconds);
+  if (elapsed < 60) return "now";
+  if (elapsed < 3_600) return `${Math.floor(elapsed / 60)}m`;
+  if (elapsed < 86_400) return `${Math.floor(elapsed / 3_600)}h`;
+  return `${Math.floor(elapsed / 86_400)}d`;
+}

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -1,7 +1,16 @@
 import type { ReactNode, SVGProps } from "react";
 
 type IconName =
-  "chevron-down" | "compose" | "inbox" | "panel-right" | "search" | "thread";
+  | "chevron-down"
+  | "chevron-right"
+  | "compose"
+  | "folder"
+  | "inbox"
+  | "panel-right"
+  | "search"
+  | "thread"
+  | "tree"
+  | "warning";
 
 type IconProps = SVGProps<SVGSVGElement> & {
   name: IconName;
@@ -10,11 +19,15 @@ type IconProps = SVGProps<SVGSVGElement> & {
 
 const paths: Record<IconName, ReactNode> = {
   "chevron-down": <path d="m3.6 6 4.4 4.4L12.4 6" />,
+  "chevron-right": <path d="m6 3.6 4.4 4.4L6 12.4" />,
   compose: (
     <>
       <path d="M7.3 3H3.4C2.6 3 2 3.6 2 4.4v8.2c0 .8.6 1.4 1.4 1.4h8.2c.8 0 1.4-.6 1.4-1.4V8.7" />
       <path d="M12.6 1.9a1.6 1.6 0 0 1 2.3 2.3L9 10.1l-3 .7.7-3 5.9-5.9Z" />
     </>
+  ),
+  folder: (
+    <path d="M1.8 4.2C1.8 3.5 2.3 3 3 3h3l1.4 1.6H13c.7 0 1.2.5 1.2 1.2v6c0 .7-.5 1.2-1.2 1.2H3c-.7 0-1.2-.5-1.2-1.2V4.2Z" />
   ),
   inbox: (
     <>
@@ -39,6 +52,19 @@ const paths: Record<IconName, ReactNode> = {
       <path d="M2.5 3.5h11M5.5 8h8M5.5 12.5h8" />
       <circle cx="3" cy="8" r=".2" />
       <circle cx="3" cy="12.5" r=".2" />
+    </>
+  ),
+  tree: (
+    <>
+      <path d="M2.5 3.5h11M5.5 8h8M5.5 12.5h8" />
+      <circle cx="3" cy="8" r=".2" />
+      <circle cx="3" cy="12.5" r=".2" />
+    </>
+  ),
+  warning: (
+    <>
+      <path d="M8 2 1.8 13h12.4L8 2Z" />
+      <path d="M8 6.5v3M8 11.6v.1" />
     </>
   ),
 };

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -8,12 +8,15 @@
   --color-border-soft: #1d232d;
   --color-text: #e8ebf0;
   --color-text-muted: #a8b1bf;
-  --color-text-subtle: #78828f;
-  --color-text-faint: #7d8794;
+  --color-text-subtle: #818b98;
+  --color-text-faint: #7e8996;
   --color-blue: #62a8fa;
   --color-blue-strong: #7bb5f8;
   --color-blue-dim: rgba(98, 168, 250, 0.12);
   --color-red: #f0716f;
+  --color-green: #46d17e;
+  --color-green-dim: rgba(70, 209, 126, 0.12);
+  --color-red-dim: rgba(240, 113, 111, 0.1);
   --color-focus: #7bb5f8;
   --space-1: 4px;
   --space-2: 8px;
@@ -180,12 +183,17 @@ button:focus-visible {
 
 .thread-list {
   flex: 1;
-  padding: 10px 18px;
+  padding: 0 8px 16px;
   border-top: 1px solid var(--color-border-soft);
+  overflow-y: auto;
 }
 
 .thread-list h2 {
-  margin: 0 0 var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 14px 10px 5px;
   color: var(--color-text-faint);
   font-size: 10.5px;
   font-weight: 650;
@@ -193,9 +201,267 @@ button:focus-visible {
   text-transform: uppercase;
 }
 
+.thread-list h2 span {
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
 .sidebar-empty {
+  margin: 0;
+  padding: var(--space-3) 10px;
   color: var(--color-text-subtle);
   font-size: var(--font-size-sm);
+}
+
+.sidebar-mode-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 7px 18px 9px;
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.sidebar-mode-label span:last-child {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0;
+}
+
+.thread-card,
+.compact-thread,
+.project-header {
+  width: 100%;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+}
+
+.thread-card {
+  display: block;
+  padding: 9px 11px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background var(--duration-ui),
+    border-color var(--duration-ui),
+    opacity var(--duration-ui);
+}
+
+.thread-card:hover,
+.thread-card.selected {
+  background: var(--color-panel-hover);
+}
+
+.thread-card.selected {
+  border-color: var(--color-border-soft);
+}
+
+.thread-card.system-error {
+  border-color: rgba(240, 113, 111, 0.28);
+  background: var(--color-red-dim);
+  cursor: default;
+}
+
+.thread-card-title-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.thread-card-title-row strong {
+  flex: 1;
+  overflow: hidden;
+  font-size: var(--font-size-body);
+  font-weight: 560;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thread-card-title-row time {
+  flex: none;
+  color: var(--color-text-faint);
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.thread-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+}
+
+.thread-card-meta > span:not(.status-pill) {
+  padding: 1px 7px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 999px;
+  color: var(--color-text-subtle);
+  background: var(--color-panel-hover);
+  font-size: 10.5px;
+  white-space: nowrap;
+}
+
+.thread-card p {
+  margin: 4px 0 0 14px;
+  overflow: hidden;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+}
+
+.status-dot.active {
+  background: var(--color-green);
+  animation: status-pulse 1.6s infinite;
+}
+
+.status-dot.settled {
+  background: var(--color-text-faint);
+}
+
+.status-dot.error {
+  background: var(--color-red);
+}
+
+.status-pill {
+  padding: 1.5px 8px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 620;
+  white-space: nowrap;
+}
+
+.status-pill.active {
+  color: var(--color-green);
+  background: var(--color-green-dim);
+}
+
+.status-pill.settled {
+  color: var(--color-text-muted);
+  background: var(--color-panel-hover);
+}
+
+.status-pill.error {
+  color: var(--color-red);
+  background: var(--color-red-dim);
+}
+
+.watching-placeholder {
+  opacity: 0.7;
+}
+
+.compact-section h2 {
+  padding-left: 10px;
+}
+
+.project-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 560;
+  transition:
+    color var(--duration-ui),
+    background var(--duration-ui);
+}
+
+.project-header:hover {
+  color: var(--color-text);
+  background: var(--color-panel-raised);
+}
+
+.project-header svg:first-child {
+  color: var(--color-text-faint);
+  transition: transform var(--duration-ui);
+}
+
+.project-header svg.rotated {
+  transform: rotate(90deg);
+}
+
+.project-header small {
+  margin-left: auto;
+  color: var(--color-text-faint);
+  font-size: var(--font-size-xs);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-thread {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px 6px 34px;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-size: 13px;
+  transition:
+    color var(--duration-ui),
+    background var(--duration-ui);
+}
+
+.compact-thread:hover,
+.compact-thread.selected {
+  color: var(--color-text);
+  background: var(--color-panel-hover);
+}
+
+.compact-thread.system-error {
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.compact-thread > span:first-child {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mini-spinner {
+  width: 12px;
+  height: 12px;
+  flex: none;
+  border: 1.8px solid var(--color-border);
+  border-top-color: var(--color-green);
+  border-radius: 50%;
+  animation: spin 800ms linear infinite;
+}
+
+.status-warning {
+  display: inline-flex;
+  flex: none;
+  color: var(--color-red);
+}
+
+@keyframes status-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(70, 209, 126, 0.4);
+  }
+  60% {
+    box-shadow: 0 0 0 5px rgba(70, 209, 126, 0);
+  }
 }
 
 .workspace {

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -1,0 +1,156 @@
+import type {
+  ServerNotificationMethod,
+  ServerNotificationParams,
+  Thread,
+} from "../../protocol-client/index.js";
+
+export type SidebarMode = "inbox" | "projects";
+
+interface SidebarStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+export interface InboxSection {
+  key: "needs" | "active" | "settled";
+  label: string;
+  threads: Thread[];
+}
+
+export interface ProjectGroup {
+  key: string;
+  label: string;
+  threads: Thread[];
+}
+
+export function readSidebarMode(
+  storage: Pick<SidebarStorage, "getItem">,
+): SidebarMode {
+  return storage.getItem("zenx-sidebar-mode") === "projects"
+    ? "projects"
+    : "inbox";
+}
+
+export function writeSidebarMode(
+  storage: Pick<SidebarStorage, "setItem">,
+  mode: SidebarMode,
+): void {
+  storage.setItem("zenx-sidebar-mode", mode);
+}
+
+export function deriveInboxSections(
+  threads: readonly Thread[],
+): InboxSection[] {
+  const sorted = sortByRecency(threads);
+  return [
+    {
+      key: "needs",
+      label: "Needs you",
+      threads: sorted.filter((thread) => thread.status.type === "systemError"),
+    },
+    {
+      key: "active",
+      label: "In progress",
+      threads: sorted.filter((thread) => thread.status.type === "active"),
+    },
+    {
+      key: "settled",
+      label: "Completed",
+      threads: sorted.filter((thread) => thread.status.type === "idle"),
+    },
+  ];
+}
+
+export function deriveProjectGroups(
+  threads: readonly Thread[],
+): ProjectGroup[] {
+  const groups = new Map<string, Thread[]>();
+  for (const thread of sortByRecency(threads)) {
+    const key =
+      thread.status.type === "systemError" || thread.cwd.length === 0
+        ? "__unavailable__"
+        : thread.cwd;
+    const list = groups.get(key) ?? [];
+    list.push(thread);
+    groups.set(key, list);
+  }
+  return [...groups.entries()]
+    .map(([key, groupedThreads]) => ({
+      key,
+      label:
+        key === "__unavailable__" ? "Unavailable journals" : projectLabel(key),
+      threads: groupedThreads,
+    }))
+    .sort((left, right) => {
+      if (left.key === "__unavailable__") return 1;
+      if (right.key === "__unavailable__") return -1;
+      return left.label.localeCompare(right.label);
+    });
+}
+
+export function applyThreadNotification(
+  threads: readonly Thread[],
+  method: ServerNotificationMethod,
+  params: ServerNotificationParams[ServerNotificationMethod],
+  nowSeconds = Math.floor(Date.now() / 1_000),
+): Thread[] {
+  if (method === "thread/started") {
+    const started = (params as ServerNotificationParams["thread/started"])
+      .thread;
+    return [started, ...threads.filter((thread) => thread.id !== started.id)];
+  }
+  if (method === "thread/name/updated") {
+    const update = params as ServerNotificationParams["thread/name/updated"];
+    return threads.map((thread) =>
+      thread.id === update.threadId
+        ? { ...thread, name: update.threadName, updatedAt: nowSeconds }
+        : thread,
+    );
+  }
+  if (method === "turn/started") {
+    const event = params as ServerNotificationParams["turn/started"];
+    return threads.map((thread) =>
+      thread.id === event.threadId && thread.status.type !== "systemError"
+        ? {
+            ...thread,
+            status: { type: "active" as const, activeFlags: [] },
+            updatedAt: nowSeconds,
+          }
+        : thread,
+    );
+  }
+  if (method === "turn/completed") {
+    const event = params as ServerNotificationParams["turn/completed"];
+    return threads.map((thread) =>
+      thread.id === event.threadId && thread.status.type !== "systemError"
+        ? {
+            ...thread,
+            status: { type: "idle" as const },
+            updatedAt: nowSeconds,
+          }
+        : thread,
+    );
+  }
+  return [...threads];
+}
+
+export function threadTitle(thread: Thread): string {
+  if (thread.name !== null && thread.name.trim().length > 0) return thread.name;
+  if (thread.preview.trim().length > 0) return thread.preview;
+  return thread.status.type === "systemError"
+    ? `Unavailable thread · ${thread.id.slice(0, 8)}`
+    : "Untitled thread";
+}
+
+function sortByRecency(threads: readonly Thread[]): Thread[] {
+  return [...threads].sort(
+    (left, right) =>
+      right.updatedAt - left.updatedAt || left.id.localeCompare(right.id),
+  );
+}
+
+function projectLabel(cwd: string): string {
+  const normalized = cwd.replace(/[\\/]+$/u, "");
+  const parts = normalized.split(/[\\/]/u).filter(Boolean);
+  return parts.at(-1) ?? cwd;
+}

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Thread } from "../src/protocol-client/index.js";
+import {
+  applyThreadNotification,
+  deriveInboxSections,
+  deriveProjectGroups,
+  readSidebarMode,
+  threadTitle,
+  writeSidebarMode,
+} from "../src/renderer/src/thread-list.js";
+
+test("persists the selected sidebar mode and defaults invalid values to inbox", () => {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+  assert.equal(readSidebarMode(storage), "inbox");
+  writeSidebarMode(storage, "projects");
+  assert.equal(readSidebarMode(storage), "projects");
+  values.set("zenx-sidebar-mode", "unexpected");
+  assert.equal(readSidebarMode(storage), "inbox");
+});
+
+test("derives recency-first inbox groups and preserves system errors", () => {
+  const unavailable = makeThread("broken", 30, { type: "systemError" });
+  const active = makeThread("active", 20, {
+    type: "active",
+    activeFlags: [],
+  });
+  const older = makeThread("older", 10, { type: "idle" });
+  const newer = makeThread("newer", 40, { type: "idle" });
+  const sections = deriveInboxSections([older, unavailable, active, newer]);
+  assert.deepEqual(
+    sections.map((section) => [
+      section.key,
+      section.threads.map((thread) => thread.id),
+    ]),
+    [
+      ["needs", ["broken"]],
+      ["active", ["active"]],
+      ["settled", ["newer", "older"]],
+    ],
+  );
+  assert.match(threadTitle(unavailable), /Unavailable thread/u);
+});
+
+test("derives project groups only from cwd and isolates unavailable journals", () => {
+  const zen = makeThread("zen", 20, { type: "idle" }, "/work/zen");
+  const nested = makeThread("nested", 10, { type: "idle" }, "/tmp/zen");
+  const imzen = makeThread("imzen", 30, { type: "idle" }, "/work/imzen");
+  const unavailable = makeThread("broken", 40, { type: "systemError" }, "");
+  const groups = deriveProjectGroups([zen, nested, imzen, unavailable]);
+  assert.deepEqual(
+    groups.map((group) => [
+      group.label,
+      group.threads.map((thread) => thread.id),
+    ]),
+    [
+      ["imzen", ["imzen"]],
+      ["zen", ["zen"]],
+      ["zen", ["nested"]],
+      ["Unavailable journals", ["broken"]],
+    ],
+  );
+});
+
+test("applies name and turn lifecycle notifications without altering errors", () => {
+  const idle = makeThread("thread", 10, { type: "idle" });
+  const broken = makeThread("broken", 10, { type: "systemError" });
+  const named = applyThreadNotification(
+    [idle, broken],
+    "thread/name/updated",
+    { threadId: idle.id, threadName: "Renamed" },
+    20,
+  );
+  assert.equal(named[0]?.name, "Renamed");
+  const active = applyThreadNotification(
+    named,
+    "turn/started",
+    { threadId: idle.id, turn: makeTurn("turn", "inProgress") },
+    30,
+  );
+  assert.equal(active[0]?.status.type, "active");
+  const settled = applyThreadNotification(
+    active,
+    "turn/completed",
+    { threadId: idle.id, turn: makeTurn("turn", "completed") },
+    40,
+  );
+  assert.equal(settled[0]?.status.type, "idle");
+  assert.equal(settled[1]?.status.type, "systemError");
+});
+
+function makeThread(
+  id: string,
+  updatedAt: number,
+  status: Thread["status"],
+  cwd = "/work/zen",
+): Thread {
+  return {
+    id,
+    sessionId: id,
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: status.type === "systemError" ? "" : `${id} preview`,
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: status.type === "systemError" ? "" : "fake",
+    createdAt: updatedAt - 1,
+    updatedAt,
+    recencyAt: null,
+    status,
+    path: null,
+    cwd,
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns: [],
+  };
+}
+
+function makeTurn(id: string, status: "inProgress" | "completed") {
+  return {
+    id,
+    items: [],
+    itemsView: "full" as const,
+    status,
+    error: null,
+    startedAt: null,
+    completedAt: null,
+    durationMs: null,
+  };
+}


### PR DESCRIPTION
## Summary

- render thread/list as an inbox grouped by needs-you, running, and completed state with recency-first cards
- add the compact project view derived solely from thread cwd, including pinned support and collapsible groups
- persist only the inbox/project display preference in localStorage
- apply thread/name/updated and turn lifecycle notifications to live labels, state pills, and sorting
- keep systemError journals visible as read-only failure rows and reserve a non-functional Watching placeholder for v1
- migrate the prototype SVG controls and raise secondary text contrast to at least 4.60:1 on hover surfaces

## Validation

- npm run check --workspace apps/zenx
- npm run check
- npm run dev --workspace apps/zenx
- unit coverage for grouping, recency, cwd derivation, systemError handling, lifecycle events, and preference persistence

Visual screenshot automation was unavailable because macOS was locked; Electron startup and renderer build completed successfully, so this non-code environment condition did not block the PR.

Closes #6