### PR TITLE
Core/protocol: implement same-Turn turn/steer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,9 @@
 - **Turn** — 一次交换：从一条用户输入开始、到 agent 完成响应为止追加的那段连续 Item。
 - **AgentRuntime** — 驱动一个 Thread 的循环：从 ItemList 编译上下文 → 调用模型 → 执行工具，把发生的一切追加为 Item。
 - **AppServer** — 按 threadId 把请求路由到 Thread、驱动 AgentRuntime、向订阅者广播 item 事件的唯一服务入口。
+- **SoftSteerDeliveryAnchor** — 当前执行在每次模型采样前设置的临时 response id；
+  steer 的 canonical `user_message.deliveryAfter` 持久化这个排序锚点，使下一次
+  采样能从 ItemList 重建正确上下文，而不形成第二份 mailbox 或会话状态。
 - **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
   append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
   canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、
@@ -80,7 +83,11 @@ canonical Item 追加，已有 Item 不改写、不删除。
 Turn 边界对齐 Codex rollout 语义：canonical `turn_started` 开始 Turn，
 `turn_completed` / `turn_aborted` 结束 Turn；完成的语义 Item 在二者之间追加。
 canonical `user_message` 可携带接入端提供的可选 `clientId`，仅用于跨接入端关联
-同一条用户消息，并投影为 wire `userMessage.clientId`。
+同一条用户消息，并投影为 wire `userMessage.clientId`。active Turn 接受的 soft
+steer 仍是普通 canonical `user_message`；若它在一次模型响应或其工具执行期间
+到达，`deliveryAfter` 记录该模型响应的稳定 id。journal 顺序继续表达事实发生
+顺序，模型采样投影则把 steer 放在该响应及其 tool results 之后。执行中的当前
+anchor 仅是可丢弃 checkpoint；会改变重放或上下文的排序事实已经进入 Item。
 崩溃重放时，尾部只有 `turn_started` 而没有终止 Item 的 Turn 派生为
 interrupted，不追加 synthetic recovery record，也不恢复半截 stream。wire
 `turn/started` / `turn/completed` 是这些 canonical lifecycle Item 的协议投影。
@@ -109,7 +116,7 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
   stub 记录原版 `codex --remote` 与固定版本 T3 Code 的实际调用，机会性扩展
   兼容面。当前请求子集包括 `account/read`、`skills/list`、`model/list`、
   `thread/start`、`thread/resume`、`thread/read`、`thread/list`、
-  `thread/unsubscribe`、`turn/start`、`turn/interrupt`，以及 Thread / Turn /
+  `thread/unsubscribe`、`turn/start`、`turn/steer`、`turn/interrupt`，以及 Thread / Turn /
   Item 事件流和 command item 审批请求。精确清单见
   `src/protocol/codex/README.md`。
 - `account/read`、`skills/list` 与 `model/list` 只投影宿主公开能力，不向 Zen Core 或 Thread 写入账户、skill、provider 状态。
@@ -164,7 +171,10 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
 ## 并发
 
 一个 Thread 内最多运行一个 Turn；App Server 只保留当前进程内的执行句柄和
-AbortController，不把它们当成会话事实。跨 Thread 直接并发运行，没有
+AbortController，以及可从 active Turn Item 重建的 SoftSteerDeliveryAnchor，
+不把它们当成会话事实。Thread 的 runtime append、steer、interrupt 与终态提交
+经过同一个 mutation boundary 线性化，禁止 canonical 用户消息落到 terminal
+Item 之后。跨 Thread 直接并发运行，没有
 ProjectCoordinator、调度队列或可持久化的 scheduler。进程崩了就崩了：重启后
 从 journal 恢复 Thread 内容，未完成的 Turn 派生为中断，由用户重发。
 

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -2,14 +2,18 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 
 import type {
+  AgentMessageItem,
   ApprovalPolicy,
   CanonicalItem,
   SandboxMode,
   ThreadConfigurationChangedItem,
   ThreadMetadataItem,
+  TurnCompletedItem,
+  UserMessageItem,
 } from "./item.js";
 import type { ThreadJournal } from "./journal.js";
 import type { ModelCatalog, ModelCatalogEntry } from "./model-catalog.js";
+import { compileModelMessages } from "./model.js";
 import { AgentRuntime, type RuntimeEvent } from "./runtime.js";
 import {
   Thread,
@@ -63,6 +67,10 @@ export interface TurnHandle {
   done: Promise<void>;
 }
 
+export interface SteerTurnOptions {
+  clientId?: string;
+}
+
 export interface ThreadSettingsUpdatedEvent {
   type: "thread_settings_updated";
   threadId: string;
@@ -93,7 +101,12 @@ export class ZenAppServer {
   readonly #threads = new Map<string, Thread>();
   readonly #activeTurns = new Map<
     string,
-    { turnId: string; controller: AbortController; done: Promise<void> }
+    {
+      turnId: string;
+      controller: AbortController;
+      done: Promise<void>;
+      deliveryAnchorId?: string;
+    }
   >();
   readonly #subscribers = new Set<(event: AppServerEvent) => void>();
   readonly #mutationChains = new Map<string, Promise<void>>();
@@ -243,7 +256,7 @@ export class ZenAppServer {
     if (text.length === 0) {
       throw new AppServerError("invalid_request", "Turn input cannot be empty");
     }
-    return await this.#withThreadMutation(threadId, async () => {
+    const launch = await this.#withThreadMutation(threadId, async () => {
       if (this.#activeTurns.has(threadId)) {
         throw new AppServerError(
           "thread_busy",
@@ -267,6 +280,7 @@ export class ZenAppServer {
       const configuration = thread.effectiveConfiguration();
       const turnId = this.#id();
       const controller = new AbortController();
+      const ready = deferred<void>();
 
       const done = new Promise<void>((resolve, reject) => {
         setImmediate(() => {
@@ -287,7 +301,31 @@ export class ZenAppServer {
                 },
                 signal: controller.signal,
                 commit: async (item) => {
-                  await this.#commit(thread, item);
+                  await this.#withThreadMutation(threadId, async () => {
+                    await this.#commit(thread, item);
+                  });
+                },
+                prepareModelSample: async (modelResponseId) =>
+                  await this.#withThreadMutation(threadId, async () => {
+                    const active = this.#activeTurns.get(threadId);
+                    if (active?.turnId !== turnId) {
+                      throw new AppServerError(
+                        "turn_not_running",
+                        `Turn ${turnId} is not running on thread ${threadId}`,
+                      );
+                    }
+                    active.deliveryAnchorId = modelResponseId;
+                    return compileModelMessages(thread.items);
+                  }),
+                commitFinal: async (message, modelResponseId) =>
+                  await this.#commitFinalResponse(
+                    thread,
+                    turnId,
+                    message,
+                    modelResponseId,
+                  ),
+                initialInputCommitted: () => {
+                  ready.resolve();
                 },
                 emit: (event) => {
                   this.#emit(event);
@@ -298,7 +336,10 @@ export class ZenAppServer {
               });
               resolve();
             } catch (error) {
-              reject(error instanceof Error ? error : new Error(String(error)));
+              const normalized =
+                error instanceof Error ? error : new Error(String(error));
+              ready.reject(normalized);
+              reject(normalized);
             } finally {
               const active = this.#activeTurns.get(threadId);
               if (active?.turnId === turnId) {
@@ -310,22 +351,150 @@ export class ZenAppServer {
       });
 
       this.#activeTurns.set(threadId, { turnId, controller, done });
-      return { id: turnId, done };
+      return { handle: { id: turnId, done }, ready: ready.promise };
+    });
+    try {
+      await launch.ready;
+    } catch (error) {
+      await launch.handle.done.catch(() => undefined);
+      throw error;
+    }
+    return launch.handle;
+  }
+
+  async steerTurn(
+    threadId: string,
+    expectedTurnId: string,
+    text: string,
+    options: SteerTurnOptions = {},
+  ): Promise<TurnHandle> {
+    if (text.length === 0) {
+      throw new AppServerError(
+        "invalid_request",
+        "Steer input cannot be empty",
+      );
+    }
+    return await this.#withThreadMutation(threadId, async () => {
+      const thread = await this.#requireThread(threadId);
+      if (options.clientId !== undefined) {
+        const duplicate = thread.items.find(
+          (item): item is UserMessageItem =>
+            item.type === "user_message" && item.clientId === options.clientId,
+        );
+        if (duplicate !== undefined) {
+          if (duplicate.turnId === expectedTurnId && duplicate.text === text) {
+            const duplicateActive = this.#activeTurns.get(threadId);
+            return {
+              id: expectedTurnId,
+              done:
+                duplicateActive?.turnId === expectedTurnId
+                  ? duplicateActive.done
+                  : Promise.resolve(),
+            };
+          }
+          throw new AppServerError(
+            "idempotency_conflict",
+            `clientUserMessageId ${options.clientId} was already used for different input`,
+          );
+        }
+      }
+
+      const active = this.#activeTurns.get(threadId);
+      if (
+        active === undefined ||
+        active.turnId !== expectedTurnId ||
+        active.controller.signal.aborted
+      ) {
+        throw new AppServerError(
+          "turn_not_running",
+          `Turn ${expectedTurnId} is not running on thread ${threadId}`,
+        );
+      }
+      if (
+        thread.items.some(
+          (item) =>
+            item.turnId === expectedTurnId &&
+            (item.type === "turn_completed" || item.type === "turn_aborted"),
+        )
+      ) {
+        throw new AppServerError(
+          "turn_not_running",
+          `Turn ${expectedTurnId} is already terminal on thread ${threadId}`,
+        );
+      }
+
+      const message: UserMessageItem = {
+        id: this.#id(),
+        threadId,
+        turnId: expectedTurnId,
+        createdAt: this.#now(),
+        type: "user_message",
+        text,
+        ...(options.clientId === undefined
+          ? {}
+          : { clientId: options.clientId }),
+        ...(active.deliveryAnchorId === undefined
+          ? {}
+          : { deliveryAfter: active.deliveryAnchorId }),
+      };
+      await this.#commit(thread, message);
+      this.#emit({ type: "item_completed", item: message });
+      return { id: expectedTurnId, done: active.done };
     });
   }
 
   async interruptTurn(threadId: string, turnId: string): Promise<void> {
-    const active = this.#activeTurns.get(threadId);
-    if (active === undefined || active.turnId !== turnId) {
-      throw new AppServerError(
-        "turn_not_running",
-        `Turn ${turnId} is not running on thread ${threadId}`,
+    const activeHandle = await this.#withThreadMutation(threadId, async () => {
+      const active = this.#activeTurns.get(threadId);
+      if (active === undefined || active.turnId !== turnId) {
+        throw new AppServerError(
+          "turn_not_running",
+          `Turn ${turnId} is not running on thread ${threadId}`,
+        );
+      }
+      active.controller.abort(
+        new DOMException("Interrupted by user", "AbortError"),
       );
-    }
-    active.controller.abort(
-      new DOMException("Interrupted by user", "AbortError"),
-    );
-    await active.done;
+      return { done: active.done };
+    });
+    await activeHandle.done;
+  }
+
+  async #commitFinalResponse(
+    thread: Thread,
+    turnId: string,
+    message: AgentMessageItem,
+    modelResponseId: string,
+  ): Promise<boolean> {
+    return await this.#withThreadMutation(thread.id, async () => {
+      const active = this.#activeTurns.get(thread.id);
+      if (active?.turnId !== turnId) {
+        throw new AppServerError(
+          "turn_not_running",
+          `Turn ${turnId} is not running on thread ${thread.id}`,
+        );
+      }
+      await this.#commit(thread, message);
+      const pendingSteer = thread.items.some(
+        (item) =>
+          item.type === "user_message" &&
+          item.turnId === turnId &&
+          item.deliveryAfter === modelResponseId,
+      );
+      if (pendingSteer) {
+        return false;
+      }
+      const completed: TurnCompletedItem = {
+        id: this.#id(),
+        threadId: thread.id,
+        turnId,
+        createdAt: this.#now(),
+        type: "turn_completed",
+        status: "completed",
+      };
+      await this.#commit(thread, completed);
+      return true;
+    });
   }
 
   async #loadThread(threadId: string): Promise<Thread | undefined> {
@@ -491,4 +660,18 @@ export class AppServerError extends Error {
     this.name = "AppServerError";
     this.code = code;
   }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: Error): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
 }

--- a/src/item.ts
+++ b/src/item.ts
@@ -58,6 +58,11 @@ export interface UserMessageItem extends ItemBase {
   turnId: string;
   text: string;
   clientId?: string;
+  /**
+   * Model-response item whose tool/result step must finish before this
+   * same-Turn steer is presented to the next model sample.
+   */
+  deliveryAfter?: string;
 }
 
 export interface AgentMessageItem extends ItemBase {
@@ -76,6 +81,8 @@ export interface ToolCallItem extends ItemBase {
   type: "tool_call";
   turnId: string;
   callId: string;
+  /** Stable id of the model response that produced this call. */
+  modelResponseId?: string;
   name: string;
   arguments: Record<string, unknown>;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -66,6 +66,7 @@ export interface ModelAdapter {
 export function compileModelMessages(
   items: readonly CanonicalItem[],
 ): ModelMessage[] {
+  items = orderSteeredMessagesForSampling(items);
   const messages: ModelMessage[] = [];
   for (let index = 0; index < items.length; index += 1) {
     const item = items[index];
@@ -146,6 +147,119 @@ export function compileModelMessages(
     }
   }
   return messages;
+}
+
+/**
+ * Canonical order records when facts happened. A steer accepted while a model
+ * response or its tools are in flight therefore appears before that response
+ * in the journal. `deliveryAfter` is the durable ordering anchor that lets the
+ * sampling projection place the message after the completed assistant step.
+ */
+function orderSteeredMessagesForSampling(
+  items: readonly CanonicalItem[],
+): readonly CanonicalItem[] {
+  const anchored = new Map<
+    string,
+    Array<{
+      item: Extract<CanonicalItem, { type: "user_message" }>;
+      index: number;
+    }>
+  >();
+  const unanchored: Array<{ item: CanonicalItem; originalIndex: number }> = [];
+  for (let index = 0; index < items.length; index += 1) {
+    const item = items[index];
+    if (item === undefined) {
+      continue;
+    }
+    if (item.type === "user_message" && item.deliveryAfter !== undefined) {
+      const pending = anchored.get(item.deliveryAfter) ?? [];
+      pending.push({ item, index });
+      anchored.set(item.deliveryAfter, pending);
+    } else {
+      unanchored.push({ item, originalIndex: index });
+    }
+  }
+  if (anchored.size === 0) {
+    return items;
+  }
+
+  const insertion = new Map<number, CanonicalItem[]>();
+  const fallback = new Map<number, CanonicalItem[]>();
+  for (const [anchorId, pending] of anchored) {
+    const anchorIndex = unanchored.findIndex(
+      ({ item }) =>
+        item.id === anchorId ||
+        (item.type === "tool_call" && item.modelResponseId === anchorId),
+    );
+    if (anchorIndex < 0) {
+      for (const { item, index } of pending) {
+        const target = fallback.get(index) ?? [];
+        target.push(item);
+        fallback.set(index, target);
+      }
+      continue;
+    }
+
+    let insertionIndex = anchorIndex;
+    const anchor = unanchored[anchorIndex]?.item;
+    if (anchor?.type === "agent_message" || anchor?.type === "tool_call") {
+      const callIds = new Set<string>();
+      const firstCallIndex =
+        anchor.type === "tool_call" ? anchorIndex : anchorIndex + 1;
+      for (
+        let cursor = firstCallIndex;
+        cursor < unanchored.length;
+        cursor += 1
+      ) {
+        const candidate = unanchored[cursor]?.item;
+        if (
+          candidate?.type !== "tool_call" ||
+          candidate.modelResponseId !== anchorId
+        ) {
+          break;
+        }
+        callIds.add(candidate.callId);
+      }
+      if (callIds.size > 0) {
+        for (
+          let cursor = anchorIndex + 1;
+          cursor < unanchored.length;
+          cursor += 1
+        ) {
+          const candidate = unanchored[cursor]?.item;
+          if (
+            candidate?.type === "tool_result" &&
+            callIds.has(candidate.callId)
+          ) {
+            insertionIndex = cursor;
+          }
+        }
+      }
+    }
+    const target = insertion.get(insertionIndex) ?? [];
+    target.push(...pending.map(({ item }) => item));
+    insertion.set(insertionIndex, target);
+  }
+
+  const ordered: CanonicalItem[] = [];
+  for (let index = 0; index < unanchored.length; index += 1) {
+    const entry = unanchored[index];
+    if (entry === undefined) {
+      continue;
+    }
+    for (const [originalIndex, values] of [...fallback]) {
+      if (originalIndex <= entry.originalIndex) {
+        ordered.push(...values);
+        fallback.delete(originalIndex);
+      }
+    }
+    ordered.push(entry.item);
+    ordered.push(...(insertion.get(index) ?? []));
+  }
+  for (const values of fallback.values()) {
+    ordered.push(...values);
+  }
+  return ordered;
 }
 
 export class FakeModel implements ModelAdapter {

--- a/src/protocol/codex/README.md
+++ b/src/protocol/codex/README.md
@@ -20,6 +20,7 @@ Client requests：
 - `thread/settings/update`
 - `thread/unsubscribe`
 - `turn/start`
+- `turn/steer`
 - `turn/interrupt`
 
 Client notification：`initialized`。
@@ -62,6 +63,21 @@ MCP `-c` 配置由 CLI remote bridge 启动边界验证后忽略，不进入 wir
 `--remote`、可选的 `--auth-token-file` 和这两项配置外，不接受宿主或 runtime
 选项；这些配置属于中央 App Server。T3 MCP tools 尚未实现。Unix socket 与
 非本机监听尚未实现。
+
+## Soft steer
+
+`turn/steer` 对齐 Codex 0.146.0 的 same-Turn 行为。请求必须包含
+`threadId`、作为 fencing token 的 `expectedTurnId`，以及非空 `input`；Zen
+当前只接受 `[{ type: "text", text: string }]`，可选
+`clientUserMessageId` 用于可靠重试。成功返回 `{ turnId }`，其中 id 必须仍是
+同一个 active Turn，不产生新的 `turn/started`。无 active Turn、fence 过期、
+目标已经终态或不可表示的 input 都明确失败。
+
+接受成功前，输入已经作为 canonical `user_message` 写入 journal。相同
+`clientUserMessageId`、Turn 与内容的重试返回原成功且不重复追加；冲突复用失败。
+steer 不取消当前 model stream、tool 或 approval，也不处理 approval。若它在
+一次模型响应期间到达，Runtime 会完成该响应及其工具结果，然后在下一次 sampling
+前按 journal 中的 steer FIFO 顺序注入；因此原本可能结束的响应也会继续下一轮。
 
 ## 兼容范围
 

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -371,6 +371,30 @@ export class CodexConnection {
         });
         return;
       }
+      case "turn/steer": {
+        rejectUnsupportedValues(params, [
+          "threadId",
+          "expectedTurnId",
+          "input",
+          "clientUserMessageId",
+        ]);
+        const threadId = requiredString(params, "threadId");
+        const expectedTurnId = requiredString(params, "expectedTurnId");
+        const text = readTextInput(params.input);
+        const clientId = optionalNonEmptyString(
+          params.clientUserMessageId,
+          "clientUserMessageId",
+        );
+        this.#subscribedThreads.add(threadId);
+        const handle = await this.#appServer.steerTurn(
+          threadId,
+          expectedTurnId,
+          text,
+          clientId === undefined ? {} : { clientId },
+        );
+        this.#send({ id: request.id, result: { turnId: handle.id } });
+        return;
+      }
       case "turn/interrupt": {
         await this.#appServer.interruptTurn(
           requiredString(params, "threadId"),

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -15,7 +15,7 @@ import type {
   TurnStartedItem,
   UserMessageItem,
 } from "./item.js";
-import { compileModelMessages, type ModelAdapter } from "./model.js";
+import type { ModelAdapter, ModelMessage } from "./model.js";
 import type { Thread } from "./thread.js";
 import type { ApprovalHandler, ToolExecutor } from "./tool.js";
 
@@ -65,7 +65,13 @@ export interface RunTurnOptions {
   configuration: RuntimeConfiguration;
   signal: AbortSignal;
   commit: (item: CanonicalItem) => Promise<void>;
+  prepareModelSample: (modelResponseId: string) => Promise<ModelMessage[]>;
+  commitFinal: (
+    message: AgentMessageItem,
+    modelResponseId: string,
+  ) => Promise<boolean>;
   emit: (event: RuntimeEvent) => void;
+  initialInputCommitted?: () => void;
   requestApproval?: ApprovalHandler;
 }
 
@@ -120,6 +126,7 @@ export class AgentRuntime {
           : { clientId: options.clientId }),
       };
       await this.#completeItem(userItem, options);
+      options.initialInputCommitted?.();
 
       for (let round = 0; ; round += 1) {
         options.signal.throwIfAborted();
@@ -133,17 +140,11 @@ export class AgentRuntime {
             type: "agent_message",
             text: result.text,
           };
-          await options.commit(agentItem);
+          const terminal = await options.commitFinal(agentItem, result.itemId);
           options.emit({ type: "item_completed", item: agentItem });
-          const completed: TurnCompletedItem = {
-            id: this.#id(),
-            threadId: options.thread.id,
-            turnId,
-            createdAt: this.#now(),
-            type: "turn_completed",
-            status: "completed",
-          };
-          await options.commit(completed);
+          if (!terminal) {
+            continue;
+          }
           options.emit({
             type: "turn_completed",
             threadId: options.thread.id,
@@ -180,6 +181,7 @@ export class AgentRuntime {
             createdAt: this.#now(),
             type: "tool_call",
             callId: toolCall.callId,
+            modelResponseId: result.itemId,
             name: toolCall.name,
             arguments: toolCall.arguments,
           };
@@ -281,9 +283,11 @@ export class AgentRuntime {
       arguments: Record<string, unknown>;
     }> = [];
 
+    const messages = await options.prepareModelSample(itemId);
+
     for await (const event of this.#model.stream({
       model: options.configuration.model,
-      messages: compileModelMessages(options.thread.items),
+      messages,
       tools: this.#tools.definitions,
       signal: options.signal,
       sessionId: options.thread.id,

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -348,6 +348,107 @@ test("resumes an active thread when T3 repeats its effective model", async () =>
   }
 });
 
+test("dispatches Codex turn/steer to the same active Turn for every subscriber", async () => {
+  const appServer = testHost("always");
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await CodexClient.connect(server.url);
+  const steering = await CodexClient.connect(server.url);
+  const approvalSeen = deferred<void>();
+  const releaseApproval = deferred<{ decision: "decline" }>();
+  const turnCompleted = deferred<void>();
+  try {
+    await initiating.initialize({
+      name: "initiating",
+      title: "Initiating",
+      version: "1",
+    });
+    await steering.initialize({
+      name: "steering",
+      title: "Steering",
+      version: "1",
+    });
+    initiating.onServerRequest(
+      "item/commandExecution/requestApproval",
+      async () => {
+        approvalSeen.resolve();
+        return await releaseApproval.promise;
+      },
+    );
+    initiating.onNotification("turn/completed", () => {
+      turnCompleted.resolve();
+    });
+    const started = await initiating.request("thread/start", {
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+    });
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    await steering.request("thread/resume", { threadId: thread.id });
+    const turnStart = await initiating.request("turn/start", {
+      threadId: thread.id,
+      input: [{ type: "text", text: "!shell printf active" }],
+    });
+    const turn = responseResult<Record<string, unknown>>(turnStart, "turn");
+    await within(approvalSeen.promise);
+
+    const observedByInitiator = deferred<Record<string, unknown>>();
+    const observedBySteerer = deferred<Record<string, unknown>>();
+    const observeSteer =
+      (target: ReturnType<typeof deferred<Record<string, unknown>>>) =>
+      (params: unknown): void => {
+        if (
+          isRecord(params) &&
+          isRecord(params.item) &&
+          params.item.type === "userMessage" &&
+          params.item.clientId === "steer-protocol-id"
+        ) {
+          target.resolve(params);
+        }
+      };
+    initiating.onNotification(
+      "item/completed",
+      observeSteer(observedByInitiator),
+    );
+    steering.onNotification("item/completed", observeSteer(observedBySteerer));
+
+    assert.deepEqual(
+      await steering.request("turn/steer", {
+        threadId: thread.id,
+        expectedTurnId: turn.id,
+        input: [{ type: "text", text: "change direction" }],
+        clientUserMessageId: "steer-protocol-id",
+      }),
+      { turnId: turn.id },
+    );
+    const observations = await within(
+      Promise.all([observedByInitiator.promise, observedBySteerer.promise]),
+    );
+    for (const observation of observations) {
+      assert.equal(observation.threadId, thread.id);
+      assert.equal(observation.turnId, turn.id);
+    }
+
+    await assert.rejects(
+      steering.request("turn/steer", {
+        threadId: thread.id,
+        expectedTurnId: "stale-turn",
+        input: [{ type: "text", text: "must fail" }],
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32000,
+    );
+    releaseApproval.resolve({ decision: "decline" });
+    await within(turnCompleted.promise);
+  } finally {
+    initiating.close();
+    steering.close();
+    await server.close();
+  }
+});
+
 test("synchronizes ZAS-owned thread names without adding Agent items", async () => {
   const appServer = testHost();
   const server = await serveCodexWebSocket({

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -345,9 +345,10 @@ test("validates canonical items before appending them to the journal", async () 
     runtimeIdFactory: () => "duplicate-id",
   });
   const thread = await server.startThread();
-  const turn = await server.startTurn(thread.id, "must not persist");
-
-  await assert.rejects(turn.done, /Duplicate item id duplicate-id/u);
+  await assert.rejects(
+    server.startTurn(thread.id, "must not persist"),
+    /Duplicate item id duplicate-id/u,
+  );
   assert.deepEqual(
     (await journal.read(thread.id)).map((item) => item.type),
     ["thread_metadata"],
@@ -1246,3 +1247,300 @@ test("runs an OpenAI-compatible tool round through the same Runtime and ItemList
     "provider complete",
   );
 });
+
+test("soft steer stays in one Turn and forces a new sample after streamed output", async () => {
+  const firstSampleEntered = testDeferred<void>();
+  const releaseFirstSample = testDeferred<void>();
+  const requests: ModelMessage[][] = [];
+  let sample = 0;
+  const model: ModelAdapter = {
+    provider: "steer-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      requests.push(structuredClone(request.messages));
+      sample += 1;
+      if (sample === 1) {
+        firstSampleEntered.resolve();
+        await releaseFirstSample.promise;
+        yield { type: "text_delta", delta: "first answer" };
+        return;
+      }
+      yield { type: "text_delta", delta: "steered answer" };
+    },
+  };
+  const server = createServer({ model });
+  const events: AppServerEvent[] = [];
+  server.subscribe((event) => events.push(event));
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "initial request", {
+    clientId: "initial-client-id",
+  });
+  await firstSampleEntered.promise;
+
+  const steered = await server.steerTurn(
+    thread.id,
+    active.id,
+    "follow this correction",
+    { clientId: "steer-client-id" },
+  );
+  assert.equal(steered.id, active.id);
+  assert.equal(
+    (
+      await server.steerTurn(thread.id, active.id, "follow this correction", {
+        clientId: "steer-client-id",
+      })
+    ).id,
+    active.id,
+  );
+  await server.steerTurn(thread.id, active.id, "then preserve the tests", {
+    clientId: "steer-client-id-2",
+  });
+  await assert.rejects(
+    server.steerTurn(thread.id, active.id, "conflicting correction", {
+      clientId: "steer-client-id",
+    }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "idempotency_conflict",
+  );
+
+  releaseFirstSample.resolve();
+  await active.done;
+
+  assert.equal(requests.length, 2);
+  assert.deepEqual(requests[1], [
+    { role: "user", text: "initial request" },
+    { role: "assistant", text: "first answer" },
+    { role: "user", text: "follow this correction" },
+    { role: "user", text: "then preserve the tests" },
+  ]);
+  const snapshot = await server.readThread(thread.id);
+  assert.equal(snapshot.turns.length, 1);
+  assert.equal(snapshot.turns[0]?.id, active.id);
+  assert.equal(snapshot.turns[0]?.status, "completed");
+  assert.deepEqual(
+    snapshot.items
+      .filter((item) => item.type === "user_message")
+      .map((item) => item.text),
+    ["initial request", "follow this correction", "then preserve the tests"],
+  );
+  assert.equal(
+    snapshot.items.filter((item) => item.type === "turn_started").length,
+    1,
+  );
+  assert.equal(
+    events.filter(
+      (event) =>
+        event.type === "item_completed" &&
+        event.item.type === "user_message" &&
+        event.item.clientId === "steer-client-id",
+    ).length,
+    1,
+  );
+});
+
+test("soft steer waits behind a tool result and does not cancel approval", async () => {
+  const approvalRequested = testDeferred<void>();
+  const releaseApproval = testDeferred<"accept">();
+  const requests: ModelMessage[][] = [];
+  let sample = 0;
+  const model: ModelAdapter = {
+    provider: "steer-tool-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      requests.push(structuredClone(request.messages));
+      sample += 1;
+      if (sample === 1) {
+        yield {
+          type: "tool_call",
+          callId: "steer-call",
+          name: "shell",
+          arguments: { command: "printf tool" },
+        };
+        return;
+      }
+      yield { type: "text_delta", delta: "done after correction" };
+    },
+  };
+  const tools: ToolExecutor = {
+    definitions: [
+      {
+        name: "shell",
+        description: "shell",
+        inputSchema: { type: "object" },
+      },
+    ],
+    async execute() {
+      return { output: "tool complete", exitCode: 0 };
+    },
+  };
+  const server = createServer({
+    model,
+    tools,
+    approvalPolicy: "always",
+  });
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "use a tool", {
+    requestApproval: async () => {
+      approvalRequested.resolve();
+      return await releaseApproval.promise;
+    },
+  });
+  await testWithin(
+    Promise.race([
+      approvalRequested.promise,
+      active.done.then(() => {
+        throw new Error("Turn finished before requesting approval");
+      }),
+    ]),
+    "approval request",
+  );
+
+  await server.steerTurn(thread.id, active.id, "change the final response", {
+    clientId: "approval-steer",
+  });
+  assert.equal(requests.length, 1);
+  releaseApproval.resolve("accept");
+  await testWithin(active.done, "steered approval turn");
+
+  assert.equal(requests.length, 2);
+  assert.deepEqual(requests[1], [
+    { role: "user", text: "use a tool" },
+    {
+      role: "assistant",
+      toolCalls: [
+        {
+          callId: "steer-call",
+          name: "shell",
+          arguments: { command: "printf tool" },
+        },
+      ],
+    },
+    { role: "tool", callId: "steer-call", text: "tool complete", exitCode: 0 },
+    { role: "user", text: "change the final response" },
+  ]);
+});
+
+test("soft steer never acknowledges a failed journal append or crosses a terminal fence", async () => {
+  const backing = new InMemoryThreadJournal();
+  const journal: ThreadJournal = {
+    append: async (item) => {
+      if (item.type === "user_message" && item.text === "must not persist") {
+        throw new Error("steer journal unavailable");
+      }
+      await backing.append(item);
+    },
+    listThreadIds: async () => await backing.listThreadIds(),
+    read: async (threadId) => await backing.read(threadId),
+  };
+  const modelEntered = testDeferred<void>();
+  const releaseModel = testDeferred<void>();
+  const model: ModelAdapter = {
+    provider: "steer-failure-test",
+    async *stream(): AsyncIterable<ModelEvent> {
+      modelEntered.resolve();
+      await releaseModel.promise;
+      yield { type: "text_delta", delta: "finished" };
+    },
+  };
+  const server = createServer({ journal, model });
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "initial");
+  await modelEntered.promise;
+
+  await assert.rejects(
+    server.steerTurn(thread.id, active.id, "must not persist", {
+      clientId: "failed-steer-id",
+    }),
+    /steer journal unavailable/u,
+  );
+  assert.equal(
+    (await server.readThread(thread.id)).items.some(
+      (item) =>
+        item.type === "user_message" && item.clientId === "failed-steer-id",
+    ),
+    false,
+  );
+
+  releaseModel.resolve();
+  await active.done;
+  await assert.rejects(
+    server.steerTurn(thread.id, active.id, "too late"),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "turn_not_running",
+  );
+  assert.equal(
+    (await server.readThread(thread.id)).items.at(-1)?.type,
+    "turn_completed",
+  );
+});
+
+test("an interrupt that wins the mutation fence rejects a racing soft steer", async () => {
+  const modelEntered = testDeferred<void>();
+  const releaseModel = testDeferred<void>();
+  const model: ModelAdapter = {
+    provider: "steer-interrupt-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      modelEntered.resolve();
+      await releaseModel.promise;
+      request.signal.throwIfAborted();
+      yield { type: "text_delta", delta: "too late" };
+    },
+  };
+  const server = createServer({ model });
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "wait");
+  await modelEntered.promise;
+
+  const interrupted = server.interruptTurn(thread.id, active.id);
+  await assert.rejects(
+    server.steerTurn(thread.id, active.id, "must lose the fence"),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "turn_not_running",
+  );
+  releaseModel.resolve();
+  await interrupted;
+
+  const snapshot = await server.readThread(thread.id);
+  assert.equal(snapshot.turns[0]?.status, "interrupted");
+  assert.equal(
+    snapshot.items.some(
+      (item) =>
+        item.type === "user_message" && item.text === "must lose the fence",
+    ),
+    false,
+  );
+});
+
+function testDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T extends void ? void : T) => void;
+} {
+  let resolve!: (value: T extends void ? void : T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise as (value: T extends void ? void : T) => void;
+  });
+  return { promise, resolve };
+}
+
+async function testWithin<T>(promise: Promise<T>, label: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out waiting for ${label}`)),
+          1_000,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}


### PR DESCRIPTION
Closes #26

## What changed

- adds Codex 0.146.0 `turn/steer` request handling with required `expectedTurnId` fencing
- persists accepted steering input as the canonical `user_message` before acknowledgement
- uses a durable `deliveryAfter` response anchor so Item-first journal order can be projected into correct model sampling order
- linearizes runtime append, steer, interrupt, and terminal commit per Thread
- supports retry idempotency through `clientUserMessageId` and rejects conflicting reuse
- keeps model streaming, tool execution, and approval pending while Soft steer waits for the next sampling boundary
- updates the pinned protocol and architecture documentation

## Review focus

- no second durable mailbox or hidden queue was introduced
- a steer that arrives during a would-be final answer forces another model sample
- an interrupt that wins the mutation fence prevents later steering into the aborted Turn
- all subscribers observe the same canonical user-message projection

## Validation

- `npm run check`
- 84 Node tests passed
- 42 IMZen tests passed
- `git diff --check`
