### PR TITLE
ZenX: mirror authoritative thread model settings

### DIFF
--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   AppServerHostStatus,
   ApprovalDecision,
 } from "../../main/app-server-manager.js";
-import type { Thread } from "../../protocol-client/index.js";
+import type {
+  ModelSummary,
+  ServerNotificationParams,
+  Thread,
+} from "../../protocol-client/index.js";
 import { Icon } from "./icons";
 import { Sidebar } from "./Sidebar";
 import { ThreadView } from "./ThreadView";
+import { ModelSelector } from "./ModelSelector";
 import {
   addApprovalRequest,
   markApprovalResponding,
@@ -15,6 +20,13 @@ import {
   restoreApprovalPending,
   type ApprovalCardState,
 } from "./approval-state";
+import {
+  applySettingsMirror,
+  canChangeThreadModel,
+  settingsFromSnapshot,
+  validateModelCatalog,
+  type SelectedThreadSettings,
+} from "./model-settings";
 import {
   applyThreadNotification,
   readSidebarMode,
@@ -25,6 +37,7 @@ import {
 import { applyThreadViewNotification } from "./thread-view-state";
 
 export function App() {
+  const selectionEpoch = useRef(0);
   const [railOpen, setRailOpen] = useState(true);
   const [serverStatus, setServerStatus] = useState<AppServerHostStatus>({
     type: "starting",
@@ -35,6 +48,14 @@ export function App() {
   const [threadLoading, setThreadLoading] = useState(false);
   const [threadError, setThreadError] = useState<string | null>(null);
   const [approvals, setApprovals] = useState<ApprovalCardState[]>([]);
+  const [models, setModels] = useState<ModelSummary[]>([]);
+  const [modelCatalogError, setModelCatalogError] = useState<string | null>(
+    null,
+  );
+  const [selectedSettings, setSelectedSettings] =
+    useState<SelectedThreadSettings | null>(null);
+  const [switchingModel, setSwitchingModel] = useState(false);
+  const [modelUpdateError, setModelUpdateError] = useState<string | null>(null);
   const [sidebarMode, setSidebarMode] = useState<SidebarMode>(() => {
     try {
       return readSidebarMode(window.localStorage);
@@ -61,10 +82,25 @@ export function App() {
         }
       }
     };
+    const loadModels = async () => {
+      try {
+        const result = await window.zenx.protocol.request("model/list", {});
+        validateModelCatalog(result.data);
+        if (active) {
+          setModels(result.data);
+          setModelCatalogError(null);
+        }
+      } catch (error) {
+        if (active) setModelCatalogError(describeError(error));
+      }
+    };
     const dispose = window.zenx.protocol.onStatus((status) => {
       if (!active) return;
       setServerStatus(status);
-      if (status.type === "ready") void loadThreads();
+      if (status.type === "ready") {
+        void loadThreads();
+        void loadModels();
+      }
     });
     const disposeNotifications = window.zenx.protocol.onNotification(
       (method, params) => {
@@ -77,6 +113,18 @@ export function App() {
               ? null
               : applyThreadViewNotification(current, method, params),
           );
+          if (method === "thread/settings/updated") {
+            const event =
+              params as ServerNotificationParams["thread/settings/updated"];
+            setSelectedSettings((current) =>
+              applySettingsMirror(
+                current,
+                event.threadId,
+                event.threadSettings,
+              ),
+            );
+            setModelUpdateError(null);
+          }
         }
       },
     );
@@ -102,7 +150,10 @@ export function App() {
       .then((status) => {
         if (!active) return;
         setServerStatus(status);
-        if (status.type === "ready") void loadThreads();
+        if (status.type === "ready") {
+          void loadThreads();
+          void loadModels();
+        }
       })
       .catch((error: unknown) => {
         if (active) {
@@ -127,38 +178,51 @@ export function App() {
   const pendingThreadIds = pendingApprovalThreadIds(approvals);
 
   const selectThread = async (threadId: string) => {
+    const epoch = ++selectionEpoch.current;
     setSelectedThreadId(threadId);
     setThreadDetail(null);
+    setSelectedSettings(null);
+    setModelUpdateError(null);
     setThreadLoading(true);
     setThreadError(null);
     try {
       const result = await window.zenx.protocol.request("thread/resume", {
         threadId,
       });
+      if (selectionEpoch.current !== epoch) return;
       setThreadDetail(result.thread);
+      setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
     } catch (error) {
-      setThreadError(describeError(error));
+      if (selectionEpoch.current === epoch) {
+        setThreadError(describeError(error));
+      }
     } finally {
-      setThreadLoading(false);
+      if (selectionEpoch.current === epoch) setThreadLoading(false);
     }
   };
 
   const newThread = async () => {
+    const epoch = ++selectionEpoch.current;
     setThreadLoading(true);
     setThreadError(null);
+    setModelUpdateError(null);
     try {
       const result = await window.zenx.protocol.request("thread/start", {});
+      if (selectionEpoch.current !== epoch) return;
       setSelectedThreadId(result.thread.id);
       setThreadDetail(result.thread);
+      setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
       setThreads((current) =>
         applyThreadNotification(current, "thread/started", {
           thread: result.thread,
         }),
       );
     } catch (error) {
-      setThreadError(describeError(error));
+      if (selectionEpoch.current === epoch) {
+        setThreadError(describeError(error));
+      }
     } finally {
-      setThreadLoading(false);
+      if (selectionEpoch.current === epoch) setThreadLoading(false);
     }
   };
 
@@ -190,6 +254,31 @@ export function App() {
     } catch (error) {
       setApprovals((current) => restoreApprovalPending(current, requestId));
       throw error;
+    }
+  };
+  const changeModel = async (model: string) => {
+    if (
+      threadDetail === null ||
+      selectedSettings === null ||
+      model === selectedSettings.model
+    ) {
+      return;
+    }
+    if (!canChangeThreadModel(threadDetail)) {
+      setModelUpdateError("Wait for the current turn to finish.");
+      return;
+    }
+    setSwitchingModel(true);
+    setModelUpdateError(null);
+    try {
+      await window.zenx.protocol.request("thread/settings/update", {
+        threadId: threadDetail.id,
+        model,
+      });
+    } catch (error) {
+      setModelUpdateError(describeError(error));
+    } finally {
+      setSwitchingModel(false);
     }
   };
   const changeSidebarMode = (mode: SidebarMode) => {
@@ -225,9 +314,21 @@ export function App() {
             <p>
               {selectedThread === null
                 ? "Select a thread or create a new one."
-                : `${selectedThread.cwd} · ${selectedThread.modelProvider}`}
+                : `${selectedThread.cwd} · ${selectedSettings?.model ?? selectedThread.modelProvider}`}
             </p>
           </div>
+          {selectedSettings === null ? null : (
+            <ModelSelector
+              disabled={
+                threadDetail === null || !canChangeThreadModel(threadDetail)
+              }
+              error={modelUpdateError ?? modelCatalogError}
+              models={models}
+              onChange={(model) => void changeModel(model)}
+              selectedModel={selectedSettings.model}
+              switching={switchingModel}
+            />
+          )}
           <button
             className={`toolbar-button${railOpen ? " active" : ""}`}
             type="button"

--- a/apps/zenx/src/renderer/src/ModelSelector.tsx
+++ b/apps/zenx/src/renderer/src/ModelSelector.tsx
@@ -1,0 +1,47 @@
+import type { ModelSummary } from "../../protocol-client/index.js";
+import { modelOptions } from "./model-settings";
+
+interface ModelSelectorProps {
+  disabled: boolean;
+  error: string | null;
+  models: readonly ModelSummary[];
+  onChange(model: string): void;
+  selectedModel: string;
+  switching: boolean;
+}
+
+export function ModelSelector({
+  disabled,
+  error,
+  models,
+  onChange,
+  selectedModel,
+  switching,
+}: ModelSelectorProps) {
+  const options = modelOptions(models, selectedModel);
+  return (
+    <div className="model-control">
+      <label htmlFor="thread-model">Model</label>
+      <select
+        aria-describedby={error === null ? undefined : "model-error"}
+        disabled={disabled || switching}
+        id="thread-model"
+        onChange={(event) => onChange(event.target.value)}
+        value={selectedModel}
+      >
+        {options.map((model) => (
+          <option disabled={model.unavailable} key={model.id} value={model.id}>
+            {model.displayName}
+            {model.isDefault ? " · Default" : ""}
+            {model.unavailable ? " · Unavailable" : ""}
+          </option>
+        ))}
+      </select>
+      {error === null ? null : (
+        <span id="model-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/zenx/src/renderer/src/model-settings.ts
+++ b/apps/zenx/src/renderer/src/model-settings.ts
@@ -1,0 +1,84 @@
+import type {
+  ModelSummary,
+  ThreadSettingsSnapshot,
+  UpdatedThreadSettings,
+  Thread,
+} from "../../protocol-client/index.js";
+
+export interface SelectedThreadSettings {
+  threadId: string;
+  model: string;
+  modelProvider: string;
+}
+
+export function canChangeThreadModel(thread: Thread): boolean {
+  return !thread.turns.some((turn) => turn.status === "inProgress");
+}
+
+export function settingsFromSnapshot(
+  threadId: string,
+  snapshot: ThreadSettingsSnapshot,
+): SelectedThreadSettings {
+  return {
+    threadId,
+    model: snapshot.model,
+    modelProvider: snapshot.modelProvider,
+  };
+}
+
+export function applySettingsMirror(
+  current: SelectedThreadSettings | null,
+  threadId: string,
+  settings: UpdatedThreadSettings,
+): SelectedThreadSettings | null {
+  return current?.threadId === threadId
+    ? {
+        threadId,
+        model: settings.model,
+        modelProvider: settings.modelProvider,
+      }
+    : current;
+}
+
+export function validateModelCatalog(models: readonly ModelSummary[]): void {
+  const defaults = models.filter((model) => model.isDefault);
+  if (defaults.length !== 1 || defaults[0]?.hidden === true) {
+    throw new Error("App Server must expose exactly one visible default model");
+  }
+}
+
+export function modelOptions(
+  models: readonly ModelSummary[],
+  selectedModel: string,
+): Array<ModelSummary & { unavailable: boolean }> {
+  const visible = models
+    .filter((model) => !model.hidden)
+    .map((model) => ({ ...model, unavailable: false }));
+  if (visible.some((model) => model.id === selectedModel)) return visible;
+  const selected = models.find((model) => model.id === selectedModel);
+  if (selected === undefined) {
+    return [
+      ...visible,
+      {
+        id: selectedModel,
+        model: selectedModel,
+        upgrade: null,
+        upgradeInfo: null,
+        availabilityNux: null,
+        displayName: selectedModel,
+        description: "Configured by the App Server",
+        hidden: true,
+        supportedReasoningEfforts: [],
+        defaultReasoningEffort: "medium",
+        inputModalities: ["text"],
+        supportsPersonality: false,
+        additionalSpeedTiers: [],
+        serviceTiers: [],
+        defaultServiceTier: null,
+        isDefault: false,
+        unavailable: true,
+      },
+    ];
+  }
+  return [...visible, { ...selected, unavailable: true }];
+}

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -73,6 +73,7 @@ button:focus-visible {
 }
 
 textarea:focus-visible,
+select:focus-visible,
 summary:focus-visible {
   outline: 2px solid var(--color-focus);
   outline-offset: 2px;
@@ -518,6 +519,63 @@ summary:focus-visible {
   margin: 1px 0 0;
   color: var(--color-text-subtle);
   font-size: 11.5px;
+}
+
+.model-control {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.model-control label {
+  color: var(--color-text-faint);
+  font-size: 10.5px;
+  font-weight: 650;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+}
+
+.model-control select {
+  max-width: 190px;
+  min-height: 30px;
+  padding: 4px 28px 4px 9px;
+  border: 1px solid var(--color-border-soft);
+  border-radius: 8px;
+  color: var(--color-text-muted);
+  background: var(--color-panel-raised);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition:
+    color var(--duration-ui),
+    border-color var(--duration-ui),
+    opacity var(--duration-ui);
+}
+
+.model-control select:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.model-control select:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+}
+
+.model-control > span {
+  position: absolute;
+  top: 34px;
+  right: 0;
+  z-index: 2;
+  width: max-content;
+  max-width: 280px;
+  padding: 5px 8px;
+  border: 1px solid rgba(240, 113, 111, 0.32);
+  border-radius: var(--radius-sm);
+  color: #f4a09e;
+  background: var(--color-panel-raised);
+  font-size: var(--font-size-xs);
 }
 
 .toolbar-button {

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -120,6 +120,19 @@ export function applyThreadNotification(
         : thread,
     );
   }
+  if (method === "thread/settings/updated") {
+    const update =
+      params as ServerNotificationParams["thread/settings/updated"];
+    return threads.map((thread) =>
+      thread.id === update.threadId && thread.status.type !== "systemError"
+        ? {
+            ...thread,
+            modelProvider: update.threadSettings.modelProvider,
+            updatedAt: nowSeconds,
+          }
+        : thread,
+    );
+  }
   if (method === "turn/started") {
     const event = params as ServerNotificationParams["turn/started"];
     return threads.map((thread) =>

--- a/apps/zenx/src/renderer/src/thread-view-state.ts
+++ b/apps/zenx/src/renderer/src/thread-view-state.ts
@@ -18,6 +18,16 @@ export function applyThreadViewNotification(
       ? { ...thread, name: event.threadName, updatedAt: nowSeconds }
       : thread;
   }
+  if (method === "thread/settings/updated") {
+    const event = params as ServerNotificationParams["thread/settings/updated"];
+    return event.threadId === thread.id
+      ? {
+          ...thread,
+          modelProvider: event.threadSettings.modelProvider,
+          updatedAt: nowSeconds,
+        }
+      : thread;
+  }
   if (method === "turn/started") {
     const event = params as ServerNotificationParams["turn/started"];
     return event.threadId === thread.id

--- a/apps/zenx/test/model-settings.test.ts
+++ b/apps/zenx/test/model-settings.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ModelSummary,
+  Thread,
+  ThreadSettingsSnapshot,
+  UpdatedThreadSettings,
+} from "../src/protocol-client/index.js";
+import {
+  applySettingsMirror,
+  canChangeThreadModel,
+  modelOptions,
+  settingsFromSnapshot,
+  validateModelCatalog,
+} from "../src/renderer/src/model-settings.js";
+
+test("shows only visible models while preserving a hidden authoritative value", () => {
+  const visible = model("visible", { isDefault: true });
+  const hidden = model("hidden", { hidden: true });
+  validateModelCatalog([visible, hidden]);
+  assert.deepEqual(
+    modelOptions([visible, hidden], visible.id).map((entry) => entry.id),
+    [visible.id],
+  );
+  assert.deepEqual(
+    modelOptions([visible, hidden], hidden.id).map((entry) => [
+      entry.id,
+      entry.unavailable,
+    ]),
+    [
+      [visible.id, false],
+      [hidden.id, true],
+    ],
+  );
+  assert.throws(
+    () => validateModelCatalog([model("one"), model("two")]),
+    /exactly one visible default/u,
+  );
+});
+
+test("initializes from resume, mirrors only ZAS events, and blocks active turns", () => {
+  const snapshot = settingsSnapshot("model-a");
+  const selected = settingsFromSnapshot("thread-1", snapshot);
+  assert.equal(selected.model, "model-a");
+  const ignored = applySettingsMirror(
+    selected,
+    "thread-2",
+    updatedSettings("model-b"),
+  );
+  assert.equal(ignored, selected);
+  const mirrored = applySettingsMirror(
+    selected,
+    "thread-1",
+    updatedSettings("model-b"),
+  );
+  assert.equal(mirrored?.model, "model-b");
+
+  const idle = makeThread("completed");
+  const active = makeThread("inProgress");
+  assert.equal(canChangeThreadModel(idle), true);
+  assert.equal(canChangeThreadModel(active), false);
+});
+
+function model(
+  id: string,
+  overrides: Partial<ModelSummary> = {},
+): ModelSummary {
+  return {
+    id,
+    model: id,
+    upgrade: null,
+    upgradeInfo: null,
+    availabilityNux: null,
+    displayName: id,
+    description: id,
+    hidden: false,
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: "medium",
+    inputModalities: ["text"],
+    supportsPersonality: false,
+    additionalSpeedTiers: [],
+    serviceTiers: [],
+    defaultServiceTier: null,
+    isDefault: false,
+    ...overrides,
+  };
+}
+
+function settingsSnapshot(modelId: string): ThreadSettingsSnapshot {
+  return {
+    model: modelId,
+    modelProvider: "fake",
+    serviceTier: null,
+    cwd: "/workspace",
+    instructionSources: [],
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+    reasoningEffort: null,
+  };
+}
+
+function updatedSettings(modelId: string): UpdatedThreadSettings {
+  return {
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    collaborationMode: {
+      mode: "default",
+      settings: { model: modelId, reasoning_effort: "medium" },
+    },
+    cwd: "/workspace",
+    effort: null,
+    model: modelId,
+    modelProvider: "fake",
+    personality: null,
+    sandboxPolicy: { type: "dangerFullAccess" },
+    serviceTier: null,
+    summary: null,
+  };
+}
+
+function makeThread(status: "completed" | "inProgress"): Thread {
+  return {
+    id: "thread-1",
+    sessionId: "thread-1",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "fake",
+    createdAt: 1,
+    updatedAt: 1,
+    recencyAt: null,
+    status:
+      status === "inProgress"
+        ? { type: "active", activeFlags: [] }
+        : { type: "idle" },
+    path: null,
+    cwd: "/workspace",
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns: [
+      {
+        id: "turn-1",
+        items: [],
+        itemsView: "full",
+        status,
+        error: null,
+        startedAt: null,
+        completedAt: null,
+        durationMs: null,
+      },
+    ],
+  };
+}

--- a/apps/zenx/test/protocol-client.test.ts
+++ b/apps/zenx/test/protocol-client.test.ts
@@ -14,11 +14,12 @@ import {
   type ServerNotificationMethod,
 } from "../src/protocol-client/index.js";
 
-function testHost() {
+function testHost(models: readonly string[] = ["fake"]) {
   return createHostedAppServer({
     cwd: process.cwd(),
     dataDirectory: path.join(os.tmpdir(), "unused-zenx-test-data"),
     model: "fake",
+    models,
     approvalPolicy: "never",
     provider: { type: "fake" },
     journal: new InMemoryThreadJournal(),
@@ -203,6 +204,62 @@ test("projects the same turn events to two subscribed ZenX clients", async () =>
       Promise.all([firstCompleted.promise, secondCompleted.promise]),
     );
     assert.deepEqual(secondEvents, firstEvents);
+  } finally {
+    initiating.close();
+    observing.close();
+    await server.close();
+  }
+});
+
+test("mirrors model updates to two clients and resumes ZAS authority", async () => {
+  const appServer = testHost(["fake", "other"]);
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zenx-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-model-initiating"),
+  );
+  const observing = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-model-observing"),
+  );
+  try {
+    const models = await initiating.request("model/list", {});
+    assert.deepEqual(
+      models.data.map((model) => [model.id, model.isDefault]),
+      [
+        ["fake", true],
+        ["other", false],
+      ],
+    );
+    const started = await initiating.request("thread/start", {});
+    await observing.request("thread/resume", {
+      threadId: started.thread.id,
+    });
+    const firstUpdated = deferred<string>();
+    const secondUpdated = deferred<string>();
+    initiating.onNotification("thread/settings/updated", (params) => {
+      firstUpdated.resolve(params.threadSettings.model);
+    });
+    observing.onNotification("thread/settings/updated", (params) => {
+      secondUpdated.resolve(params.threadSettings.model);
+    });
+
+    await initiating.request("thread/settings/update", {
+      threadId: started.thread.id,
+      model: "other",
+    });
+    assert.deepEqual(
+      await within(Promise.all([firstUpdated.promise, secondUpdated.promise])),
+      ["other", "other"],
+    );
+
+    const resumed = await observing.request("thread/resume", {
+      threadId: started.thread.id,
+    });
+    assert.equal(resumed.model, "other");
+    assert.equal(resumed.thread.modelProvider, "fake");
   } finally {
     initiating.close();
     observing.close();


### PR DESCRIPTION
## Summary
- drive the thread model selector from `model/list`, hiding hidden entries while still displaying a hidden/unlisted ZAS-authoritative current value as unavailable
- initialize selection only from `thread/start`/`thread/resume` snapshots and update it only from `thread/settings/updated`
- send `thread/settings/update` without optimistic state, skip same-value changes, and disable changes during an active turn
- mirror provider metadata into thread projections and guard rapid thread selection from stale resume responses
- test two protocol clients receiving the same setting event and a later resume returning the authoritative model

## Validation
- `npm run check --workspace apps/zenx` (22 tests)
- `npm run check` (79 Node + 42 IMZen tests)
- production Electron via CDP: fake → other switch, active-turn disabled state, restart/resume still reports other

Closes #9