### PR TITLE
ZenX: add thread view with streaming and interrupt

### DIFF
--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -3,6 +3,7 @@ import type { AppServerHostStatus } from "../../main/app-server-manager.js";
 import type { Thread } from "../../protocol-client/index.js";
 import { Icon } from "./icons";
 import { Sidebar } from "./Sidebar";
+import { ThreadView } from "./ThreadView";
 import {
   applyThreadNotification,
   readSidebarMode,
@@ -10,6 +11,7 @@ import {
   writeSidebarMode,
   type SidebarMode,
 } from "./thread-list";
+import { applyThreadViewNotification } from "./thread-view-state";
 
 export function App() {
   const [railOpen, setRailOpen] = useState(true);
@@ -18,6 +20,9 @@ export function App() {
   });
   const [threads, setThreads] = useState<Thread[]>([]);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
+  const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
+  const [threadLoading, setThreadLoading] = useState(false);
+  const [threadError, setThreadError] = useState<string | null>(null);
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>(() => {
     try {
       return readSidebarMode(window.localStorage);
@@ -55,6 +60,11 @@ export function App() {
           setThreads((current) =>
             applyThreadNotification(current, method, params),
           );
+          setThreadDetail((current) =>
+            current === null
+              ? null
+              : applyThreadViewNotification(current, method, params),
+          );
         }
       },
     );
@@ -80,7 +90,61 @@ export function App() {
   }, []);
 
   const selectedThread =
-    threads.find((thread) => thread.id === selectedThreadId) ?? null;
+    threadDetail ??
+    threads.find((thread) => thread.id === selectedThreadId) ??
+    null;
+
+  const selectThread = async (threadId: string) => {
+    setSelectedThreadId(threadId);
+    setThreadDetail(null);
+    setThreadLoading(true);
+    setThreadError(null);
+    try {
+      const result = await window.zenx.protocol.request("thread/resume", {
+        threadId,
+      });
+      setThreadDetail(result.thread);
+    } catch (error) {
+      setThreadError(describeError(error));
+    } finally {
+      setThreadLoading(false);
+    }
+  };
+
+  const newThread = async () => {
+    setThreadLoading(true);
+    setThreadError(null);
+    try {
+      const result = await window.zenx.protocol.request("thread/start", {});
+      setSelectedThreadId(result.thread.id);
+      setThreadDetail(result.thread);
+      setThreads((current) =>
+        applyThreadNotification(current, "thread/started", {
+          thread: result.thread,
+        }),
+      );
+    } catch (error) {
+      setThreadError(describeError(error));
+    } finally {
+      setThreadLoading(false);
+    }
+  };
+
+  const startTurn = async (text: string) => {
+    if (threadDetail === null) throw new Error("No thread is selected");
+    await window.zenx.protocol.request("turn/start", {
+      threadId: threadDetail.id,
+      input: [{ type: "text", text }],
+    });
+  };
+
+  const interruptTurn = async (turnId: string) => {
+    if (threadDetail === null) throw new Error("No thread is selected");
+    await window.zenx.protocol.request("turn/interrupt", {
+      threadId: threadDetail.id,
+      turnId,
+    });
+  };
   const changeSidebarMode = (mode: SidebarMode) => {
     setSidebarMode(mode);
     try {
@@ -95,7 +159,8 @@ export function App() {
       <Sidebar
         mode={sidebarMode}
         onModeChange={changeSidebarMode}
-        onSelectThread={setSelectedThreadId}
+        onNewThread={() => void newThread()}
+        onSelectThread={(threadId) => void selectThread(threadId)}
         selectedThreadId={selectedThreadId}
         serverReady={serverStatus.type === "ready"}
         threads={threads}
@@ -146,6 +211,20 @@ export function App() {
             <h2>Starting Zen App Server</h2>
             <p>Connecting to the local agent runtime…</p>
           </section>
+        ) : threadLoading ? (
+          <section className="empty-canvas" aria-live="polite">
+            <div className="loading-ring" aria-hidden="true" />
+            <h2>Loading conversation</h2>
+            <p>Reconstructing this thread from its journal…</p>
+          </section>
+        ) : threadError !== null ? (
+          <section className="empty-canvas thread-load-error" role="alert">
+            <div className="empty-glyph" aria-hidden="true">
+              <Icon name="warning" size={22} />
+            </div>
+            <h2>Could not open conversation</h2>
+            <p>{threadError}</p>
+          </section>
         ) : selectedThread === null ? (
           <section className="empty-canvas" aria-label="Empty conversation">
             <div className="empty-glyph" aria-hidden="true">
@@ -153,18 +232,24 @@ export function App() {
             </div>
             <h2>No thread selected</h2>
             <p>Create a conversation to start working with Zen.</p>
-            <button className="primary-button" type="button">
+            <button
+              className="primary-button"
+              type="button"
+              onClick={() => void newThread()}
+            >
               <Icon name="compose" size={15} />
               New conversation
             </button>
           </section>
+        ) : threadDetail !== null ? (
+          <ThreadView
+            onInterrupt={interruptTurn}
+            onStartTurn={startTurn}
+            thread={threadDetail}
+          />
         ) : (
-          <section className="empty-canvas" aria-label="Selected thread">
-            <div className="empty-glyph" aria-hidden="true">
-              <Icon name="thread" size={22} />
-            </div>
-            <h2>Thread selected</h2>
-            <p>Conversation history will appear here in the thread view.</p>
+          <section className="empty-canvas" aria-live="polite">
+            <div className="loading-ring" aria-hidden="true" />
           </section>
         )}
       </main>
@@ -176,11 +261,34 @@ export function App() {
       >
         <div className="rail-content">
           <h2>Details</h2>
-          <p>Thread information and activity will appear here.</p>
-          <div className="rail-placeholder" aria-hidden="true" />
-          <div className="rail-placeholder short" aria-hidden="true" />
+          {selectedThread === null ? (
+            <p>Select a conversation to inspect its runtime context.</p>
+          ) : (
+            <dl className="thread-facts">
+              <div>
+                <dt>Workspace</dt>
+                <dd>{selectedThread.cwd}</dd>
+              </div>
+              <div>
+                <dt>Provider</dt>
+                <dd>{selectedThread.modelProvider}</dd>
+              </div>
+              <div>
+                <dt>Turns</dt>
+                <dd>{selectedThread.turns.length}</dd>
+              </div>
+              <div>
+                <dt>Thread ID</dt>
+                <dd>{selectedThread.id}</dd>
+              </div>
+            </dl>
+          )}
         </div>
       </aside>
     </div>
   );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
 interface SidebarProps {
   mode: SidebarMode;
   onModeChange(mode: SidebarMode): void;
+  onNewThread(): void;
   onSelectThread(threadId: string): void;
   selectedThreadId: string | null;
   serverReady: boolean;
@@ -21,6 +22,7 @@ interface SidebarProps {
 export function Sidebar({
   mode,
   onModeChange,
+  onNewThread,
   onSelectThread,
   selectedThreadId,
   serverReady,
@@ -56,7 +58,7 @@ export function Sidebar({
       </header>
 
       <nav className="sidebar-nav" aria-label="Primary">
-        <button className="nav-item" type="button">
+        <button className="nav-item" type="button" onClick={onNewThread}>
           <Icon name="compose" />
           New conversation
         </button>

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useRef, useState } from "react";
+
+import type { Thread, ThreadItem, Turn } from "../../protocol-client/index.js";
+import { Icon } from "./icons";
+import { activeTurn } from "./thread-view-state";
+
+interface ThreadViewProps {
+  thread: Thread;
+  onInterrupt(turnId: string): Promise<void>;
+  onStartTurn(text: string): Promise<void>;
+}
+
+export function ThreadView({
+  thread,
+  onInterrupt,
+  onStartTurn,
+}: ThreadViewProps) {
+  const [draft, setDraft] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [interrupting, setInterrupting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const runningTurn = activeTurn(thread);
+
+  useEffect(() => {
+    const scroll = scrollRef.current;
+    if (scroll !== null) scroll.scrollTop = scroll.scrollHeight;
+  }, [thread.turns]);
+
+  const submit = async () => {
+    const text = draft.trim();
+    if (text.length === 0 || runningTurn !== null || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onStartTurn(text);
+      setDraft("");
+    } catch (requestError) {
+      setError(describeError(requestError));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const interrupt = async () => {
+    if (runningTurn === null || interrupting) return;
+    setInterrupting(true);
+    setError(null);
+    try {
+      await onInterrupt(runningTurn.id);
+    } catch (requestError) {
+      setError(describeError(requestError));
+    } finally {
+      setInterrupting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="messages" ref={scrollRef}>
+        <div className="messages-inner">
+          {thread.turns.length === 0 ? (
+            <div className="thread-empty">
+              <div className="empty-glyph" aria-hidden="true">
+                <Icon name="thread" size={22} />
+              </div>
+              <h2>Ready for the first message</h2>
+              <p>Send a prompt below to begin this thread.</p>
+            </div>
+          ) : (
+            thread.turns.map((turn, index) => (
+              <TurnBlock index={index} key={turn.id} turn={turn} />
+            ))
+          )}
+        </div>
+      </div>
+
+      <div className="composer-wrap">
+        <div className="composer">
+          <textarea
+            aria-label="Message"
+            disabled={runningTurn !== null || submitting}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                void submit();
+              }
+            }}
+            placeholder={
+              runningTurn === null
+                ? "Send a message…"
+                : "Wait for the current turn to finish or interrupt it."
+            }
+            rows={1}
+            value={draft}
+          />
+          <div className="composer-row">
+            <span className={error === null ? undefined : "composer-error"}>
+              {error ??
+                (runningTurn === null
+                  ? "Enter to send · Shift+Enter for a new line"
+                  : "A thread can run only one turn at a time.")}
+            </span>
+            {runningTurn === null ? (
+              <button
+                className="send-button"
+                type="button"
+                disabled={draft.trim().length === 0 || submitting}
+                onClick={() => void submit()}
+              >
+                {submitting ? "Starting…" : "Send"}
+              </button>
+            ) : (
+              <button
+                className="interrupt-button"
+                type="button"
+                disabled={interrupting}
+                onClick={() => void interrupt()}
+              >
+                <Icon name="stop" size={12} />
+                {interrupting ? "Stopping…" : "Interrupt"}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function TurnBlock({ turn, index }: { turn: Turn; index: number }) {
+  return (
+    <section
+      className={`turn-block ${turn.status}`}
+      aria-label={`Turn ${index + 1}`}
+    >
+      <div className="turn-boundary">
+        <span>Turn {index + 1}</span>
+        <span>{turnLabel(turn)}</span>
+      </div>
+      {turn.items.map((item) => (
+        <ItemView item={item} key={item.id} />
+      ))}
+      {turn.error === null ? null : (
+        <div className="turn-error" role="alert">
+          {turn.error.message}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ItemView({ item }: { item: ThreadItem }) {
+  if (item.type === "userMessage") {
+    return (
+      <article className="message-item user-message">
+        <div className="message-author">
+          <span className="avatar user-avatar">You</span>
+          <strong>You</strong>
+        </div>
+        <div className="user-bubble">
+          {item.content.map((content) => content.text).join("\n")}
+        </div>
+      </article>
+    );
+  }
+  if (item.type === "agentMessage") {
+    return (
+      <article className="message-item agent-message">
+        <div className="message-author">
+          <span className="avatar agent-avatar">Z</span>
+          <strong>Zen</strong>
+        </div>
+        <div className="agent-copy">
+          {item.text}
+          {item.text.length === 0 ? <span className="stream-cursor" /> : null}
+        </div>
+      </article>
+    );
+  }
+  if (item.type === "reasoning") {
+    return (
+      <details className="reasoning-item">
+        <summary>
+          <Icon name="reasoning" size={13} /> Reasoning
+        </summary>
+        {item.summary.map((summary, index) => (
+          <p key={index}>{summary}</p>
+        ))}
+      </details>
+    );
+  }
+  return <CommandItemView item={item} />;
+}
+
+function CommandItemView({
+  item,
+}: {
+  item: Extract<ThreadItem, { type: "commandExecution" }>;
+}) {
+  return (
+    <article className={`command-item ${item.status}`}>
+      <div className="command-heading">
+        {item.status === "inProgress" ? (
+          <span className="mini-spinner" />
+        ) : (
+          <Icon
+            name={item.status === "completed" ? "check" : "warning"}
+            size={13}
+          />
+        )}
+        <strong>shell</strong>
+        <code>{item.command}</code>
+        <span>{commandStatus(item.status)}</span>
+      </div>
+      {item.aggregatedOutput === null ||
+      item.aggregatedOutput.length === 0 ? null : (
+        <pre>{item.aggregatedOutput}</pre>
+      )}
+    </article>
+  );
+}
+
+function turnLabel(turn: Turn): string {
+  switch (turn.status) {
+    case "inProgress":
+      return "Running";
+    case "completed":
+      return "Complete";
+    case "interrupted":
+      return "Interrupted";
+    case "failed":
+      return "Failed";
+  }
+}
+
+function commandStatus(
+  status: Extract<ThreadItem, { type: "commandExecution" }>["status"],
+): string {
+  switch (status) {
+    case "inProgress":
+      return "Running";
+    case "completed":
+      return "Complete";
+    case "failed":
+      return "Failed";
+    case "declined":
+      return "Declined";
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -1,15 +1,18 @@
 import type { ReactNode, SVGProps } from "react";
 
 type IconName =
+  | "check"
   | "chevron-down"
   | "chevron-right"
   | "compose"
   | "folder"
   | "inbox"
   | "panel-right"
+  | "reasoning"
   | "search"
   | "thread"
   | "tree"
+  | "stop"
   | "warning";
 
 type IconProps = SVGProps<SVGSVGElement> & {
@@ -18,6 +21,7 @@ type IconProps = SVGProps<SVGSVGElement> & {
 };
 
 const paths: Record<IconName, ReactNode> = {
+  check: <path d="m2.4 8.4 3.4 3.4 7.8-7.8" />,
   "chevron-down": <path d="m3.6 6 4.4 4.4L12.4 6" />,
   "chevron-right": <path d="m6 3.6 4.4 4.4L6 12.4" />,
   compose: (
@@ -41,6 +45,12 @@ const paths: Record<IconName, ReactNode> = {
       <path d="M10.2 2.2v11.6" />
     </>
   ),
+  reasoning: (
+    <>
+      <path d="M8 2.1a4.4 4.4 0 0 0-2.7 7.9c.5.4.8.9.8 1.5h3.8c0-.6.3-1.1.8-1.5A4.4 4.4 0 0 0 8 2.1Z" />
+      <path d="M6.5 13.8h3M6.2 11.5h3.6" />
+    </>
+  ),
   search: (
     <>
       <circle cx="7.2" cy="7.2" r="4.6" />
@@ -54,6 +64,7 @@ const paths: Record<IconName, ReactNode> = {
       <circle cx="3" cy="12.5" r=".2" />
     </>
   ),
+  stop: <rect x="3.2" y="3.2" width="9.6" height="9.6" rx="1.5" />,
   tree: (
     <>
       <path d="M2.5 3.5h11M5.5 8h8M5.5 12.5h8" />

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -70,6 +70,12 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
+textarea:focus-visible,
+summary:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
 .app-shell {
   display: flex;
   width: 100%;
@@ -602,6 +608,358 @@ button:focus-visible {
 
 .primary-button:active {
   transform: translateY(1px);
+}
+
+.messages {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  scroll-behavior: smooth;
+}
+
+.messages-inner {
+  width: min(100%, 780px);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 30px 34px 20px;
+}
+
+.thread-empty {
+  display: flex;
+  min-height: 380px;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  text-align: center;
+}
+
+.thread-empty h2 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 620;
+}
+
+.thread-empty p {
+  margin: var(--space-1) 0 0;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-body);
+}
+
+.turn-block + .turn-block {
+  margin-top: 28px;
+}
+
+.turn-boundary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: 22px;
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+
+.turn-boundary::after {
+  height: 1px;
+  flex: 1;
+  background: var(--color-border-soft);
+  content: "";
+}
+
+.turn-boundary span:nth-child(2) {
+  color: var(--color-text-subtle);
+  letter-spacing: 0;
+}
+
+.message-item {
+  margin: 0 0 24px;
+}
+
+.message-author {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: var(--font-size-sm);
+}
+
+.message-author strong {
+  font-weight: 650;
+}
+
+.avatar {
+  display: grid;
+  width: 25px;
+  height: 25px;
+  flex: none;
+  place-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  color: var(--color-text-muted);
+  background: var(--color-panel-raised);
+  font-size: 9px;
+  font-weight: 700;
+}
+
+.agent-avatar {
+  color: #dbe9fa;
+  border-color: rgba(98, 168, 250, 0.3);
+  background: #263e5d;
+}
+
+.user-bubble {
+  width: fit-content;
+  max-width: min(90%, 620px);
+  margin-left: 33px;
+  padding: 9px 13px;
+  border: 1px solid var(--color-border);
+  border-radius: 4px 12px 12px;
+  color: var(--color-text);
+  background: var(--color-panel-raised);
+  font-size: var(--font-size-body);
+  white-space: pre-wrap;
+}
+
+.agent-copy {
+  margin-left: 33px;
+  color: var(--color-text);
+  font-size: var(--font-size-body);
+  line-height: 1.7;
+  white-space: pre-wrap;
+}
+
+.stream-cursor {
+  display: inline-block;
+  width: 7px;
+  height: 15px;
+  margin-left: 2px;
+  vertical-align: -2px;
+  background: var(--color-blue);
+  animation: blink 900ms steps(1) infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0.2;
+  }
+}
+
+.reasoning-item {
+  margin: -8px 0 24px 33px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-sm);
+}
+
+.reasoning-item summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 5px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.reasoning-item p {
+  margin: 8px 0 0 19px;
+  color: var(--color-text-muted);
+  white-space: pre-wrap;
+}
+
+.command-item {
+  margin: 0 0 24px 33px;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-panel-raised);
+}
+
+.command-heading {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 36px;
+  padding: 7px 10px;
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+}
+
+.command-heading > svg {
+  color: var(--color-green);
+}
+
+.command-item.failed .command-heading > svg,
+.command-item.declined .command-heading > svg {
+  color: var(--color-red);
+}
+
+.command-heading strong {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.command-heading code {
+  overflow: hidden;
+  color: var(--color-text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.command-item pre {
+  max-height: 280px;
+  margin: 0;
+  padding: 10px 12px;
+  overflow: auto;
+  border-top: 1px solid var(--color-border-soft);
+  color: var(--color-text-muted);
+  background: #0d1014;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11.5px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.turn-error {
+  margin: 0 0 22px 33px;
+  padding: 8px 11px;
+  border: 1px solid rgba(240, 113, 111, 0.34);
+  border-radius: var(--radius-md);
+  color: #f49a98;
+  background: var(--color-red-dim);
+  font-size: var(--font-size-sm);
+}
+
+.composer-wrap {
+  padding: 10px 28px 18px;
+  background: linear-gradient(transparent, var(--color-bg) 25%);
+}
+
+.composer {
+  width: min(100%, 780px);
+  margin: 0 auto;
+  padding: 10px 11px 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-panel-raised);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+  transition: border-color var(--duration-ui);
+}
+
+.composer:focus-within {
+  border-color: rgba(123, 181, 248, 0.7);
+}
+
+.composer textarea {
+  width: 100%;
+  min-height: 38px;
+  max-height: 150px;
+  resize: vertical;
+  border: 0;
+  color: var(--color-text);
+  background: transparent;
+  font: inherit;
+  font-size: var(--font-size-body);
+  line-height: 1.55;
+}
+
+.composer textarea:focus {
+  outline: 0;
+}
+
+.composer textarea::placeholder {
+  color: var(--color-text-faint);
+}
+
+.composer textarea:disabled {
+  cursor: not-allowed;
+  opacity: 0.72;
+}
+
+.composer-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.composer-row > span {
+  flex: 1;
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+}
+
+.composer-row > .composer-error {
+  color: #f49a98;
+}
+
+.send-button,
+.interrupt-button {
+  display: inline-flex;
+  min-height: 28px;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border: 0;
+  border-radius: 7px;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: 650;
+  transition:
+    filter var(--duration-ui),
+    opacity var(--duration-ui);
+}
+
+.send-button {
+  color: #071221;
+  background: var(--color-blue);
+}
+
+.interrupt-button {
+  color: #f7b3b1;
+  background: rgba(240, 113, 111, 0.16);
+}
+
+.send-button:hover:not(:disabled),
+.interrupt-button:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.send-button:disabled,
+.interrupt-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.thread-load-error .empty-glyph {
+  color: var(--color-red);
+}
+
+.thread-facts {
+  margin: 18px 0 0;
+}
+
+.thread-facts > div {
+  padding: 10px 0;
+  border-top: 1px solid var(--color-border-soft);
+}
+
+.thread-facts dt {
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+}
+
+.thread-facts dd {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 .detail-rail {

--- a/apps/zenx/src/renderer/src/thread-view-state.ts
+++ b/apps/zenx/src/renderer/src/thread-view-state.ts
@@ -1,0 +1,118 @@
+import type {
+  ServerNotificationMethod,
+  ServerNotificationParams,
+  Thread,
+  ThreadItem,
+  Turn,
+} from "../../protocol-client/index.js";
+
+export function applyThreadViewNotification(
+  thread: Thread,
+  method: ServerNotificationMethod,
+  params: ServerNotificationParams[ServerNotificationMethod],
+  nowSeconds = Math.floor(Date.now() / 1_000),
+): Thread {
+  if (method === "thread/name/updated") {
+    const event = params as ServerNotificationParams["thread/name/updated"];
+    return event.threadId === thread.id
+      ? { ...thread, name: event.threadName, updatedAt: nowSeconds }
+      : thread;
+  }
+  if (method === "turn/started") {
+    const event = params as ServerNotificationParams["turn/started"];
+    return event.threadId === thread.id
+      ? {
+          ...thread,
+          status: { type: "active", activeFlags: [] },
+          turns: upsertTurn(thread.turns, event.turn),
+          updatedAt: nowSeconds,
+        }
+      : thread;
+  }
+  if (method === "item/started" || method === "item/completed") {
+    const event = params as
+      | ServerNotificationParams["item/started"]
+      | ServerNotificationParams["item/completed"];
+    if (event.threadId !== thread.id) return thread;
+    return updateTurnItems(thread, event.turnId, (items) =>
+      upsertItem(items, event.item),
+    );
+  }
+  if (method === "item/agentMessage/delta") {
+    const event = params as ServerNotificationParams["item/agentMessage/delta"];
+    if (event.threadId !== thread.id) return thread;
+    return updateTurnItems(thread, event.turnId, (items) =>
+      items.map((item) =>
+        item.id === event.itemId && item.type === "agentMessage"
+          ? { ...item, text: item.text + event.delta }
+          : item,
+      ),
+    );
+  }
+  if (method === "item/commandExecution/outputDelta") {
+    const event =
+      params as ServerNotificationParams["item/commandExecution/outputDelta"];
+    if (event.threadId !== thread.id) return thread;
+    return updateTurnItems(thread, event.turnId, (items) =>
+      items.map((item) =>
+        item.id === event.itemId && item.type === "commandExecution"
+          ? {
+              ...item,
+              aggregatedOutput: (item.aggregatedOutput ?? "") + event.delta,
+            }
+          : item,
+      ),
+    );
+  }
+  if (method === "turn/completed") {
+    const event = params as ServerNotificationParams["turn/completed"];
+    if (event.threadId !== thread.id) return thread;
+    const existing = thread.turns.find((turn) => turn.id === event.turn.id);
+    const completed = {
+      ...event.turn,
+      items: existing?.items ?? event.turn.items,
+    };
+    return {
+      ...thread,
+      status: { type: "idle" },
+      turns: upsertTurn(thread.turns, completed),
+      updatedAt: nowSeconds,
+    };
+  }
+  return thread;
+}
+
+export function activeTurn(thread: Thread): Turn | null {
+  return (
+    [...thread.turns].reverse().find((turn) => turn.status === "inProgress") ??
+    null
+  );
+}
+
+function upsertTurn(turns: readonly Turn[], next: Turn): Turn[] {
+  const index = turns.findIndex((turn) => turn.id === next.id);
+  if (index < 0) return [...turns, next];
+  return turns.map((turn, turnIndex) => (turnIndex === index ? next : turn));
+}
+
+function upsertItem(
+  items: readonly ThreadItem[],
+  next: ThreadItem,
+): ThreadItem[] {
+  const index = items.findIndex((item) => item.id === next.id);
+  if (index < 0) return [...items, next];
+  return items.map((item, itemIndex) => (itemIndex === index ? next : item));
+}
+
+function updateTurnItems(
+  thread: Thread,
+  turnId: string,
+  update: (items: ThreadItem[]) => ThreadItem[],
+): Thread {
+  return {
+    ...thread,
+    turns: thread.turns.map((turn) =>
+      turn.id === turnId ? { ...turn, items: update(turn.items) } : turn,
+    ),
+  };
+}

--- a/apps/zenx/test/thread-view-integration.test.ts
+++ b/apps/zenx/test/thread-view-integration.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { AppServerManager } from "../src/main/app-server-manager.js";
+import type { Thread } from "../src/protocol-client/index.js";
+import { applyThreadViewNotification } from "../src/renderer/src/thread-view-state.js";
+
+test("projects a streamed tool turn from the hosted App Server", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-view-"));
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+  try {
+    await manager.start();
+    const started = await manager.request("thread/start", {});
+    let projected: Thread = started.thread;
+    const complete = deferred<void>();
+    const dispose = manager.onNotification((method, params) => {
+      projected = applyThreadViewNotification(projected, method, params);
+      if (method === "turn/completed") complete.resolve();
+    });
+
+    await manager.request("turn/start", {
+      threadId: projected.id,
+      input: [{ type: "text", text: "!shell printf zenx-stream" }],
+    });
+    await within(complete.promise);
+    dispose();
+
+    const currentTurn = projected.turns.at(-1);
+    assert.equal(currentTurn?.status, "completed");
+    const command = currentTurn?.items.find(
+      (item) => item.type === "commandExecution",
+    );
+    assert.equal(command?.status, "completed");
+    assert.equal(command?.aggregatedOutput, "zenx-stream");
+    assert(
+      currentTurn?.items.some(
+        (item) => item.type === "agentMessage" && item.text.length > 0,
+      ),
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function within<T>(promise: Promise<T>, milliseconds = 10_000) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Timed out waiting for turn/completed")),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/apps/zenx/test/thread-view-state.test.ts
+++ b/apps/zenx/test/thread-view-state.test.ts
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Thread, ThreadItem, Turn } from "../src/protocol-client/index.js";
+import {
+  activeTurn,
+  applyThreadViewNotification,
+} from "../src/renderer/src/thread-view-state.js";
+
+test("keeps interrupted history from thread/resume as terminal history", () => {
+  const interrupted = turn("turn-old", "interrupted", [
+    userItem("user-old", "stop here"),
+    agentItem("agent-old", "partial answer"),
+  ]);
+  const resumed = thread([interrupted]);
+
+  assert.equal(activeTurn(resumed), null);
+  assert.equal(resumed.turns[0]?.status, "interrupted");
+  assert.equal(resumed.turns[0]?.items[1]?.type, "agentMessage");
+});
+
+test("streams agent text in memory and replaces it with the completed item", () => {
+  let current = thread();
+  const running = turn("turn-1", "inProgress");
+  current = applyThreadViewNotification(
+    current,
+    "turn/started",
+    { threadId: current.id, turn: running },
+    20,
+  );
+  current = applyThreadViewNotification(current, "item/started", {
+    threadId: current.id,
+    turnId: running.id,
+    item: agentItem("agent-1", ""),
+    startedAtMs: 20_000,
+  });
+  current = applyThreadViewNotification(current, "item/agentMessage/delta", {
+    threadId: current.id,
+    turnId: running.id,
+    itemId: "agent-1",
+    delta: "transient ",
+  });
+  current = applyThreadViewNotification(current, "item/agentMessage/delta", {
+    threadId: current.id,
+    turnId: running.id,
+    itemId: "agent-1",
+    delta: "text",
+  });
+  assert.equal(agentText(current), "transient text");
+
+  current = applyThreadViewNotification(current, "item/completed", {
+    threadId: current.id,
+    turnId: running.id,
+    item: agentItem("agent-1", "canonical final text"),
+    completedAtMs: 21_000,
+  });
+  current = applyThreadViewNotification(current, "turn/completed", {
+    threadId: current.id,
+    turn: turn(running.id, "completed"),
+  });
+
+  assert.equal(agentText(current), "canonical final text");
+  assert.equal(current.turns[0]?.status, "completed");
+  assert.equal(current.turns[0]?.items.length, 1);
+  assert.equal(current.status.type, "idle");
+});
+
+test("streams command output and replaces it with the completed projection", () => {
+  const running = turn("turn-command", "inProgress", [
+    commandItem("command-1", "inProgress", null),
+  ]);
+  let current = thread([running]);
+  current = applyThreadViewNotification(
+    current,
+    "item/commandExecution/outputDelta",
+    {
+      threadId: current.id,
+      turnId: running.id,
+      itemId: "command-1",
+      delta: "temporary output",
+    },
+  );
+  assert.equal(commandOutput(current), "temporary output");
+
+  current = applyThreadViewNotification(current, "item/completed", {
+    threadId: current.id,
+    turnId: running.id,
+    item: commandItem("command-1", "completed", "final output"),
+    completedAtMs: 30_000,
+  });
+  assert.equal(commandOutput(current), "final output");
+});
+
+function thread(turns: Turn[] = []): Thread {
+  return {
+    id: "thread-1",
+    sessionId: "thread-1",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "fake",
+    createdAt: 10,
+    updatedAt: 10,
+    recencyAt: null,
+    status: { type: "idle" },
+    path: null,
+    cwd: "/workspace",
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns,
+  };
+}
+
+function turn(
+  id: string,
+  status: Turn["status"],
+  items: ThreadItem[] = [],
+): Turn {
+  return {
+    id,
+    items,
+    itemsView: "full",
+    status,
+    error: null,
+    startedAt: 10,
+    completedAt: status === "inProgress" ? null : 11,
+    durationMs: status === "inProgress" ? null : 1_000,
+  };
+}
+
+function userItem(id: string, text: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id,
+    clientId: null,
+    content: [{ type: "text", text, text_elements: [] }],
+  };
+}
+
+function agentItem(id: string, text: string): ThreadItem {
+  return {
+    type: "agentMessage",
+    id,
+    text,
+    phase: "final_answer",
+    memoryCitation: null,
+  };
+}
+
+function commandItem(
+  id: string,
+  status: Extract<ThreadItem, { type: "commandExecution" }>["status"],
+  aggregatedOutput: string | null,
+): ThreadItem {
+  return {
+    type: "commandExecution",
+    id,
+    pluginId: null,
+    scriptPath: null,
+    command: "printf zenx",
+    cwd: "/workspace",
+    processId: null,
+    source: "agent",
+    status,
+    commandActions: [],
+    aggregatedOutput,
+    exitCode: status === "completed" ? 0 : null,
+    durationMs: null,
+  };
+}
+
+function agentText(value: Thread): string | undefined {
+  const item = value.turns[0]?.items[0];
+  return item?.type === "agentMessage" ? item.text : undefined;
+}
+
+function commandOutput(value: Thread): string | null | undefined {
+  const item = value.turns[0]?.items[0];
+  return item?.type === "commandExecution" ? item.aggregatedOutput : undefined;
+}


### PR DESCRIPTION
## Summary
- reconstruct full thread history through `thread/resume` and render turn boundaries, messages, reasoning, tool calls, outputs, and terminal states
- keep agent and command deltas renderer-local, replacing transient state with completed protocol items
- add an explicit single-active-turn composer with send and interrupt actions
- cover interrupted resumes, delta replacement, and a hosted App Server shell-tool streaming loop

## Validation
- `npm run check --workspace apps/zenx`
- `npm run check`
- Electron development startup (visual capture unavailable while macOS session is locked)

Closes #7