### PR TITLE
ZenX: add command approval flow

### DIFF
--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -13,7 +13,16 @@ export default defineConfig({
       },
     },
   },
-  preload: {},
+  preload: {
+    build: {
+      rollupOptions: {
+        output: {
+          format: "cjs",
+          entryFileNames: "[name].cjs",
+        },
+      },
+    },
+  },
   renderer: {
     plugins: [react()],
   },

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -10,6 +10,8 @@ import {
   type ClientRequestResults,
   type ServerNotificationMethod,
   type ServerNotificationParams,
+  type ServerRequestParams,
+  type ServerRequestResults,
 } from "../protocol-client/index.js";
 import {
   isHostEvent,
@@ -38,10 +40,37 @@ type NotificationListener = (
   params: ServerNotificationParams[ServerNotificationMethod],
 ) => void;
 
+export type ApprovalDecision =
+  ServerRequestResults["item/commandExecution/requestApproval"]["decision"];
+
+export interface ApprovalRequestEvent {
+  requestId: string;
+  params: ServerRequestParams["item/commandExecution/requestApproval"];
+}
+
+export interface ApprovalResolvedEvent {
+  requestId: string;
+  threadId: string;
+  decision: ApprovalDecision | null;
+}
+
+interface PendingApproval {
+  event: ApprovalRequestEvent;
+  decision: ApprovalDecision | null;
+  resolve(result: { decision: ApprovalDecision }): void;
+}
+
 export class AppServerManager {
   readonly #options: AppServerManagerOptions;
   readonly #statusListeners = new Set<(status: AppServerHostStatus) => void>();
   readonly #notificationListeners = new Set<NotificationListener>();
+  readonly #approvalListeners = new Set<
+    (event: ApprovalRequestEvent) => void
+  >();
+  readonly #approvalResolvedListeners = new Set<
+    (event: ApprovalResolvedEvent) => void
+  >();
+  readonly #pendingApprovals = new Map<string, PendingApproval>();
   #status: AppServerHostStatus = { type: "stopped" };
   #child: ChildProcess | undefined;
   #client: ZenXProtocolClient | undefined;
@@ -133,9 +162,40 @@ export class AppServerManager {
     return () => this.#notificationListeners.delete(listener);
   }
 
+  onApprovalRequest(
+    listener: (event: ApprovalRequestEvent) => void,
+  ): () => void {
+    this.#approvalListeners.add(listener);
+    return () => this.#approvalListeners.delete(listener);
+  }
+
+  get pendingApprovalRequests(): readonly ApprovalRequestEvent[] {
+    return [...this.#pendingApprovals.values()].map((pending) => pending.event);
+  }
+
+  onApprovalResolved(
+    listener: (event: ApprovalResolvedEvent) => void,
+  ): () => void {
+    this.#approvalResolvedListeners.add(listener);
+    return () => this.#approvalResolvedListeners.delete(listener);
+  }
+
+  respondToApproval(requestId: string, decision: ApprovalDecision): void {
+    const pending = this.#pendingApprovals.get(requestId);
+    if (pending === undefined) {
+      throw new Error(`Approval request ${requestId} is no longer pending`);
+    }
+    if (pending.decision !== null) {
+      throw new Error(`Approval request ${requestId} already has a response`);
+    }
+    pending.decision = decision;
+    pending.resolve({ decision });
+  }
+
   async stop(): Promise<void> {
     if (this.#stopping) return;
     this.#stopping = true;
+    this.#cancelPendingApprovals();
     this.#client?.close();
     this.#client = undefined;
     const child = this.#child;
@@ -150,6 +210,24 @@ export class AppServerManager {
   }
 
   #forwardNotifications(client: ZenXProtocolClient): void {
+    client.onServerRequest(
+      "item/commandExecution/requestApproval",
+      async (params, context) => {
+        const requestId = String(context.requestId);
+        if (this.#pendingApprovals.has(requestId)) {
+          throw new Error(`Duplicate approval request ${requestId}`);
+        }
+        return await new Promise<{ decision: ApprovalDecision }>((resolve) => {
+          const event = { requestId, params };
+          this.#pendingApprovals.set(requestId, {
+            event,
+            decision: null,
+            resolve,
+          });
+          for (const listener of this.#approvalListeners) listener(event);
+        });
+      },
+    );
     for (const method of [
       "thread/started",
       "thread/name/updated",
@@ -164,11 +242,34 @@ export class AppServerManager {
       "error",
     ] as const) {
       client.onNotification(method, (params) => {
+        if (method === "serverRequest/resolved") {
+          this.#resolveApproval(
+            params as ServerNotificationParams["serverRequest/resolved"],
+          );
+        }
         for (const listener of this.#notificationListeners) {
           listener(method, params);
         }
       });
     }
+  }
+
+  #resolveApproval(
+    params: ServerNotificationParams["serverRequest/resolved"],
+  ): void {
+    const pending = this.#pendingApprovals.get(params.requestId);
+    if (pending === undefined) return;
+    if (pending.decision === null) {
+      pending.decision = "cancel";
+      pending.resolve({ decision: "cancel" });
+    }
+    const event = {
+      requestId: params.requestId,
+      threadId: params.threadId,
+      decision: pending.decision,
+    } satisfies ApprovalResolvedEvent;
+    this.#pendingApprovals.delete(params.requestId);
+    for (const listener of this.#approvalResolvedListeners) listener(event);
   }
 
   #handleChildExit(
@@ -178,6 +279,7 @@ export class AppServerManager {
   ): void {
     if (this.#child !== child) return;
     this.#child = undefined;
+    this.#cancelPendingApprovals();
     this.#client?.close();
     this.#client = undefined;
     if (!this.#stopping) {
@@ -193,6 +295,13 @@ export class AppServerManager {
   #setStatus(status: AppServerHostStatus): void {
     this.#status = status;
     for (const listener of this.#statusListeners) listener(status);
+  }
+
+  #cancelPendingApprovals(): void {
+    for (const pending of this.#pendingApprovals.values()) {
+      pending.resolve({ decision: "cancel" });
+    }
+    this.#pendingApprovals.clear();
   }
 }
 

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { isClientRequestMethod } from "../protocol-client/index.js";
 import { ipcChannels } from "../preload/ipc.js";
 import { AppServerManager } from "./app-server-manager.js";
+import type { ApprovalDecision } from "./app-server-manager.js";
 import { resolveZenXHostConfig } from "./host-config.js";
 
 let appServerManager: AppServerManager | undefined;
@@ -18,7 +19,7 @@ function createWindow(): BrowserWindow {
     show: false,
     backgroundColor: "#0b0d10",
     webPreferences: {
-      preload: join(__dirname, "../preload/index.mjs"),
+      preload: join(__dirname, "../preload/index.cjs"),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
@@ -79,12 +80,25 @@ app.on("window-all-closed", () => {
 function installProtocolIpc(manager: AppServerManager): void {
   ipcMain.handle(ipcChannels.getStatus, () => manager.status);
   ipcMain.handle(
+    ipcChannels.getPendingApprovals,
+    () => manager.pendingApprovalRequests,
+  );
+  ipcMain.handle(
     ipcChannels.request,
     async (_event, method: unknown, params: unknown) => {
       if (!isClientRequestMethod(method)) {
         throw new Error(`Unsupported ZenX protocol method: ${String(method)}`);
       }
       return await manager.request(method, params as never);
+    },
+  );
+  ipcMain.handle(
+    ipcChannels.respondApproval,
+    (_event, requestId: unknown, decision: unknown) => {
+      if (typeof requestId !== "string" || !isApprovalDecision(decision)) {
+        throw new Error("Invalid ZenX approval response");
+      }
+      manager.respondToApproval(requestId, decision);
     },
   );
   manager.onStatus((status) => {
@@ -97,11 +111,34 @@ function installProtocolIpc(manager: AppServerManager): void {
       window.webContents.send(ipcChannels.notification, method, params);
     }
   });
+  manager.onApprovalRequest((approval) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(ipcChannels.approvalRequest, approval);
+    }
+  });
+  manager.onApprovalResolved((approval) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(ipcChannels.approvalResolved, approval);
+    }
+  });
 }
 
 function installFailedProtocolIpc(message: string): void {
   ipcMain.handle(ipcChannels.getStatus, () => ({ type: "error", message }));
+  ipcMain.handle(ipcChannels.getPendingApprovals, () => []);
   ipcMain.handle(ipcChannels.request, () => {
     throw new Error(`Zen App Server is not ready: ${message}`);
   });
+  ipcMain.handle(ipcChannels.respondApproval, () => {
+    throw new Error(`Zen App Server is not ready: ${message}`);
+  });
+}
+
+function isApprovalDecision(value: unknown): value is ApprovalDecision {
+  return (
+    value === "accept" ||
+    value === "acceptForSession" ||
+    value === "decline" ||
+    value === "cancel"
+  );
 }

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -2,6 +2,11 @@ import { contextBridge, ipcRenderer } from "electron";
 
 import type { AppServerHostStatus } from "../main/app-server-manager.js";
 import type {
+  ApprovalDecision,
+  ApprovalRequestEvent,
+  ApprovalResolvedEvent,
+} from "../main/app-server-manager.js";
+import type {
   ClientRequestMethod,
   ClientRequestParams,
   ClientRequestResults,
@@ -15,11 +20,42 @@ contextBridge.exposeInMainWorld("zenx", {
   protocol: {
     getStatus: async (): Promise<AppServerHostStatus> =>
       await ipcRenderer.invoke(ipcChannels.getStatus),
+    getPendingApprovals: async (): Promise<ApprovalRequestEvent[]> =>
+      await ipcRenderer.invoke(ipcChannels.getPendingApprovals),
     request: async <M extends ClientRequestMethod>(
       method: M,
       params: ClientRequestParams[M],
     ): Promise<ClientRequestResults[M]> =>
       await ipcRenderer.invoke(ipcChannels.request, method, params),
+    respondToApproval: async (
+      requestId: string,
+      decision: ApprovalDecision,
+    ): Promise<void> =>
+      await ipcRenderer.invoke(
+        ipcChannels.respondApproval,
+        requestId,
+        decision,
+      ),
+    onApprovalRequest: (
+      listener: (event: ApprovalRequestEvent) => void,
+    ): (() => void) => {
+      const wrapped = (
+        _event: Electron.IpcRendererEvent,
+        approval: ApprovalRequestEvent,
+      ) => listener(approval);
+      ipcRenderer.on(ipcChannels.approvalRequest, wrapped);
+      return () => ipcRenderer.off(ipcChannels.approvalRequest, wrapped);
+    },
+    onApprovalResolved: (
+      listener: (event: ApprovalResolvedEvent) => void,
+    ): (() => void) => {
+      const wrapped = (
+        _event: Electron.IpcRendererEvent,
+        approval: ApprovalResolvedEvent,
+      ) => listener(approval);
+      ipcRenderer.on(ipcChannels.approvalResolved, wrapped);
+      return () => ipcRenderer.off(ipcChannels.approvalResolved, wrapped);
+    },
     onStatus: (
       listener: (status: AppServerHostStatus) => void,
     ): (() => void) => {

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -1,6 +1,10 @@
 export const ipcChannels = {
   getStatus: "zenx:app-server:get-status",
+  getPendingApprovals: "zenx:protocol:get-pending-approvals",
   request: "zenx:protocol:request",
+  approvalRequest: "zenx:protocol:approval-request",
+  approvalResolved: "zenx:protocol:approval-resolved",
+  respondApproval: "zenx:protocol:respond-approval",
   status: "zenx:app-server:status",
   notification: "zenx:protocol:notification",
 } as const;

--- a/apps/zenx/src/protocol-client/protocol-client.ts
+++ b/apps/zenx/src/protocol-client/protocol-client.ts
@@ -17,6 +17,7 @@ import type {
   ServerNotificationMethod,
   ServerNotificationParams,
   ServerRequestMethod,
+  ServerRequestContext,
   ServerRequestParams,
   ServerRequestResults,
 } from "./types.js";
@@ -24,6 +25,7 @@ import type {
 type UnknownNotificationHandler = (params: unknown) => void | Promise<void>;
 type UnknownServerRequestHandler = (
   params: unknown,
+  context: ServerRequestContext,
 ) => unknown | Promise<unknown>;
 
 export interface ZenXProtocolClientOptions {
@@ -156,10 +158,11 @@ export class ZenXProtocolClient {
     method: M,
     handler: (
       params: ServerRequestParams[M],
+      context: ServerRequestContext,
     ) => ServerRequestResults[M] | Promise<ServerRequestResults[M]>,
   ): () => void {
-    const wrapped: UnknownServerRequestHandler = async (params) =>
-      await handler(params as ServerRequestParams[M]);
+    const wrapped: UnknownServerRequestHandler = async (params, context) =>
+      await handler(params as ServerRequestParams[M], context);
     this.#serverRequestHandlers.set(method, wrapped);
     return () => {
       if (this.#serverRequestHandlers.get(method) === wrapped) {
@@ -302,7 +305,9 @@ export class ZenXProtocolClient {
         return;
       }
       try {
-        const result = await handler(message.params);
+        const result = await handler(message.params, {
+          requestId: message.id,
+        });
         this.#send({ id: message.id, result });
       } catch (error) {
         this.#send({

--- a/apps/zenx/src/protocol-client/types.ts
+++ b/apps/zenx/src/protocol-client/types.ts
@@ -212,6 +212,10 @@ export interface ServerRequestResults {
 
 export type ServerRequestMethod = keyof ServerRequestParams;
 
+export interface ServerRequestContext {
+  requestId: string | number;
+}
+
 export type ConnectionStatus =
   | { type: "connecting" }
   | { type: "ready"; reconnected: boolean }

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,9 +1,20 @@
 import { useEffect, useState } from "react";
-import type { AppServerHostStatus } from "../../main/app-server-manager.js";
+import type {
+  AppServerHostStatus,
+  ApprovalDecision,
+} from "../../main/app-server-manager.js";
 import type { Thread } from "../../protocol-client/index.js";
 import { Icon } from "./icons";
 import { Sidebar } from "./Sidebar";
 import { ThreadView } from "./ThreadView";
+import {
+  addApprovalRequest,
+  markApprovalResponding,
+  pendingApprovalThreadIds,
+  resolveApproval,
+  restoreApprovalPending,
+  type ApprovalCardState,
+} from "./approval-state";
 import {
   applyThreadNotification,
   readSidebarMode,
@@ -23,6 +34,7 @@ export function App() {
   const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
   const [threadLoading, setThreadLoading] = useState(false);
   const [threadError, setThreadError] = useState<string | null>(null);
+  const [approvals, setApprovals] = useState<ApprovalCardState[]>([]);
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>(() => {
     try {
       return readSidebarMode(window.localStorage);
@@ -68,6 +80,23 @@ export function App() {
         }
       },
     );
+    const disposeApprovals = window.zenx.protocol.onApprovalRequest((event) => {
+      if (active) {
+        setApprovals((current) => addApprovalRequest(current, event));
+      }
+    });
+    const disposeResolved = window.zenx.protocol.onApprovalResolved((event) => {
+      if (active) {
+        setApprovals((current) => resolveApproval(current, event));
+      }
+    });
+    void window.zenx.protocol
+      .getPendingApprovals()
+      .then((pending) => {
+        if (!active) return;
+        setApprovals((current) => pending.reduce(addApprovalRequest, current));
+      })
+      .catch(() => undefined);
     void window.zenx.protocol
       .getStatus()
       .then((status) => {
@@ -86,6 +115,8 @@ export function App() {
       active = false;
       dispose();
       disposeNotifications();
+      disposeApprovals();
+      disposeResolved();
     };
   }, []);
 
@@ -93,6 +124,7 @@ export function App() {
     threadDetail ??
     threads.find((thread) => thread.id === selectedThreadId) ??
     null;
+  const pendingThreadIds = pendingApprovalThreadIds(approvals);
 
   const selectThread = async (threadId: string) => {
     setSelectedThreadId(threadId);
@@ -145,6 +177,21 @@ export function App() {
       turnId,
     });
   };
+
+  const respondToApproval = async (
+    requestId: string,
+    decision: ApprovalDecision,
+  ) => {
+    setApprovals((current) =>
+      markApprovalResponding(current, requestId, decision),
+    );
+    try {
+      await window.zenx.protocol.respondToApproval(requestId, decision);
+    } catch (error) {
+      setApprovals((current) => restoreApprovalPending(current, requestId));
+      throw error;
+    }
+  };
   const changeSidebarMode = (mode: SidebarMode) => {
     setSidebarMode(mode);
     try {
@@ -161,6 +208,7 @@ export function App() {
         onModeChange={changeSidebarMode}
         onNewThread={() => void newThread()}
         onSelectThread={(threadId) => void selectThread(threadId)}
+        pendingApprovalThreadIds={pendingThreadIds}
         selectedThreadId={selectedThreadId}
         serverReady={serverStatus.type === "ready"}
         threads={threads}
@@ -243,7 +291,11 @@ export function App() {
           </section>
         ) : threadDetail !== null ? (
           <ThreadView
+            approvals={approvals.filter(
+              (approval) => approval.params.threadId === threadDetail.id,
+            )}
             onInterrupt={interruptTurn}
+            onRespondToApproval={respondToApproval}
             onStartTurn={startTurn}
             thread={threadDetail}
           />

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -14,6 +14,7 @@ interface SidebarProps {
   onModeChange(mode: SidebarMode): void;
   onNewThread(): void;
   onSelectThread(threadId: string): void;
+  pendingApprovalThreadIds: ReadonlySet<string>;
   selectedThreadId: string | null;
   serverReady: boolean;
   threads: readonly Thread[];
@@ -24,6 +25,7 @@ export function Sidebar({
   onModeChange,
   onNewThread,
   onSelectThread,
+  pendingApprovalThreadIds,
   selectedThreadId,
   serverReady,
   threads,
@@ -77,12 +79,14 @@ export function Sidebar({
         ) : mode === "inbox" ? (
           <InboxView
             onSelectThread={onSelectThread}
+            pendingApprovalThreadIds={pendingApprovalThreadIds}
             selectedThreadId={selectedThreadId}
             threads={threads}
           />
         ) : (
           <ProjectsView
             onSelectThread={onSelectThread}
+            pendingApprovalThreadIds={pendingApprovalThreadIds}
             selectedThreadId={selectedThreadId}
             threads={threads}
           />
@@ -96,8 +100,12 @@ function InboxView({
   threads,
   selectedThreadId,
   onSelectThread,
-}: Pick<SidebarProps, "threads" | "selectedThreadId" | "onSelectThread">) {
-  const sections = deriveInboxSections(threads);
+  pendingApprovalThreadIds,
+}: Pick<
+  SidebarProps,
+  "threads" | "selectedThreadId" | "onSelectThread" | "pendingApprovalThreadIds"
+>) {
+  const sections = deriveInboxSections(threads, pendingApprovalThreadIds);
   return (
     <>
       {sections.map((section) =>
@@ -110,6 +118,7 @@ function InboxView({
               <ThreadCard
                 key={thread.id}
                 onSelectThread={onSelectThread}
+                pendingApproval={pendingApprovalThreadIds.has(thread.id)}
                 selected={thread.id === selectedThreadId}
                 thread={thread}
               />
@@ -133,7 +142,11 @@ function ProjectsView({
   threads,
   selectedThreadId,
   onSelectThread,
-}: Pick<SidebarProps, "threads" | "selectedThreadId" | "onSelectThread">) {
+  pendingApprovalThreadIds,
+}: Pick<
+  SidebarProps,
+  "threads" | "selectedThreadId" | "onSelectThread" | "pendingApprovalThreadIds"
+>) {
   const groups = deriveProjectGroups(threads);
   const pinned = threads.filter((thread) => thread.isPinned);
   return (
@@ -145,6 +158,7 @@ function ProjectsView({
             <CompactThreadRow
               key={thread.id}
               onSelectThread={onSelectThread}
+              pendingApproval={pendingApprovalThreadIds.has(thread.id)}
               selected={thread.id === selectedThreadId}
               thread={thread}
             />
@@ -158,6 +172,7 @@ function ProjectsView({
             group={group}
             key={group.key}
             onSelectThread={onSelectThread}
+            pendingApprovalThreadIds={pendingApprovalThreadIds}
             selectedThreadId={selectedThreadId}
           />
         ))}
@@ -170,10 +185,12 @@ function ProjectRows({
   group,
   selectedThreadId,
   onSelectThread,
+  pendingApprovalThreadIds,
 }: {
   group: ReturnType<typeof deriveProjectGroups>[number];
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
+  pendingApprovalThreadIds: ReadonlySet<string>;
 }) {
   const [open, setOpen] = useState(true);
   const activeCount = useMemo(
@@ -205,6 +222,7 @@ function ProjectRows({
             <CompactThreadRow
               key={thread.id}
               onSelectThread={onSelectThread}
+              pendingApproval={pendingApprovalThreadIds.has(thread.id)}
               selected={thread.id === selectedThreadId}
               thread={thread}
             />
@@ -218,26 +236,33 @@ function ThreadCard({
   thread,
   selected,
   onSelectThread,
+  pendingApproval,
 }: {
   thread: Thread;
   selected: boolean;
   onSelectThread(threadId: string): void;
+  pendingApproval: boolean;
 }) {
   const content = (
     <>
       <div className="thread-card-title-row">
-        <StatusDot thread={thread} />
+        <StatusDot pendingApproval={pendingApproval} thread={thread} />
         <strong>{threadTitle(thread)}</strong>
         <time>{formatRecency(thread.updatedAt)}</time>
       </div>
       <div className="thread-card-meta">
-        <StatusPill thread={thread} />
+        <StatusPill pendingApproval={pendingApproval} thread={thread} />
         {thread.cwd.length > 0 ? <span>{projectName(thread.cwd)}</span> : null}
         {thread.modelProvider.length > 0 ? (
           <span>{thread.modelProvider}</span>
         ) : null}
       </div>
-      <p>{thread.preview || "Thread journal could not be loaded."}</p>
+      <p>
+        {thread.preview ||
+          (thread.status.type === "systemError"
+            ? "Thread journal could not be loaded."
+            : "No messages yet.")}
+      </p>
     </>
   );
   return thread.status.type === "systemError" ? (
@@ -259,15 +284,17 @@ function CompactThreadRow({
   thread,
   selected,
   onSelectThread,
+  pendingApproval,
 }: {
   thread: Thread;
   selected: boolean;
   onSelectThread(threadId: string): void;
+  pendingApproval: boolean;
 }) {
   const contents = (
     <>
       <span>{threadTitle(thread)}</span>
-      <StatusGlyph thread={thread} />
+      <StatusGlyph pendingApproval={pendingApproval} thread={thread} />
     </>
   );
   return thread.status.type === "systemError" ? (
@@ -285,24 +312,54 @@ function CompactThreadRow({
   );
 }
 
-function StatusDot({ thread }: { thread: Thread }) {
+function StatusDot({
+  thread,
+  pendingApproval,
+}: {
+  thread: Thread;
+  pendingApproval: boolean;
+}) {
   return (
-    <span className={`status-dot ${statusClass(thread)}`} aria-hidden="true" />
+    <span
+      className={`status-dot ${statusClass(thread, pendingApproval)}`}
+      aria-hidden="true"
+    />
   );
 }
 
-function StatusPill({ thread }: { thread: Thread }) {
-  const label =
-    thread.status.type === "active"
+function StatusPill({
+  thread,
+  pendingApproval,
+}: {
+  thread: Thread;
+  pendingApproval: boolean;
+}) {
+  const label = pendingApproval
+    ? "Approval needed"
+    : thread.status.type === "active"
       ? "Running"
       : thread.status.type === "systemError"
         ? "Unavailable"
         : "Complete";
-  return <span className={`status-pill ${statusClass(thread)}`}>{label}</span>;
+  return (
+    <span className={`status-pill ${statusClass(thread, pendingApproval)}`}>
+      {label}
+    </span>
+  );
 }
 
-function StatusGlyph({ thread }: { thread: Thread }) {
-  return thread.status.type === "active" ? (
+function StatusGlyph({
+  thread,
+  pendingApproval,
+}: {
+  thread: Thread;
+  pendingApproval: boolean;
+}) {
+  return pendingApproval ? (
+    <span className="status-approval" aria-label="Approval needed">
+      <Icon name="warning" size={13} />
+    </span>
+  ) : thread.status.type === "active" ? (
     <span className="mini-spinner" aria-label="Running" />
   ) : thread.status.type === "systemError" ? (
     <span className="status-warning" aria-label="Unavailable">
@@ -311,12 +368,14 @@ function StatusGlyph({ thread }: { thread: Thread }) {
   ) : null;
 }
 
-function statusClass(thread: Thread): string {
-  return thread.status.type === "active"
-    ? "active"
-    : thread.status.type === "systemError"
-      ? "error"
-      : "settled";
+function statusClass(thread: Thread, pendingApproval: boolean): string {
+  return pendingApproval
+    ? "approval"
+    : thread.status.type === "active"
+      ? "active"
+      : thread.status.type === "systemError"
+        ? "error"
+        : "settled";
 }
 
 function projectName(cwd: string): string {

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1,18 +1,27 @@
 import { useEffect, useRef, useState } from "react";
 
+import type { ApprovalDecision } from "../../main/app-server-manager.js";
 import type { Thread, ThreadItem, Turn } from "../../protocol-client/index.js";
+import type { ApprovalCardState } from "./approval-state";
 import { Icon } from "./icons";
 import { activeTurn } from "./thread-view-state";
 
 interface ThreadViewProps {
+  approvals: readonly ApprovalCardState[];
   thread: Thread;
   onInterrupt(turnId: string): Promise<void>;
+  onRespondToApproval(
+    requestId: string,
+    decision: ApprovalDecision,
+  ): Promise<void>;
   onStartTurn(text: string): Promise<void>;
 }
 
 export function ThreadView({
+  approvals,
   thread,
   onInterrupt,
+  onRespondToApproval,
   onStartTurn,
 }: ThreadViewProps) {
   const [draft, setDraft] = useState("");
@@ -69,7 +78,15 @@ export function ThreadView({
             </div>
           ) : (
             thread.turns.map((turn, index) => (
-              <TurnBlock index={index} key={turn.id} turn={turn} />
+              <TurnBlock
+                approvals={approvals.filter(
+                  (approval) => approval.params.turnId === turn.id,
+                )}
+                index={index}
+                key={turn.id}
+                onRespondToApproval={onRespondToApproval}
+                turn={turn}
+              />
             ))
           )}
         </div>
@@ -129,7 +146,20 @@ export function ThreadView({
   );
 }
 
-function TurnBlock({ turn, index }: { turn: Turn; index: number }) {
+function TurnBlock({
+  turn,
+  index,
+  approvals,
+  onRespondToApproval,
+}: {
+  turn: Turn;
+  index: number;
+  approvals: readonly ApprovalCardState[];
+  onRespondToApproval(
+    requestId: string,
+    decision: ApprovalDecision,
+  ): Promise<void>;
+}) {
   return (
     <section
       className={`turn-block ${turn.status}`}
@@ -140,7 +170,18 @@ function TurnBlock({ turn, index }: { turn: Turn; index: number }) {
         <span>{turnLabel(turn)}</span>
       </div>
       {turn.items.map((item) => (
-        <ItemView item={item} key={item.id} />
+        <div key={item.id}>
+          <ItemView item={item} />
+          {approvals
+            .filter((approval) => approval.params.itemId === item.id)
+            .map((approval) => (
+              <ApprovalCard
+                approval={approval}
+                key={approval.requestId}
+                onRespond={onRespondToApproval}
+              />
+            ))}
+        </div>
       ))}
       {turn.error === null ? null : (
         <div className="turn-error" role="alert">
@@ -149,6 +190,105 @@ function TurnBlock({ turn, index }: { turn: Turn; index: number }) {
       )}
     </section>
   );
+}
+
+function ApprovalCard({
+  approval,
+  onRespond,
+}: {
+  approval: ApprovalCardState;
+  onRespond(requestId: string, decision: ApprovalDecision): Promise<void>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const respond = async (decision: "accept" | "decline") => {
+    setError(null);
+    try {
+      await onRespond(approval.requestId, decision);
+    } catch (requestError) {
+      setError(describeError(requestError));
+    }
+  };
+  return (
+    <article className={`approval-card ${approval.status}`}>
+      <header>
+        <span className="approval-icon" aria-hidden="true">
+          <Icon name="warning" size={14} />
+        </span>
+        <div>
+          <strong>Command needs approval</strong>
+          <span>Review what Zen is asking to run.</span>
+        </div>
+      </header>
+      <dl>
+        <div>
+          <dt>Command</dt>
+          <dd>
+            <code>{approval.params.command}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Working directory</dt>
+          <dd>{approval.params.cwd}</dd>
+        </div>
+      </dl>
+      {error === null ? null : (
+        <p className="approval-error" role="alert">
+          {error}
+        </p>
+      )}
+      {approval.status === "pending" ? (
+        <div className="approval-actions">
+          <button
+            className="approval-decline"
+            type="button"
+            onClick={() => void respond("decline")}
+          >
+            Do not run it
+          </button>
+          <button
+            className="approval-accept"
+            type="button"
+            onClick={() => void respond("accept")}
+          >
+            Run this command
+          </button>
+        </div>
+      ) : approval.status === "responding" ? (
+        <p className="approval-result" aria-live="polite">
+          Sending {approval.decision === "accept" ? "approval" : "refusal"}…
+        </p>
+      ) : (
+        <p className={`approval-result ${approvalResultClass(approval)}`}>
+          <Icon
+            name={approval.decision === "accept" ? "check" : "warning"}
+            size={13}
+          />
+          {approvalResultLabel(approval)}
+        </p>
+      )}
+    </article>
+  );
+}
+
+function approvalResultClass(approval: ApprovalCardState): string {
+  return approval.decision === "accept" ||
+    approval.decision === "acceptForSession"
+    ? "accepted"
+    : "not-run";
+}
+
+function approvalResultLabel(approval: ApprovalCardState): string {
+  switch (approval.decision) {
+    case "accept":
+      return "Approved — the command may run.";
+    case "acceptForSession":
+      return "Approved for this session.";
+    case "decline":
+      return "Declined — the command was not run.";
+    case "cancel":
+    case null:
+      return "Resolved without running the command.";
+  }
 }
 
 function ItemView({ item }: { item: ThreadItem }) {

--- a/apps/zenx/src/renderer/src/approval-state.ts
+++ b/apps/zenx/src/renderer/src/approval-state.ts
@@ -1,0 +1,68 @@
+import type {
+  ApprovalDecision,
+  ApprovalRequestEvent,
+  ApprovalResolvedEvent,
+} from "../../main/app-server-manager.js";
+
+export interface ApprovalCardState extends ApprovalRequestEvent {
+  status: "pending" | "responding" | "resolved";
+  decision: ApprovalDecision | null;
+}
+
+export function addApprovalRequest(
+  approvals: readonly ApprovalCardState[],
+  event: ApprovalRequestEvent,
+): ApprovalCardState[] {
+  if (approvals.some((approval) => approval.requestId === event.requestId)) {
+    return [...approvals];
+  }
+  return [...approvals, { ...event, status: "pending", decision: null }];
+}
+
+export function markApprovalResponding(
+  approvals: readonly ApprovalCardState[],
+  requestId: string,
+  decision: ApprovalDecision,
+): ApprovalCardState[] {
+  return approvals.map((approval) =>
+    approval.requestId === requestId && approval.status === "pending"
+      ? { ...approval, status: "responding", decision }
+      : approval,
+  );
+}
+
+export function restoreApprovalPending(
+  approvals: readonly ApprovalCardState[],
+  requestId: string,
+): ApprovalCardState[] {
+  return approvals.map((approval) =>
+    approval.requestId === requestId && approval.status === "responding"
+      ? { ...approval, status: "pending", decision: null }
+      : approval,
+  );
+}
+
+export function resolveApproval(
+  approvals: readonly ApprovalCardState[],
+  event: ApprovalResolvedEvent,
+): ApprovalCardState[] {
+  return approvals.map((approval) =>
+    approval.requestId === event.requestId
+      ? {
+          ...approval,
+          status: "resolved",
+          decision: event.decision,
+        }
+      : approval,
+  );
+}
+
+export function pendingApprovalThreadIds(
+  approvals: readonly ApprovalCardState[],
+): Set<string> {
+  return new Set(
+    approvals
+      .filter((approval) => approval.status !== "resolved")
+      .map((approval) => approval.params.threadId),
+  );
+}

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -1,5 +1,10 @@
 import type { AppServerHostStatus } from "../../main/app-server-manager.js";
 import type {
+  ApprovalDecision,
+  ApprovalRequestEvent,
+  ApprovalResolvedEvent,
+} from "../../main/app-server-manager.js";
+import type {
   ClientRequestMethod,
   ClientRequestParams,
   ClientRequestResults,
@@ -13,10 +18,21 @@ declare global {
       platform: NodeJS.Platform;
       protocol: {
         getStatus(): Promise<AppServerHostStatus>;
+        getPendingApprovals(): Promise<ApprovalRequestEvent[]>;
         request<M extends ClientRequestMethod>(
           method: M,
           params: ClientRequestParams[M],
         ): Promise<ClientRequestResults[M]>;
+        respondToApproval(
+          requestId: string,
+          decision: ApprovalDecision,
+        ): Promise<void>;
+        onApprovalRequest(
+          listener: (event: ApprovalRequestEvent) => void,
+        ): () => void;
+        onApprovalResolved(
+          listener: (event: ApprovalResolvedEvent) => void,
+        ): () => void;
         onStatus(listener: (status: AppServerHostStatus) => void): () => void;
         onNotification(
           listener: <M extends ServerNotificationMethod>(

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -14,6 +14,8 @@
   --color-blue-strong: #7bb5f8;
   --color-blue-dim: rgba(98, 168, 250, 0.12);
   --color-red: #f0716f;
+  --color-amber: #f4b860;
+  --color-amber-dim: rgba(244, 184, 96, 0.12);
   --color-green: #46d17e;
   --color-green-dim: rgba(70, 209, 126, 0.12);
   --color-red-dim: rgba(240, 113, 111, 0.1);
@@ -344,6 +346,11 @@ summary:focus-visible {
   background: var(--color-red);
 }
 
+.status-dot.approval {
+  background: var(--color-amber);
+  box-shadow: 0 0 0 3px var(--color-amber-dim);
+}
+
 .status-pill {
   padding: 1.5px 8px;
   border-radius: 999px;
@@ -365,6 +372,11 @@ summary:focus-visible {
 .status-pill.error {
   color: var(--color-red);
   background: var(--color-red-dim);
+}
+
+.status-pill.approval {
+  color: var(--color-amber);
+  background: var(--color-amber-dim);
 }
 
 .watching-placeholder {
@@ -458,6 +470,12 @@ summary:focus-visible {
   display: inline-flex;
   flex: none;
   color: var(--color-red);
+}
+
+.status-approval {
+  display: inline-flex;
+  flex: none;
+  color: var(--color-amber);
 }
 
 @keyframes status-pulse {
@@ -821,6 +839,148 @@ summary:focus-visible {
   font-size: 11.5px;
   line-height: 1.55;
   white-space: pre-wrap;
+}
+
+.approval-card {
+  margin: -12px 0 24px 33px;
+  padding: 13px;
+  border: 1px solid rgba(244, 184, 96, 0.38);
+  border-radius: var(--radius-md);
+  background: linear-gradient(
+    135deg,
+    rgba(244, 184, 96, 0.11),
+    var(--color-panel-raised) 58%
+  );
+}
+
+.approval-card.resolved {
+  border-color: var(--color-border);
+  background: var(--color-panel-raised);
+}
+
+.approval-card header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.approval-icon {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  place-items: center;
+  border-radius: 8px;
+  color: var(--color-amber);
+  background: var(--color-amber-dim);
+}
+
+.approval-card header > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+}
+
+.approval-card header strong {
+  font-size: var(--font-size-body);
+  font-weight: 650;
+}
+
+.approval-card header span,
+.approval-card dt {
+  color: var(--color-text-subtle);
+  font-size: var(--font-size-xs);
+}
+
+.approval-card dl {
+  display: grid;
+  gap: 8px;
+  margin: 13px 0;
+}
+
+.approval-card dl > div {
+  display: grid;
+  grid-template-columns: 108px minmax(0, 1fr);
+  align-items: baseline;
+  gap: 10px;
+}
+
+.approval-card dd {
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.approval-card code {
+  color: var(--color-text);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  font-size: 11.5px;
+}
+
+.approval-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding-top: 2px;
+}
+
+.approval-actions button {
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 7px;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  font-weight: 650;
+  transition:
+    filter var(--duration-ui),
+    background var(--duration-ui),
+    border-color var(--duration-ui);
+}
+
+.approval-decline {
+  color: #f4a09e;
+  background: rgba(240, 113, 111, 0.09);
+}
+
+.approval-decline:hover {
+  border-color: rgba(240, 113, 111, 0.45);
+  background: rgba(240, 113, 111, 0.15);
+}
+
+.approval-accept {
+  color: #211606;
+  border-color: var(--color-amber) !important;
+  background: var(--color-amber);
+}
+
+.approval-accept:hover {
+  filter: brightness(1.08);
+}
+
+.approval-result,
+.approval-error {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 10px 0 0;
+  font-size: var(--font-size-sm);
+}
+
+.approval-result {
+  color: var(--color-amber);
+}
+
+.approval-result.accepted {
+  color: var(--color-green);
+}
+
+.approval-result.not-run,
+.approval-error {
+  color: #f4a09e;
 }
 
 .turn-error {

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -40,23 +40,36 @@ export function writeSidebarMode(
 
 export function deriveInboxSections(
   threads: readonly Thread[],
+  pendingApprovalThreadIds: ReadonlySet<string> = new Set(),
 ): InboxSection[] {
   const sorted = sortByRecency(threads);
   return [
     {
       key: "needs",
       label: "Needs you",
-      threads: sorted.filter((thread) => thread.status.type === "systemError"),
+      threads: sorted.filter(
+        (thread) =>
+          thread.status.type === "systemError" ||
+          pendingApprovalThreadIds.has(thread.id),
+      ),
     },
     {
       key: "active",
       label: "In progress",
-      threads: sorted.filter((thread) => thread.status.type === "active"),
+      threads: sorted.filter(
+        (thread) =>
+          thread.status.type === "active" &&
+          !pendingApprovalThreadIds.has(thread.id),
+      ),
     },
     {
       key: "settled",
       label: "Completed",
-      threads: sorted.filter((thread) => thread.status.type === "idle"),
+      threads: sorted.filter(
+        (thread) =>
+          thread.status.type === "idle" &&
+          !pendingApprovalThreadIds.has(thread.id),
+      ),
     },
   ];
 }
@@ -116,6 +129,18 @@ export function applyThreadNotification(
             status: { type: "active" as const, activeFlags: [] },
             updatedAt: nowSeconds,
           }
+        : thread,
+    );
+  }
+  if (method === "item/completed") {
+    const event = params as ServerNotificationParams["item/completed"];
+    if (event.item.type !== "userMessage") return [...threads];
+    const preview = event.item.content
+      .map((content) => content.text)
+      .join("\n");
+    return threads.map((thread) =>
+      thread.id === event.threadId && thread.status.type !== "systemError"
+        ? { ...thread, preview, updatedAt: nowSeconds }
         : thread,
     );
   }

--- a/apps/zenx/test/approval-flow.test.ts
+++ b/apps/zenx/test/approval-flow.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  AppServerManager,
+  type ApprovalRequestEvent,
+  type ApprovalResolvedEvent,
+} from "../src/main/app-server-manager.js";
+
+test("broadcasts approval state to two renderer clients and completes both decisions", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-approval-"));
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "always",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+  try {
+    await manager.start();
+    const firstRequests: ApprovalRequestEvent[] = [];
+    const secondRequests: ApprovalRequestEvent[] = [];
+    const firstResolved: ApprovalResolvedEvent[] = [];
+    const secondResolved: ApprovalResolvedEvent[] = [];
+    const approvalSeen = deferred<void>();
+    const approvalResolved = deferred<void>();
+    const turnCompleted = deferred<void>();
+    const outputDeltas: string[] = [];
+    manager.onApprovalRequest((event) => {
+      firstRequests.push(event);
+      approvalSeen.resolve();
+    });
+    manager.onApprovalRequest((event) => secondRequests.push(event));
+    manager.onApprovalResolved((event) => {
+      firstResolved.push(event);
+      approvalResolved.resolve();
+    });
+    manager.onApprovalResolved((event) => secondResolved.push(event));
+    manager.onNotification((method, params) => {
+      if (method === "item/commandExecution/outputDelta") {
+        outputDeltas.push((params as { delta: string }).delta);
+      }
+      if (method === "turn/completed") turnCompleted.resolve();
+    });
+
+    const started = await manager.request("thread/start", {
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+    });
+    await manager.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "!shell printf zenx-approved" }],
+    });
+    await within(approvalSeen.promise);
+    assert.deepEqual(secondRequests, firstRequests);
+    assert.deepEqual(manager.pendingApprovalRequests, firstRequests);
+
+    const request = firstRequests[0];
+    assert(request !== undefined);
+    manager.respondToApproval(request.requestId, "accept");
+    assert.throws(
+      () => manager.respondToApproval(request.requestId, "decline"),
+      /already has a response|no longer pending/u,
+    );
+    await within(
+      Promise.all([approvalResolved.promise, turnCompleted.promise]),
+    );
+
+    assert.deepEqual(secondResolved, firstResolved);
+    assert.equal(firstResolved[0]?.decision, "accept");
+    assert.equal(outputDeltas.join(""), "zenx-approved");
+
+    const declineSeen = deferred<void>();
+    const declineResolved = deferred<void>();
+    const declineCompleted = deferred<void>();
+    const disposeRequest = manager.onApprovalRequest(() =>
+      declineSeen.resolve(),
+    );
+    const disposeResolved = manager.onApprovalResolved((event) => {
+      if (event.requestId !== request.requestId) declineResolved.resolve();
+    });
+    const disposeNotifications = manager.onNotification((method) => {
+      if (method === "turn/completed") declineCompleted.resolve();
+    });
+    await manager.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "!shell printf must-not-run" }],
+    });
+    await within(declineSeen.promise);
+    const decline = manager.pendingApprovalRequests[0];
+    assert(decline !== undefined);
+    manager.respondToApproval(decline.requestId, "decline");
+    await within(
+      Promise.all([declineResolved.promise, declineCompleted.promise]),
+    );
+    disposeRequest();
+    disposeResolved();
+    disposeNotifications();
+
+    const read = await manager.request("thread/read", {
+      threadId: started.thread.id,
+      includeTurns: true,
+    });
+    const commands = read.thread.turns.flatMap((turn) =>
+      turn.items.filter((item) => item.type === "commandExecution"),
+    );
+    assert.deepEqual(
+      commands.map((command) => command.status),
+      ["completed", "declined"],
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function within<T>(promise: Promise<T>, milliseconds = 10_000) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Timed out waiting for approval flow")),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/apps/zenx/test/approval-state.test.ts
+++ b/apps/zenx/test/approval-state.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ApprovalRequestEvent,
+  ApprovalResolvedEvent,
+} from "../src/main/app-server-manager.js";
+import {
+  addApprovalRequest,
+  markApprovalResponding,
+  pendingApprovalThreadIds,
+  resolveApproval,
+  restoreApprovalPending,
+} from "../src/renderer/src/approval-state.js";
+
+test("keeps approval interaction transient and resolves the same card", () => {
+  const request: ApprovalRequestEvent = {
+    requestId: "approval_1",
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      startedAtMs: 10,
+      environmentId: null,
+      reason: null,
+      command: "printf zenx",
+      cwd: "/workspace",
+      commandActions: [],
+      proposedExecpolicyAmendment: null,
+      networkApprovalContext: null,
+      proposedNetworkPolicyAmendments: null,
+    },
+  };
+  const pending = addApprovalRequest([], request);
+  assert.deepEqual([...pendingApprovalThreadIds(pending)], ["thread-1"]);
+  const responding = markApprovalResponding(
+    pending,
+    request.requestId,
+    "accept",
+  );
+  assert.equal(responding[0]?.status, "responding");
+  assert.equal(responding[0]?.decision, "accept");
+
+  const restored = restoreApprovalPending(responding, request.requestId);
+  assert.equal(restored[0]?.status, "pending");
+  const resolvedEvent: ApprovalResolvedEvent = {
+    requestId: request.requestId,
+    threadId: request.params.threadId,
+    decision: "decline",
+  };
+  const resolved = resolveApproval(restored, resolvedEvent);
+  assert.equal(resolved[0]?.status, "resolved");
+  assert.equal(resolved[0]?.decision, "decline");
+  assert.equal(pendingApprovalThreadIds(resolved).size, 0);
+});

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -47,6 +47,25 @@ test("derives recency-first inbox groups and preserves system errors", () => {
   assert.match(threadTitle(unavailable), /Unavailable thread/u);
 });
 
+test("moves active approval threads to Needs you without duplicating them", () => {
+  const pending = makeThread("pending", 40, {
+    type: "active",
+    activeFlags: [],
+  });
+  const active = makeThread("active", 30, {
+    type: "active",
+    activeFlags: [],
+  });
+  const sections = deriveInboxSections(
+    [active, pending],
+    new Set([pending.id]),
+  );
+  assert.deepEqual(
+    sections.map((section) => section.threads.map((thread) => thread.id)),
+    [["pending"], ["active"], []],
+  );
+});
+
 test("derives project groups only from cwd and isolates unavailable journals", () => {
   const zen = makeThread("zen", 20, { type: "idle" }, "/work/zen");
   const nested = makeThread("nested", 10, { type: "idle" }, "/tmp/zen");
@@ -84,8 +103,25 @@ test("applies name and turn lifecycle notifications without altering errors", ()
     30,
   );
   assert.equal(active[0]?.status.type, "active");
-  const settled = applyThreadNotification(
+  const previewed = applyThreadNotification(
     active,
+    "item/completed",
+    {
+      threadId: idle.id,
+      turnId: "turn",
+      item: {
+        type: "userMessage",
+        id: "message",
+        clientId: null,
+        content: [{ type: "text", text: "Newest prompt", text_elements: [] }],
+      },
+      completedAtMs: 35_000,
+    },
+    35,
+  );
+  assert.equal(previewed[0]?.preview, "Newest prompt");
+  const settled = applyThreadNotification(
+    previewed,
     "turn/completed",
     { threadId: idle.id, turn: makeTurn("turn", "completed") },
     40,


### PR DESCRIPTION
## Summary
- bridge the existing command-approval server request through main/preload IPC without adding protocol methods or persistent state
- render command/cwd approval cards with explicit run/do-not-run actions and resolve them only after `serverRequest/resolved`
- move pending threads into Needs you with an amber marker, then restore their lifecycle group after resolution
- broadcast one App Server client request to every open ZenX renderer so either window can answer and all windows resolve together
- fix the production sandboxed preload output to CommonJS after CDP QA exposed the previous blank-window `.mjs` load failure

## Code-aligned acceptance note
Zen scopes a server request to the connection that started the turn. To keep Zen Core and the wire protocol unchanged, the two-client acceptance is covered as two renderer clients sharing ZenX main's owning protocol connection; the real request ID and `serverRequest/resolved` notification still drive the state.

## Validation
- `npm run check --workspace apps/zenx` (19 tests)
- `npm run check` (79 Node + 42 IMZen tests)
- production Electron via CDP: create thread → shell approval card → approve → streamed output → resolved card/turn

Closes #8