### PR TITLE
ZenX composer: steer and atomic interrupt-send

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -16,6 +16,9 @@
 - **TurnReplacementIntent** — canonical `turn_replacement_requested` Item 记录一次
   fenced Interrupt & send 的旧/新 Turn id、输入与幂等 key，使显式客户端重试能
   从 abort/start 崩溃间隙继续，而不依赖隐藏 command queue 或恢复表。
+- **ComposerSubmission** — 接入端一次待确认的用户提交；只在 UI 内保留草稿、
+  发送意图和稳定 `clientUserMessageId`，是否已进入会话仍完全由 App Server 的
+  canonical Item 投影决定。
 - **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
   append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
   canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -21,7 +21,8 @@ import {
 
 export type AppServerHostStatus =
   | { type: "starting" }
-  | { type: "ready" }
+  | { type: "ready"; reconnected: boolean }
+  | { type: "reconnecting"; attempt: number; delayMs: number }
   | { type: "error"; message: string }
   | { type: "stopped" };
 
@@ -131,7 +132,7 @@ export class AppServerManager {
         bearerTokenFile: this.#options.tokenFile,
       });
       this.#forwardNotifications(this.#client);
-      this.#setStatus({ type: "ready" });
+      this.#setStatus({ type: "ready", reconnected: false });
     } catch (error) {
       const message = asError(error).message;
       this.#setStatus({ type: "error", message });
@@ -210,6 +211,20 @@ export class AppServerManager {
   }
 
   #forwardNotifications(client: ZenXProtocolClient): void {
+    client.onStatus((status) => {
+      if (client !== this.#client || this.#stopping) return;
+      if (status.type === "reconnecting") {
+        this.#setStatus({
+          type: "reconnecting",
+          attempt: status.attempt,
+          delayMs: status.delayMs,
+        });
+      } else if (status.type === "ready" && status.reconnected) {
+        this.#setStatus({ type: "ready", reconnected: true });
+      } else if (status.type === "protocolError") {
+        this.#setStatus({ type: "error", message: status.error.message });
+      }
+    });
     client.onServerRequest(
       "item/commandExecution/requestApproval",
       async (params, context) => {

--- a/apps/zenx/src/protocol-client/methods.ts
+++ b/apps/zenx/src/protocol-client/methods.ts
@@ -12,6 +12,8 @@ export const clientRequestMethods = [
   "thread/settings/update",
   "thread/unsubscribe",
   "turn/start",
+  "turn/steer",
+  "turn/replace",
   "turn/interrupt",
 ] as const satisfies readonly Exclude<ClientRequestMethod, "initialize">[];
 

--- a/apps/zenx/src/protocol-client/types.ts
+++ b/apps/zenx/src/protocol-client/types.ts
@@ -110,6 +110,18 @@ export interface ClientRequestParams {
     input: Array<{ type: "text"; text: string }>;
     clientUserMessageId?: string;
   } & ThreadConfigurationParams;
+  "turn/steer": {
+    threadId: string;
+    expectedTurnId: string;
+    input: Array<{ type: "text"; text: string }>;
+    clientUserMessageId?: string;
+  };
+  "turn/replace": {
+    threadId: string;
+    expectedTurnId: string;
+    input: Array<{ type: "text"; text: string }>;
+    clientUserMessageId: string;
+  };
   "turn/interrupt": { threadId: string; turnId: string };
 }
 
@@ -134,6 +146,8 @@ export interface ClientRequestResults {
     status: "unsubscribed" | "notSubscribed";
   };
   "turn/start": { turn: Turn };
+  "turn/steer": { turnId: string };
+  "turn/replace": { interruptedTurnId: string; turnId: string };
   "turn/interrupt": Record<string, never>;
 }
 

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -35,9 +35,20 @@ import {
   type SidebarMode,
 } from "./thread-list";
 import { applyThreadViewNotification } from "./thread-view-state";
+import {
+  acceptComposerSubmission,
+  beginComposerSubmission,
+  editComposer,
+  emptyComposerState,
+  failComposerSubmission,
+  type ComposerIntent,
+  type ComposerState,
+} from "./composer-state";
 
 export function App() {
   const selectionEpoch = useRef(0);
+  const selectedThreadIdRef = useRef<string | null>(null);
+  const composerStatesRef = useRef<Record<string, ComposerState>>({});
   const [railOpen, setRailOpen] = useState(true);
   const [serverStatus, setServerStatus] = useState<AppServerHostStatus>({
     type: "starting",
@@ -64,6 +75,34 @@ export function App() {
     }
   });
   const [requestError, setRequestError] = useState<string | null>(null);
+  const [composerStates, setComposerStates] = useState<
+    Record<string, ComposerState>
+  >({});
+
+  const resumeThread = async (threadId: string) => {
+    const epoch = ++selectionEpoch.current;
+    selectedThreadIdRef.current = threadId;
+    setSelectedThreadId(threadId);
+    setThreadDetail(null);
+    setSelectedSettings(null);
+    setModelUpdateError(null);
+    setThreadLoading(true);
+    setThreadError(null);
+    try {
+      const result = await window.zenx.protocol.request("thread/resume", {
+        threadId,
+      });
+      if (selectionEpoch.current !== epoch) return;
+      setThreadDetail(result.thread);
+      setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
+    } catch (error) {
+      if (selectionEpoch.current === epoch) {
+        setThreadError(describeError(error));
+      }
+    } finally {
+      if (selectionEpoch.current === epoch) setThreadLoading(false);
+    }
+  };
 
   useEffect(() => {
     let active = true;
@@ -100,6 +139,9 @@ export function App() {
       if (status.type === "ready") {
         void loadThreads();
         void loadModels();
+        if (status.reconnected && selectedThreadIdRef.current !== null) {
+          void resumeThread(selectedThreadIdRef.current);
+        }
       }
     });
     const disposeNotifications = window.zenx.protocol.onNotification(
@@ -177,29 +219,7 @@ export function App() {
     null;
   const pendingThreadIds = pendingApprovalThreadIds(approvals);
 
-  const selectThread = async (threadId: string) => {
-    const epoch = ++selectionEpoch.current;
-    setSelectedThreadId(threadId);
-    setThreadDetail(null);
-    setSelectedSettings(null);
-    setModelUpdateError(null);
-    setThreadLoading(true);
-    setThreadError(null);
-    try {
-      const result = await window.zenx.protocol.request("thread/resume", {
-        threadId,
-      });
-      if (selectionEpoch.current !== epoch) return;
-      setThreadDetail(result.thread);
-      setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
-    } catch (error) {
-      if (selectionEpoch.current === epoch) {
-        setThreadError(describeError(error));
-      }
-    } finally {
-      if (selectionEpoch.current === epoch) setThreadLoading(false);
-    }
-  };
+  const selectThread = resumeThread;
 
   const newThread = async () => {
     const epoch = ++selectionEpoch.current;
@@ -209,6 +229,7 @@ export function App() {
     try {
       const result = await window.zenx.protocol.request("thread/start", {});
       if (selectionEpoch.current !== epoch) return;
+      selectedThreadIdRef.current = result.thread.id;
       setSelectedThreadId(result.thread.id);
       setThreadDetail(result.thread);
       setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
@@ -226,12 +247,83 @@ export function App() {
     }
   };
 
-  const startTurn = async (text: string) => {
-    if (threadDetail === null) throw new Error("No thread is selected");
-    await window.zenx.protocol.request("turn/start", {
-      threadId: threadDetail.id,
-      input: [{ type: "text", text }],
-    });
+  const updateComposer = (
+    threadId: string,
+    update: (state: ComposerState) => ComposerState,
+  ): ComposerState => {
+    const current = composerStatesRef.current[threadId] ?? emptyComposerState();
+    const next = update(current);
+    if (next !== current) {
+      composerStatesRef.current = {
+        ...composerStatesRef.current,
+        [threadId]: next,
+      };
+      setComposerStates(composerStatesRef.current);
+    }
+    return next;
+  };
+
+  const changeDraft = (threadId: string, draft: string) => {
+    updateComposer(threadId, (state) => editComposer(state, draft));
+  };
+
+  const submitComposer = async (
+    intent: ComposerIntent,
+    expectedTurnId: string | null,
+  ) => {
+    if (threadDetail === null) return;
+    const threadId = threadDetail.id;
+    if (composerStatesRef.current[threadId]?.submission?.status === "pending") {
+      return;
+    }
+    const started = updateComposer(threadId, (state) =>
+      beginComposerSubmission(state, intent, expectedTurnId, () =>
+        crypto.randomUUID(),
+      ),
+    );
+    const submission = started.submission;
+    if (submission === null || submission.status !== "pending") return;
+    try {
+      const input = [{ type: "text" as const, text: submission.text }];
+      if (submission.intent === "start") {
+        await window.zenx.protocol.request("turn/start", {
+          threadId,
+          input,
+          clientUserMessageId: submission.clientUserMessageId,
+        });
+      } else if (submission.intent === "steer") {
+        if (submission.expectedTurnId === null) {
+          throw new Error("The active turn changed before steering");
+        }
+        await window.zenx.protocol.request("turn/steer", {
+          threadId,
+          expectedTurnId: submission.expectedTurnId,
+          input,
+          clientUserMessageId: submission.clientUserMessageId,
+        });
+      } else {
+        if (submission.expectedTurnId === null) {
+          throw new Error("The active turn changed before replacement");
+        }
+        await window.zenx.protocol.request("turn/replace", {
+          threadId,
+          expectedTurnId: submission.expectedTurnId,
+          input,
+          clientUserMessageId: submission.clientUserMessageId,
+        });
+      }
+      updateComposer(threadId, (state) =>
+        acceptComposerSubmission(state, submission.clientUserMessageId),
+      );
+    } catch (error) {
+      updateComposer(threadId, (state) =>
+        failComposerSubmission(
+          state,
+          submission.clientUserMessageId,
+          describeError(error),
+        ),
+      );
+    }
   };
 
   const interruptTurn = async (turnId: string) => {
@@ -355,10 +447,32 @@ export function App() {
             <span>Restart ZenX after checking the host configuration.</span>
           </section>
         ) : serverStatus.type !== "ready" ? (
-          <section className="empty-canvas" aria-live="polite">
-            <div className="loading-ring" aria-hidden="true" />
-            <h2>Starting Zen App Server</h2>
-            <p>Connecting to the local agent runtime…</p>
+          <section
+            className="empty-canvas"
+            aria-live="polite"
+            role={serverStatus.type === "stopped" ? "alert" : undefined}
+          >
+            {serverStatus.type === "starting" ? (
+              <div className="loading-ring" aria-hidden="true" />
+            ) : (
+              <div className="empty-glyph" aria-hidden="true">
+                <Icon name="warning" size={22} />
+              </div>
+            )}
+            <h2>
+              {serverStatus.type === "starting"
+                ? "Starting Zen App Server"
+                : serverStatus.type === "reconnecting"
+                  ? "Reconnecting to Zen App Server"
+                  : "Zen App Server disconnected"}
+            </h2>
+            <p>
+              {serverStatus.type === "starting"
+                ? "Connecting to the local agent runtime…"
+                : serverStatus.type === "reconnecting"
+                  ? `Attempt ${serverStatus.attempt}. Your draft is preserved; the current thread will be rebuilt from App Server history after reconnecting.`
+                  : "Your draft is preserved. Restart ZenX to reconnect and rebuild the thread from App Server history."}
+            </p>
           </section>
         ) : threadLoading ? (
           <section className="empty-canvas" aria-live="polite">
@@ -395,9 +509,11 @@ export function App() {
             approvals={approvals.filter(
               (approval) => approval.params.threadId === threadDetail.id,
             )}
+            composer={composerStates[threadDetail.id] ?? emptyComposerState()}
+            onDraftChange={(draft) => changeDraft(threadDetail.id, draft)}
             onInterrupt={interruptTurn}
             onRespondToApproval={respondToApproval}
-            onStartTurn={startTurn}
+            onSubmit={submitComposer}
             thread={threadDetail}
           />
         ) : (

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -2,32 +2,42 @@ import { useEffect, useRef, useState } from "react";
 
 import type { ApprovalDecision } from "../../main/app-server-manager.js";
 import type { Thread, ThreadItem, Turn } from "../../protocol-client/index.js";
-import type { ApprovalCardState } from "./approval-state";
-import { Icon } from "./icons";
-import { activeTurn } from "./thread-view-state";
+import type { ApprovalCardState } from "./approval-state.js";
+import {
+  defaultComposerIntent,
+  type ComposerIntent,
+  type ComposerState,
+} from "./composer-state.js";
+import { Icon } from "./icons.js";
+import { activeTurn } from "./thread-view-state.js";
 
 interface ThreadViewProps {
   approvals: readonly ApprovalCardState[];
+  composer: ComposerState;
   thread: Thread;
+  onDraftChange(draft: string): void;
   onInterrupt(turnId: string): Promise<void>;
   onRespondToApproval(
     requestId: string,
     decision: ApprovalDecision,
   ): Promise<void>;
-  onStartTurn(text: string): Promise<void>;
+  onSubmit(
+    intent: ComposerIntent,
+    expectedTurnId: string | null,
+  ): Promise<void>;
 }
 
 export function ThreadView({
   approvals,
+  composer,
   thread,
+  onDraftChange,
   onInterrupt,
   onRespondToApproval,
-  onStartTurn,
+  onSubmit,
 }: ThreadViewProps) {
-  const [draft, setDraft] = useState("");
-  const [submitting, setSubmitting] = useState(false);
   const [interrupting, setInterrupting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [interruptError, setInterruptError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const runningTurn = activeTurn(thread);
 
@@ -36,33 +46,33 @@ export function ThreadView({
     if (scroll !== null) scroll.scrollTop = scroll.scrollHeight;
   }, [thread.turns]);
 
-  const submit = async () => {
-    const text = draft.trim();
-    if (text.length === 0 || runningTurn !== null || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      await onStartTurn(text);
-      setDraft("");
-    } catch (requestError) {
-      setError(describeError(requestError));
-    } finally {
-      setSubmitting(false);
-    }
+  const submit = (intent: ComposerIntent) => {
+    if (composer.draft.trim().length === 0 || isSubmitting(composer)) return;
+    if (intent === "start" && runningTurn !== null) return;
+    if (intent !== "start" && runningTurn === null) return;
+    void onSubmit(intent, runningTurn?.id ?? null);
   };
 
   const interrupt = async () => {
     if (runningTurn === null || interrupting) return;
     setInterrupting(true);
-    setError(null);
+    setInterruptError(null);
     try {
       await onInterrupt(runningTurn.id);
     } catch (requestError) {
-      setError(describeError(requestError));
+      setInterruptError(describeError(requestError));
     } finally {
       setInterrupting(false);
     }
   };
+  const pendingApproval =
+    runningTurn !== null &&
+    approvals.some(
+      (approval) =>
+        approval.params.turnId === runningTurn.id &&
+        approval.status === "pending",
+    );
+  const submitting = isSubmitting(composer);
 
   return (
     <>
@@ -96,54 +106,121 @@ export function ThreadView({
         <div className="composer">
           <textarea
             aria-label="Message"
-            disabled={runningTurn !== null || submitting}
-            onChange={(event) => setDraft(event.target.value)}
+            onChange={(event) => onDraftChange(event.target.value)}
             onKeyDown={(event) => {
               if (event.key === "Enter" && !event.shiftKey) {
                 event.preventDefault();
-                void submit();
+                submit(defaultComposerIntent(runningTurn !== null));
               }
             }}
             placeholder={
               runningTurn === null
                 ? "Send a message…"
-                : "Wait for the current turn to finish or interrupt it."
+                : "Steer the active turn…"
             }
             rows={1}
-            value={draft}
+            value={composer.draft}
           />
           <div className="composer-row">
-            <span className={error === null ? undefined : "composer-error"}>
-              {error ??
-                (runningTurn === null
-                  ? "Enter to send · Shift+Enter for a new line"
-                  : "A thread can run only one turn at a time.")}
+            <span
+              className={
+                composer.submission?.status === "failed" ||
+                interruptError !== null
+                  ? "composer-error"
+                  : undefined
+              }
+              role={
+                composer.submission?.status === "failed" ||
+                interruptError !== null
+                  ? "alert"
+                  : undefined
+              }
+            >
+              {composerStatus(
+                composer,
+                runningTurn !== null,
+                pendingApproval,
+                interruptError,
+              )}
             </span>
             {runningTurn === null ? (
               <button
                 className="send-button"
                 type="button"
-                disabled={draft.trim().length === 0 || submitting}
-                onClick={() => void submit()}
+                disabled={composer.draft.trim().length === 0 || submitting}
+                onClick={() => submit("start")}
               >
                 {submitting ? "Starting…" : "Send"}
               </button>
             ) : (
-              <button
-                className="interrupt-button"
-                type="button"
-                disabled={interrupting}
-                onClick={() => void interrupt()}
-              >
-                <Icon name="stop" size={12} />
-                {interrupting ? "Stopping…" : "Interrupt"}
-              </button>
+              <div className="active-turn-actions">
+                <button
+                  className="stop-button"
+                  type="button"
+                  aria-label="Interrupt without sending the draft"
+                  disabled={interrupting || submitting}
+                  onClick={() => void interrupt()}
+                >
+                  <Icon name="stop" size={12} />
+                  {interrupting ? "Stopping…" : "Interrupt"}
+                </button>
+                <button
+                  className="replace-button"
+                  type="button"
+                  aria-label="Interrupt the active turn and send this draft as a new turn"
+                  disabled={composer.draft.trim().length === 0 || submitting}
+                  onClick={() => submit("replace")}
+                >
+                  {submitting && composer.submission?.intent === "replace"
+                    ? "Replacing…"
+                    : "Interrupt & send"}
+                </button>
+                <button
+                  className="send-button"
+                  type="button"
+                  aria-label="Steer the active turn with this message"
+                  disabled={composer.draft.trim().length === 0 || submitting}
+                  onClick={() => submit("steer")}
+                >
+                  {submitting && composer.submission?.intent === "steer"
+                    ? "Steering…"
+                    : "Steer now"}
+                </button>
+              </div>
             )}
           </div>
         </div>
       </div>
     </>
   );
+}
+
+function isSubmitting(composer: ComposerState): boolean {
+  return composer.submission?.status === "pending";
+}
+
+function composerStatus(
+  composer: ComposerState,
+  active: boolean,
+  pendingApproval: boolean,
+  interruptError: string | null,
+): string {
+  if (interruptError !== null) return interruptError;
+  if (composer.submission?.status === "failed") {
+    return `${composer.submission.error ?? "Send failed"} Draft kept; retry uses the same message ID.`;
+  }
+  if (composer.submission?.status === "pending") {
+    return composer.submission.intent === "replace"
+      ? "Interrupting the current turn, then starting the replacement…"
+      : composer.submission.intent === "steer"
+        ? "Adding guidance to the current turn…"
+        : "Starting a new turn…";
+  }
+  if (!active) return "Enter to send · Shift+Enter for a new line";
+  if (pendingApproval) {
+    return "Steering adds guidance but does not approve the pending command. Interrupt & send cancels it.";
+  }
+  return "Enter steers this turn · Interrupt stops only · Interrupt & send starts a replacement turn";
 }
 
 function TurnBlock({

--- a/apps/zenx/src/renderer/src/composer-state.ts
+++ b/apps/zenx/src/renderer/src/composer-state.ts
@@ -1,0 +1,100 @@
+export type ComposerIntent = "start" | "steer" | "replace";
+
+export interface ComposerSubmission {
+  intent: ComposerIntent;
+  expectedTurnId: string | null;
+  clientUserMessageId: string;
+  draftAtSubmit: string;
+  text: string;
+  status: "pending" | "failed";
+  error: string | null;
+}
+
+export interface ComposerState {
+  draft: string;
+  submission: ComposerSubmission | null;
+}
+
+export function emptyComposerState(): ComposerState {
+  return { draft: "", submission: null };
+}
+
+export function defaultComposerIntent(active: boolean): "start" | "steer" {
+  return active ? "steer" : "start";
+}
+
+export function editComposer(
+  state: ComposerState,
+  draft: string,
+): ComposerState {
+  const submission =
+    state.submission?.status === "failed" &&
+    draft !== state.submission.draftAtSubmit
+      ? null
+      : state.submission;
+  return { draft, submission };
+}
+
+export function beginComposerSubmission(
+  state: ComposerState,
+  intent: ComposerIntent,
+  expectedTurnId: string | null,
+  createId: () => string,
+): ComposerState {
+  if (state.submission?.status === "pending") return state;
+  const text = state.draft.trim();
+  if (text.length === 0) return state;
+  const retry =
+    state.submission?.status === "failed" &&
+    state.submission.intent === intent &&
+    state.submission.expectedTurnId === expectedTurnId &&
+    state.submission.draftAtSubmit === state.draft;
+  return {
+    ...state,
+    submission: {
+      intent,
+      expectedTurnId,
+      clientUserMessageId: retry
+        ? state.submission!.clientUserMessageId
+        : createId(),
+      draftAtSubmit: state.draft,
+      text,
+      status: "pending",
+      error: null,
+    },
+  };
+}
+
+export function acceptComposerSubmission(
+  state: ComposerState,
+  clientUserMessageId: string,
+): ComposerState {
+  const submission = matchingSubmission(state, clientUserMessageId);
+  if (submission === null) return state;
+  return {
+    draft: state.draft === submission.draftAtSubmit ? "" : state.draft,
+    submission: null,
+  };
+}
+
+export function failComposerSubmission(
+  state: ComposerState,
+  clientUserMessageId: string,
+  error: string,
+): ComposerState {
+  const submission = matchingSubmission(state, clientUserMessageId);
+  if (submission === null) return state;
+  return {
+    ...state,
+    submission: { ...submission, status: "failed", error },
+  };
+}
+
+function matchingSubmission(
+  state: ComposerState,
+  clientUserMessageId: string,
+): ComposerSubmission | null {
+  return state.submission?.clientUserMessageId === clientUserMessageId
+    ? state.submission
+    : null;
+}

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1100,6 +1100,7 @@ summary:focus-visible {
 .composer-row {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 12px;
 }
 
@@ -1114,7 +1115,8 @@ summary:focus-visible {
 }
 
 .send-button,
-.interrupt-button {
+.stop-button,
+.replace-button {
   display: inline-flex;
   min-height: 28px;
   align-items: center;
@@ -1136,18 +1138,34 @@ summary:focus-visible {
   background: var(--color-blue);
 }
 
-.interrupt-button {
+.stop-button {
   color: #f7b3b1;
   background: rgba(240, 113, 111, 0.16);
 }
 
+.replace-button {
+  border: 1px solid rgba(240, 113, 111, 0.42);
+  color: #f7b3b1;
+  background: transparent;
+}
+
+.active-turn-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
 .send-button:hover:not(:disabled),
-.interrupt-button:hover:not(:disabled) {
+.stop-button:hover:not(:disabled),
+.replace-button:hover:not(:disabled) {
   filter: brightness(1.1);
 }
 
 .send-button:disabled,
-.interrupt-button:disabled {
+.stop-button:disabled,
+.replace-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -32,6 +32,7 @@ test("hosts a real App Server and removes its private token on shutdown", async 
   const tokenFile = path.join(directory, "runtime", "app-server.token");
   try {
     await manager.start();
+    assert.deepEqual(manager.status, { type: "ready", reconnected: false });
     assert.deepEqual(await manager.request("thread/list", {}), {
       data: [],
       nextCursor: null,

--- a/apps/zenx/test/composer-state.test.ts
+++ b/apps/zenx/test/composer-state.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  acceptComposerSubmission,
+  beginComposerSubmission,
+  defaultComposerIntent,
+  editComposer,
+  emptyComposerState,
+  failComposerSubmission,
+} from "../src/renderer/src/composer-state.js";
+
+test("maps idle, active, and replacement submissions without a queue", () => {
+  let ids = 0;
+  const createId = () => `message-${++ids}`;
+  const idle = editComposer(emptyComposerState(), "first");
+  const start = beginComposerSubmission(idle, "start", null, createId);
+  assert.deepEqual(start.submission, {
+    intent: "start",
+    expectedTurnId: null,
+    clientUserMessageId: "message-1",
+    draftAtSubmit: "first",
+    text: "first",
+    status: "pending",
+    error: null,
+  });
+
+  const active = beginComposerSubmission(
+    editComposer(emptyComposerState(), "guide it"),
+    "steer",
+    "turn-1",
+    createId,
+  );
+  assert.equal(active.submission?.intent, "steer");
+  assert.equal(active.submission?.expectedTurnId, "turn-1");
+
+  const replacement = beginComposerSubmission(
+    editComposer(emptyComposerState(), "do this instead"),
+    "replace",
+    "turn-1",
+    createId,
+  );
+  assert.equal(replacement.submission?.intent, "replace");
+  assert.equal("queue" in replacement, false);
+  assert.equal(defaultComposerIntent(false), "start");
+  assert.equal(defaultComposerIntent(true), "steer");
+});
+
+test("a pending request is a click fence, not a local queue", () => {
+  const pending = beginComposerSubmission(
+    editComposer(emptyComposerState(), "one"),
+    "steer",
+    "turn-1",
+    () => "message-1",
+  );
+  const second = beginComposerSubmission(
+    editComposer(pending, "two"),
+    "steer",
+    "turn-1",
+    () => "message-2",
+  );
+  assert.equal(second.submission?.clientUserMessageId, "message-1");
+  assert.equal(second.submission?.text, "one");
+  assert.equal(second.draft, "two");
+});
+
+test("keeps the draft and stable message id across a transport retry", () => {
+  let ids = 0;
+  const createId = () => `message-${++ids}`;
+  let state = beginComposerSubmission(
+    editComposer(emptyComposerState(), "retry me"),
+    "steer",
+    "turn-1",
+    createId,
+  );
+  state = failComposerSubmission(state, "message-1", "socket closed");
+  assert.equal(state.draft, "retry me");
+  assert.equal(state.submission?.status, "failed");
+
+  state = beginComposerSubmission(state, "steer", "turn-1", createId);
+  assert.equal(state.submission?.clientUserMessageId, "message-1");
+  assert.equal(ids, 1);
+});
+
+test("editing a failed draft creates a new operation id", () => {
+  let ids = 0;
+  const createId = () => `message-${++ids}`;
+  let state = beginComposerSubmission(
+    editComposer(emptyComposerState(), "old"),
+    "start",
+    null,
+    createId,
+  );
+  state = failComposerSubmission(state, "message-1", "offline");
+  state = editComposer(state, "new");
+  state = beginComposerSubmission(state, "start", null, createId);
+  assert.equal(state.submission?.clientUserMessageId, "message-2");
+});
+
+test("acceptance clears only the submitted draft and never invents history", () => {
+  const createId = () => "message-1";
+  let state = beginComposerSubmission(
+    editComposer(emptyComposerState(), "submitted"),
+    "start",
+    null,
+    createId,
+  );
+  state = editComposer(state, "typed while sending");
+  state = acceptComposerSubmission(state, "message-1");
+  assert.equal(state.draft, "typed while sending");
+  assert.equal(state.submission, null);
+  assert.deepEqual(Object.keys(state).sort(), ["draft", "submission"]);
+});

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import test from "node:test";
+
+import type { Thread, Turn } from "../src/protocol-client/index.js";
+import type { ApprovalCardState } from "../src/renderer/src/approval-state.js";
+import {
+  beginComposerSubmission,
+  editComposer,
+  emptyComposerState,
+  type ComposerState,
+} from "../src/renderer/src/composer-state.js";
+import { ThreadView } from "../src/renderer/src/ThreadView.js";
+
+const noop = async () => undefined;
+
+test("idle composer exposes only normal send", () => {
+  const html = render(false, []);
+  assert.match(html, />Send</);
+  assert.doesNotMatch(html, /Steer now/);
+  assert.doesNotMatch(html, /Interrupt &amp; send/);
+  assert.doesNotMatch(html, /Queue/i);
+});
+
+test("active composer stays editable and exposes three distinct actions", () => {
+  const html = render(true, []);
+  assert.match(html, /aria-label="Message"/);
+  assert.doesNotMatch(html, /<textarea[^>]*disabled/);
+  assert.match(html, /Steer now/);
+  assert.match(html, /Interrupt &amp; send/);
+  assert.match(html, /Interrupt without sending the draft/);
+  assert.doesNotMatch(html, /Queue/i);
+});
+
+test("pending approval explains steer and hard-steer behavior", () => {
+  const approval = {
+    requestId: "approval-1",
+    status: "pending",
+    decision: null,
+    params: {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      itemId: "command-1",
+      command: "printf ok",
+      cwd: "/workspace",
+    },
+  } as ApprovalCardState;
+  const html = render(true, [approval]);
+  assert.match(html, /does not approve the pending command/);
+  assert.match(html, /Interrupt &amp; send cancels it/);
+});
+
+test("pending submission fences duplicate actions without locking the editor", () => {
+  const composer = beginComposerSubmission(
+    editComposer(emptyComposerState(), "guidance"),
+    "steer",
+    "turn-1",
+    () => "message-1",
+  );
+  const html = render(true, [], composer);
+  assert.doesNotMatch(html, /<textarea[^>]*disabled/);
+  assert.match(html, /<button[^>]*disabled[^>]*>.*Steering…/s);
+  assert.match(html, /Adding guidance to the current turn/);
+});
+
+function render(
+  active: boolean,
+  approvals: readonly ApprovalCardState[],
+  composer: ComposerState = emptyComposerState(),
+) {
+  return renderToStaticMarkup(
+    createElement(ThreadView, {
+      approvals,
+      composer,
+      thread: thread(active ? [turn()] : []),
+      onDraftChange: () => undefined,
+      onInterrupt: noop,
+      onRespondToApproval: noop,
+      onSubmit: noop,
+    }),
+  );
+}
+
+function thread(turns: Turn[]): Thread {
+  return {
+    id: "thread-1",
+    sessionId: "thread-1",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "fake",
+    createdAt: 10,
+    updatedAt: 10,
+    recencyAt: null,
+    status:
+      turns.length === 0
+        ? { type: "idle" }
+        : { type: "active", activeFlags: [] },
+    path: null,
+    cwd: "/workspace",
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns,
+  };
+}
+
+function turn(): Turn {
+  return {
+    id: "turn-1",
+    items: [],
+    itemsView: "full",
+    status: "inProgress",
+    error: null,
+    startedAt: 10,
+    completedAt: null,
+    durationMs: null,
+  };
+}

--- a/apps/zenx/test/thread-view-integration.test.ts
+++ b/apps/zenx/test/thread-view-integration.test.ts
@@ -59,6 +59,79 @@ test("projects a streamed tool turn from the hosted App Server", async () => {
   }
 });
 
+test("drives soft steer and atomic Interrupt & send through the hosted App Server", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-steer-"));
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "always",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+  try {
+    await manager.start();
+    const started = await manager.request("thread/start", {});
+    const approval = deferred<void>();
+    const approvalCancelled = deferred<void>();
+    const disposeApproval = manager.onApprovalRequest(() => approval.resolve());
+    const disposeResolved = manager.onApprovalResolved((event) => {
+      if (event.decision === "cancel") approvalCancelled.resolve();
+    });
+    const old = await manager.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "!shell printf old" }],
+      clientUserMessageId: "start-old",
+    });
+    await within(approval.promise);
+
+    const steered = await manager.request("turn/steer", {
+      threadId: started.thread.id,
+      expectedTurnId: old.turn.id,
+      input: [{ type: "text", text: "use this guidance" }],
+      clientUserMessageId: "steer-one",
+    });
+    assert.equal(steered.turnId, old.turn.id);
+
+    const replaced = await manager.request("turn/replace", {
+      threadId: started.thread.id,
+      expectedTurnId: old.turn.id,
+      input: [{ type: "text", text: "replacement work" }],
+      clientUserMessageId: "replace-one",
+    });
+    assert.equal(replaced.interruptedTurnId, old.turn.id);
+    assert.notEqual(replaced.turnId, old.turn.id);
+    await within(approvalCancelled.promise);
+    assert.equal(manager.pendingApprovalRequests.length, 0);
+
+    const read = await manager.request("thread/read", {
+      threadId: started.thread.id,
+      includeTurns: true,
+    });
+    assert.equal(read.thread.turns[0]?.status, "interrupted");
+    assert.equal(read.thread.turns[1]?.id, replaced.turnId);
+    assert(
+      read.thread.turns[1]?.items.some(
+        (item) =>
+          item.type === "userMessage" &&
+          item.clientId === "replace-one" &&
+          item.content[0]?.text === "replacement work",
+      ),
+    );
+    disposeApproval();
+    disposeResolved();
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((resolvePromise) => {

--- a/apps/zenx/test/thread-view-state.test.ts
+++ b/apps/zenx/test/thread-view-state.test.ts
@@ -91,6 +91,30 @@ test("streams command output and replaces it with the completed projection", () 
   assert.equal(commandOutput(current), "final output");
 });
 
+test("projects hard steer as an interrupted turn followed by one successor", () => {
+  const old = turn("turn-old", "inProgress", [
+    userItem("user-old", "old work"),
+  ]);
+  let current = thread([old]);
+  current = applyThreadViewNotification(current, "turn/completed", {
+    threadId: current.id,
+    turn: turn(old.id, "interrupted", old.items),
+  });
+  current = applyThreadViewNotification(current, "turn/started", {
+    threadId: current.id,
+    turn: turn("turn-new", "inProgress", [userItem("user-new", "replacement")]),
+  });
+
+  assert.deepEqual(
+    current.turns.map(({ id, status }) => ({ id, status })),
+    [
+      { id: "turn-old", status: "interrupted" },
+      { id: "turn-new", status: "inProgress" },
+    ],
+  );
+  assert.equal(activeTurn(current)?.id, "turn-new");
+});
+
 function thread(turns: Turn[] = []): Thread {
   return {
     id: "thread-1",

--- a/apps/zenx/tsconfig.node.json
+++ b/apps/zenx/tsconfig.node.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -598,10 +598,13 @@ export class ZenAppServer {
       );
       return { pending: result };
     });
-    if ("complete" in planned) {
+    if ("complete" in planned && planned.complete !== undefined) {
       return planned.complete;
     }
-    return await planned.pending;
+    if ("pending" in planned && planned.pending !== undefined) {
+      return await planned.pending;
+    }
+    throw new Error("Turn replacement did not produce a result");
   }
 
   async steerTurn(


### PR DESCRIPTION
Closes #28
Part of #25
Updates the manual acceptance surface in #10.

## What changed

- keep the active-Turn composer editable and make Enter / the primary action call `turn/steer`
- add explicit atomic `Interrupt & send` through `turn/replace`, while standalone Interrupt remains stop-only
- add typed ZenX support for both protocol methods and always send the observed Turn fence
- preserve per-thread drafts across view unmounts, retain failed input, and reuse a stable `clientUserMessageId` on explicit retry
- render only App Server canonical notifications; no optimistic user messages and no local Queue/retry worker
- explain approval cancellation and disconnected/stale failure states explicitly
- add component/state tests and a real hosted App Server soft/hard integration path

## Review invariants

- ZenX remains a pure App Server protocol client
- no Core Project/runtime state was introduced
- Queue remains absent
- `ComposerSubmission` is UI-only and documented in `ARCHITECTURE.md`

## Verification

- `npm --workspace apps/zenx run check` — 33 tests, typecheck, Electron production build
- `npm run check` — 87 Node tests + 42 IMZen tests, format/lint/typecheck
- real hosted App Server test covers pending approval → same-Turn steer → atomic replacement → cancelled approval → interrupted old Turn/new successor

## Manual desktop note

ZenX dev Electron launched successfully. Automated click-through could not run because the local Computer Use bridge returned `native pipe startup failed`; the component accessibility tests and real host integration are the recorded replacement evidence. #10 remains the human gate.
