### PR TITLE
feat(zenx): add agent control tools

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,9 @@
   协商实际影响且禁止静默降级。
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
   重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
+- **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
+  只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
+  不持有第二套 Project、Thread、Turn、transcript 或调度状态。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -27,6 +27,13 @@ provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协�
 和调度状态不进入 Zen Core，命中 Trigger 仍只通过 App Server 发起普通 Turn；在真实
 桌面验收完成前不夸大为稳定发布。
 
+ZenX Agent 的自控工具同样属于产品层：bundled capability package 经现有 registry
+显式授权 workspace/local-device 权限后才向 Agent 暴露；Project 列表只按已配置
+workspace 与 Thread 实际 cwd 派生；Thread 的创建、读取、状态与
+`start | steer | replace` 发送全部经由 App Server。工具调用和目标 Thread 的结果分别
+进入各自权威 ItemList，不另建委派记录、消息队列或 transcript；互相监听
+`turn_completed` 后继续发起普通 Turn 是允许的。
+
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。
 

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -50,6 +50,28 @@ Capability grants, per-call approval, and the execution sandbox remain separate
 concepts. A host may impose a background-only execution policy without treating
 that restriction as a missing grant.
 
+### Bundled self-control provider
+
+The `zenx-self-control` package is a bundled, cross-platform,
+`background_safe` capability. It is hidden from the Agent until the existing
+Capabilities UI grants its workspace-read and local-device-control permissions;
+grant/revoke uses the same host restart behavior as every other package. Its
+provider-valid tools are `zenx_projects_list`, `zenx_threads_list`,
+`zenx_threads_create`, `zenx_threads_read`, `zenx_threads_status`, and
+`zenx_threads_send`.
+
+Projects are bounded groupings derived from the configured workspace and
+canonical Thread cwd metadata, not runtime objects. Reads expose bounded recent
+Turn/item projections and omit command output. Create and send operations use a
+narrow in-memory request port attached to the current `AppServerManager`, and
+that port issues only typed `thread/list`, `thread/start`, `thread/read`,
+`turn/start`, `turn/steer`, and `turn/replace` requests. `steer` and `replace`
+require the expected active Turn ID; all sends require a stable client message
+ID. Tool calls, results, interruption, and replacement remain auditable in the
+canonical ItemLists and capability audit projection. Mutual `turn_completed`
+relays are intentionally allowed; there is no blanket cycle ban or second
+transcript/queue.
+
 The bundled browser provider uses hidden Electron windows in a dedicated,
 ephemeral Chromium partition. Its list/open/navigate/inspect/click/type/close tools
 target one explicit `sessionId` and `tabId` through Chromium DevTools Protocol
@@ -188,6 +210,10 @@ The automated integration suite runs the timer → wakeup → App Server Turn �
 streamed response → history chain, explicit cyclic/self relay and cancellation,
 bounded source snapshots, two-member Room routing, strict persisted-state
 validation, long timers, OAuth cleanup, link policy, and local signal routing.
+The self-control tracer explicitly grants its bundled package before exercising
+the child-host capability bridge, derived projects, Thread create/list/read/status,
+active `start | steer | replace`, follow-up delivery, bounded redaction, canonical
+command audit, and the real OpenAI subscription tool serialization boundary.
 The packaged capability smoke covers a real hidden dedicated browser
 open/inspect/navigate/click/type/close, including forged/stale/changed/hidden and
 password target rejection. It also seeds a cookie and session storage, closes

--- a/apps/zenx/src/main/capabilities/self-control-package.ts
+++ b/apps/zenx/src/main/capabilities/self-control-package.ts
@@ -1,0 +1,712 @@
+import path from "node:path";
+
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type {
+  ClientRequestMethod,
+  ClientRequestParams,
+  ClientRequestResults,
+  Thread,
+  ThreadItem,
+} from "../../protocol-client/index.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+export const ZENX_SELF_CONTROL_CAPABILITY_ID = "zenx-self-control";
+export const ZENX_SELF_CONTROL_WORKSPACE_PERMISSION =
+  "zenx-self-control.workspace-read";
+export const ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION =
+  "zenx-self-control.local-device-control";
+
+type SelfControlRequestMethod = Extract<
+  ClientRequestMethod,
+  | "thread/list"
+  | "thread/start"
+  | "thread/read"
+  | "turn/start"
+  | "turn/steer"
+  | "turn/replace"
+>;
+
+export interface AppServerRequestPort {
+  readonly configuredWorkspace: string;
+  request<M extends SelfControlRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]>;
+}
+
+interface AppServerRequestTarget {
+  request<M extends SelfControlRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]>;
+}
+
+export class MutableAppServerRequestPort implements AppServerRequestPort {
+  #target: AppServerRequestTarget | undefined;
+  #configuredWorkspace: string | undefined;
+
+  get configuredWorkspace(): string {
+    if (this.#configuredWorkspace === undefined) {
+      throw new Error("ZenX self-control App Server port is not attached");
+    }
+    return this.#configuredWorkspace;
+  }
+
+  attach(target: AppServerRequestTarget, configuredWorkspace: string): void {
+    this.#target = target;
+    this.#configuredWorkspace = path.resolve(configuredWorkspace);
+  }
+
+  detach(target?: AppServerRequestTarget): void {
+    if (target !== undefined && target !== this.#target) return;
+    this.#target = undefined;
+    this.#configuredWorkspace = undefined;
+  }
+
+  async request<M extends SelfControlRequestMethod>(
+    method: M,
+    params: ClientRequestParams[M],
+  ): Promise<ClientRequestResults[M]> {
+    if (this.#target === undefined) {
+      throw new Error("ZenX self-control App Server port is not attached");
+    }
+    return await this.#target.request(method, params);
+  }
+}
+
+const SOURCE = "zenx.app-server";
+const DEFAULT_LIST_LIMIT = 50;
+const MAX_LIST_LIMIT = 100;
+const DEFAULT_READ_TURNS = 5;
+const MAX_READ_TURNS = 20;
+const DEFAULT_READ_ITEMS = 20;
+const MAX_READ_ITEMS = 25;
+const MAX_TEXT_LENGTH = 1_000;
+const MAX_SEND_TEXT_LENGTH = 100_000;
+
+const manifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: ZENX_SELF_CONTROL_CAPABILITY_ID,
+  displayName: "ZenX self-control",
+  version: "1.0.0",
+  description:
+    "List derived workspaces and control Zen Threads through typed App Server requests.",
+  provider: {
+    id: "zenx-app-server",
+    platforms: ["*"],
+    interactionModes: ["background_safe"],
+    capabilities: [
+      "zenx.projects.read",
+      "zenx.threads.read",
+      "zenx.threads.control",
+    ],
+  },
+  permissions: [
+    {
+      id: ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+      title: "Read Zen workspaces and Threads",
+      description:
+        "Read configured workspace metadata and bounded canonical Thread projections.",
+      scope: "workspace",
+    },
+    {
+      id: ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      title: "Control local Zen Threads",
+      description:
+        "Create local Threads and start, steer, or replace their active Turns through App Server.",
+      scope: "local-device",
+    },
+  ],
+  tools: [
+    {
+      name: "zenx_projects_list",
+      description:
+        "List bounded workspace groupings derived from ZenX configuration and Thread cwd metadata. Projects are not runtime objects.",
+      inputSchema: boundedListSchema(),
+      permissions: [ZENX_SELF_CONTROL_WORKSPACE_PERMISSION],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.projects.read"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_list",
+      description:
+        "List bounded App Server Threads, optionally filtered by workspace/cwd or a name, preview, and ID query.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          workspace: { type: "string" },
+          cwd: { type: "string" },
+          query: { type: "string" },
+          limit: { type: "integer", minimum: 1, maximum: MAX_LIST_LIMIT },
+        },
+        additionalProperties: false,
+      },
+      permissions: [ZENX_SELF_CONTROL_WORKSPACE_PERMISSION],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.read"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_create",
+      description:
+        "Create an idle Thread through App Server thread/start with an explicit cwd and optional runtime settings.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          cwd: { type: "string" },
+          model: { type: "string" },
+          approvalPolicy: { type: "string", enum: ["on-request", "never"] },
+          sandbox: { type: "string", enum: ["danger-full-access"] },
+        },
+        required: ["cwd"],
+        additionalProperties: false,
+      },
+      permissions: [
+        ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+        ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      ],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.control"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_read",
+      description:
+        "Read bounded recent turns and safe item projections from one Thread through App Server thread/read.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          threadId: { type: "string" },
+          maxTurns: { type: "integer", minimum: 1, maximum: MAX_READ_TURNS },
+          maxItemsPerTurn: {
+            type: "integer",
+            minimum: 1,
+            maximum: MAX_READ_ITEMS,
+          },
+        },
+        required: ["threadId"],
+        additionalProperties: false,
+      },
+      permissions: [ZENX_SELF_CONTROL_WORKSPACE_PERMISSION],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.read"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_status",
+      description:
+        "Inspect authoritative idle, active, or error status and the current/last Turn identity for one Thread.",
+      inputSchema: {
+        type: "object",
+        properties: { threadId: { type: "string" } },
+        required: ["threadId"],
+        additionalProperties: false,
+      },
+      permissions: [ZENX_SELF_CONTROL_WORKSPACE_PERMISSION],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.read"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_send",
+      description:
+        "Send input through explicit App Server start, steer, or replace semantics. steer and replace require the expected active Turn ID; every mode requires a stable clientUserMessageId.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          threadId: { type: "string" },
+          mode: { type: "string", enum: ["start", "steer", "replace"] },
+          text: { type: "string" },
+          expectedTurnId: { type: "string" },
+          clientUserMessageId: { type: "string" },
+        },
+        required: ["threadId", "mode", "text", "clientUserMessageId"],
+        additionalProperties: false,
+      },
+      permissions: [
+        ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+        ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      ],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.control"],
+      maxOutputBytes: 64 * 1024,
+    },
+  ],
+  resources: [],
+};
+const controlToolNames = new Set(manifest.tools.map((tool) => tool.name));
+
+export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest = manifest;
+  readonly #appServer: AppServerRequestPort;
+
+  constructor(options: { appServer: AppServerRequestPort }) {
+    this.#appServer = options.appServer;
+  }
+
+  async invoke(name: string, invocation: ToolInvocation): Promise<unknown> {
+    if (name !== invocation.name || !controlToolNames.has(name)) {
+      throw new Error(`Unsupported ZenX self-control tool: ${name}`);
+    }
+    invocation.signal.throwIfAborted();
+    return await waitForAbort(
+      this.#executeControl(name, invocation.arguments),
+      invocation.signal,
+    );
+  }
+
+  async #executeControl(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<unknown> {
+    switch (name) {
+      case "zenx_projects_list":
+        return await this.#listProjects(args);
+      case "zenx_threads_list":
+        return await this.#listThreads(args);
+      case "zenx_threads_create":
+        return await this.#createThread(args);
+      case "zenx_threads_read":
+        return await this.#readThread(args);
+      case "zenx_threads_status":
+        return await this.#threadStatus(args);
+      case "zenx_threads_send":
+        return await this.#send(args);
+      default:
+        throw new Error(`Unsupported ZenX product tool: ${name}`);
+    }
+  }
+
+  async #listProjects(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["limit"]);
+    const limit = boundedInteger(
+      args.limit,
+      "limit",
+      DEFAULT_LIST_LIMIT,
+      MAX_LIST_LIMIT,
+    );
+    const threads = (await this.#appServer.request("thread/list", {})).data;
+    const projects = new Map<
+      string,
+      { cwd: string; configured: boolean; threadIds: string[] }
+    >();
+    const configuredWorkspace = this.#appServer.configuredWorkspace;
+    projects.set(configuredWorkspace, {
+      cwd: configuredWorkspace,
+      configured: true,
+      threadIds: [],
+    });
+    for (const thread of threads) {
+      if (thread.cwd.length === 0) continue;
+      const cwd = path.resolve(thread.cwd);
+      const project = projects.get(cwd) ?? {
+        cwd,
+        configured: cwd === configuredWorkspace,
+        threadIds: [],
+      };
+      project.threadIds.push(thread.id);
+      projects.set(cwd, project);
+    }
+    const all = [...projects.values()]
+      .sort((left, right) => left.cwd.localeCompare(right.cwd))
+      .map((project) => ({
+        workspace: project.cwd,
+        cwd: project.cwd,
+        configured: project.configured,
+        threadCount: project.threadIds.length,
+        threadIds: project.threadIds.slice(0, MAX_LIST_LIMIT),
+        threadIdsTruncated: project.threadIds.length > MAX_LIST_LIMIT,
+      }));
+    return {
+      source: SOURCE,
+      derivation: "configured workspace plus App Server Thread cwd",
+      projects: all.slice(0, limit),
+      truncated: all.length > limit,
+    };
+  }
+
+  async #listThreads(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["workspace", "cwd", "query", "limit"]);
+    const workspace = optionalString(args.workspace, "workspace");
+    const cwd = optionalString(args.cwd, "cwd");
+    if (workspace !== undefined && cwd !== undefined) {
+      if (path.resolve(workspace) !== path.resolve(cwd)) {
+        throw new Error(
+          "workspace and cwd filters must identify the same path",
+        );
+      }
+    }
+    const cwdFilter = workspace ?? cwd;
+    const resolvedFilter =
+      cwdFilter === undefined ? undefined : path.resolve(cwdFilter);
+    const query = optionalString(args.query, "query")?.toLocaleLowerCase();
+    const limit = boundedInteger(
+      args.limit,
+      "limit",
+      DEFAULT_LIST_LIMIT,
+      MAX_LIST_LIMIT,
+    );
+    const threads = (await this.#appServer.request("thread/list", {})).data
+      .filter(
+        (thread) =>
+          resolvedFilter === undefined ||
+          (thread.cwd.length > 0 &&
+            path.resolve(thread.cwd) === resolvedFilter),
+      )
+      .filter((thread) => query === undefined || matchesQuery(thread, query))
+      .sort((left, right) => right.updatedAt - left.updatedAt);
+    return {
+      source: SOURCE,
+      threads: threads.slice(0, limit).map(projectThreadSummary),
+      truncated: threads.length > limit,
+    };
+  }
+
+  async #createThread(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["cwd", "model", "approvalPolicy", "sandbox"]);
+    const cwd = path.resolve(requiredString(args.cwd, "cwd"));
+    const model = optionalString(args.model, "model");
+    const approvalPolicy = optionalEnum(args.approvalPolicy, "approvalPolicy", [
+      "on-request",
+      "never",
+    ] as const);
+    const sandbox = optionalEnum(args.sandbox, "sandbox", [
+      "danger-full-access",
+    ] as const);
+    const result = await this.#appServer.request("thread/start", {
+      cwd,
+      ...(model === undefined ? {} : { model }),
+      ...(approvalPolicy === undefined ? {} : { approvalPolicy }),
+      ...(sandbox === undefined ? {} : { sandbox }),
+    });
+    return {
+      source: SOURCE,
+      threadId: result.thread.id,
+      thread: projectThreadSummary(result.thread),
+      runtime: {
+        cwd: result.cwd,
+        model: result.model,
+        modelProvider: result.modelProvider,
+        approvalPolicy: result.approvalPolicy,
+        sandbox: result.sandbox.type,
+      },
+    };
+  }
+
+  async #readThread(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["threadId", "maxTurns", "maxItemsPerTurn"]);
+    const threadId = requiredString(args.threadId, "threadId");
+    const maxTurns = boundedInteger(
+      args.maxTurns,
+      "maxTurns",
+      DEFAULT_READ_TURNS,
+      MAX_READ_TURNS,
+    );
+    const maxItems = boundedInteger(
+      args.maxItemsPerTurn,
+      "maxItemsPerTurn",
+      DEFAULT_READ_ITEMS,
+      MAX_READ_ITEMS,
+    );
+    const thread = (
+      await this.#appServer.request("thread/read", {
+        threadId,
+        includeTurns: true,
+      })
+    ).thread;
+    const recentTurns = thread.turns.slice(-maxTurns);
+    return {
+      source: SOURCE,
+      threadId: thread.id,
+      cwd: thread.cwd,
+      status: statusType(thread),
+      turns: recentTurns.map((turn) => ({
+        turnId: turn.id,
+        status: turn.status,
+        error: turn.error?.message ?? null,
+        startedAt: turn.startedAt,
+        completedAt: turn.completedAt,
+        items: turn.items.slice(-maxItems).map(projectItem),
+        itemsTruncated: turn.items.length > maxItems,
+      })),
+      turnsTruncated: thread.turns.length > maxTurns,
+      bounds: {
+        maxTurns,
+        maxItemsPerTurn: maxItems,
+        maxTextLength: MAX_TEXT_LENGTH,
+      },
+    };
+  }
+
+  async #threadStatus(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["threadId"]);
+    const requestedThreadId = requiredString(args.threadId, "threadId");
+    const thread = (
+      await this.#appServer.request("thread/read", {
+        threadId: requestedThreadId,
+        includeTurns: true,
+      })
+    ).thread;
+    const active = [...thread.turns]
+      .reverse()
+      .find((turn) => turn.status === "inProgress");
+    const last = thread.turns.at(-1);
+    return {
+      source: SOURCE,
+      threadId: thread.id,
+      cwd: thread.cwd,
+      status: statusType(thread),
+      activeTurnId: active?.id ?? null,
+      lastTurn:
+        last === undefined
+          ? null
+          : {
+              turnId: last.id,
+              status: last.status,
+              error: last.error?.message ?? null,
+            },
+      updatedAt: thread.updatedAt,
+    };
+  }
+
+  async #send(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, [
+      "threadId",
+      "mode",
+      "text",
+      "expectedTurnId",
+      "clientUserMessageId",
+    ]);
+    const threadId = requiredString(args.threadId, "threadId");
+    const mode = requiredEnum(args.mode, "mode", [
+      "start",
+      "steer",
+      "replace",
+    ] as const);
+    const text = limitedString(args.text, "text", MAX_SEND_TEXT_LENGTH);
+    const clientUserMessageId = limitedString(
+      args.clientUserMessageId,
+      "clientUserMessageId",
+      256,
+    );
+    const expectedTurnId = optionalString(
+      args.expectedTurnId,
+      "expectedTurnId",
+    );
+    if (mode === "start") {
+      if (expectedTurnId !== undefined) {
+        throw new Error("expectedTurnId is only valid for steer or replace");
+      }
+      const result = await this.#appServer.request("turn/start", {
+        threadId,
+        input: [{ type: "text", text }],
+        clientUserMessageId,
+      });
+      return {
+        source: SOURCE,
+        threadId,
+        mode,
+        clientUserMessageId,
+        turnId: result.turn.id,
+      };
+    }
+    if (expectedTurnId === undefined) {
+      throw new Error(`${mode} requires expectedTurnId`);
+    }
+    if (mode === "steer") {
+      const result = await this.#appServer.request("turn/steer", {
+        threadId,
+        expectedTurnId,
+        input: [{ type: "text", text }],
+        clientUserMessageId,
+      });
+      return {
+        source: SOURCE,
+        threadId,
+        mode,
+        clientUserMessageId,
+        expectedTurnId,
+        turnId: result.turnId,
+      };
+    }
+    const result = await this.#appServer.request("turn/replace", {
+      threadId,
+      expectedTurnId,
+      input: [{ type: "text", text }],
+      clientUserMessageId,
+    });
+    return {
+      source: SOURCE,
+      threadId,
+      mode,
+      clientUserMessageId,
+      expectedTurnId,
+      interruptedTurnId: result.interruptedTurnId,
+      turnId: result.turnId,
+    };
+  }
+}
+
+function boundedListSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      limit: { type: "integer", minimum: 1, maximum: MAX_LIST_LIMIT },
+    },
+    additionalProperties: false,
+  };
+}
+
+function projectThreadSummary(thread: Thread): Record<string, unknown> {
+  return {
+    threadId: thread.id,
+    cwd: thread.cwd,
+    name: thread.name,
+    preview: clip(thread.preview),
+    status: statusType(thread),
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+  };
+}
+
+function projectItem(item: ThreadItem): Record<string, unknown> {
+  switch (item.type) {
+    case "userMessage":
+      return {
+        itemId: item.id,
+        type: item.type,
+        clientId: item.clientId,
+        text: clip(item.content.map((entry) => entry.text).join("\n")),
+      };
+    case "agentMessage":
+      return { itemId: item.id, type: item.type, text: clip(item.text) };
+    case "reasoning":
+      return {
+        itemId: item.id,
+        type: item.type,
+        summary: clip(item.summary.join("\n")),
+      };
+    case "commandExecution":
+      return {
+        itemId: item.id,
+        type: item.type,
+        command: clip(item.command),
+        cwd: item.cwd,
+        status: item.status,
+        exitCode: item.exitCode,
+        outputOmitted: true,
+      };
+  }
+}
+
+function statusType(thread: Thread): "idle" | "active" | "systemError" {
+  return thread.status.type;
+}
+
+function matchesQuery(thread: Thread, query: string): boolean {
+  return [thread.id, thread.name ?? "", thread.preview].some((value) =>
+    value.toLocaleLowerCase().includes(query),
+  );
+}
+
+function clip(value: string): string {
+  return value.length <= MAX_TEXT_LENGTH
+    ? value
+    : `${value.slice(0, MAX_TEXT_LENGTH)}…[truncated]`;
+}
+
+function assertOnly(args: Record<string, unknown>, keys: string[]): void {
+  const allowed = new Set(keys);
+  const unexpected = Object.keys(args).find((key) => !allowed.has(key));
+  if (unexpected !== undefined) {
+    throw new Error(`Unexpected argument: ${unexpected}`);
+  }
+}
+
+function requiredString(value: unknown, label: string): string {
+  return limitedString(value, label, 4_096);
+}
+
+function limitedString(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (value.length > maxLength) {
+    throw new Error(`${label} exceeds ${String(maxLength)} characters`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, label: string): string | undefined {
+  if (value === undefined) return undefined;
+  return requiredString(value, label);
+}
+
+function boundedInteger(
+  value: unknown,
+  label: string,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) return fallback;
+  if (
+    !Number.isInteger(value) ||
+    (value as number) < 1 ||
+    (value as number) > maximum
+  ) {
+    throw new Error(`${label} must be an integer from 1 to ${String(maximum)}`);
+  }
+  return value as number;
+}
+
+function requiredEnum<const T extends readonly string[]>(
+  value: unknown,
+  label: string,
+  values: T,
+): T[number] {
+  if (typeof value !== "string" || !values.includes(value)) {
+    throw new Error(`${label} must be one of: ${values.join(", ")}`);
+  }
+  return value;
+}
+
+function optionalEnum<const T extends readonly string[]>(
+  value: unknown,
+  label: string,
+  values: T,
+): T[number] | undefined {
+  return value === undefined ? undefined : requiredEnum(value, label, values);
+}
+
+async function waitForAbort<T>(
+  operation: Promise<T>,
+  signal: AbortSignal,
+): Promise<T> {
+  signal.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const aborted = (): void => {
+      cleanup();
+      reject(
+        signal.reason ??
+          new DOMException("The operation was aborted", "AbortError"),
+      );
+    };
+    const cleanup = (): void => signal.removeEventListener("abort", aborted);
+    signal.addEventListener("abort", aborted, { once: true });
+    void operation.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -17,11 +17,16 @@ import type {
   RoomMember,
 } from "./trigger-types.js";
 import { ZenXCapabilityService } from "./capability-service.js";
+import {
+  MutableAppServerRequestPort,
+  ZenXSelfControlCapabilityPackage,
+} from "./capabilities/self-control-package.js";
 
 let appServerManager: AppServerManager | undefined;
 let settingsService: ZenXSettingsService | undefined;
 let triggerService: ZenXTriggerService | undefined;
 let capabilityService: ZenXCapabilityService | undefined;
+const selfControlPort = new MutableAppServerRequestPort();
 let quitting = false;
 
 function createWindow(): BrowserWindow {
@@ -73,6 +78,9 @@ app.whenReady().then(async () => {
   try {
     capabilityService = new ZenXCapabilityService({ userDataDirectory });
     await capabilityService.initialize();
+    capabilityService.register(
+      new ZenXSelfControlCapabilityPackage({ appServer: selfControlPort }),
+    );
     await settingsService.initialize(process.env);
     let startupError: unknown;
     let hostConfig;
@@ -96,6 +104,7 @@ app.whenReady().then(async () => {
       execPath: process.execPath,
       capabilityHost: capabilityService,
     });
+    selfControlPort.attach(appServerManager, hostConfig.cwd);
     installProtocolIpc(appServerManager);
     installCapabilityIpc(capabilityService, appServerManager);
     triggerService = new ZenXTriggerService(
@@ -126,8 +135,10 @@ app.whenReady().then(async () => {
         execPath: process.execPath,
         capabilityHost: capabilityService,
       });
+      selfControlPort.attach(appServerManager, hostConfig.cwd);
       await appServerManager.start();
     } else {
+      selfControlPort.attach(appServerManager, hostConfig.cwd);
       await appServerManager.restart(hostConfig);
     }
   });
@@ -145,7 +156,10 @@ app.on("before-quit", (event) => {
   triggerService?.stop();
   void appServerManager
     .stop()
-    .then(async () => await capabilityService?.close())
+    .then(async () => {
+      selfControlPort.detach();
+      await capabilityService?.close();
+    })
     .finally(() => app.quit());
 });
 

--- a/apps/zenx/test/self-control-capability.test.ts
+++ b/apps/zenx/test/self-control-capability.test.ts
@@ -1,0 +1,769 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { ZenAppServer } from "../../../src/app-server.js";
+import { InMemoryThreadJournal } from "../../../src/journal.js";
+import {
+  type ModelAdapter,
+  type ModelRequest,
+  type ModelEvent,
+} from "../../../src/model.js";
+import { OpenAiSubscriptionModel } from "../../../src/model/openai-subscription.js";
+import { StaticModelCatalog } from "../../../src/model-catalog.js";
+import { AgentRuntime } from "../../../src/runtime.js";
+import { InMemoryThreadMetadataStore } from "../../../src/thread-metadata.js";
+import {
+  ShellToolExecutor,
+  type ToolExecutor,
+  type ToolInvocation,
+} from "../../../src/tool.js";
+import { serveCodexWebSocket } from "../../../src/protocol/codex/websocket.js";
+import {
+  MutableAppServerRequestPort,
+  ZENX_SELF_CONTROL_CAPABILITY_ID,
+  ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+  ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+  ZenXSelfControlCapabilityPackage,
+  type AppServerRequestPort,
+} from "../src/main/capabilities/self-control-package.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import type { ZenXCapabilityHost } from "../src/main/capabilities/types.js";
+import { ZenXCapabilityService } from "../src/main/capability-service.js";
+import { AppServerManager } from "../src/main/app-server-manager.js";
+import {
+  ZenXProtocolClient,
+  type ClientRequestMethod,
+  type ClientRequestParams,
+  type ClientRequestResults,
+  type ServerNotificationParams,
+} from "../src/protocol-client/index.js";
+
+const SELF_CONTROL_TOOL_NAMES = [
+  "zenx_projects_list",
+  "zenx_threads_list",
+  "zenx_threads_create",
+  "zenx_threads_read",
+  "zenx_threads_status",
+  "zenx_threads_send",
+];
+
+test("real ZenX host control tools make active semantics explicit", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-control-host-"));
+  const requestPort = new MutableAppServerRequestPort();
+  const capabilities = await grantedSelfControl(directory, requestPort);
+  const manager = managerFor(directory, capabilities);
+  requestPort.attach(manager, directory);
+  const tools = capabilityTools(capabilities);
+  try {
+    await manager.start();
+    const created = await invoke(tools, "zenx_threads_create", {
+      cwd: directory,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const threadId = stringField(created, "threadId");
+
+    const firstCommand = waitForCommand(manager, threadId);
+    const first = await invoke(tools, "zenx_threads_send", {
+      threadId,
+      mode: "start",
+      text: slowShell("steer-finished"),
+      clientUserMessageId: "host-start-steer",
+    });
+    const firstTurnId = stringField(first, "turnId");
+    await firstCommand;
+    const active = await invoke(tools, "zenx_threads_status", { threadId });
+    assert.equal(active.status, "active");
+    assert.equal(active.activeTurnId, firstTurnId);
+
+    const steered = await invoke(tools, "zenx_threads_send", {
+      threadId,
+      mode: "steer",
+      text: "Use the steering update.",
+      expectedTurnId: firstTurnId,
+      clientUserMessageId: "host-steer",
+    });
+    assert.equal(steered.mode, "steer");
+    assert.equal(steered.expectedTurnId, firstTurnId);
+    await waitUntilIdle(tools, threadId);
+
+    const secondCommand = waitForCommand(manager, threadId);
+    const second = await invoke(tools, "zenx_threads_send", {
+      threadId,
+      mode: "start",
+      text: slowShell("replace-finished"),
+      clientUserMessageId: "host-start-replace",
+    });
+    const secondTurnId = stringField(second, "turnId");
+    await secondCommand;
+    const replaced = await invoke(tools, "zenx_threads_send", {
+      threadId,
+      mode: "replace",
+      text: "Replacement prompt.",
+      expectedTurnId: secondTurnId,
+      clientUserMessageId: "host-replace",
+    });
+    assert.equal(replaced.interruptedTurnId, secondTurnId);
+    assert.notEqual(replaced.turnId, secondTurnId);
+    await waitUntilIdle(tools, threadId);
+
+    await invoke(tools, "zenx_threads_send", {
+      threadId,
+      mode: "start",
+      text: "Follow-up prompt.",
+      clientUserMessageId: "host-follow-up",
+    });
+    await waitUntilIdle(tools, threadId);
+
+    const recent = await invoke(tools, "zenx_threads_read", {
+      threadId,
+      maxTurns: 4,
+      maxItemsPerTurn: 25,
+    });
+    assert.equal(recent.source, "zenx.app-server");
+    const turns = recent.turns as Array<{
+      status: string;
+      items: Array<{ type: string; clientId?: string }>;
+    }>;
+    assert(turns.some((turn) => turn.status === "interrupted"));
+    assert(
+      turns.some((turn) =>
+        turn.items.some((item) => item.clientId === "host-follow-up"),
+      ),
+    );
+
+    const projects = await invoke(tools, "zenx_projects_list", { limit: 10 });
+    assert(
+      (projects.projects as Array<{ cwd: string; threadIds: string[] }>).some(
+        (project) =>
+          project.cwd === path.resolve(directory) &&
+          project.threadIds.includes(threadId),
+      ),
+    );
+    const listed = await invoke(tools, "zenx_threads_list", {
+      workspace: directory,
+      query: threadId.slice(0, 8),
+      limit: 10,
+    });
+    assert.equal(
+      (listed.threads as Array<{ threadId: string }>)[0]?.threadId,
+      threadId,
+    );
+
+    const bridgeThread = await manager.request("thread/start", {
+      cwd: directory,
+      approvalPolicy: "never",
+      sandbox: "danger-full-access",
+    });
+    const bridgeCompleted = waitForManagerTurnCompleted(
+      manager,
+      bridgeThread.thread.id,
+    );
+    await manager.request("turn/start", {
+      threadId: bridgeThread.thread.id,
+      input: [{ type: "text", text: '!tool zenx_projects_list {"limit":10}' }],
+      clientUserMessageId: "host-capability-bridge",
+    });
+    await bridgeCompleted;
+    const bridgeRead = await manager.request("thread/read", {
+      threadId: bridgeThread.thread.id,
+      includeTurns: true,
+    });
+    assert(
+      bridgeRead.thread.turns
+        .flatMap((turn) => turn.items)
+        .some(
+          (item) =>
+            item.type === "commandExecution" &&
+            item.command.startsWith("zenx_projects_list ") &&
+            item.status === "completed",
+        ),
+    );
+    assert(
+      capabilities
+        .snapshot()
+        .recentInvocations.some(
+          (record) =>
+            record.toolName === "zenx_projects_list" &&
+            record.status === "completed",
+        ),
+    );
+
+    await assert.rejects(
+      invoke(tools, "zenx_threads_send", {
+        threadId,
+        mode: "steer",
+        text: "missing expected turn",
+        clientUserMessageId: "invalid-steer",
+      }),
+      /requires expectedTurnId/u,
+    );
+  } finally {
+    await manager.stop();
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("an Agent drives the complete bounded tracer bullet through App Server wire calls", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-control-agent-"),
+  );
+  const workspace = path.resolve(os.tmpdir(), "zenx-agent-workspace");
+  const requestPort = new MutableAppServerRequestPort();
+  const capabilities = await grantedSelfControl(directory, requestPort);
+  const tools = capabilityTools(capabilities);
+  const appServer = new ZenAppServer({
+    journal: new InMemoryThreadJournal(),
+    runtime: new AgentRuntime({
+      model: new TracerBulletModel(workspace),
+      tools,
+    }),
+    modelCatalog: new StaticModelCatalog([{ id: "tracer", isDefault: true }]),
+    threadMetadata: new InMemoryThreadMetadataStore(),
+    defaults: {
+      cwd: workspace,
+      model: "tracer",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+  });
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zenx-agent-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const client = await ZenXProtocolClient.connect({
+    url: server.url,
+    clientInfo: {
+      name: "zenx-agent-control-smoke",
+      title: "ZenX Agent Control Smoke",
+      version: "0.1.0",
+    },
+  });
+  requestPort.attach(client, workspace);
+  const approvals: string[] = [];
+  client.onServerRequest(
+    "item/commandExecution/requestApproval",
+    async (params) => {
+      approvals.push(params.command);
+      return { decision: "accept" };
+    },
+  );
+  try {
+    const source = await client.request("thread/start", {
+      cwd: workspace,
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+    });
+    const completed = waitForTurnCompleted(client, source.thread.id);
+    const sourceTurn = await client.request("turn/start", {
+      threadId: source.thread.id,
+      input: [{ type: "text", text: "Run the ZenX tracer bullet." }],
+      clientUserMessageId: "tracer-source",
+    });
+    await completed;
+
+    const sourceRead = await client.request("thread/read", {
+      threadId: source.thread.id,
+      includeTurns: true,
+    });
+    const completedSourceTurn = sourceRead.thread.turns.find(
+      (turn) => turn.id === sourceTurn.turn.id,
+    );
+    assert.equal(completedSourceTurn?.status, "completed");
+    const calls = completedSourceTurn?.items.filter(
+      (item) => item.type === "commandExecution",
+    );
+    assert.deepEqual(
+      calls?.map((call) => call.command.split(" ")[0]),
+      [
+        "zenx_projects_list",
+        "zenx_threads_list",
+        "zenx_threads_create",
+        "zenx_threads_send",
+        "zenx_threads_status",
+        "zenx_threads_read",
+        "zenx_threads_send",
+      ],
+    );
+    assert(calls?.every((call) => call.status === "completed"));
+    assert.equal(approvals.length, 7);
+    assert(approvals.every((command) => command.startsWith("zenx_")));
+
+    const listed = await client.request("thread/list", {});
+    const target = listed.data.find((thread) => thread.id !== source.thread.id);
+    assert.notEqual(target, undefined);
+    const targetRead = await client.request("thread/read", {
+      threadId: target!.id,
+      includeTurns: true,
+    });
+    assert.equal(targetRead.thread.cwd, workspace);
+    assert.deepEqual(
+      targetRead.thread.turns.map((turn) => turn.status),
+      ["completed", "completed"],
+    );
+    assert.deepEqual(
+      targetRead.thread.turns
+        .flatMap((turn) => turn.items)
+        .filter((item) => item.type === "userMessage")
+        .map((item) => item.clientId),
+      ["tracer-child-start", "tracer-child-follow-up"],
+    );
+  } finally {
+    client.close();
+    await server.close();
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("bounded reads omit command output and truncate message text", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-control-bound-"),
+  );
+  const hugeMessage = "long-message".repeat(500);
+  const secretOutput = "secret-like-output".repeat(500);
+  const port: AppServerRequestPort = {
+    configuredWorkspace: "/tmp/work",
+    async request<M extends ClientRequestMethod>(
+      method: M,
+      _params: ClientRequestParams[M],
+    ): Promise<ClientRequestResults[M]> {
+      assert.equal(method, "thread/read");
+      return {
+        thread: {
+          id: "thread-bounded",
+          sessionId: "thread-bounded",
+          forkedFromId: null,
+          parentThreadId: null,
+          preview: "",
+          ephemeral: false,
+          isPinned: false,
+          modelProvider: "fake",
+          createdAt: 1,
+          updatedAt: 2,
+          recencyAt: null,
+          status: { type: "idle" },
+          path: null,
+          cwd: "/tmp/work",
+          cliVersion: "zen/0.1.0",
+          source: "appServer",
+          threadSource: null,
+          agentNickname: null,
+          agentRole: null,
+          gitInfo: null,
+          name: null,
+          turns: [
+            {
+              id: "turn-bounded",
+              itemsView: "full",
+              status: "completed",
+              error: null,
+              startedAt: 1,
+              completedAt: 2,
+              durationMs: 1_000,
+              items: [
+                {
+                  type: "agentMessage",
+                  id: "agent-long",
+                  text: hugeMessage,
+                  phase: "final_answer",
+                  memoryCitation: null,
+                },
+                {
+                  type: "commandExecution",
+                  id: "command-secret",
+                  pluginId: null,
+                  scriptPath: null,
+                  command: "inspect",
+                  cwd: "/tmp/work",
+                  processId: null,
+                  source: "agent",
+                  status: "completed",
+                  commandActions: [],
+                  aggregatedOutput: secretOutput,
+                  exitCode: 0,
+                  durationMs: null,
+                },
+              ],
+            },
+          ],
+        },
+      } as ClientRequestResults[M];
+    },
+  };
+  const capabilities = await grantedSelfControl(directory, port);
+  try {
+    const result = await invoke(
+      capabilityTools(capabilities),
+      "zenx_threads_read",
+      {
+        threadId: "thread-bounded",
+        maxTurns: 1,
+        maxItemsPerTurn: 2,
+      },
+    );
+    const serialized = JSON.stringify(result);
+    assert.doesNotMatch(serialized, /secret-like-output/u);
+    assert.match(serialized, /\[truncated\]/u);
+    assert.match(serialized, /"outputOmitted":true/u);
+  } finally {
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("all hosted tool definitions serialize through the OpenAI subscription boundary", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-control-openai-"),
+  );
+  const capabilities = await grantedSelfControl(
+    directory,
+    new MutableAppServerRequestPort(),
+  );
+  try {
+    const tools = [
+      ...new ShellToolExecutor({ environment: {} }).definitions,
+      ...capabilities.hostSnapshot().definitions,
+    ];
+    let capturedInit: RequestInit | undefined;
+    const adapter = new OpenAiSubscriptionModel({
+      acquireAccessLease: async () => ({ accessToken: subscriptionJwt() }),
+      endpoint: "https://example.test/backend-api/codex/responses",
+      fetch: async (_input, init) => {
+        capturedInit = init;
+        return completedSubscriptionResponse();
+      },
+    });
+
+    for await (const _event of adapter.stream({
+      model: "gpt-5.6-terra",
+      messages: [],
+      tools,
+      signal: new AbortController().signal,
+    })) {
+      // Consuming the stream proves request serialization completed.
+    }
+
+    const body = JSON.parse(String(capturedInit?.body)) as {
+      tools: Array<{ name: string }>;
+    };
+    assert.deepEqual(
+      body.tools.map((tool) => tool.name),
+      ["shell", ...SELF_CONTROL_TOOL_NAMES],
+    );
+    assert(
+      body.tools.every((tool) => /^[a-zA-Z0-9_-]{1,64}$/u.test(tool.name)),
+    );
+  } finally {
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+class TracerBulletModel implements ModelAdapter {
+  readonly provider = "tracer";
+  readonly #workspace: string;
+
+  constructor(workspace: string) {
+    this.#workspace = workspace;
+  }
+
+  async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
+    const firstUser = request.messages.find(
+      (message) => message.role === "user",
+    );
+    if (
+      firstUser?.role !== "user" ||
+      !firstUser.text.includes("tracer bullet")
+    ) {
+      yield {
+        type: "text_delta",
+        delta: `Completed: ${firstUser?.text ?? ""}`,
+      };
+      return;
+    }
+    const results = request.messages.filter(
+      (message) => message.role === "tool",
+    );
+    const call = (name: string, args: Record<string, unknown>): ModelEvent => ({
+      type: "tool_call",
+      callId: `tracer-${String(results.length)}`,
+      name,
+      arguments: args,
+    });
+    switch (results.length) {
+      case 0:
+        yield call("zenx_projects_list", { limit: 10 });
+        return;
+      case 1:
+        yield call("zenx_threads_list", {
+          workspace: this.#workspace,
+          limit: 10,
+        });
+        return;
+      case 2:
+        yield call("zenx_threads_create", {
+          cwd: this.#workspace,
+          model: "tracer",
+          approvalPolicy: "never",
+          sandbox: "danger-full-access",
+        });
+        return;
+      case 3: {
+        const target = selfControlResult(results[2]!.text);
+        yield call("zenx_threads_send", {
+          threadId: target.threadId,
+          mode: "start",
+          text: "Child initial prompt.",
+          clientUserMessageId: "tracer-child-start",
+        });
+        return;
+      }
+      case 4: {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        const target = selfControlResult(results[2]!.text);
+        yield call("zenx_threads_status", { threadId: target.threadId });
+        return;
+      }
+      case 5: {
+        const target = selfControlResult(results[2]!.text);
+        yield call("zenx_threads_read", {
+          threadId: target.threadId,
+          maxTurns: 2,
+          maxItemsPerTurn: 10,
+        });
+        return;
+      }
+      case 6: {
+        const target = selfControlResult(results[2]!.text);
+        yield call("zenx_threads_send", {
+          threadId: target.threadId,
+          mode: "start",
+          text: "Child follow-up prompt.",
+          clientUserMessageId: "tracer-child-follow-up",
+        });
+        return;
+      }
+      default:
+        yield { type: "text_delta", delta: "ZenX tracer bullet completed." };
+    }
+  }
+}
+
+async function grantedSelfControl(
+  directory: string,
+  appServer: AppServerRequestPort,
+): Promise<ZenXCapabilityService> {
+  const capabilities = new ZenXCapabilityService({
+    userDataDirectory: directory,
+    grantStore: new MemoryZenXCapabilityGrantStore(),
+    localDirectory: path.join(directory, "no-local-capabilities"),
+  });
+  await capabilities.initialize();
+  capabilities.register(new ZenXSelfControlCapabilityPackage({ appServer }));
+  assert(
+    capabilities
+      .hostSnapshot()
+      .definitions.every(
+        (definition) => !SELF_CONTROL_TOOL_NAMES.includes(definition.name),
+      ),
+    "self-control tools must stay hidden until explicitly granted",
+  );
+  await capabilities.grant(ZENX_SELF_CONTROL_CAPABILITY_ID, [
+    ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+    ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+  ]);
+  assert.deepEqual(
+    capabilities
+      .hostSnapshot()
+      .definitions.filter((definition) =>
+        SELF_CONTROL_TOOL_NAMES.includes(definition.name),
+      )
+      .map((definition) => definition.name),
+    SELF_CONTROL_TOOL_NAMES,
+  );
+  return capabilities;
+}
+
+function capabilityTools(capabilities: ZenXCapabilityService): ToolExecutor {
+  return {
+    definitions: capabilities.hostSnapshot().definitions,
+    async execute(invocation: ToolInvocation) {
+      return await capabilities.execute(invocation);
+    },
+  };
+}
+
+function managerFor(
+  directory: string,
+  capabilityHost: ZenXCapabilityHost,
+): AppServerManager {
+  return new AppServerManager({
+    entryPath: fileURLToPath(
+      new URL("../src/main/app-server-host.ts", import.meta.url),
+    ),
+    tokenFile: path.join(directory, "runtime", "token"),
+    hostConfig: {
+      cwd: directory,
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+    capabilityHost,
+  });
+}
+
+async function invoke(
+  tools: ToolExecutor,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const result = await tools.execute({
+    callId: `test-${Date.now().toString(36)}-${Math.random().toString(36)}`,
+    name,
+    arguments: args,
+    cwd: process.cwd(),
+    signal: new AbortController().signal,
+  });
+  assert.equal(result.exitCode, 0);
+  const envelope = JSON.parse(result.output) as {
+    capabilityId: string;
+    result: Record<string, unknown>;
+  };
+  assert.equal(envelope.capabilityId, ZENX_SELF_CONTROL_CAPABILITY_ID);
+  return envelope.result;
+}
+
+function waitForCommand(
+  manager: AppServerManager,
+  threadId: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      dispose();
+      reject(new Error("Timed out waiting for command execution"));
+    }, 10_000);
+    const dispose = manager.onNotification((method, params) => {
+      if (method === "item/started") {
+        const started = params as ServerNotificationParams["item/started"];
+        if (
+          started.threadId !== threadId ||
+          started.item.type !== "commandExecution"
+        ) {
+          return;
+        }
+        clearTimeout(timer);
+        dispose();
+        resolve();
+      }
+    });
+  });
+}
+
+async function waitUntilIdle(
+  tools: ToolExecutor,
+  threadId: string,
+): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    const status = await invoke(tools, "zenx_threads_status", { threadId });
+    if (status.status === "idle") return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("Timed out waiting for Thread to become idle");
+}
+
+function waitForTurnCompleted(
+  client: ZenXProtocolClient,
+  threadId: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      dispose();
+      reject(new Error("Timed out waiting for turn/completed"));
+    }, 10_000);
+    const dispose = client.onNotification("turn/completed", (params) => {
+      if (params.threadId === threadId) {
+        clearTimeout(timer);
+        dispose();
+        resolve();
+      }
+    });
+  });
+}
+
+function waitForManagerTurnCompleted(
+  manager: AppServerManager,
+  threadId: string,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      dispose();
+      reject(new Error("Timed out waiting for hosted turn/completed"));
+    }, 10_000);
+    const dispose = manager.onNotification((method, params) => {
+      if (method !== "turn/completed") return;
+      const completed = params as ServerNotificationParams["turn/completed"];
+      if (completed.threadId !== threadId) return;
+      clearTimeout(timer);
+      dispose();
+      resolve();
+    });
+  });
+}
+
+function selfControlResult(text: string): { threadId: string } {
+  const envelope = JSON.parse(text) as {
+    capabilityId: string;
+    result: { threadId: string };
+  };
+  assert.equal(envelope.capabilityId, ZENX_SELF_CONTROL_CAPABILITY_ID);
+  return envelope.result;
+}
+
+function slowShell(label: string): string {
+  return `!shell node -e "setTimeout(() => console.log('${label}'), 300)"`;
+}
+
+function stringField(value: Record<string, unknown>, key: string): string {
+  const field = value[key];
+  assert.equal(typeof field, "string");
+  return field as string;
+}
+
+function subscriptionJwt(): string {
+  const encode = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "acct_zenx_tool_contract",
+    },
+  })}.signature`;
+}
+
+function completedSubscriptionResponse(): Response {
+  return new Response(
+    `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        status: "completed",
+        output: [],
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    })}\r\n\r\ndata: [DONE]\r\n\r\n`,
+    {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}


### PR DESCRIPTION
## What changed

- adds the bundled `zenx-self-control` capability package through PR #40's public `ZenXCapabilityService.register()` / `ZenXCapabilityRegistry` seam
- exposes the provider-valid `zenx_projects_list`, `zenx_threads_list`, `zenx_threads_create`, `zenx_threads_read`, `zenx_threads_status`, and `zenx_threads_send` tools only after explicit workspace/local-device grants
- derives project/workspace groupings only from configured workspace and App Server Thread cwd metadata
- delegates native operations through a narrow mutable typed App Server request port attached to the current `AppServerManager`
- preserves explicit `start | steer | replace` semantics, stable client message IDs, expected active-Turn fencing, bounded reads, omitted command output, and canonical/capability audit

## Why

ZenX Agents need a real tracer bullet for discovering workspaces, delegating into another Thread, inspecting bounded recent work/status, and sending follow-ups without introducing Project runtime state, a second transcript, or direct journal mutations.

This is stacked on PR #40 at `a68c543` and targets `codex/issue-36-zenx-capabilities`, so the review contains only issue #35's self-control package and minimal product composition. Implements #35.

## Validation

- `npx tsx --test apps/zenx/test/self-control-capability.test.ts` — passed: 4 focused tests
- `npm --workspace apps/zenx run check` — passed: typecheck, 87 tests, production Electron/Vite build
- `npm test` — passed: 87 Node tests and 38 IMZen tests
- `npm run check` — passed: format, lint, typecheck, 87 Node tests, 38 IMZen tests
- real ZenX child-host bridge covers granted capability dispatch, create, prompt, active status, soft steer, fenced replace, bounded read, project/thread listing, follow-up, canonical command Item, and capability audit
- scripted AgentRuntime/App Server WebSocket tracer calls the complete seven-step product-tool flow after explicit grant and verifies canonical source tool Items plus two target Thread Turns
- OpenAI subscription regression passes the granted hosted definitions through the real Responses request serializer and verifies its provider name contract

## Diff and boundaries relative to #40

- adds one `ZenXSelfControlCapabilityPackage`, its typed in-memory `AppServerRequestPort`, product docs, composition-root registration/reattachment, and focused tests
- does not change #40's CLI host, `AppServerManager`, capability IPC/host messages, runtime, registry/service contracts, or browser/computer providers
- removes the former `HostedToolExtension`; there is one tool-host architecture, owned by #40
- Project remains a derived cwd/workspace grouping; no Core Project object, plugin protocol, persistent delegation model, queue, or second transcript was added
- failures are terminal and are not queued or repaired; mutual `turn_completed` relay loops remain allowed with no blanket cycle ban

## Coordination for #36

#36 owns the generic capability host and needs no self-control-specific integration. Its `ZenXCapabilityService.register()` / registry and grant/revoke restart behavior are the only composition seam consumed here. Future packages should register independently through that seam rather than copy the App Server request port or self-control dispatch logic.
