### PR TITLE
Core/protocol: add atomic Interrupt & send

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,6 +13,9 @@
 - **SoftSteerDeliveryAnchor** — 当前执行在每次模型采样前设置的临时 response id；
   steer 的 canonical `user_message.deliveryAfter` 持久化这个排序锚点，使下一次
   采样能从 ItemList 重建正确上下文，而不形成第二份 mailbox 或会话状态。
+- **TurnReplacementIntent** — canonical `turn_replacement_requested` Item 记录一次
+  fenced Interrupt & send 的旧/新 Turn id、输入与幂等 key，使显式客户端重试能
+  从 abort/start 崩溃间隙继续，而不依赖隐藏 command queue 或恢复表。
 - **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
   append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
   canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、
@@ -91,6 +94,13 @@ anchor 仅是可丢弃 checkpoint；会改变重放或上下文的排序事实�
 崩溃重放时，尾部只有 `turn_started` 而没有终止 Item 的 Turn 派生为
 interrupted，不追加 synthetic recovery record，也不恢复半截 stream。wire
 `turn/started` / `turn/completed` 是这些 canonical lifecycle Item 的协议投影。
+Hard steer 在任何副作用前先追加 `turn_replacement_requested`，再以普通
+`turn_aborted` 结束旧 Turn，并以普通 `turn_started` + `user_message` 开始保留 id
+的后继 Turn。replacement intent 不进入模型上下文；后继用户消息落盘后它即由
+ItemList 推导为 resolved。进程不会自动继续未完成 intent，只有携带同一
+`clientUserMessageId` 的显式 `turn/replace` 重试可以继续 abort/start 间隙；若
+后继 `turn_started` 已落盘而初始用户消息未落盘，则明确报告 incomplete，不恢复
+半截执行。
 
 审批请求与应答是正在运行的 Turn 和接入端之间的瞬态交互，不写 journal。
 最终执行或拒绝的结果由完整的 tool-result Item 表达。
@@ -102,6 +112,10 @@ protocol 兼容子集**（Thread / Turn / Item 三原语）。transport 只是�
 承载方式，不是第二套协议。当前兼容基线钉在 **codex-cli 0.146.0**，实现
 JSONL stdio 与 loopback WebSocket 两种承载；Unix socket 尚未实现。兼容原版
 Codex CLI、T3 Code 是收益，不是核心设计前提。
+
+Zen 只在 Codex 0.146.0 没有等价原子语义时增加一项明确命名的协议扩展：
+`turn/replace`。它不是 Codex compatibility claim，也不得复用或改变标准
+`turn/steer`；客户端必须显式调用并处理 unsupported。
 
 规则：
 
@@ -123,6 +137,9 @@ Codex CLI、T3 Code 是收益，不是核心设计前提。
 - `thread/settings/update` 修改后续 Turn 使用的配置；`turn/start` 携带的模型
   override 复用同一内部更新路径。成功变更必须先追加
   `thread_configuration_changed`，再广播 `thread/settings/updated`。
+- `turn/replace` 是 fenced Hard steer：成功响应前，旧 Turn 的 `turn_aborted`、
+  新 Turn 的 `turn_started` 与初始 `user_message` 均已 durable；普通客户端不得
+  用两个独立请求模拟其原子用户意图。
 - ZAS 是 Thread 生效配置的唯一权威。所有接入端通过
   `thread/settings/updated` 与 `thread/resume` 返回值镜像同一份配置；恢复
   Thread 时不得用客户端缓存覆盖 ZAS，只有用户明确选择新模型时才提交配置

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -8,7 +8,9 @@ import type {
   SandboxMode,
   ThreadConfigurationChangedItem,
   ThreadMetadataItem,
+  TurnAbortedItem,
   TurnCompletedItem,
+  TurnReplacementRequestedItem,
   UserMessageItem,
 } from "./item.js";
 import type { ThreadJournal } from "./journal.js";
@@ -71,6 +73,16 @@ export interface SteerTurnOptions {
   clientId?: string;
 }
 
+export interface ReplaceTurnOptions {
+  clientId: string;
+  requestApproval?: ApprovalHandler;
+}
+
+export interface ReplaceTurnResult {
+  interruptedTurnId: string;
+  turn: TurnHandle;
+}
+
 export interface ThreadSettingsUpdatedEvent {
   type: "thread_settings_updated";
   threadId: string;
@@ -110,6 +122,10 @@ export class ZenAppServer {
   >();
   readonly #subscribers = new Set<(event: AppServerEvent) => void>();
   readonly #mutationChains = new Map<string, Promise<void>>();
+  readonly #replacementOperations = new Map<
+    string,
+    { clientId: string; result: Promise<ReplaceTurnResult> }
+  >();
 
   constructor(options: {
     journal: ThreadJournal;
@@ -212,7 +228,10 @@ export class ZenAppServer {
         );
       }
       this.#requireAvailableModel(input.model);
-      if (this.#activeTurns.has(threadId)) {
+      if (
+        this.#activeTurns.has(threadId) ||
+        this.#pendingReplacement(thread) !== undefined
+      ) {
         throw new AppServerError(
           "thread_busy",
           `Thread ${threadId} already has a running turn`,
@@ -253,6 +272,22 @@ export class ZenAppServer {
       requestApproval?: ApprovalHandler;
     } = {},
   ): Promise<TurnHandle> {
+    return await this.#launchTurn(threadId, text, options);
+  }
+
+  async #launchTurn(
+    threadId: string,
+    text: string,
+    options: {
+      clientId?: string;
+      model?: string;
+      requestApproval?: ApprovalHandler;
+    },
+    internal: {
+      turnId?: string;
+      replacementClientId?: string;
+    } = {},
+  ): Promise<TurnHandle> {
     if (text.length === 0) {
       throw new AppServerError("invalid_request", "Turn input cannot be empty");
     }
@@ -265,6 +300,17 @@ export class ZenAppServer {
       }
 
       const thread = await this.#requireThread(threadId);
+      const pendingReplacement = this.#pendingReplacement(thread);
+      if (
+        pendingReplacement !== undefined &&
+        (internal.replacementClientId !== pendingReplacement.clientId ||
+          internal.turnId !== pendingReplacement.successorTurnId)
+      ) {
+        throw new AppServerError(
+          "replacement_pending",
+          `Thread ${threadId} has an unfinished replacement operation`,
+        );
+      }
       const initialConfiguration = thread.effectiveConfiguration();
       if (initialConfiguration.provider !== this.#runtime.provider) {
         throw new AppServerError(
@@ -278,7 +324,7 @@ export class ZenAppServer {
         });
       }
       const configuration = thread.effectiveConfiguration();
-      const turnId = this.#id();
+      const turnId = internal.turnId ?? this.#id();
       const controller = new AbortController();
       const ready = deferred<void>();
 
@@ -360,6 +406,202 @@ export class ZenAppServer {
       throw error;
     }
     return launch.handle;
+  }
+
+  async replaceTurn(
+    threadId: string,
+    expectedTurnId: string,
+    text: string,
+    options: ReplaceTurnOptions,
+  ): Promise<ReplaceTurnResult> {
+    if (text.length === 0) {
+      throw new AppServerError(
+        "invalid_request",
+        "Replacement input cannot be empty",
+      );
+    }
+    if (options.clientId.length === 0) {
+      throw new AppServerError(
+        "invalid_request",
+        "Replacement client id cannot be empty",
+      );
+    }
+
+    const planned = await this.#withThreadMutation(threadId, async () => {
+      const thread = await this.#requireThread(threadId);
+      const existing = thread.items.find(
+        (item): item is TurnReplacementRequestedItem =>
+          item.type === "turn_replacement_requested" &&
+          item.clientId === options.clientId,
+      );
+      const existingUserMessage = thread.items.find(
+        (item): item is UserMessageItem =>
+          item.type === "user_message" && item.clientId === options.clientId,
+      );
+      if (existing === undefined && existingUserMessage !== undefined) {
+        throw new AppServerError(
+          "idempotency_conflict",
+          `clientUserMessageId ${options.clientId} was already used for a user message`,
+        );
+      }
+      if (existing !== undefined) {
+        if (existing.turnId !== expectedTurnId || existing.text !== text) {
+          throw new AppServerError(
+            "idempotency_conflict",
+            `clientUserMessageId ${options.clientId} was already used for a different replacement`,
+          );
+        }
+        const runningDuplicate = this.#replacementOperations.get(threadId);
+        if (runningDuplicate !== undefined) {
+          if (runningDuplicate.clientId !== options.clientId) {
+            throw new AppServerError(
+              "replacement_pending",
+              `Thread ${threadId} already has a replacement in progress`,
+            );
+          }
+          return { pending: runningDuplicate.result };
+        }
+        const successorInput = thread.items.find(
+          (item): item is UserMessageItem =>
+            item.type === "user_message" &&
+            item.turnId === existing.successorTurnId &&
+            item.clientId === options.clientId,
+        );
+        if (successorInput !== undefined) {
+          const successor = this.#activeTurns.get(threadId);
+          return {
+            complete: {
+              interruptedTurnId: expectedTurnId,
+              turn: {
+                id: existing.successorTurnId,
+                done:
+                  successor?.turnId === existing.successorTurnId
+                    ? successor.done
+                    : Promise.resolve(),
+              },
+            },
+          };
+        }
+        if (
+          thread.items.some(
+            (item) =>
+              item.type === "turn_started" &&
+              item.turnId === existing.successorTurnId,
+          )
+        ) {
+          throw new AppServerError(
+            "replacement_incomplete",
+            `Replacement successor ${existing.successorTurnId} started without a durable user message`,
+          );
+        }
+      }
+
+      const inFlight = this.#replacementOperations.get(threadId);
+      if (inFlight !== undefined) {
+        if (inFlight.clientId !== options.clientId) {
+          throw new AppServerError(
+            "replacement_pending",
+            `Thread ${threadId} already has a replacement in progress`,
+          );
+        }
+        return { pending: inFlight.result };
+      }
+
+      let intent = existing;
+      let oldDone: Promise<void> = Promise.resolve();
+      if (intent === undefined) {
+        const active = this.#activeTurns.get(threadId);
+        if (
+          active === undefined ||
+          active.turnId !== expectedTurnId ||
+          active.controller.signal.aborted ||
+          this.#isTerminal(thread, expectedTurnId)
+        ) {
+          throw new AppServerError(
+            "turn_not_running",
+            `Turn ${expectedTurnId} is not running on thread ${threadId}`,
+          );
+        }
+        intent = {
+          id: this.#id(),
+          threadId,
+          turnId: expectedTurnId,
+          successorTurnId: this.#id(),
+          createdAt: this.#now(),
+          type: "turn_replacement_requested",
+          text,
+          clientId: options.clientId,
+        };
+        await this.#commit(thread, intent);
+        this.#emit({ type: "item_completed", item: intent });
+        active.controller.abort(
+          new DOMException("Replaced by user", "AbortError"),
+        );
+        oldDone = active.done;
+      } else {
+        const active = this.#activeTurns.get(threadId);
+        if (active?.turnId === expectedTurnId) {
+          active.controller.abort(
+            new DOMException("Replaced by user", "AbortError"),
+          );
+          oldDone = active.done;
+        } else if (active !== undefined) {
+          throw new AppServerError(
+            "replacement_pending",
+            `Thread ${threadId} is running a different Turn`,
+          );
+        } else if (!this.#isTerminal(thread, expectedTurnId)) {
+          const aborted: TurnAbortedItem = {
+            id: this.#id(),
+            threadId,
+            turnId: expectedTurnId,
+            createdAt: this.#now(),
+            type: "turn_aborted",
+            reason: "Replacement continued by explicit client retry",
+          };
+          await this.#commit(thread, aborted);
+          this.#emit({
+            type: "turn_completed",
+            threadId,
+            turnId: expectedTurnId,
+            status: "interrupted",
+          });
+        }
+      }
+
+      const replacementIntent = intent;
+      const result = Promise.resolve().then(async () => {
+        await oldDone;
+        const turn = await this.#launchTurn(
+          threadId,
+          replacementIntent.text,
+          {
+            clientId: replacementIntent.clientId,
+            ...(options.requestApproval === undefined
+              ? {}
+              : { requestApproval: options.requestApproval }),
+          },
+          {
+            turnId: replacementIntent.successorTurnId,
+            replacementClientId: replacementIntent.clientId,
+          },
+        );
+        return { interruptedTurnId: expectedTurnId, turn };
+      });
+      this.#replacementOperations.set(threadId, {
+        clientId: options.clientId,
+        result,
+      });
+      void result.then(
+        () => this.#clearReplacementOperation(threadId, result),
+        () => this.#clearReplacementOperation(threadId, result),
+      );
+      return { pending: result };
+    });
+    if ("complete" in planned) {
+      return planned.complete;
+    }
+    return await planned.pending;
   }
 
   async steerTurn(
@@ -474,6 +716,9 @@ export class ZenAppServer {
           `Turn ${turnId} is not running on thread ${thread.id}`,
         );
       }
+      if (active.controller.signal.aborted) {
+        throw active.controller.signal.reason;
+      }
       await this.#commit(thread, message);
       const pendingSteer = thread.items.some(
         (item) =>
@@ -495,6 +740,44 @@ export class ZenAppServer {
       await this.#commit(thread, completed);
       return true;
     });
+  }
+
+  #pendingReplacement(
+    thread: Thread,
+  ): TurnReplacementRequestedItem | undefined {
+    const intents = thread.items.filter(
+      (item): item is TurnReplacementRequestedItem =>
+        item.type === "turn_replacement_requested",
+    );
+    for (const intent of intents.reverse()) {
+      const successorInput = thread.items.some(
+        (item) =>
+          item.type === "user_message" &&
+          item.turnId === intent.successorTurnId &&
+          item.clientId === intent.clientId,
+      );
+      if (!successorInput) {
+        return intent;
+      }
+    }
+    return undefined;
+  }
+
+  #isTerminal(thread: Thread, turnId: string): boolean {
+    return thread.items.some(
+      (item) =>
+        item.turnId === turnId &&
+        (item.type === "turn_completed" || item.type === "turn_aborted"),
+    );
+  }
+
+  #clearReplacementOperation(
+    threadId: string,
+    result: Promise<ReplaceTurnResult>,
+  ): void {
+    if (this.#replacementOperations.get(threadId)?.result === result) {
+      this.#replacementOperations.delete(threadId);
+    }
   }
 
   async #loadThread(threadId: string): Promise<Thread | undefined> {

--- a/src/item.ts
+++ b/src/item.ts
@@ -4,6 +4,7 @@ export type ItemType =
   | "turn_started"
   | "turn_completed"
   | "turn_aborted"
+  | "turn_replacement_requested"
   | "user_message"
   | "agent_message"
   | "reasoning"
@@ -51,6 +52,14 @@ export interface TurnAbortedItem extends ItemBase {
   type: "turn_aborted";
   turnId: string;
   reason: string;
+}
+
+export interface TurnReplacementRequestedItem extends ItemBase {
+  type: "turn_replacement_requested";
+  turnId: string;
+  successorTurnId: string;
+  text: string;
+  clientId: string;
 }
 
 export interface UserMessageItem extends ItemBase {
@@ -108,6 +117,7 @@ export type CanonicalItem =
   | TurnStartedItem
   | TurnCompletedItem
   | TurnAbortedItem
+  | TurnReplacementRequestedItem
   | UserMessageItem
   | AgentMessageItem
   | ReasoningItem

--- a/src/model.ts
+++ b/src/model.ts
@@ -142,6 +142,7 @@ export function compileModelMessages(
       case "thread_metadata":
       case "turn_aborted":
       case "turn_completed":
+      case "turn_replacement_requested":
       case "turn_started":
         break;
     }

--- a/src/protocol/codex/README.md
+++ b/src/protocol/codex/README.md
@@ -23,6 +23,10 @@ Client requests：
 - `turn/steer`
 - `turn/interrupt`
 
+Zen extension：
+
+- `turn/replace`
+
 Client notification：`initialized`。
 
 Server notifications：
@@ -78,6 +82,26 @@ MCP `-c` 配置由 CLI remote bridge 启动边界验证后忽略，不进入 wir
 steer 不取消当前 model stream、tool 或 approval，也不处理 approval。若它在
 一次模型响应期间到达，Runtime 会完成该响应及其工具结果，然后在下一次 sampling
 前按 journal 中的 steer FIFO 顺序注入；因此原本可能结束的响应也会继续下一轮。
+
+## Hard steer：Zen `turn/replace` extension
+
+Codex 0.146.0 没有原子的 Interrupt & send 方法。Zen 因此增加明确的
+`turn/replace` 扩展；它不是标准 `turn/steer` mode，也不扩大 Codex 兼容声明。
+请求必须包含 `threadId`、`expectedTurnId`、text-only `input` 与非空
+`clientUserMessageId`。成功返回 `{ interruptedTurnId, turnId }`。
+
+App Server 在同一 Thread mutation boundary 内验证 active-Turn fence，先写入
+canonical `turn_replacement_requested` intent，再中断并等待旧 Turn 的
+`turn_aborted` durable，最后用 intent 中保留的 successor id 写入新的
+`turn_started` 与 `user_message`。响应只在这些事实全部 durable 后发送；任何
+时刻都不会有两个 active Turn。tool 与 pending approval 使用既有 AbortController
+路径取消并以既有 canonical 结果收口。
+
+相同 id、旧 Turn 与 input 的重试返回同一个 successor，不重复 abort/start/message；
+冲突复用失败。若进程停在旧 Turn 已 abort、successor 尚未 start 的间隙，Zen
+不会自动恢复；显式同 key 重试可以从 intent 继续。若 successor 的
+`turn_started` 已 durable 而初始 `user_message` 未 durable，则返回
+`replacement_incomplete`，不恢复半截执行或发明新 Turn。
 
 ## 兼容范围
 

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -395,6 +395,40 @@ export class CodexConnection {
         this.#send({ id: request.id, result: { turnId: handle.id } });
         return;
       }
+      case "turn/replace": {
+        rejectUnsupportedValues(params, [
+          "threadId",
+          "expectedTurnId",
+          "input",
+          "clientUserMessageId",
+        ]);
+        const threadId = requiredString(params, "threadId");
+        const expectedTurnId = requiredString(params, "expectedTurnId");
+        const text = readTextInput(params.input);
+        const clientId = requiredString(params, "clientUserMessageId");
+        this.#subscribedThreads.add(threadId);
+        const replacement = await this.#appServer.replaceTurn(
+          threadId,
+          expectedTurnId,
+          text,
+          {
+            clientId,
+            requestApproval: async (approval) =>
+              await this.#requestApproval(approval),
+          },
+        );
+        this.#send({
+          id: request.id,
+          result: {
+            interruptedTurnId: replacement.interruptedTurnId,
+            turnId: replacement.turn.id,
+          },
+        });
+        void replacement.turn.done.catch((error: unknown) => {
+          this.#sendTurnExecutionFailure(threadId, replacement.turn.id, error);
+        });
+        return;
+      }
       case "turn/interrupt": {
         await this.#appServer.interruptTurn(
           requiredString(params, "threadId"),

--- a/src/protocol/codex/mapper.ts
+++ b/src/protocol/codex/mapper.ts
@@ -242,6 +242,7 @@ export function projectCompletedItem(
     case "tool_result":
     case "turn_aborted":
     case "turn_completed":
+    case "turn_replacement_requested":
     case "turn_started":
       return null;
   }

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -449,6 +449,118 @@ test("dispatches Codex turn/steer to the same active Turn for every subscriber",
   }
 });
 
+test("turn/replace atomically interrupts the fenced Turn before starting its successor", async () => {
+  const appServer = testHost("always");
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await CodexClient.connect(server.url);
+  const replacing = await CodexClient.connect(server.url);
+  const approvalSeen = deferred<void>();
+  const releaseOldApproval = deferred<{ decision: "decline" }>();
+  const approvalResolved = deferred<void>();
+  const replacementCompleted = deferred<void>();
+  const observed: Array<{ method: string; params: unknown }> = [];
+  try {
+    await initiating.initialize({
+      name: "initiating",
+      title: "Initiating",
+      version: "1",
+    });
+    await replacing.initialize({
+      name: "replacing",
+      title: "Replacing",
+      version: "1",
+    });
+    initiating.onServerRequest(
+      "item/commandExecution/requestApproval",
+      async () => {
+        approvalSeen.resolve();
+        return await releaseOldApproval.promise;
+      },
+    );
+    initiating.onNotification("serverRequest/resolved", () => {
+      approvalResolved.resolve();
+    });
+    for (const method of ["turn/completed", "turn/started", "item/completed"]) {
+      replacing.onNotification(method, (params) => {
+        observed.push({ method, params });
+        if (
+          method === "turn/completed" &&
+          isRecord(params) &&
+          isRecord(params.turn) &&
+          params.turn.status === "completed"
+        ) {
+          replacementCompleted.resolve();
+        }
+      });
+    }
+
+    const started = await initiating.request("thread/start", {
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+    });
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    await replacing.request("thread/resume", { threadId: thread.id });
+    const turnStart = await initiating.request("turn/start", {
+      threadId: thread.id,
+      input: [{ type: "text", text: "!shell printf old" }],
+    });
+    const oldTurn = responseResult<Record<string, unknown>>(turnStart, "turn");
+    await within(approvalSeen.promise);
+
+    const response = await replacing.request("turn/replace", {
+      threadId: thread.id,
+      expectedTurnId: oldTurn.id,
+      input: [{ type: "text", text: "replacement request" }],
+      clientUserMessageId: "replace-protocol-id",
+    });
+    assert(isRecord(response));
+    assert.equal(response.interruptedTurnId, oldTurn.id);
+    assert.equal(typeof response.turnId, "string");
+    assert.notEqual(response.turnId, oldTurn.id);
+    await within(approvalResolved.promise);
+    await within(replacementCompleted.promise);
+    releaseOldApproval.resolve({ decision: "decline" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const oldCompletedIndex = observed.findIndex(
+      ({ method, params }) =>
+        method === "turn/completed" &&
+        isRecord(params) &&
+        isRecord(params.turn) &&
+        params.turn.id === oldTurn.id &&
+        params.turn.status === "interrupted",
+    );
+    const newStartedIndex = observed.findIndex(
+      ({ method, params }) =>
+        method === "turn/started" &&
+        isRecord(params) &&
+        isRecord(params.turn) &&
+        params.turn.id === response.turnId,
+    );
+    const replacementInputIndex = observed.findIndex(
+      ({ method, params }) =>
+        method === "item/completed" &&
+        isRecord(params) &&
+        isRecord(params.item) &&
+        params.item.type === "userMessage" &&
+        params.item.clientId === "replace-protocol-id",
+    );
+    assert(oldCompletedIndex >= 0);
+    assert(newStartedIndex > oldCompletedIndex);
+    assert(replacementInputIndex > newStartedIndex);
+  } finally {
+    releaseOldApproval.resolve({ decision: "decline" });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    initiating.close();
+    replacing.close();
+    await server.close();
+  }
+});
+
 test("synchronizes ZAS-owned thread names without adding Agent items", async () => {
   const appServer = testHost();
   const server = await serveCodexWebSocket({

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1515,6 +1515,205 @@ test("an interrupt that wins the mutation fence rejects a racing soft steer", as
   );
 });
 
+test("hard steer aborts the fenced Turn and starts one idempotent successor", async () => {
+  const firstSampleEntered = testDeferred<void>();
+  let samples = 0;
+  const model: ModelAdapter = {
+    provider: "replace-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      samples += 1;
+      if (samples === 1) {
+        firstSampleEntered.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          request.signal.addEventListener(
+            "abort",
+            () => reject(request.signal.reason),
+            { once: true },
+          );
+        });
+        return;
+      }
+      yield { type: "text_delta", delta: "replacement complete" };
+    },
+  };
+  const server = createServer({ model });
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "old work");
+  await firstSampleEntered.promise;
+
+  const replacementRequest = server.replaceTurn(
+    thread.id,
+    active.id,
+    "new direction",
+    { clientId: "replace-client-id" },
+  );
+  const concurrentRetry = server.replaceTurn(
+    thread.id,
+    active.id,
+    "new direction",
+    { clientId: "replace-client-id" },
+  );
+  const [replacement, concurrentDuplicate] = await Promise.all([
+    replacementRequest,
+    concurrentRetry,
+  ]);
+  assert.equal(replacement.interruptedTurnId, active.id);
+  assert.notEqual(replacement.turn.id, active.id);
+  assert.equal(concurrentDuplicate.turn.id, replacement.turn.id);
+  await replacement.turn.done;
+
+  const duplicate = await server.replaceTurn(
+    thread.id,
+    active.id,
+    "new direction",
+    { clientId: "replace-client-id" },
+  );
+  assert.equal(duplicate.turn.id, replacement.turn.id);
+  await assert.rejects(
+    server.replaceTurn(thread.id, active.id, "conflicting direction", {
+      clientId: "replace-client-id",
+    }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "idempotency_conflict",
+  );
+  await assert.rejects(
+    server.replaceTurn(thread.id, active.id, "late replacement", {
+      clientId: "late-replacement-id",
+    }),
+    (error: unknown) =>
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "turn_not_running",
+  );
+
+  const snapshot = await server.readThread(thread.id);
+  assert.deepEqual(
+    snapshot.turns.map((turn) => [turn.id, turn.status]),
+    [
+      [active.id, "interrupted"],
+      [replacement.turn.id, "completed"],
+    ],
+  );
+  const relevant = snapshot.items.filter(
+    (item) =>
+      item.type === "turn_replacement_requested" ||
+      item.type === "turn_aborted" ||
+      item.type === "turn_started" ||
+      item.type === "user_message",
+  );
+  assert.deepEqual(
+    relevant.map((item) => item.type),
+    [
+      "turn_started",
+      "user_message",
+      "turn_replacement_requested",
+      "turn_aborted",
+      "turn_started",
+      "user_message",
+    ],
+  );
+  const successorInput = relevant.at(-1);
+  assert.equal(
+    successorInput?.type === "user_message"
+      ? successorInput.clientId
+      : undefined,
+    "replace-client-id",
+  );
+  assert.equal(
+    snapshot.items.filter((item) => item.type === "turn_replacement_requested")
+      .length,
+    1,
+  );
+});
+
+test("hard steer resumes only by explicit retry after the abort/start durable gap", async () => {
+  const backing = new InMemoryThreadJournal();
+  let startedItems = 0;
+  let failSuccessorStart = true;
+  const journal: ThreadJournal = {
+    append: async (item) => {
+      if (item.type === "turn_started") {
+        startedItems += 1;
+        if (startedItems === 2 && failSuccessorStart) {
+          failSuccessorStart = false;
+          throw new Error("successor start journal failure");
+        }
+      }
+      await backing.append(item);
+    },
+    listThreadIds: async () => await backing.listThreadIds(),
+    read: async (threadId) => await backing.read(threadId),
+  };
+  const oldSampleEntered = testDeferred<void>();
+  let samples = 0;
+  const model: ModelAdapter = {
+    provider: "replace-retry-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      samples += 1;
+      if (samples === 1) {
+        oldSampleEntered.resolve();
+        await new Promise<void>((_resolve, reject) => {
+          request.signal.addEventListener(
+            "abort",
+            () => reject(request.signal.reason),
+            { once: true },
+          );
+        });
+        return;
+      }
+      yield { type: "text_delta", delta: "retried successor" };
+    },
+  };
+  const firstHost = createServer({ journal, model });
+  const thread = await firstHost.startThread();
+  const active = await firstHost.startTurn(thread.id, "old work");
+  await oldSampleEntered.promise;
+
+  await assert.rejects(
+    firstHost.replaceTurn(thread.id, active.id, "retry this replacement", {
+      clientId: "replace-retry-id",
+    }),
+    /successor start journal failure/u,
+  );
+  const interrupted = await firstHost.readThread(thread.id);
+  const intent = interrupted.items.find(
+    (item) => item.type === "turn_replacement_requested",
+  );
+  assert(intent !== undefined);
+  assert.equal(interrupted.turns[0]?.status, "interrupted");
+  assert.equal(
+    interrupted.items.some(
+      (item) =>
+        item.type === "turn_started" && item.turnId === intent.successorTurnId,
+    ),
+    false,
+  );
+
+  const restarted = createServer({ journal, model });
+  const recovered = await restarted.replaceTurn(
+    thread.id,
+    active.id,
+    "retry this replacement",
+    { clientId: "replace-retry-id" },
+  );
+  assert.equal(recovered.turn.id, intent.successorTurnId);
+  await recovered.turn.done;
+  const snapshot = await restarted.readThread(thread.id);
+  assert.deepEqual(
+    snapshot.turns.map((turn) => turn.status),
+    ["interrupted", "completed"],
+  );
+  assert.equal(
+    snapshot.items.filter(
+      (item) =>
+        item.type === "user_message" && item.clientId === "replace-retry-id",
+    ).length,
+    1,
+  );
+});
+
 function testDeferred<T>(): {
   promise: Promise<T>;
   resolve: (value: T extends void ? void : T) => void;


### PR DESCRIPTION
Closes #27

## What changed

- adds the explicit Zen `turn/replace` extension instead of overloading Codex `turn/steer`
- fences the expected active Turn, persists a canonical replacement intent, aborts the old execution, and starts one reserved successor Turn
- acknowledges only after old `turn_aborted`, new `turn_started`, and successor `user_message` are durable
- coalesces concurrent retries with the same `clientUserMessageId` and rejects conflicting reuse
- preserves crash-boundary facts in ItemList without a hidden durable command table
- permits only an explicit same-key retry to continue the abort/start gap
- refuses to resume a successor whose `turn_started` exists without its initial user message
- keeps tool and approval cancellation on the existing AbortController path

## Review focus

- old Turn completion/interrupt/steer/replacement races share the Thread mutation fence
- no interval exposes two active Turns
- ordinary `turn/start` and settings changes cannot bypass an unresolved replacement intent
- `turn_replacement_requested` is ignored by model and Codex Item projection but remains visible in the canonical journal

## Validation

- `npm run check`
- 87 Node tests passed
- 42 IMZen tests passed
- `git diff --check`
