### PR TITLE
feat(zenx): add pluggable browser and computer capabilities

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,9 @@
   `turn/start` 所需的最小 host-local App Server 边界；它不引入另一套 Runtime、队列或重试器。
 - **ZenXExternalLinkPolicy** — ZenX renderer 与 Electron 主进程共同执行的外链 allowlist；
   只有 `http:`、`https:`、`mailto:` 可交给操作系统，页内锚点留在 renderer 处理。
+- **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、
+  显式权限与 provider，把已授权的结构化工具和 skill/prompt 资源组合进本机 host；执行历史仍只由
+  canonical tool call/result 投影，credential、浏览器会话和默认屏幕内容不进入 journal。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -66,6 +66,11 @@
 - **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、
   显式权限与 provider，把已授权的结构化工具和 skill/prompt 资源组合进本机 host；执行历史仍只由
   canonical tool call/result 投影，credential、浏览器会话和默认屏幕内容不进入 journal。
+- **ZenXCapabilityInteractionMode** — ZenX 把工具声明为不改变全局输入/焦点的 `background_safe`
+  、必须接管前台的 `foreground_required` 或在独立桌面执行的 `isolated`，让产品提示、调度和 host policy
+  协商实际影响且禁止静默降级。
+- **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
+  重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -19,8 +19,10 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
 Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
-首批 browser provider 以独立临时 session 暴露有界 DOM 操作，computer provider
-以短时截图 artifact 和带目标上下文的 macOS 输入操作暴露本机能力；manifest、权限、
+首批 browser provider 以独立临时 profile/session 暴露跨平台有界 DOM 操作，computer
+公共 contract 暴露语义动作、平台能力与 background-safe/foreground-required 影响协商；
+当前 macOS provider 以 AX/窗口定向截图和明确提示、可取消的前台输入形成 tracer bullet，
+后续 Windows provider 可用 UIA/Windows Graphics Capture/SendInput 接入同一 seam；manifest、权限、
 provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协议。上述外层配置
 和调度状态不进入 Zen Core，命中 Trigger 仍只通过 App Server 发起普通 Turn；在真实
 桌面验收完成前不夸大为稳定发布。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -17,10 +17,13 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 
 **ZenX 正在开发**，是与 CLI、IMZen 平级的本地桌面接入端。当前已跑通 Electron
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
-Interrupt & send；下一阶段把 Provider/onboarding、安全 Markdown，以及 Trigger /
-Watching / Room 这些通用编排工具难以完整表达的 ZenX 外层产品体验做成可运行的
-vertical slice。上述外层配置和调度状态不进入 Zen Core，命中 Trigger 仍只通过
-App Server 发起普通 Turn；在真实桌面验收完成前不夸大为稳定发布。
+Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
+以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
+首批 browser provider 以独立临时 session 暴露有界 DOM 操作，computer provider
+以短时截图 artifact 和带目标上下文的 macOS 输入操作暴露本机能力；manifest、权限、
+provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协议。上述外层配置
+和调度状态不进入 Zen Core，命中 Trigger 仍只通过 App Server 发起普通 Turn；在真实
+桌面验收完成前不夸大为稳定发布。
 
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -14,7 +14,7 @@ import {
   JsonlThreadMetadataStore,
   type ThreadMetadataStore,
 } from "../../../src/thread-metadata.js";
-import { ShellToolExecutor } from "../../../src/tool.js";
+import { ShellToolExecutor, type ToolExecutor } from "../../../src/tool.js";
 import { OpenAiSubscriptionAuthProfile } from "./subscription-auth.js";
 
 export type HostProvider =
@@ -41,6 +41,7 @@ export interface ZenHostOptions {
   secretEnvironmentVariables?: readonly string[];
   journal?: ThreadJournal;
   threadMetadata?: ThreadMetadataStore;
+  tools?: ToolExecutor;
 }
 
 export function createHostedAppServer(options: ZenHostOptions): ZenAppServer {
@@ -57,13 +58,15 @@ export function createHostedAppServer(options: ZenHostOptions): ZenAppServer {
       new JsonlThreadJournal(path.join(options.dataDirectory, "threads")),
     runtime: new AgentRuntime({
       model,
-      tools: new ShellToolExecutor({
-        blockedEnvironmentVariables: options.secretEnvironmentVariables ?? [],
-        redactedValues:
-          options.provider.type === "openai-compatible"
-            ? [options.provider.apiKey]
-            : [],
-      }),
+      tools:
+        options.tools ??
+        new ShellToolExecutor({
+          blockedEnvironmentVariables: options.secretEnvironmentVariables ?? [],
+          redactedValues:
+            options.provider.type === "openai-compatible"
+              ? [options.provider.apiKey]
+              : [],
+        }),
     }),
     modelCatalog: new StaticModelCatalog(
       modelIds.map((id) => ({ id, isDefault: id === options.model })),

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -42,22 +42,90 @@ snapshot rather than copying a second authoritative transcript.
 ## Capabilities
 
 ZenX owns a capability registry outside Zen Core. Settings shows every bundled
-or local package, its requested permission scopes, enabled tools, instruction
-resources, and recent in-memory audit projection. Granting or revoking a package
-restarts the local host so the Agent sees exactly the currently authorized tool
-definitions. Capability grants are separate from per-call approval and from the
-execution sandbox.
+or local package, its provider/platform metadata, requested permission scopes,
+tool capabilities and interaction mode, instruction resources, and recent
+in-memory audit projection. Granting or revoking a package restarts the local
+host so the Agent sees exactly the currently authorized tool definitions.
+Capability grants, per-call approval, and the execution sandbox remain separate
+concepts. A host may impose a background-only execution policy without treating
+that restriction as a missing grant.
 
-The bundled browser provider opens visible, ephemeral Electron sessions. Its
-tools list/open/navigate/inspect/click/type one explicit `sessionId` and `tabId`;
-inspection returns bounded visible text and targets, never cookies, storage,
-headers, or unrelated tabs. The bundled computer provider currently supports
-macOS. It inspects the frontmost app/window and display geometry, writes an
-explicit screenshot to a mode-0600 five-minute temp artifact instead of the
-Thread journal, and uses an ephemeral Swift/CoreGraphics helper for bounded
-click/type/key/scroll actions. Computer input requires macOS Accessibility;
-screenshots require Screen Recording; the helper requires Apple Command Line
-Tools on first input use.
+The bundled browser provider uses hidden Electron windows in a dedicated,
+ephemeral Chromium partition. Its list/open/navigate/inspect/click/type/close tools
+target one explicit `sessionId` and `tabId` through Chromium DevTools Protocol
+(CDP) DOM evaluation, without
+moving the OS pointer or activating a browser window. Inspection returns bounded
+visible text plus opaque IDs bound to the latest tab/document observation, never
+raw CSS selectors, cookies, storage, headers, or unrelated tabs. Actions
+revalidate visibility, supported action, and semantic identity, then invalidate
+the observation; navigation and close do likewise. Password values are omitted
+and secure controls reject typing. `browser_type` is deliberately non-secret-only
+because its text argument is part of the canonical tool call. Sessions have hard
+per-session/global tab caps plus explicit tab/session close tools.
+`browser_close_session` destroys all session windows, awaits storage/cache/auth
+cleanup, and advances the partition generation; reopening the same `sessionId`
+therefore starts without the prior cookies or session storage. Generation state
+exists only for active/pending sessions, so logical session bookkeeping is bounded.
+Attaching the user's existing Chrome profile or tabs is not implemented; it
+would be a separate explicit opt-in mode with different privacy and interaction
+impact. This implementation does not claim parity with any proprietary browser
+automation product.
+
+The computer contract is platform-neutral: tools describe semantic observation,
+press/value/capture operations and their interaction impact, while a platform
+provider reports what it implements. The current macOS provider offers targeted
+AXUIElement inspect/AXPress/AXValue and window-scoped capture as
+`background_safe`; these operations require an exact window title, expose at
+most 32 controls, issue short-lived opaque IDs, and revalidate semantic identity
+plus geometry before acting. Stale, moved, or ambiguous controls fail closed.
+It also offers a reliable `foreground_required` baseline for
+global click/key/scroll through a private Swift/CGEvent helper. Arbitrary
+foreground text entry is omitted from this tracer bullet because an untargeted
+text tool cannot prove that the focused control is non-secret. Foreground
+tool names and the running card explicitly warn that the real pointer, keyboard,
+or focused application can be taken over; execution waits briefly so the user
+can press Stop, and cancellation terminates the helper. A background-safe action
+never falls back to foreground input: missing accessibility semantics is
+reported as unsupported/foreground-required.
+
+The macOS provider requires Accessibility permission; window capture also
+requires Screen Recording, and first-use helper compilation requires Apple
+Command Line Tools. A Windows provider remains required after this tracer bullet
+and can implement the same semantic backend with UI Automation, Windows Graphics
+Capture, and SendInput. Linux is currently unsupported for computer control.
+Full arbitrary GUI automation cannot always be background-safe; an isolated
+macOS/Windows session, VM, or remote host is the intended route to arbitrary
+control without disturbing the user's desktop.
+
+### Provider reuse route
+
+This tracer bullet deliberately keeps the provider boundary compatible with
+mature external implementations while retaining a runnable bundled baseline:
+
+- macOS follows Peekaboo's observe → opaque observation element ID → native semantic action
+  → explicit foreground fallback layering. Peekaboo is MIT and is the preferred
+  next adapter, but it is not bundled here: the CLI is not currently a ZenX
+  dependency, its released/source toolchain and permission-onboarding lifecycle
+  must be packaged and signed deliberately, and its JSON compatibility must be
+  pinned before ZenX can rely on it. The current minimal Swift AX/CGEvent helper
+  is therefore provisional rather than a claim that ZenX should maintain a
+  complete macOS automation stack. See
+  <https://github.com/openclaw/Peekaboo>.
+- Windows should begin as a thin optional adapter over Microsoft's MIT-licensed,
+  Public Preview `winapp` CLI. UIA inspect/search/get/set-value/invoke/wait and
+  WGC capture map to background-safe semantic tools; click/drag/SendInput map to
+  foreground-required tools. Provider-private HWND/UIA values must be translated
+  to observation-scoped opaque ZenX target IDs/results. See
+  <https://github.com/microsoft/winappCli/blob/main/docs/ui-automation.md>.
+- Browser automation currently uses the bundled Chromium CDP path and an
+  ephemeral partition. A Playwright adapter should preserve the same tools while
+  using isolated non-persistent `BrowserContext`s; attaching an existing user
+  profile remains a separate opt-in provider. See
+  <https://playwright.dev/docs/api/class-browsercontext>.
+- A future `isolated` interaction mode/provider can place arbitrary control in a
+  VM, cloud desktop, or remote host. OSWorld's provider separation across
+  VMware/VirtualBox/Docker/cloud is a useful reference, but no VM lifecycle is
+  implemented in this PR. See <https://github.com/xlang-ai/OSWorld>.
 
 Local packages are JSON manifests placed in Electron `userData/capabilities`.
 They use schema version 1, declare permissions, structured tools and optional
@@ -71,6 +139,12 @@ directory:
   "displayName": "Local example",
   "version": "1.0.0",
   "description": "One narrow local operation",
+  "provider": {
+    "id": "local-example-process",
+    "platforms": ["darwin", "win32"],
+    "interactionModes": ["background_safe"],
+    "capabilities": ["example.run"]
+  },
   "permissions": [
     {
       "id": "local-example.run",
@@ -84,7 +158,9 @@ directory:
       "name": "local_example_run",
       "description": "Run the example",
       "inputSchema": { "type": "object" },
-      "permissions": ["local-example.run"]
+      "permissions": ["local-example.run"],
+      "interactionMode": "background_safe",
+      "capabilities": ["example.run"]
     }
   ],
   "resources": [],
@@ -94,7 +170,9 @@ directory:
 
 The executable receives one JSON request on stdin and returns one JSON value on
 stdout. It runs without a shell, with a minimal environment and bounded
-transport/output. Discovery failures stay visible; ZenX does not retry them with
+transport/output. Tool `maxOutputBytes` must be an integer from 1 KiB through
+1 MiB, and the result envelope still honors that bound when provider metadata is
+large. Discovery failures stay visible; ZenX does not retry them with
 a durable repair workflow. There is no marketplace, signing, remote discovery,
 or distribution layer.
 
@@ -110,10 +188,21 @@ The automated integration suite runs the timer → wakeup → App Server Turn �
 streamed response → history chain, explicit cyclic/self relay and cancellation,
 bounded source snapshots, two-member Room routing, strict persisted-state
 validation, long timers, OAuth cleanup, link policy, and local signal routing.
-The packaged capability smoke covers real browser
-open/inspect/navigate/click/type and real macOS computer inspect/screenshot; set
-`ZENX_SMOKE_COMPUTER_INPUT=1` to target the smoke-owned browser input with real
-computer click/type. The 2026-08-09 packaged Electron smoke also covered onboarding/host
+The packaged capability smoke covers a real hidden dedicated browser
+open/inspect/navigate/click/type/close, including forged/stale/changed/hidden and
+password target rejection. It also seeds a cookie and session storage, closes
+the session, reopens the same ID, and verifies both are absent. It asserts those
+background-safe browser operations
+leave the real pointer position and foreground application unchanged. The macOS
+AX helper and foreground helper compile in that packaged run, but arbitrary
+third-party AX window/action smoke remains permission- and target-dependent; its
+opaque latest-observation and forged/stale/secure paths are unit-covered. The
+compiled helper enforces semantic fingerprint/geometry revalidation and rejects
+ambiguous matches, but that path is not claimed as a live third-party-app smoke.
+It does
+not run foreground takeover against the user's desktop; foreground execution
+and immediate pre-input cancellation are covered by provider/bridge tests. The
+2026-08-09 packaged Electron smoke also covered onboarding/host
 restart, Thread creation, Markdown rendering and copy affordances, the persistent
 Projects/Inbox toggle, Watching, and a real timer wakeup card.
 

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -39,18 +39,81 @@ bounded recent context window. Agent replies in the Room link back to their
 source Thread and Turn. Thread watches similarly inject a bounded completed-Turn
 snapshot rather than copying a second authoritative transcript.
 
+## Capabilities
+
+ZenX owns a capability registry outside Zen Core. Settings shows every bundled
+or local package, its requested permission scopes, enabled tools, instruction
+resources, and recent in-memory audit projection. Granting or revoking a package
+restarts the local host so the Agent sees exactly the currently authorized tool
+definitions. Capability grants are separate from per-call approval and from the
+execution sandbox.
+
+The bundled browser provider opens visible, ephemeral Electron sessions. Its
+tools list/open/navigate/inspect/click/type one explicit `sessionId` and `tabId`;
+inspection returns bounded visible text and targets, never cookies, storage,
+headers, or unrelated tabs. The bundled computer provider currently supports
+macOS. It inspects the frontmost app/window and display geometry, writes an
+explicit screenshot to a mode-0600 five-minute temp artifact instead of the
+Thread journal, and uses an ephemeral Swift/CoreGraphics helper for bounded
+click/type/key/scroll actions. Computer input requires macOS Accessibility;
+screenshots require Screen Recording; the helper requires Apple Command Line
+Tools on first input use.
+
+Local packages are JSON manifests placed in Electron `userData/capabilities`.
+They use schema version 1, declare permissions, structured tools and optional
+`skill`/`prompt` resources, and point at an executable inside the same package
+directory:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "local-example",
+  "displayName": "Local example",
+  "version": "1.0.0",
+  "description": "One narrow local operation",
+  "permissions": [
+    {
+      "id": "local-example.run",
+      "title": "Run example",
+      "description": "Run the local example executable",
+      "scope": "workspace"
+    }
+  ],
+  "tools": [
+    {
+      "name": "local_example_run",
+      "description": "Run the example",
+      "inputSchema": { "type": "object" },
+      "permissions": ["local-example.run"]
+    }
+  ],
+  "resources": [],
+  "runtime": { "type": "process", "command": "./provider" }
+}
+```
+
+The executable receives one JSON request on stdin and returns one JSON value on
+stdout. It runs without a shell, with a minimal environment and bounded
+transport/output. Discovery failures stay visible; ZenX does not retry them with
+a durable repair workflow. There is no marketplace, signing, remote discovery,
+or distribution layer.
+
 ## Verification
 
 ```sh
 npm --workspace apps/zenx run check
 npm run check
+npm --workspace apps/zenx run smoke:capabilities
 ```
 
 The automated integration suite runs the timer → wakeup → App Server Turn →
 streamed response → history chain, explicit cyclic/self relay and cancellation,
 bounded source snapshots, two-member Room routing, strict persisted-state
 validation, long timers, OAuth cleanup, link policy, and local signal routing.
-The 2026-08-09 packaged Electron smoke also covered onboarding/host
+The packaged capability smoke covers real browser
+open/inspect/navigate/click/type and real macOS computer inspect/screenshot; set
+`ZENX_SMOKE_COMPUTER_INPUT=1` to target the smoke-owned browser input with real
+computer click/type. The 2026-08-09 packaged Electron smoke also covered onboarding/host
 restart, Thread creation, Markdown rendering and copy affordances, the persistent
 Projects/Inbox toggle, Watching, and a real timer wakeup card.
 

--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -9,6 +9,10 @@ export default defineConfig({
         input: {
           index: resolve(__dirname, "src/main/index.ts"),
           "app-server-host": resolve(__dirname, "src/main/app-server-host.ts"),
+          "capability-smoke": resolve(
+            __dirname,
+            "src/main/capability-smoke.ts",
+          ),
         },
       },
     },

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -9,6 +9,7 @@
     "build": "electron-vite build",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "test": "tsx --test test/**/*.test.ts",
+    "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "check": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {

--- a/apps/zenx/src/main/app-server-host.ts
+++ b/apps/zenx/src/main/app-server-host.ts
@@ -8,8 +8,10 @@ import {
   type HostCommand,
   type HostEvent,
 } from "./host-messages.js";
+import { ZenXHostToolExecutor } from "./capability-tool-executor.js";
 
 let server: CodexWebSocketServer | undefined;
+let tools: ZenXHostToolExecutor | undefined;
 let shuttingDown = false;
 
 process.on("message", (message: unknown) => {
@@ -29,6 +31,10 @@ process.once("SIGINT", () => void shutdown());
 process.once("SIGTERM", () => void shutdown());
 
 async function handleCommand(command: HostCommand): Promise<void> {
+  if (command.type === "capability/result") {
+    tools?.handleResult(command);
+    return;
+  }
   if (command.type === "shutdown") {
     await shutdown();
     return;
@@ -36,8 +42,17 @@ async function handleCommand(command: HostCommand): Promise<void> {
   if (server !== undefined) {
     throw new Error("ZenX App Server host already started");
   }
+  tools = new ZenXHostToolExecutor({
+    capabilities: command.capabilities,
+    blockedEnvironmentVariables: command.config.secretEnvironmentVariables,
+    redactedValues:
+      command.config.provider.type === "openai-compatible"
+        ? [command.config.provider.apiKey]
+        : [],
+    send,
+  });
   server = await serveCodexWebSocket({
-    appServer: createHostedAppServer(command.config),
+    appServer: createHostedAppServer({ ...command.config, tools }),
     zenHome: command.config.dataDirectory,
     listen: "ws://127.0.0.1:0",
     bearerToken: command.bearerToken,
@@ -50,6 +65,8 @@ async function shutdown(): Promise<void> {
   shuttingDown = true;
   await server?.close();
   server = undefined;
+  tools?.close();
+  tools = undefined;
   if (process.connected) process.disconnect();
   process.exit(process.exitCode ?? 0);
 }

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -18,6 +18,7 @@ import {
   type HostCommand,
   type ZenXHostConfig,
 } from "./host-messages.js";
+import type { ZenXCapabilityHost } from "./capabilities/types.js";
 
 export type AppServerHostStatus =
   | { type: "starting" }
@@ -34,6 +35,7 @@ export interface AppServerManagerOptions {
   execArgv?: string[];
   environment?: NodeJS.ProcessEnv;
   startupTimeoutMs?: number;
+  capabilityHost?: ZenXCapabilityHost;
 }
 
 type NotificationListener = (
@@ -72,6 +74,7 @@ export class AppServerManager {
     (event: ApprovalResolvedEvent) => void
   >();
   readonly #pendingApprovals = new Map<string, PendingApproval>();
+  readonly #activeCapabilityInvocations = new Map<string, AbortController>();
   #status: AppServerHostStatus = { type: "stopped" };
   #child: ChildProcess | undefined;
   #client: ZenXProtocolClient | undefined;
@@ -131,8 +134,12 @@ export class AppServerManager {
           type: "start",
           config: this.#options.hostConfig,
           bearerToken,
+          capabilities: this.#options.capabilityHost?.hostSnapshot() ?? {
+            definitions: [],
+          },
         },
       );
+      this.#installCapabilityBridge(child);
       this.#client = await ZenXProtocolClient.connect({
         url,
         clientInfo: { name: "zenx", title: "ZenX", version: "0.1.0" },
@@ -152,6 +159,10 @@ export class AppServerManager {
     await this.stop();
     this.#options.hostConfig = hostConfig;
     await this.start();
+  }
+
+  async restartCapabilities(): Promise<void> {
+    await this.restart(this.#options.hostConfig);
   }
 
   async request<M extends ClientRequestMethod>(
@@ -210,6 +221,7 @@ export class AppServerManager {
     if (this.#stopping) return;
     this.#stopping = true;
     this.#cancelPendingApprovals();
+    this.#cancelCapabilityInvocations();
     this.#client?.close();
     this.#client = undefined;
     const child = this.#child;
@@ -308,6 +320,7 @@ export class AppServerManager {
     if (this.#child !== child) return;
     this.#child = undefined;
     this.#cancelPendingApprovals();
+    this.#cancelCapabilityInvocations();
     this.#client?.close();
     this.#client = undefined;
     if (!this.#stopping) {
@@ -330,6 +343,73 @@ export class AppServerManager {
       pending.resolve({ decision: "cancel" });
     }
     this.#pendingApprovals.clear();
+  }
+
+  #installCapabilityBridge(child: ChildProcess): void {
+    child.on("message", (message: unknown) => {
+      if (!isHostEvent(message) || this.#child !== child) return;
+      if (message.type === "capability/cancel") {
+        this.#activeCapabilityInvocations
+          .get(message.invocationId)
+          ?.abort(
+            new DOMException("Capability invocation cancelled", "AbortError"),
+          );
+        return;
+      }
+      if (message.type !== "capability/invoke") return;
+      const host = this.#options.capabilityHost;
+      if (host === undefined) {
+        child.send({
+          type: "capability/result",
+          invocationId: message.invocationId,
+          error: "ZenX capability host is unavailable",
+        } satisfies HostCommand);
+        return;
+      }
+      if (this.#activeCapabilityInvocations.has(message.invocationId)) {
+        child.send({
+          type: "capability/result",
+          invocationId: message.invocationId,
+          error: `Duplicate capability invocation ${message.invocationId}`,
+        } satisfies HostCommand);
+        return;
+      }
+      const controller = new AbortController();
+      this.#activeCapabilityInvocations.set(message.invocationId, controller);
+      void host
+        .execute({ ...message.invocation, signal: controller.signal })
+        .then((result) => {
+          if (this.#child === child && child.connected) {
+            child.send({
+              type: "capability/result",
+              invocationId: message.invocationId,
+              output: result.output,
+              exitCode: result.exitCode,
+            } satisfies HostCommand);
+          }
+        })
+        .catch((error: unknown) => {
+          if (this.#child === child && child.connected) {
+            child.send({
+              type: "capability/result",
+              invocationId: message.invocationId,
+              error: asError(error).message,
+            } satisfies HostCommand);
+          }
+        })
+        .finally(() => {
+          this.#activeCapabilityInvocations.delete(message.invocationId);
+        });
+    });
+  }
+
+  #cancelCapabilityInvocations(): void {
+    for (const controller of this.#activeCapabilityInvocations.values()) {
+      controller.abort(
+        new DOMException("ZenX App Server host stopped", "AbortError"),
+      );
+    }
+    this.#activeCapabilityInvocations.clear();
   }
 }
 
@@ -373,6 +453,7 @@ async function waitForReady(
     };
     const onMessage = (message: unknown): void => {
       if (!isHostEvent(message)) return;
+      if (message.type !== "ready" && message.type !== "error") return;
       cleanup();
       if (message.type === "ready") resolve(message.url);
       else reject(new Error(message.message));

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -1,0 +1,508 @@
+import { randomUUID } from "node:crypto";
+
+import type { BrowserWindow } from "electron";
+
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+export interface BrowserTabSummary {
+  sessionId: string;
+  tabId: string;
+  title: string;
+  url: string;
+  loading: boolean;
+}
+
+export interface BrowserInspection extends BrowserTabSummary {
+  visibleText: string;
+  targets: Array<{
+    selector: string;
+    role: string;
+    name: string;
+    value?: string;
+    bounds?: { x: number; y: number; width: number; height: number };
+    screenPoint?: { x: number; y: number };
+  }>;
+}
+
+export interface ZenXBrowserBackend {
+  listTabs(sessionId: string): Promise<BrowserTabSummary[]>;
+  open(sessionId: string, url: string): Promise<BrowserTabSummary>;
+  navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+  ): Promise<BrowserTabSummary>;
+  inspect(sessionId: string, tabId: string): Promise<BrowserInspection>;
+  click(
+    sessionId: string,
+    tabId: string,
+    selector: string,
+  ): Promise<BrowserTabSummary>;
+  type(
+    sessionId: string,
+    tabId: string,
+    selector: string,
+    text: string,
+    submit: boolean,
+  ): Promise<BrowserTabSummary>;
+  close(): Promise<void> | void;
+}
+
+export const browserCapabilityManifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: "browser",
+  displayName: "Browser",
+  version: "1.0.0",
+  description:
+    "A dedicated ephemeral ZenX browser session with bounded DOM inspection and narrow navigation and interaction tools.",
+  permissions: [
+    {
+      id: "browser.tabs.read",
+      title: "Inspect browser tabs",
+      description:
+        "List tabs and inspect bounded visible text and interactive targets.",
+      scope: "browser-session",
+    },
+    {
+      id: "browser.navigate",
+      title: "Open and navigate pages",
+      description:
+        "Open URLs or navigate an explicitly targeted ZenX browser tab.",
+      scope: "browser-session",
+    },
+    {
+      id: "browser.interact",
+      title: "Interact with pages",
+      description:
+        "Click and type into an explicitly targeted visible page element.",
+      scope: "browser-session",
+    },
+  ],
+  tools: [
+    {
+      name: "browser_list_tabs",
+      description:
+        "List bounded metadata for tabs in one explicit ZenX browser session. Cookies, storage, headers, and history are never returned.",
+      inputSchema: objectSchema({ sessionId: stringSchema() }, ["sessionId"]),
+      permissions: ["browser.tabs.read"],
+      maxOutputBytes: 8 * 1024,
+    },
+    {
+      name: "browser_open",
+      description:
+        "Open an http(s) URL in a new visible tab in an explicit ephemeral ZenX browser session. Returns the new tabId.",
+      inputSchema: objectSchema(
+        { sessionId: stringSchema(), url: stringSchema() },
+        ["sessionId", "url"],
+      ),
+      permissions: ["browser.navigate"],
+    },
+    {
+      name: "browser_navigate",
+      description:
+        "Navigate one explicit ZenX browser session/tab target to an http(s) URL.",
+      inputSchema: browserTargetSchema({ url: stringSchema() }, ["url"]),
+      permissions: ["browser.navigate"],
+    },
+    {
+      name: "browser_inspect",
+      description:
+        "Inspect bounded visible text and clickable/typeable CSS targets in one explicit ZenX browser tab; never returns raw HTML, cookies, storage, headers, or unrelated tabs.",
+      inputSchema: browserTargetSchema(),
+      permissions: ["browser.tabs.read"],
+      maxOutputBytes: 12 * 1024,
+    },
+    {
+      name: "browser_click",
+      description:
+        "Click a CSS target returned by browser_inspect in one explicit session/tab.",
+      inputSchema: browserTargetSchema({ selector: stringSchema() }, [
+        "selector",
+      ]),
+      permissions: ["browser.interact"],
+    },
+    {
+      name: "browser_type",
+      description:
+        "Replace the value of an input target returned by browser_inspect in one explicit session/tab, optionally submitting its form.",
+      inputSchema: browserTargetSchema(
+        {
+          selector: stringSchema(),
+          text: stringSchema(),
+          submit: { type: "boolean" },
+        },
+        ["selector", "text"],
+      ),
+      permissions: ["browser.interact"],
+    },
+  ],
+  resources: [
+    {
+      id: "safe-browser-use",
+      kind: "skill",
+      title: "Safe browser use",
+      description:
+        "Instructions for targeted, inspect-before-act browser automation.",
+      content:
+        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Re-inspect after navigation or any DOM-changing action. Use only selectors returned by inspect, keep outputs bounded, and never ask for cookies, storage state, auth headers, or hidden page content.",
+    },
+    {
+      id: "browser-research",
+      kind: "prompt",
+      title: "Browser research prompt",
+      description: "A reusable prompt for evidence-backed browser research.",
+      content:
+        "Research the requested topic in the dedicated ZenX browser session. Keep a list of the exact page URLs inspected, distinguish page evidence from inference, and summarize only visible content returned by browser_inspect.",
+    },
+  ],
+};
+
+export class BrowserZenXCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest = browserCapabilityManifest;
+  readonly #backend: ZenXBrowserBackend;
+
+  constructor(backend: ZenXBrowserBackend) {
+    this.#backend = backend;
+  }
+
+  async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
+    const sessionId = requiredTargetId(invocation.arguments, "sessionId");
+    switch (toolName) {
+      case "browser_list_tabs":
+        return await this.#backend.listTabs(sessionId);
+      case "browser_open":
+        return await this.#backend.open(
+          sessionId,
+          safeBrowserUrl(requiredString(invocation.arguments, "url")),
+        );
+      case "browser_navigate":
+        return await this.#backend.navigate(
+          sessionId,
+          requiredTargetId(invocation.arguments, "tabId"),
+          safeBrowserUrl(requiredString(invocation.arguments, "url")),
+        );
+      case "browser_inspect":
+        return await this.#backend.inspect(
+          sessionId,
+          requiredTargetId(invocation.arguments, "tabId"),
+        );
+      case "browser_click":
+        return await this.#backend.click(
+          sessionId,
+          requiredTargetId(invocation.arguments, "tabId"),
+          requiredString(invocation.arguments, "selector"),
+        );
+      case "browser_type":
+        return await this.#backend.type(
+          sessionId,
+          requiredTargetId(invocation.arguments, "tabId"),
+          requiredString(invocation.arguments, "selector"),
+          requiredString(invocation.arguments, "text", true),
+          optionalBoolean(invocation.arguments, "submit") ?? false,
+        );
+      default:
+        throw new Error(`Unsupported browser tool: ${toolName}`);
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.#backend.close();
+  }
+}
+
+interface BrowserTab {
+  sessionId: string;
+  tabId: string;
+  window: BrowserWindow;
+}
+
+export class ElectronBrowserBackend implements ZenXBrowserBackend {
+  readonly #tabs = new Map<string, BrowserTab>();
+
+  async listTabs(sessionId: string): Promise<BrowserTabSummary[]> {
+    assertTargetId(sessionId, "sessionId");
+    return [...this.#tabs.values()]
+      .filter((tab) => tab.sessionId === sessionId && !tab.window.isDestroyed())
+      .map((tab) => summarizeTab(tab));
+  }
+
+  async open(sessionId: string, url: string): Promise<BrowserTabSummary> {
+    assertTargetId(sessionId, "sessionId");
+    const tabId = randomUUID();
+    const { BrowserWindow } = await import("electron");
+    const window = new BrowserWindow({
+      width: 1100,
+      height: 760,
+      minWidth: 640,
+      minHeight: 480,
+      show: true,
+      title: "ZenX Browser",
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        partition: `zenx-capability-${sessionId}`,
+      },
+    });
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    const tab = { sessionId, tabId, window };
+    this.#tabs.set(tabId, tab);
+    window.once("closed", () => this.#tabs.delete(tabId));
+    try {
+      await window.loadURL(url);
+      return summarizeTab(tab);
+    } catch (error) {
+      window.destroy();
+      throw error;
+    }
+  }
+
+  async navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#requireTab(sessionId, tabId);
+    await tab.window.loadURL(url);
+    return summarizeTab(tab);
+  }
+
+  async inspect(sessionId: string, tabId: string): Promise<BrowserInspection> {
+    const tab = this.#requireTab(sessionId, tabId);
+    const inspected = (await tab.window.webContents.executeJavaScript(
+      INSPECT_SCRIPT,
+      true,
+    )) as {
+      visibleText: string;
+      targets: BrowserInspection["targets"];
+    };
+    const contentBounds = tab.window.getContentBounds();
+    return {
+      ...summarizeTab(tab),
+      visibleText: inspected.visibleText.slice(0, 8_000),
+      targets: inspected.targets.slice(0, 80).map((target) => ({
+        ...target,
+        ...(target.bounds === undefined
+          ? {}
+          : {
+              screenPoint: {
+                x: Math.round(
+                  contentBounds.x + target.bounds.x + target.bounds.width / 2,
+                ),
+                y: Math.round(
+                  contentBounds.y + target.bounds.y + target.bounds.height / 2,
+                ),
+              },
+            }),
+      })),
+    };
+  }
+
+  async click(
+    sessionId: string,
+    tabId: string,
+    selector: string,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#requireTab(sessionId, tabId);
+    const found = (await tab.window.webContents.executeJavaScript(
+      `(() => { const element = document.querySelector(${JSON.stringify(selector)}); if (!(element instanceof HTMLElement)) return false; element.scrollIntoView({ block: "center", inline: "center" }); element.click(); return true; })()`,
+      true,
+    )) as boolean;
+    if (!found) throw new Error(`Browser target not found: ${selector}`);
+    await settlePage(tab.window);
+    return summarizeTab(tab);
+  }
+
+  async type(
+    sessionId: string,
+    tabId: string,
+    selector: string,
+    text: string,
+    submit: boolean,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#requireTab(sessionId, tabId);
+    const found = (await tab.window.webContents.executeJavaScript(
+      `(() => { const element = document.querySelector(${JSON.stringify(selector)}); if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) return false; element.focus(); const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value")?.set; setter?.call(element, ${JSON.stringify(text)}); element.dispatchEvent(new Event("input", { bubbles: true })); element.dispatchEvent(new Event("change", { bubbles: true })); if (${JSON.stringify(submit)}) element.form?.requestSubmit(); return true; })()`,
+      true,
+    )) as boolean;
+    if (!found) throw new Error(`Browser text target not found: ${selector}`);
+    await settlePage(tab.window);
+    return summarizeTab(tab);
+  }
+
+  close(): void {
+    for (const tab of this.#tabs.values()) {
+      if (!tab.window.isDestroyed()) tab.window.destroy();
+    }
+    this.#tabs.clear();
+  }
+
+  #requireTab(sessionId: string, tabId: string): BrowserTab {
+    assertTargetId(sessionId, "sessionId");
+    assertTargetId(tabId, "tabId");
+    const tab = this.#tabs.get(tabId);
+    if (
+      tab === undefined ||
+      tab.sessionId !== sessionId ||
+      tab.window.isDestroyed()
+    ) {
+      throw new Error(`Unknown browser target ${sessionId}/${tabId}`);
+    }
+    return tab;
+  }
+}
+
+const INSPECT_SCRIPT = `(() => {
+  const visible = (element) => {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
+  };
+  const selector = (element) => {
+    if (element.id) return "#" + CSS.escape(element.id);
+    const parts = [];
+    let current = element;
+    while (current instanceof Element && current !== document.body && parts.length < 5) {
+      let part = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (parent) {
+        const siblings = [...parent.children].filter((child) => child.tagName === current.tagName);
+        if (siblings.length > 1) part += ":nth-of-type(" + String(siblings.indexOf(current) + 1) + ")";
+      }
+      parts.unshift(part);
+      current = parent;
+    }
+    return parts.join(" > ");
+  };
+  const elements = [...document.querySelectorAll("a[href],button,input,textarea,select,[role=button],[tabindex]")]
+    .filter(visible)
+    .slice(0, 80);
+  return {
+    visibleText: (document.body?.innerText ?? "").replace(/\\s+/g, " ").trim().slice(0, 8000),
+    targets: elements.map((element) => ({
+      selector: selector(element),
+      role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
+      name: (element.getAttribute("aria-label") ?? element.textContent ?? element.getAttribute("placeholder") ?? "").replace(/\\s+/g, " ").trim().slice(0, 160),
+      ...(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? { value: element.value.slice(0, 160) } : {}),
+      bounds: (() => { const rect = element.getBoundingClientRect(); return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }; })(),
+    })),
+  };
+})()`;
+
+function summarizeTab(tab: BrowserTab): BrowserTabSummary {
+  return {
+    sessionId: tab.sessionId,
+    tabId: tab.tabId,
+    title: tab.window.getTitle().slice(0, 256),
+    url: redactUrl(tab.window.webContents.getURL()),
+    loading: tab.window.webContents.isLoading(),
+  };
+}
+
+function safeBrowserUrl(raw: string): string {
+  const url = new URL(raw);
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("ZenX browser only opens http(s) URLs");
+  }
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error("ZenX browser URLs must not contain credentials");
+  }
+  for (const key of url.searchParams.keys()) {
+    if (
+      /(?:auth|code|credential|key|password|secret|session|token)/iu.test(key)
+    ) {
+      throw new Error(
+        `ZenX browser URL contains sensitive query parameter ${key}`,
+      );
+    }
+  }
+  return url.toString();
+}
+
+function redactUrl(raw: string): string {
+  if (raw.length === 0) return "";
+  const url = new URL(raw);
+  url.username = "";
+  url.password = "";
+  url.hash = "";
+  for (const key of [...url.searchParams.keys()]) {
+    if (
+      /(?:auth|code|credential|key|password|secret|session|token)/iu.test(key)
+    ) {
+      url.searchParams.set(key, "[REDACTED]");
+    }
+  }
+  return url.toString().slice(0, 2048);
+}
+
+function requiredTargetId(
+  arguments_: Record<string, unknown>,
+  key: string,
+): string {
+  const value = requiredString(arguments_, key);
+  assertTargetId(value, key);
+  return value;
+}
+
+function assertTargetId(value: string, key: string): void {
+  if (!/^[a-zA-Z0-9_-]{1,80}$/u.test(value)) {
+    throw new Error(`${key} must contain only letters, numbers, _ or -`);
+  }
+}
+
+function requiredString(
+  arguments_: Record<string, unknown>,
+  key: string,
+  allowEmpty = false,
+): string {
+  const value = arguments_[key];
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    throw new Error(
+      `${key} must be ${allowEmpty ? "a string" : "a non-empty string"}`,
+    );
+  }
+  return value;
+}
+
+function optionalBoolean(
+  arguments_: Record<string, unknown>,
+  key: string,
+): boolean | undefined {
+  const value = arguments_[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") throw new Error(`${key} must be a boolean`);
+  return value;
+}
+
+function stringSchema(): Record<string, unknown> {
+  return { type: "string" };
+}
+
+function objectSchema(
+  properties: Record<string, unknown>,
+  required: string[],
+): Record<string, unknown> {
+  return { type: "object", properties, required, additionalProperties: false };
+}
+
+function browserTargetSchema(
+  properties: Record<string, unknown> = {},
+  required: string[] = [],
+): Record<string, unknown> {
+  return objectSchema(
+    { sessionId: stringSchema(), tabId: stringSchema(), ...properties },
+    ["sessionId", "tabId", ...required],
+  );
+}
+
+async function settlePage(window: BrowserWindow): Promise<void> {
+  if (!window.webContents.isLoading()) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, 2_000);
+    window.webContents.once("did-stop-loading", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import type { BrowserWindow } from "electron";
+import type { BrowserWindow, Session } from "electron";
 
 import type { ToolInvocation } from "../../../../../src/tool.js";
 import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
@@ -14,14 +14,16 @@ export interface BrowserTabSummary {
 }
 
 export interface BrowserInspection extends BrowserTabSummary {
+  observationId: string;
+  documentVersion: number;
   visibleText: string;
   targets: Array<{
-    selector: string;
+    targetId: string;
     role: string;
     name: string;
+    actions: Array<"click" | "type">;
+    secure?: true;
     value?: string;
-    bounds?: { x: number; y: number; width: number; height: number };
-    screenPoint?: { x: number; y: number };
   }>;
 }
 
@@ -37,15 +39,19 @@ export interface ZenXBrowserBackend {
   click(
     sessionId: string,
     tabId: string,
-    selector: string,
+    observationId: string,
+    targetId: string,
   ): Promise<BrowserTabSummary>;
   type(
     sessionId: string,
     tabId: string,
-    selector: string,
+    observationId: string,
+    targetId: string,
     text: string,
     submit: boolean,
   ): Promise<BrowserTabSummary>;
+  closeTab(sessionId: string, tabId: string): Promise<void> | void;
+  closeSession(sessionId: string): Promise<number> | number;
   close(): Promise<void> | void;
 }
 
@@ -56,6 +62,18 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
   version: "1.0.0",
   description:
     "A dedicated ephemeral ZenX browser session with bounded DOM inspection and narrow navigation and interaction tools.",
+  provider: {
+    id: "electron-dedicated-browser",
+    platforms: ["darwin", "win32", "linux"],
+    interactionModes: ["background_safe"],
+    capabilities: [
+      "dedicated_profile",
+      "cdp",
+      "dom.inspect",
+      "dom.navigate",
+      "dom.interact",
+    ],
+  },
   permissions: [
     {
       id: "browser.tabs.read",
@@ -86,17 +104,21 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
         "List bounded metadata for tabs in one explicit ZenX browser session. Cookies, storage, headers, and history are never returned.",
       inputSchema: objectSchema({ sessionId: stringSchema() }, ["sessionId"]),
       permissions: ["browser.tabs.read"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "tab_metadata.read"],
       maxOutputBytes: 8 * 1024,
     },
     {
       name: "browser_open",
       description:
-        "Open an http(s) URL in a new visible tab in an explicit ephemeral ZenX browser session. Returns the new tabId.",
+        "Open an http(s) URL in a hidden tab in an explicit ephemeral ZenX browser session. Returns the new tabId without activating an app window.",
       inputSchema: objectSchema(
         { sessionId: stringSchema(), url: stringSchema() },
         ["sessionId", "url"],
       ),
       permissions: ["browser.navigate"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "dom.navigate"],
     },
     {
       name: "browser_navigate",
@@ -104,37 +126,65 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
         "Navigate one explicit ZenX browser session/tab target to an http(s) URL.",
       inputSchema: browserTargetSchema({ url: stringSchema() }, ["url"]),
       permissions: ["browser.navigate"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "dom.navigate"],
     },
     {
       name: "browser_inspect",
       description:
-        "Inspect bounded visible text and clickable/typeable CSS targets in one explicit ZenX browser tab; never returns raw HTML, cookies, storage, headers, or unrelated tabs.",
+        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Password/secure values are never returned and secure controls cannot be typed.",
       inputSchema: browserTargetSchema(),
       permissions: ["browser.tabs.read"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "dom.inspect"],
       maxOutputBytes: 12 * 1024,
     },
     {
       name: "browser_click",
       description:
-        "Click a CSS target returned by browser_inspect in one explicit session/tab.",
-      inputSchema: browserTargetSchema({ selector: stringSchema() }, [
-        "selector",
-      ]),
+        "Click one visible, clickable opaque target from the latest browser_inspect observation. Stale, forged, hidden, or changed targets fail closed.",
+      inputSchema: browserTargetSchema(
+        { observationId: stringSchema(), targetId: stringSchema() },
+        ["observationId", "targetId"],
+      ),
       permissions: ["browser.interact"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "dom.click"],
     },
     {
       name: "browser_type",
       description:
-        "Replace the value of an input target returned by browser_inspect in one explicit session/tab, optionally submitting its form.",
+        "Replace a non-secret value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Password/secure controls and secret text are unsupported because tool arguments are journaled.",
       inputSchema: browserTargetSchema(
         {
-          selector: stringSchema(),
+          observationId: stringSchema(),
+          targetId: stringSchema(),
           text: stringSchema(),
           submit: { type: "boolean" },
         },
-        ["selector", "text"],
+        ["observationId", "targetId", "text"],
       ),
       permissions: ["browser.interact"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "cdp", "dom.set_value"],
+    },
+    {
+      name: "browser_close",
+      description:
+        "Close one explicit ZenX browser tab and invalidate its latest observation.",
+      inputSchema: browserTargetSchema(),
+      permissions: ["browser.navigate"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "tab.close"],
+    },
+    {
+      name: "browser_close_session",
+      description:
+        "Close every hidden tab in one explicit ZenX browser session, clear its storage/cache, and ensure reopening the same sessionId uses a fresh partition.",
+      inputSchema: objectSchema({ sessionId: stringSchema() }, ["sessionId"]),
+      permissions: ["browser.navigate"],
+      interactionMode: "background_safe",
+      capabilities: ["dedicated_profile", "session.close"],
     },
   ],
   resources: [
@@ -145,7 +195,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Instructions for targeted, inspect-before-act browser automation.",
       content:
-        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Re-inspect after navigation or any DOM-changing action. Use only selectors returned by inspect, keep outputs bounded, and never ask for cookies, storage state, auth headers, or hidden page content.",
+        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Typing is for non-secret text only because tool arguments are journaled, and password/secure controls are rejected. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
     },
     {
       id: "browser-research",
@@ -191,16 +241,28 @@ export class BrowserZenXCapabilityPackage implements ZenXCapabilityPackage {
         return await this.#backend.click(
           sessionId,
           requiredTargetId(invocation.arguments, "tabId"),
-          requiredString(invocation.arguments, "selector"),
+          requiredTargetId(invocation.arguments, "observationId"),
+          requiredTargetId(invocation.arguments, "targetId"),
         );
       case "browser_type":
         return await this.#backend.type(
           sessionId,
           requiredTargetId(invocation.arguments, "tabId"),
-          requiredString(invocation.arguments, "selector"),
+          requiredTargetId(invocation.arguments, "observationId"),
+          requiredTargetId(invocation.arguments, "targetId"),
           requiredString(invocation.arguments, "text", true),
           optionalBoolean(invocation.arguments, "submit") ?? false,
         );
+      case "browser_close": {
+        const tabId = requiredTargetId(invocation.arguments, "tabId");
+        await this.#backend.closeTab(sessionId, tabId);
+        return { closed: true, sessionId, tabId };
+      }
+      case "browser_close_session":
+        return {
+          closedTabs: await this.#backend.closeSession(sessionId),
+          sessionId,
+        };
       default:
         throw new Error(`Unsupported browser tool: ${toolName}`);
     }
@@ -215,10 +277,48 @@ interface BrowserTab {
   sessionId: string;
   tabId: string;
   window: BrowserWindow;
+  incarnation: BrowserSessionIncarnation;
+  documentVersion: number;
+  observation?: BrowserObservation;
 }
+
+interface BrowserSessionIncarnation {
+  generation: number;
+  partition: string;
+  pending: number;
+  invalidated: boolean;
+}
+
+export interface BrowserTargetFingerprint {
+  selector: string;
+  tag: string;
+  role: string;
+  name: string;
+  type: string;
+  id: string;
+  fieldName: string;
+  autocomplete: string;
+  href: string;
+  secure: boolean;
+  actions: Array<"click" | "type">;
+  value?: string;
+}
+
+export interface BrowserObservation {
+  id: string;
+  documentVersion: number;
+  targets: Map<string, BrowserTargetFingerprint>;
+}
+
+export const MAX_BROWSER_TABS_PER_SESSION = 8;
+export const MAX_BROWSER_TABS_GLOBAL = 24;
 
 export class ElectronBrowserBackend implements ZenXBrowserBackend {
   readonly #tabs = new Map<string, BrowserTab>();
+  readonly #sessions = new Map<string, BrowserSessionIncarnation>();
+  #pendingGlobal = 0;
+  #nextSessionGeneration = 1;
+  #closing = false;
 
   async listTabs(sessionId: string): Promise<BrowserTabSummary[]> {
     assertTargetId(sessionId, "sessionId");
@@ -229,32 +329,65 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
 
   async open(sessionId: string, url: string): Promise<BrowserTabSummary> {
     assertTargetId(sessionId, "sessionId");
+    const incarnation = this.#reserveOpen(sessionId);
     const tabId = randomUUID();
-    const { BrowserWindow } = await import("electron");
-    const window = new BrowserWindow({
-      width: 1100,
-      height: 760,
-      minWidth: 640,
-      minHeight: 480,
-      show: true,
-      title: "ZenX Browser",
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: true,
-        partition: `zenx-capability-${sessionId}`,
-      },
-    });
-    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-    const tab = { sessionId, tabId, window };
-    this.#tabs.set(tabId, tab);
-    window.once("closed", () => this.#tabs.delete(tabId));
     try {
+      const { BrowserWindow } = await import("electron");
+      const window = new BrowserWindow({
+        width: 1100,
+        height: 760,
+        minWidth: 640,
+        minHeight: 480,
+        show: false,
+        focusable: false,
+        skipTaskbar: true,
+        title: "ZenX Browser",
+        webPreferences: {
+          contextIsolation: true,
+          nodeIntegration: false,
+          sandbox: true,
+          partition: incarnation.partition,
+          backgroundThrottling: false,
+        },
+      });
+      window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+      const tab: BrowserTab = {
+        sessionId,
+        tabId,
+        window,
+        incarnation,
+        documentVersion: 0,
+      };
+      this.#tabs.set(tabId, tab);
+      window.webContents.on(
+        "did-start-navigation",
+        (_event, _url, isInPlace, isMainFrame) => {
+          if (isMainFrame && !isInPlace) this.#invalidateDocument(tab);
+        },
+      );
+      window.once("closed", () => {
+        tab.observation = undefined;
+        this.#tabs.delete(tabId);
+        this.#releaseIncarnation(sessionId, incarnation);
+      });
       await window.loadURL(url);
+      window.webContents.debugger.attach("1.3");
+      await window.webContents.debugger.sendCommand("Runtime.enable");
+      if (
+        this.#closing ||
+        incarnation.invalidated ||
+        this.#sessions.get(sessionId) !== incarnation
+      ) {
+        window.destroy();
+        throw new Error("Browser session was closed while its tab was opening");
+      }
       return summarizeTab(tab);
     } catch (error) {
-      window.destroy();
+      const tab = this.#tabs.get(tabId);
+      if (tab !== undefined && !tab.window.isDestroyed()) tab.window.destroy();
       throw error;
+    } finally {
+      this.#releaseOpen(sessionId, incarnation);
     }
   }
 
@@ -264,52 +397,68 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     url: string,
   ): Promise<BrowserTabSummary> {
     const tab = this.#requireTab(sessionId, tabId);
+    this.#invalidateDocument(tab);
     await tab.window.loadURL(url);
     return summarizeTab(tab);
   }
 
   async inspect(sessionId: string, tabId: string): Promise<BrowserInspection> {
     const tab = this.#requireTab(sessionId, tabId);
-    const inspected = (await tab.window.webContents.executeJavaScript(
-      INSPECT_SCRIPT,
-      true,
-    )) as {
+    const inspected = await evaluateInTab<{
       visibleText: string;
-      targets: BrowserInspection["targets"];
+      targets: BrowserTargetFingerprint[];
+    }>(tab, INSPECT_SCRIPT);
+    const observationId = randomUUID();
+    const targets = new Map<string, BrowserTargetFingerprint>();
+    const projectedTargets = inspected.targets.slice(0, 80).map((target) => {
+      const targetId = randomUUID();
+      targets.set(targetId, target);
+      return {
+        targetId,
+        role: target.role,
+        name: target.name,
+        actions: [...target.actions],
+        ...(target.secure ? { secure: true as const } : {}),
+        ...(target.value === undefined ? {} : { value: target.value }),
+      };
+    });
+    tab.observation = {
+      id: observationId,
+      documentVersion: tab.documentVersion,
+      targets,
     };
-    const contentBounds = tab.window.getContentBounds();
     return {
       ...summarizeTab(tab),
+      observationId,
+      documentVersion: tab.documentVersion,
       visibleText: inspected.visibleText.slice(0, 8_000),
-      targets: inspected.targets.slice(0, 80).map((target) => ({
-        ...target,
-        ...(target.bounds === undefined
-          ? {}
-          : {
-              screenPoint: {
-                x: Math.round(
-                  contentBounds.x + target.bounds.x + target.bounds.width / 2,
-                ),
-                y: Math.round(
-                  contentBounds.y + target.bounds.y + target.bounds.height / 2,
-                ),
-              },
-            }),
-      })),
+      targets: projectedTargets,
     };
   }
 
   async click(
     sessionId: string,
     tabId: string,
-    selector: string,
+    observationId: string,
+    targetId: string,
   ): Promise<BrowserTabSummary> {
     const tab = this.#requireTab(sessionId, tabId);
-    const found = (await tab.window.webContents.executeJavaScript(
-      `(() => { const element = document.querySelector(${JSON.stringify(selector)}); if (!(element instanceof HTMLElement)) return false; element.scrollIntoView({ block: "center", inline: "center" }); element.click(); return true; })()`,
-      true,
-    )) as boolean;
-    if (!found) throw new Error(`Browser target not found: ${selector}`);
+    const target = this.#requireObservedTarget(
+      tab,
+      observationId,
+      targetId,
+      "click",
+    );
+    tab.observation = undefined;
+    const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
+      tab,
+      actionScript(target, "click"),
+    );
+    if (!result.ok) {
+      throw new Error(
+        `Browser click target is stale or unsafe: ${result.reason}`,
+      );
+    }
     await settlePage(tab.window);
     return summarizeTab(tab);
   }
@@ -317,25 +466,76 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
   async type(
     sessionId: string,
     tabId: string,
-    selector: string,
+    observationId: string,
+    targetId: string,
     text: string,
     submit: boolean,
   ): Promise<BrowserTabSummary> {
     const tab = this.#requireTab(sessionId, tabId);
-    const found = (await tab.window.webContents.executeJavaScript(
-      `(() => { const element = document.querySelector(${JSON.stringify(selector)}); if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement)) return false; element.focus(); const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), "value")?.set; setter?.call(element, ${JSON.stringify(text)}); element.dispatchEvent(new Event("input", { bubbles: true })); element.dispatchEvent(new Event("change", { bubbles: true })); if (${JSON.stringify(submit)}) element.form?.requestSubmit(); return true; })()`,
-      true,
-    )) as boolean;
-    if (!found) throw new Error(`Browser text target not found: ${selector}`);
+    const target = this.#requireObservedTarget(
+      tab,
+      observationId,
+      targetId,
+      "type",
+    );
+    if (target.secure) {
+      throw new Error(
+        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
+      );
+    }
+    tab.observation = undefined;
+    const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
+      tab,
+      actionScript(target, "type", text, submit),
+    );
+    if (!result.ok) {
+      throw new Error(
+        `Browser type target is stale or unsafe: ${result.reason}`,
+      );
+    }
     await settlePage(tab.window);
     return summarizeTab(tab);
   }
 
-  close(): void {
+  closeTab(sessionId: string, tabId: string): void {
+    const tab = this.#requireTab(sessionId, tabId);
+    tab.observation = undefined;
+    this.#tabs.delete(tabId);
+    if (!tab.window.isDestroyed()) tab.window.destroy();
+    this.#releaseIncarnation(sessionId, tab.incarnation);
+  }
+
+  async closeSession(sessionId: string): Promise<number> {
+    assertTargetId(sessionId, "sessionId");
+    const incarnation = this.#sessions.get(sessionId);
+    if (incarnation !== undefined) incarnation.invalidated = true;
+    this.#sessions.delete(sessionId);
+    const tabs = [...this.#tabs.values()].filter(
+      (tab) => tab.sessionId === sessionId,
+    );
+    const electronSessions = new Set(
+      tabs.map((tab) => tab.window.webContents.session),
+    );
+    for (const tab of tabs) this.closeTab(sessionId, tab.tabId);
+    await Promise.all([...electronSessions].map(clearElectronSession));
+    return tabs.length;
+  }
+
+  async close(): Promise<void> {
+    this.#closing = true;
+    for (const incarnation of this.#sessions.values()) {
+      incarnation.invalidated = true;
+    }
+    this.#sessions.clear();
+    const electronSessions = new Set(
+      [...this.#tabs.values()].map((tab) => tab.window.webContents.session),
+    );
     for (const tab of this.#tabs.values()) {
+      tab.observation = undefined;
       if (!tab.window.isDestroyed()) tab.window.destroy();
     }
     this.#tabs.clear();
+    await Promise.all([...electronSessions].map(clearElectronSession));
   }
 
   #requireTab(sessionId: string, tabId: string): BrowserTab {
@@ -351,14 +551,131 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     }
     return tab;
   }
+
+  #requireObservedTarget(
+    tab: BrowserTab,
+    observationId: string,
+    targetId: string,
+    action: "click" | "type",
+  ): BrowserTargetFingerprint {
+    return resolveBrowserObservedTarget(
+      tab.observation,
+      tab.documentVersion,
+      observationId,
+      targetId,
+      action,
+    );
+  }
+
+  #invalidateDocument(tab: BrowserTab): void {
+    tab.documentVersion += 1;
+    tab.observation = undefined;
+  }
+
+  #reserveOpen(sessionId: string): BrowserSessionIncarnation {
+    if (this.#closing) throw new Error("ZenX browser backend is closed");
+    const existing = this.#sessions.get(sessionId);
+    const currentGlobal = this.#tabs.size + this.#pendingGlobal;
+    const currentSession =
+      [...this.#tabs.values()].filter((tab) => tab.sessionId === sessionId)
+        .length + (existing?.pending ?? 0);
+    assertBrowserTabCapacity(currentGlobal, currentSession);
+    const incarnation = existing ?? this.#createIncarnation(sessionId);
+    this.#pendingGlobal += 1;
+    incarnation.pending += 1;
+    return incarnation;
+  }
+
+  #releaseOpen(
+    sessionId: string,
+    incarnation: BrowserSessionIncarnation,
+  ): void {
+    this.#pendingGlobal -= 1;
+    incarnation.pending -= 1;
+    this.#releaseIncarnation(sessionId, incarnation);
+  }
+
+  #createIncarnation(sessionId: string): BrowserSessionIncarnation {
+    if (!Number.isSafeInteger(this.#nextSessionGeneration)) {
+      throw new Error("ZenX browser session generation space is exhausted");
+    }
+    const generation = this.#nextSessionGeneration;
+    this.#nextSessionGeneration += 1;
+    const incarnation = {
+      generation,
+      partition: browserPartitionName(sessionId, generation),
+      pending: 0,
+      invalidated: false,
+    };
+    this.#sessions.set(sessionId, incarnation);
+    return incarnation;
+  }
+
+  #releaseIncarnation(
+    sessionId: string,
+    incarnation: BrowserSessionIncarnation,
+  ): void {
+    if (
+      this.#sessions.get(sessionId) !== incarnation ||
+      incarnation.pending > 0 ||
+      [...this.#tabs.values()].some((tab) => tab.incarnation === incarnation)
+    ) {
+      return;
+    }
+    incarnation.invalidated = true;
+    this.#sessions.delete(sessionId);
+  }
+}
+
+export function resolveBrowserObservedTarget(
+  observation: BrowserObservation | undefined,
+  documentVersion: number,
+  observationId: string,
+  targetId: string,
+  action: "click" | "type",
+): BrowserTargetFingerprint {
+  if (
+    observation === undefined ||
+    observation.id !== observationId ||
+    observation.documentVersion !== documentVersion
+  ) {
+    throw new Error(
+      "Browser observation is stale or unknown; inspect the current tab again",
+    );
+  }
+  const target = observation.targets.get(targetId);
+  if (target === undefined) {
+    throw new Error("Browser target ID is forged, stale, or unknown");
+  }
+  if (!target.actions.includes(action)) {
+    if (action === "type" && target.secure) {
+      throw new Error(
+        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
+      );
+    }
+    throw new Error(`Browser target does not support ${action}`);
+  }
+  return target;
 }
 
 const INSPECT_SCRIPT = `(() => {
   const visible = (element) => {
     const style = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
-    return style.visibility !== "hidden" && style.display !== "none" && rect.width > 0 && rect.height > 0;
+    return !element.hidden && style.visibility !== "hidden" && style.display !== "none" && Number(style.opacity) !== 0 && rect.width > 0 && rect.height > 0 && rect.bottom > 0 && rect.right > 0 && rect.top < innerHeight && rect.left < innerWidth;
   };
+  const name = (element) => (element.getAttribute("aria-label") ?? element.getAttribute("placeholder") ?? element.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 160);
+  const secure = (element) => element instanceof HTMLInputElement && (
+    element.type.toLowerCase() === "password" ||
+    ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
+  );
+  const typeable = (element) => {
+    if (secure(element) || element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
+    if (element instanceof HTMLTextAreaElement) return true;
+    if (!(element instanceof HTMLInputElement)) return false;
+    return !["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase());
+  };
+  const clickable = (element) => getComputedStyle(element).pointerEvents !== "none" && !element.hasAttribute("disabled") && element.getAttribute("aria-disabled") !== "true" && element.matches("a[href],button,input:not([type=hidden]),select,[role=button],[tabindex]");
   const selector = (element) => {
     if (element.id) return "#" + CSS.escape(element.id);
     const parts = [];
@@ -380,15 +697,120 @@ const INSPECT_SCRIPT = `(() => {
     .slice(0, 80);
   return {
     visibleText: (document.body?.innerText ?? "").replace(/\\s+/g, " ").trim().slice(0, 8000),
-    targets: elements.map((element) => ({
-      selector: selector(element),
-      role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
-      name: (element.getAttribute("aria-label") ?? element.textContent ?? element.getAttribute("placeholder") ?? "").replace(/\\s+/g, " ").trim().slice(0, 160),
-      ...(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? { value: element.value.slice(0, 160) } : {}),
-      bounds: (() => { const rect = element.getBoundingClientRect(); return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }; })(),
-    })),
+    targets: elements.map((element) => {
+      const isSecure = secure(element);
+      const actions = [];
+      if (clickable(element)) actions.push("click");
+      if (typeable(element)) actions.push("type");
+      return {
+        selector: selector(element),
+        tag: element.tagName.toLowerCase(),
+        role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
+        name: name(element),
+        type: element instanceof HTMLInputElement ? element.type.toLowerCase() : "",
+        id: element.id,
+        fieldName: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.name : "",
+        autocomplete: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.autocomplete : "",
+        href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
+        secure: isSecure,
+        actions,
+        ...(!isSecure && (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) ? { value: element.value.slice(0, 160) } : {}),
+      };
+    }),
   };
 })()`;
+
+function actionScript(
+  target: BrowserTargetFingerprint,
+  action: "click" | "type",
+  text = "",
+  submit = false,
+): string {
+  const expected = JSON.stringify({
+    tag: target.tag,
+    role: target.role,
+    name: target.name,
+    type: target.type,
+    id: target.id,
+    fieldName: target.fieldName,
+    autocomplete: target.autocomplete,
+    href: target.href,
+    secure: target.secure,
+  });
+  return `(() => {
+    const expected = ${expected};
+    const selector = ${JSON.stringify(target.selector)};
+    const action = ${JSON.stringify(action)};
+    const nextValue = ${JSON.stringify(text)};
+    const shouldSubmit = ${JSON.stringify(submit)};
+    const candidates = [...document.querySelectorAll(selector)];
+    if (candidates.length !== 1) return { ok: false, reason: candidates.length === 0 ? "missing" : "ambiguous" };
+    const element = candidates[0];
+    if (!(element instanceof HTMLElement)) return { ok: false, reason: "not-an-html-element" };
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    if (element.hidden || style.visibility === "hidden" || style.display === "none" || Number(style.opacity) === 0 || rect.width <= 0 || rect.height <= 0 || rect.bottom <= 0 || rect.right <= 0 || rect.top >= innerHeight || rect.left >= innerWidth) return { ok: false, reason: "not-visible" };
+    const secure = element instanceof HTMLInputElement && (
+      element.type.toLowerCase() === "password" ||
+      ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
+    );
+    const actual = {
+      tag: element.tagName.toLowerCase(),
+      role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
+      name: (element.getAttribute("aria-label") ?? element.getAttribute("placeholder") ?? element.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 160),
+      type: element instanceof HTMLInputElement ? element.type.toLowerCase() : "",
+      id: element.id,
+      fieldName: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.name : "",
+      autocomplete: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.autocomplete : "",
+      href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
+      secure,
+    };
+    if (JSON.stringify(actual) !== JSON.stringify(expected)) return { ok: false, reason: "identity-changed" };
+    if (action === "click") {
+      if (style.pointerEvents === "none" || element.hasAttribute("disabled") || element.getAttribute("aria-disabled") === "true" || !element.matches("a[href],button,input:not([type=hidden]),select,[role=button],[tabindex]")) return { ok: false, reason: "not-clickable" };
+      element.click();
+      return { ok: true };
+    }
+    if (secure) return { ok: false, reason: "secure-control" };
+    if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) || element.disabled || element.readOnly) return { ok: false, reason: "not-typeable" };
+    if (element instanceof HTMLInputElement && ["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase())) return { ok: false, reason: "not-typeable" };
+    const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, "value")?.set;
+    if (setter === undefined) return { ok: false, reason: "value-setter-unavailable" };
+    setter.call(element, nextValue);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+    if (shouldSubmit) element.form?.requestSubmit();
+    return { ok: true };
+  })()`;
+}
+
+export function assertBrowserTabCapacity(
+  currentGlobal: number,
+  currentSession: number,
+): void {
+  if (currentGlobal >= MAX_BROWSER_TABS_GLOBAL) {
+    throw new Error(
+      `ZenX browser global tab limit (${MAX_BROWSER_TABS_GLOBAL}) reached; close a tab or session before opening another`,
+    );
+  }
+  if (currentSession >= MAX_BROWSER_TABS_PER_SESSION) {
+    throw new Error(
+      `ZenX browser session tab limit (${MAX_BROWSER_TABS_PER_SESSION}) reached; close a tab before opening another`,
+    );
+  }
+}
+
+export function browserPartitionName(
+  sessionId: string,
+  generation: number,
+): string {
+  assertTargetId(sessionId, "sessionId");
+  if (!Number.isSafeInteger(generation) || generation <= 0) {
+    throw new Error("Browser session generation must be a positive integer");
+  }
+  return `zenx-capability-${sessionId}-${String(generation)}`;
+}
 
 function summarizeTab(tab: BrowserTab): BrowserTabSummary {
   return {
@@ -496,6 +918,15 @@ function browserTargetSchema(
   );
 }
 
+async function clearElectronSession(session: Session): Promise<void> {
+  await Promise.all([
+    session.clearStorageData(),
+    session.clearCache(),
+    session.clearAuthCache(),
+  ]);
+  session.flushStorageData();
+}
+
 async function settlePage(window: BrowserWindow): Promise<void> {
   if (!window.webContents.isLoading()) return;
   await new Promise<void>((resolve) => {
@@ -505,4 +936,27 @@ async function settlePage(window: BrowserWindow): Promise<void> {
       resolve();
     });
   });
+}
+
+async function evaluateInTab<T>(
+  tab: BrowserTab,
+  expression: string,
+): Promise<T> {
+  const response = (await tab.window.webContents.debugger.sendCommand(
+    "Runtime.evaluate",
+    {
+      expression,
+      awaitPromise: true,
+      returnByValue: true,
+    },
+  )) as {
+    result?: { value?: unknown; description?: string };
+    exceptionDetails?: { text?: string };
+  };
+  if (response.exceptionDetails !== undefined) {
+    throw new Error(
+      `Browser CDP evaluation failed: ${response.exceptionDetails.text ?? response.result?.description ?? "unknown error"}`,
+    );
+  }
+  return response.result?.value as T;
 }

--- a/apps/zenx/src/main/capabilities/computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/computer-provider.ts
@@ -7,37 +7,75 @@ import path from "node:path";
 import type { ToolInvocation } from "../../../../../src/tool.js";
 import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
 
-export interface ComputerState {
+export interface ComputerTarget {
+  pid?: number;
+  bundleId?: string;
+  windowTitle?: string;
+}
+
+export interface ComputerControlSelector {
+  observationId: string;
+  targetId: string;
+}
+
+export interface ComputerInspection {
   platform: NodeJS.Platform;
-  frontmostApplication: string;
-  frontmostWindowTitle: string;
-  cursor: { x: number; y: number };
-  displays: Array<{
-    id: string;
-    bounds: { x: number; y: number; width: number; height: number };
-    scaleFactor: number;
+  observationId: string;
+  target: {
+    pid: number;
+    bundleId: string;
+    applicationName: string;
+    windowTitle?: string;
+  };
+  controls: Array<{
+    selector: ComputerControlSelector;
+    role: string;
+    title: string;
+    enabled: boolean;
+    actions: string[];
+    secure?: true;
   }>;
+  truncated: boolean;
 }
 
 export interface ZenXComputerBackend {
-  inspect(): Promise<ComputerState>;
-  screenshot(sourceId?: string): Promise<{
+  inspect(target: ComputerTarget): Promise<ComputerInspection>;
+  press(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+  }>;
+  setValue(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    value: string,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+    characterCount: number;
+  }>;
+  screenshot(target: ComputerTarget): Promise<{
     artifactPath: string;
-    sourceId: string;
-    sourceName: string;
+    target: ComputerInspection["target"];
     width: number;
     height: number;
     bytes: number;
     expiresAt: string;
   }>;
-  click(x: number, y: number, button: "left" | "right"): Promise<ComputerState>;
-  type(text: string): Promise<ComputerState>;
-  keyPress(key: ComputerKey): Promise<ComputerState>;
-  scroll(deltaY: number): Promise<ComputerState>;
+  foregroundClick(
+    x: number,
+    y: number,
+    button: "left" | "right",
+    signal: AbortSignal,
+  ): Promise<void>;
+  foregroundKeyPress(key: ComputerKey, signal: AbortSignal): Promise<void>;
+  foregroundScroll(deltaY: number, signal: AbortSignal): Promise<void>;
   close(): Promise<void> | void;
 }
 
-type ComputerKey =
+export type ComputerKey =
   | "enter"
   | "escape"
   | "tab"
@@ -48,40 +86,56 @@ type ComputerKey =
   | "arrowLeft"
   | "arrowRight";
 
+export const MAX_COMPUTER_INSPECTION_CONTROLS = 32;
+
 export const computerCapabilityManifest: ZenXCapabilityManifest = {
   schemaVersion: 1,
   id: "computer",
   displayName: "Computer",
   version: "1.0.0",
   description:
-    "Auditable macOS screen inspection and narrow pointer, keyboard, and scroll operations with explicit target context.",
+    "Negotiated macOS desktop operations: targeted accessibility actions where supported and explicitly labeled, cancellable foreground takeover as the reliable baseline.",
+  provider: {
+    id: "macos-desktop",
+    platforms: ["darwin"],
+    interactionModes: ["background_safe", "foreground_required"],
+    capabilities: [
+      "accessibility.inspect",
+      "semantic.press",
+      "semantic.set_value",
+      "window.capture",
+      "foreground.pointer",
+      "foreground.keyboard",
+      "foreground.scroll",
+    ],
+  },
   permissions: [
     {
-      id: "computer.screen.inspect",
-      title: "Inspect screen state",
+      id: "computer.accessibility.inspect",
+      title: "Inspect a targeted app",
       description:
-        "Read display geometry, cursor location, and the frontmost app/window title.",
+        "Read a bounded accessibility tree for an explicitly targeted app or window.",
       scope: "local-device",
     },
     {
-      id: "computer.screen.capture",
-      title: "Capture a screenshot",
+      id: "computer.accessibility.act",
+      title: "Act on a targeted control",
       description:
-        "Capture one explicitly selected display to a private short-lived artifact file.",
+        "Perform AXPress or set AXValue on an explicitly selected accessibility control without global input.",
       scope: "local-device",
     },
     {
-      id: "computer.pointer.control",
-      title: "Control pointer and scrolling",
+      id: "computer.window.capture",
+      title: "Capture a targeted window",
       description:
-        "Click explicit screen coordinates and issue bounded page scrolling.",
+        "Capture one explicitly targeted app window to a private short-lived artifact.",
       scope: "local-device",
     },
     {
-      id: "computer.keyboard.control",
-      title: "Control keyboard",
+      id: "computer.foreground.control",
+      title: "Control the foreground desktop",
       description:
-        "Type explicit text or press one allowlisted key in the frontmost application.",
+        "Use global pointer, keyboard, focus, or scrolling. ZenX exposes these as explicitly labeled, cancellable foreground takeover.",
       scope: "local-device",
     },
   ],
@@ -89,88 +143,66 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "computer_inspect",
       description:
-        "Inspect current app/window identity, display bounds, and cursor position without capturing pixels or unrelated screen content.",
-      inputSchema: objectSchema({}, []),
-      permissions: ["computer.screen.inspect"],
+        "Inspect at most 32 accessibility controls in one exact app window target without activating it or reading sibling windows. target.windowTitle is required.",
+      inputSchema: objectSchema({ target: targetSchema() }, ["target"]),
+      permissions: ["computer.accessibility.inspect"],
+      interactionMode: "background_safe",
+      capabilities: [
+        "accessibility.inspect",
+        "app_targeted",
+        "no_global_input",
+      ],
+      maxOutputBytes: 12 * 1024,
+    },
+    {
+      name: "computer_press",
+      description:
+        "Perform AXPress on one control returned by computer_inspect. Does not move the pointer, type keys, or activate the target app.",
+      inputSchema: objectSchema(
+        { target: targetSchema(), control: controlSchema() },
+        ["target", "control"],
+      ),
+      permissions: ["computer.accessibility.act"],
+      interactionMode: "background_safe",
+      capabilities: ["semantic.press", "app_targeted", "no_global_input"],
+    },
+    {
+      name: "computer_set_value",
+      description:
+        "Set a non-secret AXValue on one editable opaque target from the latest computer_inspect observation. Secure/password controls are rejected; supplied text is a canonical journaled tool argument.",
+      inputSchema: objectSchema(
+        {
+          target: targetSchema(),
+          control: controlSchema(),
+          value: stringSchema(),
+        },
+        ["target", "control", "value"],
+      ),
+      permissions: ["computer.accessibility.act"],
+      interactionMode: "background_safe",
+      capabilities: ["semantic.set_value", "app_targeted", "no_global_input"],
     },
     {
       name: "computer_screenshot",
       description:
-        "Capture one selected display to a private short-lived PNG artifact. Returns metadata and a path, never base64 screen pixels in the Thread journal.",
-      inputSchema: objectSchema({ sourceId: stringSchema() }, []),
-      permissions: ["computer.screen.capture"],
+        "Capture one explicit app/window target to a private five-minute PNG artifact. Returns metadata/path, never pixels in the Thread journal.",
+      inputSchema: objectSchema({ target: targetSchema() }, ["target"]),
+      permissions: ["computer.window.capture"],
+      interactionMode: "background_safe",
+      capabilities: ["window.capture", "app_targeted", "no_global_input"],
       maxOutputBytes: 4 * 1024,
     },
-    {
-      name: "computer_click",
-      description:
-        "Click explicit global screen coordinates. context must state the app/window/control expected at that point for auditability.",
-      inputSchema: objectSchema(
-        {
-          x: numberSchema(),
-          y: numberSchema(),
-          button: { type: "string", enum: ["left", "right"] },
-          context: stringSchema(),
-        },
-        ["x", "y", "context"],
-      ),
-      permissions: ["computer.pointer.control"],
-    },
-    {
-      name: "computer_type",
-      description:
-        "Type text into the frontmost control. context must identify the intended app/window/control; output records only character count, not typed text.",
-      inputSchema: objectSchema(
-        { text: stringSchema(), context: stringSchema() },
-        ["text", "context"],
-      ),
-      permissions: ["computer.keyboard.control"],
-    },
-    {
-      name: "computer_key_press",
-      description:
-        "Press one allowlisted key in the frontmost control with explicit target context.",
-      inputSchema: objectSchema(
-        {
-          key: {
-            type: "string",
-            enum: [
-              "enter",
-              "escape",
-              "tab",
-              "backspace",
-              "space",
-              "arrowUp",
-              "arrowDown",
-              "arrowLeft",
-              "arrowRight",
-            ],
-          },
-          context: stringSchema(),
-        },
-        ["key", "context"],
-      ),
-      permissions: ["computer.keyboard.control"],
-    },
-    {
-      name: "computer_scroll",
-      description:
-        "Issue a bounded page scroll to the frontmost window. Positive deltaY scrolls down; context identifies the intended target.",
-      inputSchema: objectSchema(
-        { deltaY: numberSchema(), context: stringSchema() },
-        ["deltaY", "context"],
-      ),
-      permissions: ["computer.pointer.control"],
-    },
+    ...foregroundTools(),
   ],
   resources: [
     {
-      id: "inspect-before-act",
+      id: "background-safe-computer-use",
       kind: "skill",
-      title: "Inspect before computer actions",
-      description: "Instructions for auditable, targeted desktop actions.",
+      title: "Background-safe computer use",
+      description:
+        "Instructions for app-targeted accessibility actions without foreground takeover.",
       content:
-        "Call computer_inspect before an input action and include the observed application, window, and intended control in context. Prefer browser structured tools for web pages. Use screenshots only when state metadata is insufficient. Re-inspect after actions that can change focus, and stop if the observed context differs from the intended target.",
+        "Prefer structured browser tools for web pages. For native apps, identify a pid or bundleId and optionally an exact window title, inspect that target, then act only with the observationId and opaque targetId from the latest inspect. Re-inspect after every action. computer_set_value is non-secret-only because supplied text is journaled, and secure controls are rejected. Try background-safe semantic press/value/capture first. Those tools must never fall back to pointer motion, foreground keystrokes, app activation, or workspace changes. If accessibility semantics are insufficient and foreground takeover is acceptable, choose an explicitly named computer_foreground_* tool, warn that it affects the user's live desktop, and keep the operation cancellable; otherwise report unsupported.",
     },
   ],
 };
@@ -184,51 +216,77 @@ export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
   }
 
   async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
+    if (toolName.startsWith("computer_foreground_")) {
+      return await this.#invokeForeground(toolName, invocation);
+    }
+    const target = requiredTarget(invocation.arguments);
     switch (toolName) {
       case "computer_inspect":
-        return await this.#backend.inspect();
-      case "computer_screenshot":
-        return await this.#backend.screenshot(
-          optionalString(invocation.arguments, "sourceId"),
+        requireScopedWindow(target, "computer_inspect");
+        return await this.#backend.inspect(target);
+      case "computer_press":
+        requireScopedWindow(target, "computer_press");
+        return await this.#backend.press(
+          target,
+          requiredControl(invocation.arguments),
         );
-      case "computer_click": {
-        const context = requiredContext(invocation.arguments);
+      case "computer_set_value": {
+        requireScopedWindow(target, "computer_set_value");
+        const value = requiredString(invocation.arguments, "value", true);
+        if (value.length > 4_000) {
+          throw new Error("computer_set_value is limited to 4000 characters");
+        }
+        return await this.#backend.setValue(
+          target,
+          requiredControl(invocation.arguments),
+          value,
+        );
+      }
+      case "computer_screenshot":
+        if (target.windowTitle === undefined) {
+          throw new Error("computer_screenshot requires target.windowTitle");
+        }
+        return await this.#backend.screenshot(target);
+      default:
+        throw new Error(`Unsupported computer tool: ${toolName}`);
+    }
+  }
+
+  async #invokeForeground(
+    toolName: string,
+    invocation: ToolInvocation,
+  ): Promise<unknown> {
+    switch (toolName) {
+      case "computer_foreground_click": {
         const x = requiredFiniteNumber(invocation.arguments, "x");
         const y = requiredFiniteNumber(invocation.arguments, "y");
         const button = optionalString(invocation.arguments, "button") ?? "left";
         if (button !== "left" && button !== "right") {
           throw new Error("button must be left or right");
         }
-        const state = await this.#backend.click(x, y, button);
-        return { action: { x, y, button, context }, state };
+        await foregroundTakeoverNotice(invocation.signal);
+        await this.#backend.foregroundClick(x, y, button, invocation.signal);
+        return { action: "click", x, y, button, impact: "foreground_takeover" };
       }
-      case "computer_type": {
-        const context = requiredContext(invocation.arguments);
-        const text = requiredString(invocation.arguments, "text", true);
-        if (text.length > 4_000)
-          throw new Error("computer_type text is limited to 4000 characters");
-        const state = await this.#backend.type(text);
-        return { action: { characterCount: text.length, context }, state };
-      }
-      case "computer_key_press": {
-        const context = requiredContext(invocation.arguments);
+      case "computer_foreground_key_press": {
         const key = requiredComputerKey(invocation.arguments);
-        const state = await this.#backend.keyPress(key);
-        return { action: { key, context }, state };
+        await foregroundTakeoverNotice(invocation.signal);
+        await this.#backend.foregroundKeyPress(key, invocation.signal);
+        return { action: "key_press", key, impact: "foreground_takeover" };
       }
-      case "computer_scroll": {
-        const context = requiredContext(invocation.arguments);
+      case "computer_foreground_scroll": {
         const deltaY = requiredFiniteNumber(invocation.arguments, "deltaY");
-        if (Math.abs(deltaY) > 10_000 || deltaY === 0) {
+        if (deltaY === 0 || Math.abs(deltaY) > 10_000) {
           throw new Error(
-            "deltaY must be between -10000 and 10000 and non-zero",
+            "deltaY must be non-zero and between -10000 and 10000",
           );
         }
-        const state = await this.#backend.scroll(deltaY);
-        return { action: { deltaY, context }, state };
+        await foregroundTakeoverNotice(invocation.signal);
+        await this.#backend.foregroundScroll(deltaY, invocation.signal);
+        return { action: "scroll", deltaY, impact: "foreground_takeover" };
       }
       default:
-        throw new Error(`Unsupported computer tool: ${toolName}`);
+        throw new Error(`Unsupported foreground computer tool: ${toolName}`);
     }
   }
 
@@ -237,10 +295,137 @@ export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
   }
 }
 
+export interface ComputerControlFingerprint {
+  identifier?: string;
+  role?: string;
+  subrole?: string;
+  title?: string;
+  description?: string;
+  frame?: string;
+  secure: boolean;
+  actions: string[];
+}
+
+interface ComputerObservation {
+  observationId: string;
+  targets: Map<string, ComputerControlFingerprint>;
+}
+
+export class ComputerObservationLedger {
+  readonly #latest = new Map<string, ComputerObservation>();
+
+  observe(
+    targetKey: string,
+    fingerprints: ComputerControlFingerprint[],
+  ): { observationId: string; selectors: ComputerControlSelector[] } {
+    const observationId = randomUUID();
+    const targets = new Map<string, ComputerControlFingerprint>();
+    const selectors = fingerprints.map((fingerprint) => {
+      const targetId = randomUUID();
+      targets.set(targetId, fingerprint);
+      return { observationId, targetId };
+    });
+    this.#latest.set(targetKey, { observationId, targets });
+    return { observationId, selectors };
+  }
+
+  consume(
+    targetKey: string,
+    selector: ComputerControlSelector,
+    action: "press" | "set_value",
+  ): ComputerControlFingerprint {
+    const observation = this.#latest.get(targetKey);
+    if (
+      observation === undefined ||
+      observation.observationId !== selector.observationId
+    ) {
+      throw new Error(
+        "Computer observation is stale, unknown, or scoped to another target; inspect the target again",
+      );
+    }
+    const fingerprint = observation.targets.get(selector.targetId);
+    if (fingerprint === undefined) {
+      throw new Error("Computer target ID is forged, stale, or unknown");
+    }
+    if (action === "press" && !fingerprint.actions.includes("AXPress")) {
+      throw new Error(
+        "Control does not support background-safe semantic press; foreground_required",
+      );
+    }
+    if (action === "set_value") {
+      if (fingerprint.secure) {
+        throw new Error(
+          "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
+        );
+      }
+      if (!fingerprint.actions.includes("AXSetValue")) {
+        throw new Error(
+          "Control does not support background-safe semantic set value; foreground_required",
+        );
+      }
+    }
+    this.#latest.delete(targetKey);
+    return fingerprint;
+  }
+
+  clear(): void {
+    this.#latest.clear();
+  }
+}
+
+interface MacRawControl {
+  selector: {
+    identifier?: string;
+    role?: string;
+    subrole?: string;
+    title?: string;
+    description?: string;
+    frame?: string;
+  };
+  role: string;
+  title: string;
+  enabled: boolean;
+  actions: string[];
+  secure?: boolean;
+}
+
+interface MacInspectionResult {
+  target: ComputerInspection["target"];
+  controls: MacRawControl[];
+  truncated: boolean;
+}
+
+function rawControlFingerprint(
+  control: MacRawControl,
+): ComputerControlFingerprint {
+  return {
+    ...control.selector,
+    secure: control.secure === true,
+    actions: [...control.actions],
+  };
+}
+
+function semanticControlSelector(
+  fingerprint: ComputerControlFingerprint,
+): Record<string, string> {
+  const { secure: _secure, actions: _actions, ...selector } = fingerprint;
+  return selector;
+}
+
+function computerTargetKey(target: ComputerTarget): string {
+  return JSON.stringify({
+    pid: target.pid ?? null,
+    bundleId: target.bundleId ?? null,
+    windowTitle: target.windowTitle ?? null,
+  });
+}
+
 export class ElectronMacComputerBackend implements ZenXComputerBackend {
   readonly #artifactDirectory: string;
   readonly #expiryTimers = new Set<NodeJS.Timeout>();
-  readonly #inputDriver: MacInputDriver;
+  readonly #accessibility: MacAccessibilityDriver;
+  readonly #foregroundInput: MacForegroundInputDriver;
+  readonly #observations = new ComputerObservationLedger();
 
   constructor(
     artifactDirectory = path.join(
@@ -249,56 +434,132 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
     ),
   ) {
     this.#artifactDirectory = artifactDirectory;
-    this.#inputDriver = new MacInputDriver(artifactDirectory);
+    this.#accessibility = new MacAccessibilityDriver(artifactDirectory);
+    this.#foregroundInput = new MacForegroundInputDriver(artifactDirectory);
   }
 
-  async inspect(): Promise<ComputerState> {
+  async inspect(target: ComputerTarget): Promise<ComputerInspection> {
     requireMacOs();
-    const { screen } = await import("electron");
-    const [frontmostApplication, frontmostWindowTitle] =
-      await frontmostContext();
+    const result = (await this.#accessibility.run({
+      operation: "inspect",
+      target,
+    })) as MacInspectionResult;
+    const boundedControls = result.controls.slice(
+      0,
+      MAX_COMPUTER_INSPECTION_CONTROLS,
+    );
+    const observation = this.#observations.observe(
+      computerTargetKey(target),
+      boundedControls.map(rawControlFingerprint),
+    );
     return {
       platform: process.platform,
-      frontmostApplication,
-      frontmostWindowTitle,
-      cursor: screen.getCursorScreenPoint(),
-      displays: screen.getAllDisplays().map((display) => ({
-        id: String(display.id),
-        bounds: display.bounds,
-        scaleFactor: display.scaleFactor,
+      observationId: observation.observationId,
+      target: result.target,
+      controls: boundedControls.map((control, index) => ({
+        selector: observation.selectors[index]!,
+        role: control.role,
+        title: control.title,
+        enabled: control.enabled,
+        actions: control.actions,
+        ...(control.secure ? { secure: true } : {}),
       })),
+      truncated:
+        result.truncated || result.controls.length > boundedControls.length,
     };
   }
 
-  async screenshot(sourceId?: string): Promise<{
+  async desktopContext(): Promise<{
+    pid: number;
+    bundleId: string;
+    applicationName: string;
+  }> {
+    requireMacOs();
+    return (await this.#accessibility.run({ operation: "desktopContext" })) as {
+      pid: number;
+      bundleId: string;
+      applicationName: string;
+    };
+  }
+
+  async prepareForegroundInput(signal: AbortSignal): Promise<void> {
+    requireMacOs();
+    await this.#foregroundInput.prepare(signal);
+  }
+
+  async press(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+  }> {
+    requireMacOs();
+    const fingerprint = this.#observations.consume(
+      computerTargetKey(target),
+      control,
+      "press",
+    );
+    const response = (await this.#accessibility.run({
+      operation: "press",
+      target,
+      control: semanticControlSelector(fingerprint),
+    })) as { target: ComputerInspection["target"] };
+    return { target: response.target, control };
+  }
+
+  async setValue(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    value: string,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+    characterCount: number;
+  }> {
+    requireMacOs();
+    const fingerprint = this.#observations.consume(
+      computerTargetKey(target),
+      control,
+      "set_value",
+    );
+    const response = (await this.#accessibility.run({
+      operation: "setValue",
+      target,
+      control: semanticControlSelector(fingerprint),
+      value,
+    })) as {
+      target: ComputerInspection["target"];
+      characterCount: number;
+    };
+    return { ...response, control };
+  }
+
+  async screenshot(target: ComputerTarget): Promise<{
     artifactPath: string;
-    sourceId: string;
-    sourceName: string;
+    target: ComputerInspection["target"];
     width: number;
     height: number;
     bytes: number;
     expiresAt: string;
   }> {
     requireMacOs();
-    const { desktopCapturer, screen } = await import("electron");
-    const primary = screen.getPrimaryDisplay();
+    const resolved = (await this.#accessibility.run({
+      operation: "resolveWindow",
+      target,
+    })) as { target: ComputerInspection["target"]; windowId: number };
+    const { desktopCapturer } = await import("electron");
     const sources = await desktopCapturer.getSources({
-      types: ["screen"],
-      thumbnailSize: {
-        width: Math.min(1600, Math.max(1, primary.size.width)),
-        height: Math.min(1000, Math.max(1, primary.size.height)),
-      },
+      types: ["window"],
+      thumbnailSize: { width: 1600, height: 1000 },
       fetchWindowIcons: false,
     });
-    const source =
-      sourceId === undefined
-        ? sources[0]
-        : sources.find((candidate) => candidate.id === sourceId);
-    if (source === undefined) {
+    const source = sources.find((candidate) =>
+      candidate.id.startsWith(`window:${String(resolved.windowId)}:`),
+    );
+    if (source === undefined || source.thumbnail.isEmpty()) {
       throw new Error(
-        sourceId === undefined
-          ? "No screen capture source is available; grant Screen Recording permission"
-          : `Unknown screen source: ${sourceId}`,
+        "The targeted window is not available for scoped capture; grant Screen Recording permission and ensure the window is on-screen",
       );
     }
     await mkdir(this.#artifactDirectory, { recursive: true, mode: 0o700 });
@@ -318,8 +579,7 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
     const size = source.thumbnail.getSize();
     return {
       artifactPath,
-      sourceId: source.id,
-      sourceName: source.name.slice(0, 160),
+      target: resolved.target,
       width: size.width,
       height: size.height,
       bytes: png.length,
@@ -327,47 +587,59 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
     };
   }
 
-  async click(
+  async foregroundClick(
     x: number,
     y: number,
     button: "left" | "right",
-  ): Promise<ComputerState> {
+    signal: AbortSignal,
+  ): Promise<void> {
     requireMacOs();
-    await assertPointOnDisplay(x, y);
-    await this.#inputDriver.run("click", [
-      String(Math.round(x)),
-      String(Math.round(y)),
-      button,
-    ]);
-    return await this.inspect();
+    const { screen } = await import("electron");
+    const onDisplay = screen
+      .getAllDisplays()
+      .some(
+        ({ bounds }) =>
+          x >= bounds.x &&
+          y >= bounds.y &&
+          x < bounds.x + bounds.width &&
+          y < bounds.y + bounds.height,
+      );
+    if (!onDisplay) {
+      throw new Error(
+        `Foreground click point ${String(x)},${String(y)} is outside every display`,
+      );
+    }
+    await this.#foregroundInput.run(
+      { operation: "click", x: Math.round(x), y: Math.round(y), button },
+      signal,
+    );
   }
 
-  async type(text: string): Promise<ComputerState> {
+  async foregroundKeyPress(
+    key: ComputerKey,
+    signal: AbortSignal,
+  ): Promise<void> {
     requireMacOs();
-    await this.#inputDriver.run("type", [], text);
-    return await this.inspect();
+    await this.#foregroundInput.run({ operation: "key", key }, signal);
   }
 
-  async keyPress(key: ComputerKey): Promise<ComputerState> {
+  async foregroundScroll(deltaY: number, signal: AbortSignal): Promise<void> {
     requireMacOs();
-    await this.#inputDriver.run("key", [String(KEY_CODES[key])]);
-    return await this.inspect();
-  }
-
-  async scroll(deltaY: number): Promise<ComputerState> {
-    requireMacOs();
-    await this.#inputDriver.run("scroll", [String(-Math.round(deltaY))]);
-    return await this.inspect();
+    await this.#foregroundInput.run(
+      { operation: "scroll", deltaY: Math.round(deltaY) },
+      signal,
+    );
   }
 
   async close(): Promise<void> {
+    this.#observations.clear();
     for (const timer of this.#expiryTimers) clearTimeout(timer);
     this.#expiryTimers.clear();
     await rm(this.#artifactDirectory, { recursive: true, force: true });
   }
 }
 
-class MacInputDriver {
+class MacForegroundInputDriver {
   readonly #directory: string;
   #executable: Promise<string> | undefined;
 
@@ -376,19 +648,28 @@ class MacInputDriver {
   }
 
   async run(
-    operation: string,
-    args: readonly string[],
-    stdin?: string,
+    request: Record<string, unknown>,
+    signal: AbortSignal,
   ): Promise<void> {
+    signal.throwIfAborted();
     const executable = await (this.#executable ??= this.#compile());
-    await runProcess(executable, [operation, ...args], 10_000, stdin);
+    await runProcess(executable, [], 10_000, JSON.stringify(request), signal);
+  }
+
+  async prepare(signal: AbortSignal): Promise<void> {
+    signal.throwIfAborted();
+    await (this.#executable ??= this.#compile());
+    signal.throwIfAborted();
   }
 
   async #compile(): Promise<string> {
     await mkdir(this.#directory, { recursive: true, mode: 0o700 });
-    const sourcePath = path.join(this.#directory, "zenx-computer-input.swift");
-    const executablePath = path.join(this.#directory, "zenx-computer-input");
-    await writeFile(sourcePath, MAC_INPUT_SOURCE, {
+    const sourcePath = path.join(
+      this.#directory,
+      "zenx-foreground-input.swift",
+    );
+    const executablePath = path.join(this.#directory, "zenx-foreground-input");
+    await writeFile(sourcePath, MAC_FOREGROUND_INPUT_SOURCE, {
       encoding: "utf8",
       mode: 0o600,
     });
@@ -401,7 +682,299 @@ class MacInputDriver {
   }
 }
 
-const MAC_INPUT_SOURCE = `import ApplicationServices
+class MacAccessibilityDriver {
+  readonly #directory: string;
+  #executable: Promise<string> | undefined;
+
+  constructor(directory: string) {
+    this.#directory = directory;
+  }
+
+  async run(request: Record<string, unknown>): Promise<unknown> {
+    const executable = await (this.#executable ??= this.#compile());
+    const output = await runProcess(
+      executable,
+      [],
+      10_000,
+      JSON.stringify(request),
+    );
+    try {
+      return JSON.parse(output) as unknown;
+    } catch {
+      throw new Error("macOS accessibility helper returned invalid JSON");
+    }
+  }
+
+  async #compile(): Promise<string> {
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    const sourcePath = path.join(this.#directory, "zenx-accessibility.swift");
+    const executablePath = path.join(this.#directory, "zenx-accessibility");
+    await writeFile(sourcePath, MAC_ACCESSIBILITY_SOURCE, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await runProcess(
+      "/usr/bin/swiftc",
+      ["-O", sourcePath, "-o", executablePath],
+      60_000,
+    );
+    return executablePath;
+  }
+}
+
+const MAC_ACCESSIBILITY_SOURCE = `import AppKit
+import ApplicationServices
+import Foundation
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data((message + "\\n").utf8))
+  exit(1)
+}
+
+func dictionary(_ value: Any?, _ name: String) -> [String: Any] {
+  guard let result = value as? [String: Any] else { fail(name + " must be an object") }
+  return result
+}
+
+func string(_ value: Any?) -> String? {
+  guard let value = value as? String, !value.isEmpty else { return nil }
+  return value
+}
+
+func attribute(_ element: AXUIElement, _ name: String) -> AnyObject? {
+  var value: CFTypeRef?
+  guard AXUIElementCopyAttributeValue(element, name as CFString, &value) == .success,
+        let value else { return nil }
+  return value
+}
+
+func textAttribute(_ element: AXUIElement, _ name: String) -> String {
+  return attribute(element, name) as? String ?? ""
+}
+
+func boolAttribute(_ element: AXUIElement, _ name: String) -> Bool {
+  return attribute(element, name) as? Bool ?? false
+}
+
+func elementArrayAttribute(_ element: AXUIElement, _ name: String) -> [AXUIElement] {
+  var count: CFIndex = 0
+  guard AXUIElementGetAttributeValueCount(element, name as CFString, &count) == .success,
+        count > 0 else { return [] }
+  var values: CFArray?
+  guard AXUIElementCopyAttributeValues(element, name as CFString, 0, count, &values) == .success,
+        let array = values else { return [] }
+  return (0..<CFArrayGetCount(array)).compactMap { index in
+    guard let pointer = CFArrayGetValueAtIndex(array, index) else { return nil }
+    return unsafeBitCast(pointer, to: AXUIElement.self)
+  }
+}
+
+func elementAttribute(_ element: AXUIElement, _ name: String) -> AXUIElement? {
+  guard let raw = attribute(element, name),
+        CFGetTypeID(raw) == AXUIElementGetTypeID() else { return nil }
+  return unsafeBitCast(raw, to: AXUIElement.self)
+}
+
+func actions(_ element: AXUIElement) -> [String] {
+  var names: CFArray?
+  guard AXUIElementCopyActionNames(element, &names) == .success else { return [] }
+  return (names as? [String] ?? []).sorted()
+}
+
+func isSettable(_ element: AXUIElement, _ name: String) -> Bool {
+  var settable: DarwinBoolean = false
+  return AXUIElementIsAttributeSettable(element, name as CFString, &settable) == .success && settable.boolValue
+}
+
+func isSecure(_ element: AXUIElement) -> Bool {
+  let semantics = (textAttribute(element, kAXRoleAttribute) + " " + textAttribute(element, kAXSubroleAttribute)).lowercased()
+  return semantics.contains("secure") || semantics.contains("password")
+}
+
+func frameFingerprint(_ element: AXUIElement) -> String {
+  guard let rawPosition = attribute(element, kAXPositionAttribute),
+        let rawSize = attribute(element, kAXSizeAttribute),
+        CFGetTypeID(rawPosition) == AXValueGetTypeID(),
+        CFGetTypeID(rawSize) == AXValueGetTypeID() else { return "" }
+  let positionValue = unsafeBitCast(rawPosition, to: AXValue.self)
+  let sizeValue = unsafeBitCast(rawSize, to: AXValue.self)
+  var position = CGPoint.zero
+  var size = CGSize.zero
+  guard AXValueGetValue(positionValue, .cgPoint, &position),
+        AXValueGetValue(sizeValue, .cgSize, &size) else { return "" }
+  return String(format: "%.1f,%.1f,%.1f,%.1f", position.x, position.y, size.width, size.height)
+}
+
+let data = FileHandle.standardInput.readDataToEndOfFile()
+guard let raw = try? JSONSerialization.jsonObject(with: data),
+      let request = raw as? [String: Any] else { fail("request must be JSON") }
+let operation = string(request["operation"]) ?? ""
+if operation == "desktopContext" {
+  guard let frontmost = NSWorkspace.shared.frontmostApplication else { fail("frontmost application is unavailable") }
+  let response: [String: Any] = [
+    "pid": Int(frontmost.processIdentifier),
+    "bundleId": frontmost.bundleIdentifier ?? "",
+    "applicationName": frontmost.localizedName ?? ""
+  ]
+  guard let output = try? JSONSerialization.data(withJSONObject: response) else { fail("could not encode response") }
+  FileHandle.standardOutput.write(output)
+  exit(0)
+}
+guard AXIsProcessTrusted() else {
+  fail("macOS Accessibility permission is required for background-safe computer operations")
+}
+let targetRequest = dictionary(request["target"], "target")
+
+let running: NSRunningApplication
+if let pidNumber = targetRequest["pid"] as? NSNumber {
+  guard let candidate = NSRunningApplication(processIdentifier: pid_t(pidNumber.int32Value)) else {
+    fail("target pid is not running")
+  }
+  running = candidate
+} else if let bundleId = string(targetRequest["bundleId"]) {
+  guard let candidate = NSRunningApplication.runningApplications(withBundleIdentifier: bundleId).first else {
+    fail("target bundleId is not running")
+  }
+  running = candidate
+} else {
+  fail("target requires pid or bundleId")
+}
+if let expectedBundle = string(targetRequest["bundleId"]), running.bundleIdentifier != expectedBundle {
+  fail("target pid and bundleId identify different applications")
+}
+
+let appElement = AXUIElementCreateApplication(running.processIdentifier)
+let requestedWindowTitle = string(targetRequest["windowTitle"])
+var windows = elementArrayAttribute(appElement, kAXWindowsAttribute)
+if let focused = elementAttribute(appElement, kAXFocusedWindowAttribute) { windows.append(focused) }
+if let main = elementAttribute(appElement, kAXMainWindowAttribute) { windows.append(main) }
+let selectedWindow: AXUIElement?
+if let title = requestedWindowTitle {
+  selectedWindow = windows.first(where: {
+    textAttribute($0, kAXRoleAttribute) == kAXWindowRole &&
+    textAttribute($0, kAXTitleAttribute) == title
+  })
+  if selectedWindow == nil {
+    fail("target window was not found as a scoped AXWindow")
+  }
+} else {
+  selectedWindow = nil
+}
+let root = selectedWindow ?? appElement
+var resolvedTarget: [String: Any] = [
+  "pid": Int(running.processIdentifier),
+  "bundleId": running.bundleIdentifier ?? "",
+  "applicationName": running.localizedName ?? ""
+]
+if let title = requestedWindowTitle { resolvedTarget["windowTitle"] = title }
+
+func children(_ element: AXUIElement) -> [AXUIElement] {
+  let direct = elementArrayAttribute(element, kAXChildrenAttribute)
+  if !direct.isEmpty { return direct }
+  return elementArrayAttribute(element, "AXChildrenInNavigationOrder")
+}
+
+func selector(_ element: AXUIElement) -> [String: String] {
+  var result: [String: String] = [:]
+  let identifier = textAttribute(element, kAXIdentifierAttribute)
+  let role = textAttribute(element, kAXRoleAttribute)
+  let subrole = textAttribute(element, kAXSubroleAttribute)
+  let title = textAttribute(element, kAXTitleAttribute)
+  let description = textAttribute(element, kAXDescriptionAttribute)
+  let frame = frameFingerprint(element)
+  if !identifier.isEmpty { result["identifier"] = identifier }
+  if !role.isEmpty { result["role"] = role }
+  if !subrole.isEmpty { result["subrole"] = subrole }
+  if !title.isEmpty { result["title"] = title }
+  if !description.isEmpty { result["description"] = description }
+  if !frame.isEmpty { result["frame"] = frame }
+  return result
+}
+
+func matches(_ element: AXUIElement, _ wanted: [String: Any]) -> Bool {
+  if let value = string(wanted["identifier"]), textAttribute(element, kAXIdentifierAttribute) != value { return false }
+  if let value = string(wanted["role"]), textAttribute(element, kAXRoleAttribute) != value { return false }
+  if let value = string(wanted["subrole"]), textAttribute(element, kAXSubroleAttribute) != value { return false }
+  if let value = string(wanted["title"]), textAttribute(element, kAXTitleAttribute) != value { return false }
+  if let value = string(wanted["description"]), textAttribute(element, kAXDescriptionAttribute) != value { return false }
+  if let value = string(wanted["frame"]), frameFingerprint(element) != value { return false }
+  return string(wanted["identifier"]) != nil || string(wanted["role"]) != nil || string(wanted["subrole"]) != nil || string(wanted["title"]) != nil || string(wanted["description"]) != nil || string(wanted["frame"]) != nil
+}
+
+func walk(_ root: AXUIElement, limit: Int = 120) -> ([AXUIElement], Bool) {
+  var queue: [(AXUIElement, Int)] = [(root, 0)]
+  var result: [AXUIElement] = []
+  while !queue.isEmpty && result.count < limit {
+    let (element, depth) = queue.removeFirst()
+    result.append(element)
+    if depth < 8 { queue.append(contentsOf: children(element).map { ($0, depth + 1) }) }
+  }
+  return (result, !queue.isEmpty)
+}
+
+func findControl(_ wanted: [String: Any]) -> AXUIElement {
+  let (elements, _) = walk(root)
+  let found = elements.filter { matches($0, wanted) }
+  if found.isEmpty { fail("accessibility control was not found") }
+  if found.count > 1 { fail("accessibility selector is ambiguous") }
+  return found[0]
+}
+
+var response: [String: Any]
+switch operation {
+case "inspect":
+  let (elements, truncated) = walk(root)
+  let controls = elements.compactMap { element -> [String: Any]? in
+    let controlSelector = selector(element)
+    if controlSelector.isEmpty { return nil }
+    var supportedActions = actions(element)
+    if isSettable(element, kAXValueAttribute) { supportedActions.append("AXSetValue") }
+    return [
+      "selector": controlSelector,
+      "role": textAttribute(element, kAXRoleAttribute),
+      "title": textAttribute(element, kAXTitleAttribute),
+      "enabled": boolAttribute(element, kAXEnabledAttribute),
+      "actions": supportedActions.sorted(),
+      "secure": isSecure(element)
+    ]
+  }
+  response = ["target": resolvedTarget, "controls": controls, "truncated": truncated]
+case "press":
+  let wanted = dictionary(request["control"], "control")
+  let element = findControl(wanted)
+  guard actions(element).contains(kAXPressAction) else { fail("control does not support background-safe AXPress; foreground_required") }
+  let error = AXUIElementPerformAction(element, kAXPressAction as CFString)
+  guard error == .success else { fail("AXPress failed with error " + String(error.rawValue)) }
+  response = ["target": resolvedTarget, "control": selector(element)]
+case "setValue":
+  let wanted = dictionary(request["control"], "control")
+  guard let value = request["value"] as? String else { fail("value must be a string") }
+  let element = findControl(wanted)
+  if isSecure(element) { fail("password or secure controls reject AXValue; typing tools are non-secret-only") }
+  var settable: DarwinBoolean = false
+  guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable) == .success, settable.boolValue else {
+    fail("control does not support background-safe AXValue; foreground_required")
+  }
+  let error = AXUIElementSetAttributeValue(element, kAXValueAttribute as CFString, value as CFTypeRef)
+  guard error == .success else { fail("AXValue failed with error " + String(error.rawValue)) }
+  response = ["target": resolvedTarget, "control": selector(element), "characterCount": value.count]
+case "resolveWindow":
+  guard let title = requestedWindowTitle else { fail("windowTitle is required") }
+  let info = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID) as? [[String: Any]] ?? []
+  guard let window = info.first(where: {
+    ($0[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value == running.processIdentifier &&
+    ($0[kCGWindowName as String] as? String ?? "") == title
+  }), let number = window[kCGWindowNumber as String] as? NSNumber else { fail("target window is not available for scoped capture") }
+  response = ["target": resolvedTarget, "windowId": number]
+default:
+  fail("unsupported accessibility operation")
+}
+
+guard let output = try? JSONSerialization.data(withJSONObject: response) else { fail("could not encode response") }
+FileHandle.standardOutput.write(output)
+`;
+
+const MAC_FOREGROUND_INPUT_SOURCE = `import ApplicationServices
 import Foundation
 
 func fail(_ message: String) -> Never {
@@ -410,139 +983,62 @@ func fail(_ message: String) -> Never {
 }
 
 guard AXIsProcessTrusted() else {
-  fail("macOS Accessibility permission is required for computer input")
+  fail("macOS Accessibility permission is required for foreground takeover")
 }
+let data = FileHandle.standardInput.readDataToEndOfFile()
+guard let raw = try? JSONSerialization.jsonObject(with: data),
+      let request = raw as? [String: Any],
+      let operation = request["operation"] as? String else { fail("request must be JSON") }
 
-let arguments = CommandLine.arguments
-guard arguments.count >= 2 else { fail("missing input operation") }
-let operation = arguments[1]
+let keyCodes: [String: CGKeyCode] = [
+  "enter": 36, "escape": 53, "tab": 48, "backspace": 51, "space": 49,
+  "arrowUp": 126, "arrowDown": 125, "arrowLeft": 123, "arrowRight": 124
+]
 
-func postKey(_ keyCode: CGKeyCode) {
-  CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)?.post(tap: .cghidEventTap)
+func postKey(_ code: CGKeyCode) {
+  CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: true)?.post(tap: .cghidEventTap)
   usleep(20_000)
-  CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)?.post(tap: .cghidEventTap)
+  CGEvent(keyboardEventSource: nil, virtualKey: code, keyDown: false)?.post(tap: .cghidEventTap)
 }
 
 switch operation {
 case "click":
-  guard arguments.count == 5,
-        let x = Double(arguments[2]),
-        let y = Double(arguments[3]) else { fail("invalid click arguments") }
-  let right = arguments[4] == "right"
+  guard let x = (request["x"] as? NSNumber)?.doubleValue,
+        let y = (request["y"] as? NSNumber)?.doubleValue,
+        let buttonName = request["button"] as? String else { fail("invalid click request") }
   let point = CGPoint(x: x, y: y)
-  CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
-  usleep(40_000)
+  let right = buttonName == "right"
   let button: CGMouseButton = right ? .right : .left
   let down: CGEventType = right ? .rightMouseDown : .leftMouseDown
   let up: CGEventType = right ? .rightMouseUp : .leftMouseUp
+  CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: button)?.post(tap: .cghidEventTap)
   CGEvent(mouseEventSource: nil, mouseType: down, mouseCursorPosition: point, mouseButton: button)?.post(tap: .cghidEventTap)
-  usleep(40_000)
+  usleep(30_000)
   CGEvent(mouseEventSource: nil, mouseType: up, mouseCursorPosition: point, mouseButton: button)?.post(tap: .cghidEventTap)
-case "type":
-  guard arguments.count == 2,
-        let text = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) else {
-    fail("invalid type input")
-  }
-  let units = Array(text.utf16)
-  guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
-        let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
-    fail("could not create keyboard event")
-  }
-  units.withUnsafeBufferPointer { buffer in
-    down.keyboardSetUnicodeString(stringLength: units.count, unicodeString: buffer.baseAddress)
-    up.keyboardSetUnicodeString(stringLength: units.count, unicodeString: buffer.baseAddress)
-  }
-  down.post(tap: .cghidEventTap)
-  usleep(20_000)
-  up.post(tap: .cghidEventTap)
 case "key":
-  guard arguments.count == 3, let code = UInt16(arguments[2]) else { fail("invalid key arguments") }
+  guard let key = request["key"] as? String, let code = keyCodes[key] else { fail("unsupported key") }
   postKey(code)
 case "scroll":
-  guard arguments.count == 3, let delta = Int32(arguments[2]) else { fail("invalid scroll arguments") }
-  CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1, wheel1: delta, wheel2: 0, wheel3: 0)?.post(tap: .cghidEventTap)
+  guard let delta = (request["deltaY"] as? NSNumber)?.int32Value else { fail("invalid scroll request") }
+  CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1, wheel1: -delta, wheel2: 0, wheel3: 0)?.post(tap: .cghidEventTap)
 default:
-  fail("unsupported input operation")
+  fail("unsupported foreground input operation")
 }
 `;
-
-const KEY_CODES: Record<ComputerKey | "pageUp" | "pageDown", number> = {
-  enter: 36,
-  escape: 53,
-  tab: 48,
-  backspace: 51,
-  space: 49,
-  arrowUp: 126,
-  arrowDown: 125,
-  arrowLeft: 123,
-  arrowRight: 124,
-  pageUp: 116,
-  pageDown: 121,
-};
-
-async function frontmostContext(): Promise<[string, string]> {
-  const output = await runAppleScript(
-    [
-      'tell application "System Events"',
-      "set frontProcess to first application process whose frontmost is true",
-      "set appName to name of frontProcess",
-      'set windowName to ""',
-      "try",
-      "set windowName to name of front window of frontProcess",
-      "end try",
-      "return appName & linefeed & windowName",
-      "end tell",
-    ],
-    [],
-  );
-  const [application = "", windowTitle = ""] = output.trimEnd().split("\n", 2);
-  return [application.slice(0, 160), windowTitle.slice(0, 256)];
-}
-
-async function runAppleScript(
-  lines: readonly string[],
-  args: readonly string[],
-): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const scriptArgs = lines.flatMap((line) => ["-e", line]);
-    const child = spawn("/usr/bin/osascript", [...scriptArgs, ...args], {
-      shell: false,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-    const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
-    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
-    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
-    child.once("error", (error) => {
-      clearTimeout(timer);
-      reject(error);
-    });
-    child.once("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) resolve(Buffer.concat(stdout).toString("utf8"));
-      else {
-        reject(
-          new Error(
-            `macOS Automation failed (${String(code)}): ${Buffer.concat(stderr).toString("utf8").trim().slice(0, 1024)}`,
-          ),
-        );
-      }
-    });
-  });
-}
 
 async function runProcess(
   command: string,
   args: readonly string[],
   timeoutMs: number,
   stdin?: string,
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
+  signal?: AbortSignal,
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
     const child = spawn(command, args, {
       shell: false,
-      stdio: [stdin === undefined ? "ignore" : "pipe", "ignore", "pipe"],
+      stdio: [stdin === undefined ? "ignore" : "pipe", "pipe", "pipe"],
     });
+    const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
     let settled = false;
     const finish = (callback: () => void): void => {
@@ -561,60 +1057,151 @@ async function runProcess(
         ),
       );
     }, timeoutMs);
+    const abort = (): void => {
+      child.kill("SIGKILL");
+      finish(() =>
+        reject(
+          signal?.reason ??
+            new DOMException(
+              "The foreground operation was cancelled",
+              "AbortError",
+            ),
+        ),
+      );
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    child.stdout?.on("data", (chunk: Buffer) => stdout.push(chunk));
     child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
     if (stdin !== undefined) child.stdin?.end(stdin, "utf8");
     child.once("error", (error) => finish(() => reject(error)));
-    child.once("close", (code, signal) => {
+    child.once("close", (code, exitSignal) => {
       finish(() => {
-        if (code === 0) resolve();
+        signal?.removeEventListener("abort", abort);
+        if (code === 0) resolve(Buffer.concat(stdout).toString("utf8"));
         else {
           reject(
             new Error(
-              `${path.basename(command)} failed (${signal ?? String(code)}): ${Buffer.concat(stderr).toString("utf8").trim().slice(0, 2048)}`,
+              `${path.basename(command)} failed (${exitSignal ?? String(code)}): ${Buffer.concat(stderr).toString("utf8").trim().slice(0, 2048)}`,
             ),
           );
         }
       });
     });
+    if (signal?.aborted === true) abort();
   });
 }
 
-async function assertPointOnDisplay(x: number, y: number): Promise<void> {
-  const { screen } = await import("electron");
-  const valid = screen
-    .getAllDisplays()
-    .some(
-      ({ bounds }) =>
-        x >= bounds.x &&
-        y >= bounds.y &&
-        x < bounds.x + bounds.width &&
-        y < bounds.y + bounds.height,
-    );
-  if (!valid)
-    throw new Error(`Point ${String(x)},${String(y)} is outside every display`);
+function foregroundTools(): ZenXCapabilityManifest["tools"] {
+  const shared = {
+    permissions: ["computer.foreground.control"],
+    interactionMode: "foreground_required" as const,
+    capabilities: ["global_input", "may_change_focus", "cancellable"],
+  };
+  return [
+    {
+      ...shared,
+      name: "computer_foreground_click",
+      description:
+        "FOREGROUND TAKEOVER: move and click the real global pointer. ZenX shows the running tool before input begins; Stop cancels it.",
+      inputSchema: objectSchema(
+        {
+          x: { type: "number" },
+          y: { type: "number" },
+          button: { type: "string", enum: ["left", "right"] },
+        },
+        ["x", "y"],
+      ),
+    },
+    {
+      ...shared,
+      name: "computer_foreground_key_press",
+      description:
+        "FOREGROUND TAKEOVER: press one allowlisted key in the focused control. Stop cancels the running operation.",
+      inputSchema: objectSchema(
+        {
+          key: {
+            type: "string",
+            enum: [
+              "enter",
+              "escape",
+              "tab",
+              "backspace",
+              "space",
+              "arrowUp",
+              "arrowDown",
+              "arrowLeft",
+              "arrowRight",
+            ],
+          },
+        },
+        ["key"],
+      ),
+    },
+    {
+      ...shared,
+      name: "computer_foreground_scroll",
+      description:
+        "FOREGROUND TAKEOVER: scroll the current foreground target. Stop cancels the running operation.",
+      inputSchema: objectSchema({ deltaY: { type: "number" } }, ["deltaY"]),
+    },
+  ];
 }
 
-function requireMacOs(): void {
-  if (process.platform !== "darwin") {
+function requiredTarget(arguments_: Record<string, unknown>): ComputerTarget {
+  const raw = requiredObject(arguments_, "target");
+  const pid = optionalPositiveInteger(raw, "pid");
+  const bundleId = optionalString(raw, "bundleId");
+  const windowTitle = optionalString(raw, "windowTitle");
+  if (pid === undefined && bundleId === undefined) {
+    throw new Error("target requires pid or bundleId");
+  }
+  if (windowTitle !== undefined && windowTitle.length > 256) {
+    throw new Error("target.windowTitle is limited to 256 characters");
+  }
+  return {
+    ...(pid === undefined ? {} : { pid }),
+    ...(bundleId === undefined ? {} : { bundleId }),
+    ...(windowTitle === undefined ? {} : { windowTitle }),
+  };
+}
+
+function requiredControl(
+  arguments_: Record<string, unknown>,
+): ComputerControlSelector {
+  const raw = requiredObject(arguments_, "control");
+  return {
+    observationId: requiredOpaqueId(raw, "observationId"),
+    targetId: requiredOpaqueId(raw, "targetId"),
+  };
+}
+
+function requireScopedWindow(target: ComputerTarget, toolName: string): void {
+  if (target.windowTitle === undefined) {
     throw new Error(
-      "The bundled computer provider currently supports macOS only",
+      `${toolName} requires target.windowTitle so the provider cannot inspect or act across sibling windows`,
     );
   }
 }
 
-function requiredContext(arguments_: Record<string, unknown>): string {
-  const value = requiredString(arguments_, "context");
-  if (value.length > 500)
-    throw new Error("context is limited to 500 characters");
-  return value;
-}
-
-function requiredComputerKey(arguments_: Record<string, unknown>): ComputerKey {
-  const value = requiredString(arguments_, "key");
-  if (!(value in KEY_CODES) || value === "pageUp" || value === "pageDown") {
-    throw new Error(`Unsupported computer key: ${value}`);
-  }
-  return value as ComputerKey;
+async function foregroundTakeoverNotice(signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", abort);
+      resolve();
+    }, 1_000);
+    const abort = (): void => {
+      clearTimeout(timer);
+      reject(
+        signal.reason ??
+          new DOMException(
+            "The foreground operation was cancelled",
+            "AbortError",
+          ),
+      );
+    };
+    signal.addEventListener("abort", abort, { once: true });
+  });
 }
 
 function requiredFiniteNumber(
@@ -626,6 +1213,49 @@ function requiredFiniteNumber(
     throw new Error(`${key} must be a finite number`);
   }
   return value;
+}
+
+function requiredComputerKey(arguments_: Record<string, unknown>): ComputerKey {
+  const value = requiredString(arguments_, "key");
+  if (!COMPUTER_KEYS.includes(value as ComputerKey)) {
+    throw new Error(`Unsupported computer key: ${value}`);
+  }
+  return value as ComputerKey;
+}
+
+const COMPUTER_KEYS: readonly ComputerKey[] = [
+  "enter",
+  "escape",
+  "tab",
+  "backspace",
+  "space",
+  "arrowUp",
+  "arrowDown",
+  "arrowLeft",
+  "arrowRight",
+];
+
+function requiredObject(
+  arguments_: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> {
+  const value = arguments_[key];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${key} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalPositiveInteger(
+  value: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  const candidate = value[key];
+  if (candidate === undefined) return undefined;
+  if (!Number.isSafeInteger(candidate) || (candidate as number) <= 0) {
+    throw new Error(`${key} must be a positive integer`);
+  }
+  return candidate as number;
 }
 
 function requiredString(
@@ -643,21 +1273,52 @@ function requiredString(
 }
 
 function optionalString(
-  arguments_: Record<string, unknown>,
+  value: Record<string, unknown>,
   key: string,
 ): string | undefined {
-  const value = arguments_[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== "string") throw new Error(`${key} must be a string`);
-  return value;
+  const candidate = value[key];
+  if (candidate === undefined) return undefined;
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return candidate;
+}
+
+function targetSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      pid: { type: "integer", minimum: 1 },
+      bundleId: stringSchema(),
+      windowTitle: stringSchema(),
+    },
+    additionalProperties: false,
+    anyOf: [{ required: ["pid"] }, { required: ["bundleId"] }],
+  };
+}
+
+function controlSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      observationId: stringSchema(),
+      targetId: stringSchema(),
+    },
+    additionalProperties: false,
+    required: ["observationId", "targetId"],
+  };
+}
+
+function requiredOpaqueId(value: Record<string, unknown>, key: string): string {
+  const candidate = requiredString(value, key);
+  if (!/^[a-zA-Z0-9_-]{1,80}$/u.test(candidate)) {
+    throw new Error(`${key} must be an opaque identifier`);
+  }
+  return candidate;
 }
 
 function stringSchema(): Record<string, unknown> {
   return { type: "string" };
-}
-
-function numberSchema(): Record<string, unknown> {
-  return { type: "number" };
 }
 
 function objectSchema(
@@ -665,4 +1326,12 @@ function objectSchema(
   required: string[],
 ): Record<string, unknown> {
   return { type: "object", properties, required, additionalProperties: false };
+}
+
+function requireMacOs(): void {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "The bundled computer provider currently supports macOS only",
+    );
+  }
 }

--- a/apps/zenx/src/main/capabilities/computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/computer-provider.ts
@@ -1,0 +1,668 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+export interface ComputerState {
+  platform: NodeJS.Platform;
+  frontmostApplication: string;
+  frontmostWindowTitle: string;
+  cursor: { x: number; y: number };
+  displays: Array<{
+    id: string;
+    bounds: { x: number; y: number; width: number; height: number };
+    scaleFactor: number;
+  }>;
+}
+
+export interface ZenXComputerBackend {
+  inspect(): Promise<ComputerState>;
+  screenshot(sourceId?: string): Promise<{
+    artifactPath: string;
+    sourceId: string;
+    sourceName: string;
+    width: number;
+    height: number;
+    bytes: number;
+    expiresAt: string;
+  }>;
+  click(x: number, y: number, button: "left" | "right"): Promise<ComputerState>;
+  type(text: string): Promise<ComputerState>;
+  keyPress(key: ComputerKey): Promise<ComputerState>;
+  scroll(deltaY: number): Promise<ComputerState>;
+  close(): Promise<void> | void;
+}
+
+type ComputerKey =
+  | "enter"
+  | "escape"
+  | "tab"
+  | "backspace"
+  | "space"
+  | "arrowUp"
+  | "arrowDown"
+  | "arrowLeft"
+  | "arrowRight";
+
+export const computerCapabilityManifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: "computer",
+  displayName: "Computer",
+  version: "1.0.0",
+  description:
+    "Auditable macOS screen inspection and narrow pointer, keyboard, and scroll operations with explicit target context.",
+  permissions: [
+    {
+      id: "computer.screen.inspect",
+      title: "Inspect screen state",
+      description:
+        "Read display geometry, cursor location, and the frontmost app/window title.",
+      scope: "local-device",
+    },
+    {
+      id: "computer.screen.capture",
+      title: "Capture a screenshot",
+      description:
+        "Capture one explicitly selected display to a private short-lived artifact file.",
+      scope: "local-device",
+    },
+    {
+      id: "computer.pointer.control",
+      title: "Control pointer and scrolling",
+      description:
+        "Click explicit screen coordinates and issue bounded page scrolling.",
+      scope: "local-device",
+    },
+    {
+      id: "computer.keyboard.control",
+      title: "Control keyboard",
+      description:
+        "Type explicit text or press one allowlisted key in the frontmost application.",
+      scope: "local-device",
+    },
+  ],
+  tools: [
+    {
+      name: "computer_inspect",
+      description:
+        "Inspect current app/window identity, display bounds, and cursor position without capturing pixels or unrelated screen content.",
+      inputSchema: objectSchema({}, []),
+      permissions: ["computer.screen.inspect"],
+    },
+    {
+      name: "computer_screenshot",
+      description:
+        "Capture one selected display to a private short-lived PNG artifact. Returns metadata and a path, never base64 screen pixels in the Thread journal.",
+      inputSchema: objectSchema({ sourceId: stringSchema() }, []),
+      permissions: ["computer.screen.capture"],
+      maxOutputBytes: 4 * 1024,
+    },
+    {
+      name: "computer_click",
+      description:
+        "Click explicit global screen coordinates. context must state the app/window/control expected at that point for auditability.",
+      inputSchema: objectSchema(
+        {
+          x: numberSchema(),
+          y: numberSchema(),
+          button: { type: "string", enum: ["left", "right"] },
+          context: stringSchema(),
+        },
+        ["x", "y", "context"],
+      ),
+      permissions: ["computer.pointer.control"],
+    },
+    {
+      name: "computer_type",
+      description:
+        "Type text into the frontmost control. context must identify the intended app/window/control; output records only character count, not typed text.",
+      inputSchema: objectSchema(
+        { text: stringSchema(), context: stringSchema() },
+        ["text", "context"],
+      ),
+      permissions: ["computer.keyboard.control"],
+    },
+    {
+      name: "computer_key_press",
+      description:
+        "Press one allowlisted key in the frontmost control with explicit target context.",
+      inputSchema: objectSchema(
+        {
+          key: {
+            type: "string",
+            enum: [
+              "enter",
+              "escape",
+              "tab",
+              "backspace",
+              "space",
+              "arrowUp",
+              "arrowDown",
+              "arrowLeft",
+              "arrowRight",
+            ],
+          },
+          context: stringSchema(),
+        },
+        ["key", "context"],
+      ),
+      permissions: ["computer.keyboard.control"],
+    },
+    {
+      name: "computer_scroll",
+      description:
+        "Issue a bounded page scroll to the frontmost window. Positive deltaY scrolls down; context identifies the intended target.",
+      inputSchema: objectSchema(
+        { deltaY: numberSchema(), context: stringSchema() },
+        ["deltaY", "context"],
+      ),
+      permissions: ["computer.pointer.control"],
+    },
+  ],
+  resources: [
+    {
+      id: "inspect-before-act",
+      kind: "skill",
+      title: "Inspect before computer actions",
+      description: "Instructions for auditable, targeted desktop actions.",
+      content:
+        "Call computer_inspect before an input action and include the observed application, window, and intended control in context. Prefer browser structured tools for web pages. Use screenshots only when state metadata is insufficient. Re-inspect after actions that can change focus, and stop if the observed context differs from the intended target.",
+    },
+  ],
+};
+
+export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest = computerCapabilityManifest;
+  readonly #backend: ZenXComputerBackend;
+
+  constructor(backend: ZenXComputerBackend) {
+    this.#backend = backend;
+  }
+
+  async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
+    switch (toolName) {
+      case "computer_inspect":
+        return await this.#backend.inspect();
+      case "computer_screenshot":
+        return await this.#backend.screenshot(
+          optionalString(invocation.arguments, "sourceId"),
+        );
+      case "computer_click": {
+        const context = requiredContext(invocation.arguments);
+        const x = requiredFiniteNumber(invocation.arguments, "x");
+        const y = requiredFiniteNumber(invocation.arguments, "y");
+        const button = optionalString(invocation.arguments, "button") ?? "left";
+        if (button !== "left" && button !== "right") {
+          throw new Error("button must be left or right");
+        }
+        const state = await this.#backend.click(x, y, button);
+        return { action: { x, y, button, context }, state };
+      }
+      case "computer_type": {
+        const context = requiredContext(invocation.arguments);
+        const text = requiredString(invocation.arguments, "text", true);
+        if (text.length > 4_000)
+          throw new Error("computer_type text is limited to 4000 characters");
+        const state = await this.#backend.type(text);
+        return { action: { characterCount: text.length, context }, state };
+      }
+      case "computer_key_press": {
+        const context = requiredContext(invocation.arguments);
+        const key = requiredComputerKey(invocation.arguments);
+        const state = await this.#backend.keyPress(key);
+        return { action: { key, context }, state };
+      }
+      case "computer_scroll": {
+        const context = requiredContext(invocation.arguments);
+        const deltaY = requiredFiniteNumber(invocation.arguments, "deltaY");
+        if (Math.abs(deltaY) > 10_000 || deltaY === 0) {
+          throw new Error(
+            "deltaY must be between -10000 and 10000 and non-zero",
+          );
+        }
+        const state = await this.#backend.scroll(deltaY);
+        return { action: { deltaY, context }, state };
+      }
+      default:
+        throw new Error(`Unsupported computer tool: ${toolName}`);
+    }
+  }
+
+  async close(): Promise<void> {
+    await this.#backend.close();
+  }
+}
+
+export class ElectronMacComputerBackend implements ZenXComputerBackend {
+  readonly #artifactDirectory: string;
+  readonly #expiryTimers = new Set<NodeJS.Timeout>();
+  readonly #inputDriver: MacInputDriver;
+
+  constructor(
+    artifactDirectory = path.join(
+      os.tmpdir(),
+      `zenx-capability-artifacts-${String(process.pid)}`,
+    ),
+  ) {
+    this.#artifactDirectory = artifactDirectory;
+    this.#inputDriver = new MacInputDriver(artifactDirectory);
+  }
+
+  async inspect(): Promise<ComputerState> {
+    requireMacOs();
+    const { screen } = await import("electron");
+    const [frontmostApplication, frontmostWindowTitle] =
+      await frontmostContext();
+    return {
+      platform: process.platform,
+      frontmostApplication,
+      frontmostWindowTitle,
+      cursor: screen.getCursorScreenPoint(),
+      displays: screen.getAllDisplays().map((display) => ({
+        id: String(display.id),
+        bounds: display.bounds,
+        scaleFactor: display.scaleFactor,
+      })),
+    };
+  }
+
+  async screenshot(sourceId?: string): Promise<{
+    artifactPath: string;
+    sourceId: string;
+    sourceName: string;
+    width: number;
+    height: number;
+    bytes: number;
+    expiresAt: string;
+  }> {
+    requireMacOs();
+    const { desktopCapturer, screen } = await import("electron");
+    const primary = screen.getPrimaryDisplay();
+    const sources = await desktopCapturer.getSources({
+      types: ["screen"],
+      thumbnailSize: {
+        width: Math.min(1600, Math.max(1, primary.size.width)),
+        height: Math.min(1000, Math.max(1, primary.size.height)),
+      },
+      fetchWindowIcons: false,
+    });
+    const source =
+      sourceId === undefined
+        ? sources[0]
+        : sources.find((candidate) => candidate.id === sourceId);
+    if (source === undefined) {
+      throw new Error(
+        sourceId === undefined
+          ? "No screen capture source is available; grant Screen Recording permission"
+          : `Unknown screen source: ${sourceId}`,
+      );
+    }
+    await mkdir(this.#artifactDirectory, { recursive: true, mode: 0o700 });
+    const artifactPath = path.join(
+      this.#artifactDirectory,
+      `${randomUUID()}.png`,
+    );
+    const png = source.thumbnail.toPNG();
+    await writeFile(artifactPath, png, { mode: 0o600 });
+    const expiresAt = new Date(Date.now() + 5 * 60_000);
+    const timer = setTimeout(() => {
+      this.#expiryTimers.delete(timer);
+      void rm(artifactPath, { force: true });
+    }, 5 * 60_000);
+    timer.unref();
+    this.#expiryTimers.add(timer);
+    const size = source.thumbnail.getSize();
+    return {
+      artifactPath,
+      sourceId: source.id,
+      sourceName: source.name.slice(0, 160),
+      width: size.width,
+      height: size.height,
+      bytes: png.length,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  async click(
+    x: number,
+    y: number,
+    button: "left" | "right",
+  ): Promise<ComputerState> {
+    requireMacOs();
+    await assertPointOnDisplay(x, y);
+    await this.#inputDriver.run("click", [
+      String(Math.round(x)),
+      String(Math.round(y)),
+      button,
+    ]);
+    return await this.inspect();
+  }
+
+  async type(text: string): Promise<ComputerState> {
+    requireMacOs();
+    await this.#inputDriver.run("type", [], text);
+    return await this.inspect();
+  }
+
+  async keyPress(key: ComputerKey): Promise<ComputerState> {
+    requireMacOs();
+    await this.#inputDriver.run("key", [String(KEY_CODES[key])]);
+    return await this.inspect();
+  }
+
+  async scroll(deltaY: number): Promise<ComputerState> {
+    requireMacOs();
+    await this.#inputDriver.run("scroll", [String(-Math.round(deltaY))]);
+    return await this.inspect();
+  }
+
+  async close(): Promise<void> {
+    for (const timer of this.#expiryTimers) clearTimeout(timer);
+    this.#expiryTimers.clear();
+    await rm(this.#artifactDirectory, { recursive: true, force: true });
+  }
+}
+
+class MacInputDriver {
+  readonly #directory: string;
+  #executable: Promise<string> | undefined;
+
+  constructor(directory: string) {
+    this.#directory = directory;
+  }
+
+  async run(
+    operation: string,
+    args: readonly string[],
+    stdin?: string,
+  ): Promise<void> {
+    const executable = await (this.#executable ??= this.#compile());
+    await runProcess(executable, [operation, ...args], 10_000, stdin);
+  }
+
+  async #compile(): Promise<string> {
+    await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+    const sourcePath = path.join(this.#directory, "zenx-computer-input.swift");
+    const executablePath = path.join(this.#directory, "zenx-computer-input");
+    await writeFile(sourcePath, MAC_INPUT_SOURCE, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await runProcess(
+      "/usr/bin/swiftc",
+      ["-O", sourcePath, "-o", executablePath],
+      60_000,
+    );
+    return executablePath;
+  }
+}
+
+const MAC_INPUT_SOURCE = `import ApplicationServices
+import Foundation
+
+func fail(_ message: String) -> Never {
+  FileHandle.standardError.write(Data((message + "\\n").utf8))
+  exit(1)
+}
+
+guard AXIsProcessTrusted() else {
+  fail("macOS Accessibility permission is required for computer input")
+}
+
+let arguments = CommandLine.arguments
+guard arguments.count >= 2 else { fail("missing input operation") }
+let operation = arguments[1]
+
+func postKey(_ keyCode: CGKeyCode) {
+  CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)?.post(tap: .cghidEventTap)
+  usleep(20_000)
+  CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)?.post(tap: .cghidEventTap)
+}
+
+switch operation {
+case "click":
+  guard arguments.count == 5,
+        let x = Double(arguments[2]),
+        let y = Double(arguments[3]) else { fail("invalid click arguments") }
+  let right = arguments[4] == "right"
+  let point = CGPoint(x: x, y: y)
+  CGEvent(mouseEventSource: nil, mouseType: .mouseMoved, mouseCursorPosition: point, mouseButton: .left)?.post(tap: .cghidEventTap)
+  usleep(40_000)
+  let button: CGMouseButton = right ? .right : .left
+  let down: CGEventType = right ? .rightMouseDown : .leftMouseDown
+  let up: CGEventType = right ? .rightMouseUp : .leftMouseUp
+  CGEvent(mouseEventSource: nil, mouseType: down, mouseCursorPosition: point, mouseButton: button)?.post(tap: .cghidEventTap)
+  usleep(40_000)
+  CGEvent(mouseEventSource: nil, mouseType: up, mouseCursorPosition: point, mouseButton: button)?.post(tap: .cghidEventTap)
+case "type":
+  guard arguments.count == 2,
+        let text = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) else {
+    fail("invalid type input")
+  }
+  let units = Array(text.utf16)
+  guard let down = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: true),
+        let up = CGEvent(keyboardEventSource: nil, virtualKey: 0, keyDown: false) else {
+    fail("could not create keyboard event")
+  }
+  units.withUnsafeBufferPointer { buffer in
+    down.keyboardSetUnicodeString(stringLength: units.count, unicodeString: buffer.baseAddress)
+    up.keyboardSetUnicodeString(stringLength: units.count, unicodeString: buffer.baseAddress)
+  }
+  down.post(tap: .cghidEventTap)
+  usleep(20_000)
+  up.post(tap: .cghidEventTap)
+case "key":
+  guard arguments.count == 3, let code = UInt16(arguments[2]) else { fail("invalid key arguments") }
+  postKey(code)
+case "scroll":
+  guard arguments.count == 3, let delta = Int32(arguments[2]) else { fail("invalid scroll arguments") }
+  CGEvent(scrollWheelEvent2Source: nil, units: .pixel, wheelCount: 1, wheel1: delta, wheel2: 0, wheel3: 0)?.post(tap: .cghidEventTap)
+default:
+  fail("unsupported input operation")
+}
+`;
+
+const KEY_CODES: Record<ComputerKey | "pageUp" | "pageDown", number> = {
+  enter: 36,
+  escape: 53,
+  tab: 48,
+  backspace: 51,
+  space: 49,
+  arrowUp: 126,
+  arrowDown: 125,
+  arrowLeft: 123,
+  arrowRight: 124,
+  pageUp: 116,
+  pageDown: 121,
+};
+
+async function frontmostContext(): Promise<[string, string]> {
+  const output = await runAppleScript(
+    [
+      'tell application "System Events"',
+      "set frontProcess to first application process whose frontmost is true",
+      "set appName to name of frontProcess",
+      'set windowName to ""',
+      "try",
+      "set windowName to name of front window of frontProcess",
+      "end try",
+      "return appName & linefeed & windowName",
+      "end tell",
+    ],
+    [],
+  );
+  const [application = "", windowTitle = ""] = output.trimEnd().split("\n", 2);
+  return [application.slice(0, 160), windowTitle.slice(0, 256)];
+}
+
+async function runAppleScript(
+  lines: readonly string[],
+  args: readonly string[],
+): Promise<string> {
+  return await new Promise<string>((resolve, reject) => {
+    const scriptArgs = lines.flatMap((line) => ["-e", line]);
+    const child = spawn("/usr/bin/osascript", [...scriptArgs, ...args], {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.once("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0) resolve(Buffer.concat(stdout).toString("utf8"));
+      else {
+        reject(
+          new Error(
+            `macOS Automation failed (${String(code)}): ${Buffer.concat(stderr).toString("utf8").trim().slice(0, 1024)}`,
+          ),
+        );
+      }
+    });
+  });
+}
+
+async function runProcess(
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+  stdin?: string,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(command, args, {
+      shell: false,
+      stdio: [stdin === undefined ? "ignore" : "pipe", "ignore", "pipe"],
+    });
+    const stderr: Buffer[] = [];
+    let settled = false;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      callback();
+    };
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      finish(() =>
+        reject(
+          new Error(
+            `${path.basename(command)} timed out after ${String(timeoutMs)}ms`,
+          ),
+        ),
+      );
+    }, timeoutMs);
+    child.stderr?.on("data", (chunk: Buffer) => stderr.push(chunk));
+    if (stdin !== undefined) child.stdin?.end(stdin, "utf8");
+    child.once("error", (error) => finish(() => reject(error)));
+    child.once("close", (code, signal) => {
+      finish(() => {
+        if (code === 0) resolve();
+        else {
+          reject(
+            new Error(
+              `${path.basename(command)} failed (${signal ?? String(code)}): ${Buffer.concat(stderr).toString("utf8").trim().slice(0, 2048)}`,
+            ),
+          );
+        }
+      });
+    });
+  });
+}
+
+async function assertPointOnDisplay(x: number, y: number): Promise<void> {
+  const { screen } = await import("electron");
+  const valid = screen
+    .getAllDisplays()
+    .some(
+      ({ bounds }) =>
+        x >= bounds.x &&
+        y >= bounds.y &&
+        x < bounds.x + bounds.width &&
+        y < bounds.y + bounds.height,
+    );
+  if (!valid)
+    throw new Error(`Point ${String(x)},${String(y)} is outside every display`);
+}
+
+function requireMacOs(): void {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "The bundled computer provider currently supports macOS only",
+    );
+  }
+}
+
+function requiredContext(arguments_: Record<string, unknown>): string {
+  const value = requiredString(arguments_, "context");
+  if (value.length > 500)
+    throw new Error("context is limited to 500 characters");
+  return value;
+}
+
+function requiredComputerKey(arguments_: Record<string, unknown>): ComputerKey {
+  const value = requiredString(arguments_, "key");
+  if (!(value in KEY_CODES) || value === "pageUp" || value === "pageDown") {
+    throw new Error(`Unsupported computer key: ${value}`);
+  }
+  return value as ComputerKey;
+}
+
+function requiredFiniteNumber(
+  arguments_: Record<string, unknown>,
+  key: string,
+): number {
+  const value = arguments_[key];
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${key} must be a finite number`);
+  }
+  return value;
+}
+
+function requiredString(
+  arguments_: Record<string, unknown>,
+  key: string,
+  allowEmpty = false,
+): string {
+  const value = arguments_[key];
+  if (typeof value !== "string" || (!allowEmpty && value.length === 0)) {
+    throw new Error(
+      `${key} must be ${allowEmpty ? "a string" : "a non-empty string"}`,
+    );
+  }
+  return value;
+}
+
+function optionalString(
+  arguments_: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = arguments_[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") throw new Error(`${key} must be a string`);
+  return value;
+}
+
+function stringSchema(): Record<string, unknown> {
+  return { type: "string" };
+}
+
+function numberSchema(): Record<string, unknown> {
+  return { type: "number" };
+}
+
+function objectSchema(
+  properties: Record<string, unknown>,
+  required: string[],
+): Record<string, unknown> {
+  return { type: "object", properties, required, additionalProperties: false };
+}

--- a/apps/zenx/src/main/capabilities/grant-store.ts
+++ b/apps/zenx/src/main/capabilities/grant-store.ts
@@ -1,0 +1,84 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { ZenXCapabilityGrant, ZenXCapabilityGrantStore } from "./types.js";
+
+interface GrantFile {
+  version: 1;
+  grants: Record<string, ZenXCapabilityGrant[]>;
+}
+
+export class JsonZenXCapabilityGrantStore implements ZenXCapabilityGrantStore {
+  readonly #filePath: string;
+
+  constructor(filePath: string) {
+    this.#filePath = filePath;
+  }
+
+  async load(): Promise<Record<string, ZenXCapabilityGrant[]>> {
+    let raw: string;
+    try {
+      raw = await readFile(this.#filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+      throw error;
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isGrantFile(parsed)) {
+      throw new Error("ZenX capability grant file is invalid");
+    }
+    return structuredClone(parsed.grants);
+  }
+
+  async save(
+    grants: Readonly<Record<string, ZenXCapabilityGrant[]>>,
+  ): Promise<void> {
+    await mkdir(path.dirname(this.#filePath), {
+      recursive: true,
+      mode: 0o700,
+    });
+    const temporary = `${this.#filePath}.${String(process.pid)}.tmp`;
+    await writeFile(
+      temporary,
+      `${JSON.stringify({ version: 1, grants } satisfies GrantFile, null, 2)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    await rename(temporary, this.#filePath);
+  }
+}
+
+export class MemoryZenXCapabilityGrantStore implements ZenXCapabilityGrantStore {
+  #grants: Record<string, ZenXCapabilityGrant[]> = {};
+
+  async load(): Promise<Record<string, ZenXCapabilityGrant[]>> {
+    return structuredClone(this.#grants);
+  }
+
+  async save(
+    grants: Readonly<Record<string, ZenXCapabilityGrant[]>>,
+  ): Promise<void> {
+    this.#grants = structuredClone(grants);
+  }
+}
+
+function isGrantFile(value: unknown): value is GrantFile {
+  if (!isRecord(value) || value.version !== 1 || !isRecord(value.grants)) {
+    return false;
+  }
+  return Object.values(value.grants).every(
+    (grants) =>
+      Array.isArray(grants) &&
+      grants.every(
+        (grant) =>
+          isRecord(grant) &&
+          typeof grant.permissionId === "string" &&
+          (grant.scope === "browser-session" ||
+            grant.scope === "local-device" ||
+            grant.scope === "workspace"),
+      ),
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/zenx/src/main/capabilities/local-package.ts
+++ b/apps/zenx/src/main/capabilities/local-package.ts
@@ -3,7 +3,12 @@ import { readdir, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import type { ToolInvocation } from "../../../../../src/tool.js";
-import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+import {
+  MAX_CAPABILITY_OUTPUT_BYTES,
+  MIN_CAPABILITY_OUTPUT_BYTES,
+  type ZenXCapabilityManifest,
+  type ZenXCapabilityPackage,
+} from "./types.js";
 
 interface LocalCapabilityFile extends ZenXCapabilityManifest {
   runtime: {
@@ -188,7 +193,8 @@ export class ProcessZenXCapabilityPackage implements ZenXCapabilityPackage {
 }
 
 function isLocalCapabilityFile(value: unknown): value is LocalCapabilityFile {
-  if (!isRecord(value) || !isRecord(value.runtime)) return false;
+  if (!isRecord(value) || !isRecord(value.runtime) || !isRecord(value.provider))
+    return false;
   return (
     value.schemaVersion === 1 &&
     typeof value.id === "string" &&
@@ -197,7 +203,27 @@ function isLocalCapabilityFile(value: unknown): value is LocalCapabilityFile {
     typeof value.description === "string" &&
     Array.isArray(value.permissions) &&
     Array.isArray(value.tools) &&
+    value.tools.every(
+      (tool) =>
+        isRecord(tool) &&
+        (tool.maxOutputBytes === undefined ||
+          (Number.isSafeInteger(tool.maxOutputBytes) &&
+            (tool.maxOutputBytes as number) >= MIN_CAPABILITY_OUTPUT_BYTES &&
+            (tool.maxOutputBytes as number) <= MAX_CAPABILITY_OUTPUT_BYTES)),
+    ) &&
     Array.isArray(value.resources) &&
+    typeof value.provider.id === "string" &&
+    Array.isArray(value.provider.platforms) &&
+    value.provider.platforms.every((entry) => typeof entry === "string") &&
+    Array.isArray(value.provider.interactionModes) &&
+    value.provider.interactionModes.every(
+      (entry) =>
+        entry === "background_safe" ||
+        entry === "foreground_required" ||
+        entry === "isolated",
+    ) &&
+    Array.isArray(value.provider.capabilities) &&
+    value.provider.capabilities.every((entry) => typeof entry === "string") &&
     value.runtime.type === "process" &&
     typeof value.runtime.command === "string" &&
     (value.runtime.args === undefined ||

--- a/apps/zenx/src/main/capabilities/local-package.ts
+++ b/apps/zenx/src/main/capabilities/local-package.ts
@@ -1,0 +1,223 @@
+import { spawn } from "node:child_process";
+import { readdir, readFile, realpath } from "node:fs/promises";
+import path from "node:path";
+
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+interface LocalCapabilityFile extends ZenXCapabilityManifest {
+  runtime: {
+    type: "process";
+    command: string;
+    args?: string[];
+    timeoutMs?: number;
+  };
+}
+
+export async function discoverLocalCapabilityPackages(
+  directory: string,
+): Promise<{
+  packages: ZenXCapabilityPackage[];
+  errors: string[];
+}> {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { packages: [], errors: [] };
+    }
+    throw error;
+  }
+  const packages: ZenXCapabilityPackage[] = [];
+  const errors: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const manifestPath = path.join(directory, entry.name);
+    try {
+      const parsed = JSON.parse(
+        await readFile(manifestPath, "utf8"),
+      ) as unknown;
+      if (!isLocalCapabilityFile(parsed)) {
+        throw new Error("manifest shape is invalid");
+      }
+      packages.push(
+        await ProcessZenXCapabilityPackage.create(parsed, manifestPath),
+      );
+    } catch (error) {
+      errors.push(`${entry.name}: ${describeError(error)}`);
+    }
+  }
+  return { packages, errors };
+}
+
+export class ProcessZenXCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest: ZenXCapabilityManifest;
+  readonly #command: string;
+  readonly #args: readonly string[];
+  readonly #cwd: string;
+  readonly #timeoutMs: number;
+
+  private constructor(
+    manifest: ZenXCapabilityManifest,
+    command: string,
+    args: readonly string[],
+    cwd: string,
+    timeoutMs: number,
+  ) {
+    this.manifest = manifest;
+    this.#command = command;
+    this.#args = args;
+    this.#cwd = cwd;
+    this.#timeoutMs = timeoutMs;
+  }
+
+  static async create(
+    definition: LocalCapabilityFile,
+    manifestPath: string,
+  ): Promise<ProcessZenXCapabilityPackage> {
+    const directory = path.dirname(manifestPath);
+    const requestedCommand = path.resolve(
+      directory,
+      definition.runtime.command,
+    );
+    const resolvedDirectory = await realpath(directory);
+    const resolvedCommand = await realpath(requestedCommand);
+    if (
+      resolvedCommand !== resolvedDirectory &&
+      !resolvedCommand.startsWith(`${resolvedDirectory}${path.sep}`)
+    ) {
+      throw new Error(
+        "local capability command must stay inside its package directory",
+      );
+    }
+    const { runtime: _runtime, ...manifest } = definition;
+    return new ProcessZenXCapabilityPackage(
+      manifest,
+      resolvedCommand,
+      definition.runtime.args ?? [],
+      resolvedDirectory,
+      Math.min(Math.max(definition.runtime.timeoutMs ?? 30_000, 100), 120_000),
+    );
+  }
+
+  async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
+    invocation.signal.throwIfAborted();
+    return await new Promise<unknown>((resolve, reject) => {
+      const child = spawn(this.#command, this.#args, {
+        cwd: this.#cwd,
+        env: minimalEnvironment(process.env),
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let bytes = 0;
+      let settled = false;
+      const finish = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        invocation.signal.removeEventListener("abort", abort);
+        callback();
+      };
+      const abort = (): void => {
+        child.kill("SIGTERM");
+        finish(() =>
+          reject(
+            invocation.signal.reason ??
+              new DOMException("Aborted", "AbortError"),
+          ),
+        );
+      };
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        finish(() =>
+          reject(new Error(`Local capability ${this.manifest.id} timed out`)),
+        );
+      }, this.#timeoutMs);
+      invocation.signal.addEventListener("abort", abort, { once: true });
+      child.stdout.on("data", (chunk: Buffer) => {
+        bytes += chunk.length;
+        if (bytes <= 1024 * 1024) stdout.push(chunk);
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        if (Buffer.concat(stderr).length < 8 * 1024) stderr.push(chunk);
+      });
+      child.once("error", (error) => finish(() => reject(error)));
+      child.once("close", (code) => {
+        finish(() => {
+          if (code !== 0) {
+            reject(
+              new Error(
+                `Local capability ${this.manifest.id} exited ${String(code)}: ${Buffer.concat(stderr).toString("utf8").slice(0, 2048)}`,
+              ),
+            );
+            return;
+          }
+          if (bytes > 1024 * 1024) {
+            reject(
+              new Error(
+                `Local capability ${this.manifest.id} exceeded its 1 MiB transport limit`,
+              ),
+            );
+            return;
+          }
+          try {
+            resolve(
+              JSON.parse(Buffer.concat(stdout).toString("utf8")) as unknown,
+            );
+          } catch (error) {
+            reject(
+              new Error(
+                `Local capability returned invalid JSON: ${describeError(error)}`,
+              ),
+            );
+          }
+        });
+      });
+      child.stdin.end(
+        `${JSON.stringify({
+          tool: toolName,
+          arguments: invocation.arguments,
+          context: { callId: invocation.callId, cwd: invocation.cwd },
+        })}\n`,
+      );
+    });
+  }
+}
+
+function isLocalCapabilityFile(value: unknown): value is LocalCapabilityFile {
+  if (!isRecord(value) || !isRecord(value.runtime)) return false;
+  return (
+    value.schemaVersion === 1 &&
+    typeof value.id === "string" &&
+    typeof value.displayName === "string" &&
+    typeof value.version === "string" &&
+    typeof value.description === "string" &&
+    Array.isArray(value.permissions) &&
+    Array.isArray(value.tools) &&
+    Array.isArray(value.resources) &&
+    value.runtime.type === "process" &&
+    typeof value.runtime.command === "string" &&
+    (value.runtime.args === undefined ||
+      (Array.isArray(value.runtime.args) &&
+        value.runtime.args.every((entry) => typeof entry === "string")))
+  );
+}
+
+function minimalEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const name of ["HOME", "LANG", "PATH", "SHELL", "TMPDIR"]) {
+    if (source[name] !== undefined) environment[name] = source[name];
+  }
+  return environment;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -1,0 +1,462 @@
+import { randomUUID } from "node:crypto";
+
+import type { ModelTool } from "../../../../../src/model.js";
+import type {
+  ToolExecutionResult,
+  ToolInvocation,
+} from "../../../../../src/tool.js";
+import type {
+  RegisteredZenXCapability,
+  ZenXCapabilityAuditRecord,
+  ZenXCapabilityGrant,
+  ZenXCapabilityGrantStore,
+  ZenXCapabilityHost,
+  ZenXCapabilityHostSnapshot,
+  ZenXCapabilityManifest,
+  ZenXCapabilityPackage,
+  ZenXCapabilitySnapshot,
+  ZenXCapabilityTool,
+} from "./types.js";
+
+export const CAPABILITY_RESOURCE_TOOL = "zenx_capability_resource";
+const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024;
+const MAX_AUDIT_RECORDS = 100;
+const SENSITIVE_KEY =
+  /(?:authorization|cookie|credential|password|secret|sessionMaterial|storageState|token)/iu;
+
+export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
+  readonly #grantStore: ZenXCapabilityGrantStore;
+  readonly #registered = new Map<string, RegisteredZenXCapability>();
+  readonly #toolOwners = new Map<
+    string,
+    { capabilityId: string; tool: ZenXCapabilityTool }
+  >();
+  readonly #listeners = new Set<(snapshot: ZenXCapabilitySnapshot) => void>();
+  readonly #audit: ZenXCapabilityAuditRecord[] = [];
+  readonly #discoveryErrors: string[] = [];
+  #grants: Record<string, ZenXCapabilityGrant[]> = {};
+
+  constructor(grantStore: ZenXCapabilityGrantStore) {
+    this.#grantStore = grantStore;
+  }
+
+  async initialize(): Promise<void> {
+    this.#grants = await this.#grantStore.load();
+  }
+
+  register(
+    capabilityPackage: ZenXCapabilityPackage,
+    source: "bundled" | "local" = "bundled",
+  ): void {
+    const manifest = validateManifest(capabilityPackage.manifest);
+    if (this.#registered.has(manifest.id)) {
+      throw new Error(`Capability ${manifest.id} is already registered`);
+    }
+    for (const tool of manifest.tools) {
+      if (
+        tool.name === CAPABILITY_RESOURCE_TOOL ||
+        this.#toolOwners.has(tool.name)
+      ) {
+        throw new Error(`Capability tool ${tool.name} is already registered`);
+      }
+    }
+    this.#registered.set(manifest.id, { package: capabilityPackage, source });
+    for (const tool of manifest.tools) {
+      this.#toolOwners.set(tool.name, { capabilityId: manifest.id, tool });
+    }
+    this.#emit();
+  }
+
+  async unregister(capabilityId: string): Promise<void> {
+    const registered = this.#registered.get(capabilityId);
+    if (registered === undefined) return;
+    this.#registered.delete(capabilityId);
+    for (const tool of registered.package.manifest.tools) {
+      this.#toolOwners.delete(tool.name);
+    }
+    await registered.package.close?.();
+    this.#emit();
+  }
+
+  recordDiscoveryError(message: string): void {
+    this.#discoveryErrors.push(message);
+    this.#emit();
+  }
+
+  async grant(
+    capabilityId: string,
+    permissionIds?: readonly string[],
+  ): Promise<void> {
+    const manifest = this.#requireCapability(capabilityId).package.manifest;
+    const selected =
+      permissionIds === undefined
+        ? manifest.permissions
+        : permissionIds.map((permissionId) => {
+            const permission = manifest.permissions.find(
+              (candidate) => candidate.id === permissionId,
+            );
+            if (permission === undefined) {
+              throw new Error(
+                `Capability ${capabilityId} does not request ${permissionId}`,
+              );
+            }
+            return permission;
+          });
+    const existing = new Map(
+      (this.#grants[capabilityId] ?? []).map((grant) => [
+        grant.permissionId,
+        grant,
+      ]),
+    );
+    for (const permission of selected) {
+      existing.set(permission.id, {
+        permissionId: permission.id,
+        scope: permission.scope,
+      });
+    }
+    this.#grants = {
+      ...this.#grants,
+      [capabilityId]: [...existing.values()],
+    };
+    await this.#grantStore.save(this.#grants);
+    this.#emit();
+  }
+
+  async revoke(
+    capabilityId: string,
+    permissionIds?: readonly string[],
+  ): Promise<void> {
+    this.#requireCapability(capabilityId);
+    if (permissionIds === undefined) {
+      const { [capabilityId]: _removed, ...remaining } = this.#grants;
+      this.#grants = remaining;
+    } else {
+      const revoked = new Set(permissionIds);
+      this.#grants = {
+        ...this.#grants,
+        [capabilityId]: (this.#grants[capabilityId] ?? []).filter(
+          (grant) => !revoked.has(grant.permissionId),
+        ),
+      };
+    }
+    await this.#grantStore.save(this.#grants);
+    this.#emit();
+  }
+
+  snapshot(): ZenXCapabilitySnapshot {
+    return {
+      capabilities: [...this.#registered.values()].map((registered) => {
+        const manifest = registered.package.manifest;
+        return {
+          manifest: {
+            ...manifest,
+            resources: manifest.resources.map(
+              ({ content: _content, ...resource }) => resource,
+            ),
+          },
+          source: registered.source,
+          granted: structuredClone(this.#grants[manifest.id] ?? []),
+          enabledTools: manifest.tools
+            .filter((tool) =>
+              this.#hasPermissions(manifest.id, tool.permissions),
+            )
+            .map((tool) => tool.name),
+        };
+      }),
+      recentInvocations: structuredClone(this.#audit),
+      discoveryErrors: [...this.#discoveryErrors],
+    };
+  }
+
+  hostSnapshot(): ZenXCapabilityHostSnapshot {
+    const definitions: ModelTool[] = [];
+    const resources: string[] = [];
+    for (const registered of this.#registered.values()) {
+      const manifest = registered.package.manifest;
+      for (const tool of manifest.tools) {
+        if (this.#hasPermissions(manifest.id, tool.permissions)) {
+          definitions.push({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: structuredClone(tool.inputSchema),
+          });
+        }
+      }
+      if (
+        manifest.resources.length > 0 &&
+        this.#hasPermissions(
+          manifest.id,
+          manifest.permissions.map((permission) => permission.id),
+        )
+      ) {
+        resources.push(
+          ...manifest.resources.map(
+            (resource) =>
+              `${manifest.id}/${resource.id} (${resource.kind}): ${resource.description}`,
+          ),
+        );
+      }
+    }
+    if (resources.length > 0) {
+      definitions.push({
+        name: CAPABILITY_RESOURCE_TOOL,
+        description: `Read an installed ZenX capability skill or prompt resource. Available resources: ${resources.join("; ")}`,
+        inputSchema: {
+          type: "object",
+          properties: {
+            capabilityId: { type: "string" },
+            resourceId: { type: "string" },
+          },
+          required: ["capabilityId", "resourceId"],
+          additionalProperties: false,
+        },
+      });
+    }
+    return { definitions };
+  }
+
+  async execute(invocation: ToolInvocation): Promise<ToolExecutionResult> {
+    const audit = this.#startAudit(invocation);
+    try {
+      const output =
+        invocation.name === CAPABILITY_RESOURCE_TOOL
+          ? this.#readResource(invocation.arguments)
+          : await this.#executeProvider(invocation);
+      invocation.signal.throwIfAborted();
+      const result = boundedResult(
+        invocation.name,
+        output.value,
+        output.maxOutputBytes,
+      );
+      this.#finishAudit(audit, "completed", summarize(result));
+      return { output: result, exitCode: 0 };
+    } catch (error) {
+      const cancelled = invocation.signal.aborted || isAbortError(error);
+      this.#finishAudit(
+        audit,
+        cancelled ? "cancelled" : "failed",
+        describeError(error),
+      );
+      throw error;
+    }
+  }
+
+  onChange(listener: (snapshot: ZenXCapabilitySnapshot) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  async close(): Promise<void> {
+    for (const capabilityId of [...this.#registered.keys()]) {
+      await this.unregister(capabilityId);
+    }
+  }
+
+  async #executeProvider(invocation: ToolInvocation): Promise<{
+    value: unknown;
+    maxOutputBytes: number;
+  }> {
+    const owner = this.#toolOwners.get(invocation.name);
+    if (owner === undefined) {
+      throw new Error(`Unsupported ZenX capability tool: ${invocation.name}`);
+    }
+    if (!this.#hasPermissions(owner.capabilityId, owner.tool.permissions)) {
+      throw new Error(
+        `Capability ${owner.capabilityId} is not granted for ${invocation.name}`,
+      );
+    }
+    invocation.signal.throwIfAborted();
+    const registered = this.#requireCapability(owner.capabilityId);
+    return {
+      value: await registered.package.invoke(invocation.name, invocation),
+      maxOutputBytes: owner.tool.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+    };
+  }
+
+  #readResource(arguments_: Record<string, unknown>): {
+    value: unknown;
+    maxOutputBytes: number;
+  } {
+    const capabilityId = requiredString(arguments_, "capabilityId");
+    const resourceId = requiredString(arguments_, "resourceId");
+    const manifest = this.#requireCapability(capabilityId).package.manifest;
+    if (
+      !this.#hasPermissions(
+        capabilityId,
+        manifest.permissions.map((permission) => permission.id),
+      )
+    ) {
+      throw new Error(`Capability ${capabilityId} is not fully granted`);
+    }
+    const resource = manifest.resources.find(
+      (candidate) => candidate.id === resourceId,
+    );
+    if (resource === undefined) {
+      throw new Error(
+        `Unknown capability resource ${capabilityId}/${resourceId}`,
+      );
+    }
+    return {
+      value: {
+        capabilityId,
+        resourceId,
+        kind: resource.kind,
+        title: resource.title,
+        content: resource.content,
+      },
+      maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+    };
+  }
+
+  #hasPermissions(capabilityId: string, required: readonly string[]): boolean {
+    const granted = new Set(
+      (this.#grants[capabilityId] ?? []).map((grant) => grant.permissionId),
+    );
+    return required.every((permission) => granted.has(permission));
+  }
+
+  #requireCapability(capabilityId: string): RegisteredZenXCapability {
+    const registered = this.#registered.get(capabilityId);
+    if (registered === undefined) {
+      throw new Error(`Unknown ZenX capability: ${capabilityId}`);
+    }
+    return registered;
+  }
+
+  #startAudit(invocation: ToolInvocation): ZenXCapabilityAuditRecord {
+    const owner = this.#toolOwners.get(invocation.name);
+    const record: ZenXCapabilityAuditRecord = {
+      id: randomUUID(),
+      capabilityId:
+        invocation.name === CAPABILITY_RESOURCE_TOOL
+          ? String(invocation.arguments.capabilityId ?? "unknown")
+          : (owner?.capabilityId ?? "unknown"),
+      toolName: invocation.name,
+      callId: invocation.callId,
+      cwd: invocation.cwd,
+      startedAt: new Date().toISOString(),
+      status: "running",
+    };
+    this.#audit.unshift(record);
+    this.#audit.splice(MAX_AUDIT_RECORDS);
+    this.#emit();
+    return record;
+  }
+
+  #finishAudit(
+    record: ZenXCapabilityAuditRecord,
+    status: Exclude<ZenXCapabilityAuditRecord["status"], "running">,
+    summary: string,
+  ): void {
+    record.status = status;
+    record.completedAt = new Date().toISOString();
+    record.summary = summarize(summary);
+    this.#emit();
+  }
+
+  #emit(): void {
+    const snapshot = this.snapshot();
+    for (const listener of this.#listeners) listener(snapshot);
+  }
+}
+
+function validateManifest(
+  manifest: ZenXCapabilityManifest,
+): ZenXCapabilityManifest {
+  if (manifest.schemaVersion !== 1) {
+    throw new Error(
+      `Unsupported capability manifest version: ${String(manifest.schemaVersion)}`,
+    );
+  }
+  if (!/^[a-z][a-z0-9-]{1,62}$/u.test(manifest.id)) {
+    throw new Error(`Invalid capability id: ${manifest.id}`);
+  }
+  const permissionIds = new Set(
+    manifest.permissions.map((permission) => permission.id),
+  );
+  if (permissionIds.size !== manifest.permissions.length) {
+    throw new Error(`Capability ${manifest.id} has duplicate permissions`);
+  }
+  const toolNames = new Set<string>();
+  for (const tool of manifest.tools) {
+    if (!/^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/u.test(tool.name)) {
+      throw new Error(`Invalid capability tool name: ${tool.name}`);
+    }
+    if (toolNames.has(tool.name)) {
+      throw new Error(
+        `Capability ${manifest.id} has duplicate tool ${tool.name}`,
+      );
+    }
+    toolNames.add(tool.name);
+    for (const permission of tool.permissions) {
+      if (!permissionIds.has(permission)) {
+        throw new Error(
+          `Tool ${tool.name} requests unknown permission ${permission}`,
+        );
+      }
+    }
+  }
+  return manifest;
+}
+
+function boundedResult(
+  toolName: string,
+  value: unknown,
+  maxBytes: number,
+): string {
+  const safe = redactSensitive(value);
+  const serialized = JSON.stringify({ tool: toolName, result: safe });
+  if (Buffer.byteLength(serialized, "utf8") <= maxBytes) return serialized;
+  const budget = Math.max(0, maxBytes - 160);
+  const preview = Buffer.from(JSON.stringify(safe), "utf8")
+    .subarray(0, budget)
+    .toString("utf8");
+  return JSON.stringify({
+    tool: toolName,
+    resultPreview: preview,
+    truncated: true,
+    originalBytes: Buffer.byteLength(serialized, "utf8"),
+  });
+}
+
+function redactSensitive(value: unknown, key = ""): unknown {
+  if (SENSITIVE_KEY.test(key)) return "[REDACTED]";
+  if (typeof value === "string") {
+    return value
+      .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [REDACTED]")
+      .replace(
+        /\b((?:api[_-]?key|access[_-]?token|password|secret))=[^&\s]+/giu,
+        "$1=[REDACTED]",
+      );
+  }
+  if (Array.isArray(value)) return value.map((entry) => redactSensitive(entry));
+  if (typeof value === "object" && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value).map(([childKey, child]) => [
+        childKey,
+        redactSensitive(child, childKey),
+      ]),
+    );
+  }
+  return value;
+}
+
+function requiredString(value: Record<string, unknown>, key: string): string {
+  const candidate = value[key];
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    throw new Error(`${key} must be a non-empty string`);
+  }
+  return candidate;
+}
+
+function summarize(value: string): string {
+  return value.length <= 512 ? value : `${value.slice(0, 509)}…`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -16,6 +16,11 @@ import type {
   ZenXCapabilityPackage,
   ZenXCapabilitySnapshot,
   ZenXCapabilityTool,
+  ZenXCapabilityInteractionMode,
+} from "./types.js";
+import {
+  MAX_CAPABILITY_OUTPUT_BYTES,
+  MIN_CAPABILITY_OUTPUT_BYTES,
 } from "./types.js";
 
 export const CAPABILITY_RESOURCE_TOOL = "zenx_capability_resource";
@@ -23,6 +28,11 @@ const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024;
 const MAX_AUDIT_RECORDS = 100;
 const SENSITIVE_KEY =
   /(?:authorization|cookie|credential|password|secret|sessionMaterial|storageState|token)/iu;
+
+export interface ZenXCapabilityRegistryOptions {
+  allowForegroundRequired: boolean;
+  platform: string;
+}
 
 export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   readonly #grantStore: ZenXCapabilityGrantStore;
@@ -34,10 +44,19 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   readonly #listeners = new Set<(snapshot: ZenXCapabilitySnapshot) => void>();
   readonly #audit: ZenXCapabilityAuditRecord[] = [];
   readonly #discoveryErrors: string[] = [];
+  readonly #options: ZenXCapabilityRegistryOptions;
   #grants: Record<string, ZenXCapabilityGrant[]> = {};
 
-  constructor(grantStore: ZenXCapabilityGrantStore) {
+  constructor(
+    grantStore: ZenXCapabilityGrantStore,
+    options: Partial<ZenXCapabilityRegistryOptions> = {},
+  ) {
     this.#grantStore = grantStore;
+    this.#options = {
+      allowForegroundRequired: true,
+      platform: process.platform,
+      ...options,
+    };
   }
 
   async initialize(): Promise<void> {
@@ -155,10 +174,21 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
             ),
           },
           source: registered.source,
+          available: this.#isProviderAvailable(manifest),
+          ...(this.#isProviderAvailable(manifest)
+            ? {}
+            : {
+                unavailableReason: `Provider ${manifest.provider.id} does not support ${this.#options.platform}`,
+              }),
           granted: structuredClone(this.#grants[manifest.id] ?? []),
           enabledTools: manifest.tools
-            .filter((tool) =>
-              this.#hasPermissions(manifest.id, tool.permissions),
+            .filter((tool) => this.#isToolExposed(manifest.id, tool))
+            .map((tool) => tool.name),
+          blockedTools: manifest.tools
+            .filter(
+              (tool) =>
+                this.#hasPermissions(manifest.id, tool.permissions) &&
+                !this.#isInteractionAllowed(tool.interactionMode),
             )
             .map((tool) => tool.name),
         };
@@ -173,8 +203,9 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     const resources: string[] = [];
     for (const registered of this.#registered.values()) {
       const manifest = registered.package.manifest;
+      if (!this.#isProviderAvailable(manifest)) continue;
       for (const tool of manifest.tools) {
-        if (this.#hasPermissions(manifest.id, tool.permissions)) {
+        if (this.#isToolExposed(manifest.id, tool)) {
           definitions.push({
             name: tool.name,
             description: tool.description,
@@ -227,6 +258,10 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         invocation.name,
         output.value,
         output.maxOutputBytes,
+        output.capabilityId,
+        output.provider,
+        output.interactionMode,
+        output.capabilities,
       );
       this.#finishAudit(audit, "completed", summarize(result));
       return { output: result, exitCode: 0 };
@@ -255,6 +290,10 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   async #executeProvider(invocation: ToolInvocation): Promise<{
     value: unknown;
     maxOutputBytes: number;
+    capabilityId: string;
+    provider: { id: string; platforms: string[] };
+    interactionMode: ZenXCapabilityInteractionMode;
+    capabilities: string[];
   }> {
     const owner = this.#toolOwners.get(invocation.name);
     if (owner === undefined) {
@@ -265,21 +304,47 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         `Capability ${owner.capabilityId} is not granted for ${invocation.name}`,
       );
     }
-    invocation.signal.throwIfAborted();
     const registered = this.#requireCapability(owner.capabilityId);
+    if (!this.#isProviderAvailable(registered.package.manifest)) {
+      throw new Error(
+        `Capability provider ${registered.package.manifest.provider.id} does not support ${this.#options.platform}`,
+      );
+    }
+    if (!this.#isInteractionAllowed(owner.tool.interactionMode)) {
+      throw new Error(
+        `ZenX blocked ${invocation.name}: this operation is foreground_required and could move the global pointer, synthesize foreground keyboard input, or change app/workspace focus. This host is configured for background-safe execution only; granting capability permissions does not override that execution restriction.`,
+      );
+    }
+    invocation.signal.throwIfAborted();
     return {
       value: await registered.package.invoke(invocation.name, invocation),
       maxOutputBytes: owner.tool.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+      capabilityId: owner.capabilityId,
+      provider: {
+        id: registered.package.manifest.provider.id,
+        platforms: [...registered.package.manifest.provider.platforms],
+      },
+      interactionMode: owner.tool.interactionMode,
+      capabilities: [...owner.tool.capabilities],
     };
   }
 
   #readResource(arguments_: Record<string, unknown>): {
     value: unknown;
     maxOutputBytes: number;
+    capabilityId: string;
+    provider: { id: string; platforms: string[] };
+    interactionMode: ZenXCapabilityInteractionMode;
+    capabilities: string[];
   } {
     const capabilityId = requiredString(arguments_, "capabilityId");
     const resourceId = requiredString(arguments_, "resourceId");
     const manifest = this.#requireCapability(capabilityId).package.manifest;
+    if (!this.#isProviderAvailable(manifest)) {
+      throw new Error(
+        `Capability provider ${manifest.provider.id} does not support ${this.#options.platform}`,
+      );
+    }
     if (
       !this.#hasPermissions(
         capabilityId,
@@ -305,7 +370,37 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         content: resource.content,
       },
       maxOutputBytes: DEFAULT_MAX_OUTPUT_BYTES,
+      capabilityId,
+      provider: {
+        id: manifest.provider.id,
+        platforms: [...manifest.provider.platforms],
+      },
+      interactionMode: "background_safe",
+      capabilities: ["skill_prompt.read"],
     };
+  }
+
+  #isToolExposed(capabilityId: string, tool: ZenXCapabilityTool): boolean {
+    return (
+      this.#isProviderAvailable(
+        this.#requireCapability(capabilityId).package.manifest,
+      ) &&
+      this.#hasPermissions(capabilityId, tool.permissions) &&
+      this.#isInteractionAllowed(tool.interactionMode)
+    );
+  }
+
+  #isInteractionAllowed(mode: ZenXCapabilityInteractionMode): boolean {
+    return (
+      mode !== "foreground_required" || this.#options.allowForegroundRequired
+    );
+  }
+
+  #isProviderAvailable(manifest: ZenXCapabilityManifest): boolean {
+    return (
+      manifest.provider.platforms.includes(this.#options.platform) ||
+      manifest.provider.platforms.includes("*")
+    );
   }
 
   #hasPermissions(capabilityId: string, required: readonly string[]): boolean {
@@ -331,9 +426,22 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         invocation.name === CAPABILITY_RESOURCE_TOOL
           ? String(invocation.arguments.capabilityId ?? "unknown")
           : (owner?.capabilityId ?? "unknown"),
+      providerId:
+        owner === undefined
+          ? invocation.name === CAPABILITY_RESOURCE_TOOL
+            ? (this.#registered.get(
+                String(invocation.arguments.capabilityId ?? "unknown"),
+              )?.package.manifest.provider.id ?? "unknown")
+            : "unknown"
+          : (this.#registered.get(owner.capabilityId)?.package.manifest.provider
+              .id ?? "unknown"),
       toolName: invocation.name,
       callId: invocation.callId,
       cwd: invocation.cwd,
+      interactionMode:
+        invocation.name === CAPABILITY_RESOURCE_TOOL
+          ? "background_safe"
+          : (owner?.tool.interactionMode ?? "background_safe"),
       startedAt: new Date().toISOString(),
       status: "running",
     };
@@ -377,6 +485,13 @@ function validateManifest(
   if (permissionIds.size !== manifest.permissions.length) {
     throw new Error(`Capability ${manifest.id} has duplicate permissions`);
   }
+  if (
+    manifest.provider.id.length === 0 ||
+    manifest.provider.platforms.length === 0 ||
+    manifest.provider.interactionModes.length === 0
+  ) {
+    throw new Error(`Capability ${manifest.id} has invalid provider metadata`);
+  }
   const toolNames = new Set<string>();
   for (const tool of manifest.tools) {
     if (!/^[a-zA-Z][a-zA-Z0-9_-]{0,63}$/u.test(tool.name)) {
@@ -388,6 +503,19 @@ function validateManifest(
       );
     }
     toolNames.add(tool.name);
+    if (tool.capabilities.length === 0) {
+      throw new Error(`Capability tool ${tool.name} declares no capabilities`);
+    }
+    if (
+      tool.maxOutputBytes !== undefined &&
+      (!Number.isSafeInteger(tool.maxOutputBytes) ||
+        tool.maxOutputBytes < MIN_CAPABILITY_OUTPUT_BYTES ||
+        tool.maxOutputBytes > MAX_CAPABILITY_OUTPUT_BYTES)
+    ) {
+      throw new Error(
+        `Capability tool ${tool.name} maxOutputBytes must be an integer between ${String(MIN_CAPABILITY_OUTPUT_BYTES)} and ${String(MAX_CAPABILITY_OUTPUT_BYTES)}`,
+      );
+    }
     for (const permission of tool.permissions) {
       if (!permissionIds.has(permission)) {
         throw new Error(
@@ -403,19 +531,45 @@ function boundedResult(
   toolName: string,
   value: unknown,
   maxBytes: number,
+  capabilityId: string,
+  provider: { id: string; platforms: readonly string[] },
+  interactionMode: ZenXCapabilityInteractionMode,
+  capabilities: readonly string[],
 ): string {
   const safe = redactSensitive(value);
-  const serialized = JSON.stringify({ tool: toolName, result: safe });
-  if (Buffer.byteLength(serialized, "utf8") <= maxBytes) return serialized;
-  const budget = Math.max(0, maxBytes - 160);
-  const preview = Buffer.from(JSON.stringify(safe), "utf8")
-    .subarray(0, budget)
-    .toString("utf8");
-  return JSON.stringify({
+  const envelope = {
+    capabilityId,
+    provider,
     tool: toolName,
-    resultPreview: preview,
+    interactionMode,
+    capabilities,
+    result: safe,
+  };
+  const serialized = JSON.stringify(envelope);
+  if (Buffer.byteLength(serialized, "utf8") <= maxBytes) return serialized;
+  let preview = JSON.stringify(safe);
+  const truncated = (): string =>
+    JSON.stringify({
+      capabilityId,
+      provider,
+      tool: toolName,
+      interactionMode,
+      capabilities,
+      resultPreview: preview,
+      truncated: true,
+      originalBytes: Buffer.byteLength(serialized, "utf8"),
+    });
+  let output = truncated();
+  while (Buffer.byteLength(output, "utf8") > maxBytes && preview.length > 0) {
+    const excess = Buffer.byteLength(output, "utf8") - maxBytes;
+    preview = preview.slice(0, Math.max(0, preview.length - excess));
+    output = truncated();
+  }
+  if (Buffer.byteLength(output, "utf8") <= maxBytes) return output;
+  return JSON.stringify({
+    tool: toolName.slice(0, 64),
     truncated: true,
-    originalBytes: Buffer.byteLength(serialized, "utf8"),
+    error: "Result metadata exceeded the configured output bound",
   });
 }
 

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -1,0 +1,98 @@
+import type { ModelTool } from "../../../../../src/model.js";
+import type {
+  ToolExecutionResult,
+  ToolInvocation,
+} from "../../../../../src/tool.js";
+
+export type ZenXCapabilityPermissionScope =
+  "browser-session" | "local-device" | "workspace";
+
+export interface ZenXCapabilityPermission {
+  id: string;
+  title: string;
+  description: string;
+  scope: ZenXCapabilityPermissionScope;
+}
+
+export interface ZenXCapabilityTool extends ModelTool {
+  permissions: string[];
+  maxOutputBytes?: number;
+}
+
+export interface ZenXCapabilityResource {
+  id: string;
+  kind: "skill" | "prompt";
+  title: string;
+  description: string;
+  content: string;
+}
+
+export interface ZenXCapabilityManifest {
+  schemaVersion: 1;
+  id: string;
+  displayName: string;
+  version: string;
+  description: string;
+  permissions: ZenXCapabilityPermission[];
+  tools: ZenXCapabilityTool[];
+  resources: ZenXCapabilityResource[];
+  settings?: Readonly<Record<string, unknown>>;
+  ui?: { settingsSection?: string };
+}
+
+export interface ZenXCapabilityPackage {
+  manifest: ZenXCapabilityManifest;
+  invoke(toolName: string, invocation: ToolInvocation): Promise<unknown>;
+  close?(): Promise<void> | void;
+}
+
+export interface ZenXCapabilityGrant {
+  permissionId: string;
+  scope: ZenXCapabilityPermissionScope;
+}
+
+export interface ZenXCapabilityAuditRecord {
+  id: string;
+  capabilityId: string;
+  toolName: string;
+  callId: string;
+  cwd: string;
+  startedAt: string;
+  completedAt?: string;
+  status: "running" | "completed" | "failed" | "cancelled";
+  summary?: string;
+}
+
+export interface ZenXCapabilitySummary {
+  manifest: Omit<ZenXCapabilityManifest, "resources"> & {
+    resources: Array<Omit<ZenXCapabilityResource, "content">>;
+  };
+  source: "bundled" | "local";
+  granted: ZenXCapabilityGrant[];
+  enabledTools: string[];
+}
+
+export interface ZenXCapabilitySnapshot {
+  capabilities: ZenXCapabilitySummary[];
+  recentInvocations: ZenXCapabilityAuditRecord[];
+  discoveryErrors: string[];
+}
+
+export interface ZenXCapabilityHostSnapshot {
+  definitions: ModelTool[];
+}
+
+export interface ZenXCapabilityHost {
+  hostSnapshot(): ZenXCapabilityHostSnapshot;
+  execute(invocation: ToolInvocation): Promise<ToolExecutionResult>;
+}
+
+export interface ZenXCapabilityGrantStore {
+  load(): Promise<Record<string, ZenXCapabilityGrant[]>>;
+  save(grants: Readonly<Record<string, ZenXCapabilityGrant[]>>): Promise<void>;
+}
+
+export interface RegisteredZenXCapability {
+  package: ZenXCapabilityPackage;
+  source: "bundled" | "local";
+}

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -4,6 +4,9 @@ import type {
   ToolInvocation,
 } from "../../../../../src/tool.js";
 
+export const MIN_CAPABILITY_OUTPUT_BYTES = 1024;
+export const MAX_CAPABILITY_OUTPUT_BYTES = 1024 * 1024;
+
 export type ZenXCapabilityPermissionScope =
   "browser-session" | "local-device" | "workspace";
 
@@ -14,8 +17,13 @@ export interface ZenXCapabilityPermission {
   scope: ZenXCapabilityPermissionScope;
 }
 
+export type ZenXCapabilityInteractionMode =
+  "background_safe" | "foreground_required" | "isolated";
+
 export interface ZenXCapabilityTool extends ModelTool {
   permissions: string[];
+  interactionMode: ZenXCapabilityInteractionMode;
+  capabilities: string[];
   maxOutputBytes?: number;
 }
 
@@ -33,6 +41,12 @@ export interface ZenXCapabilityManifest {
   displayName: string;
   version: string;
   description: string;
+  provider: {
+    id: string;
+    platforms: string[];
+    interactionModes: ZenXCapabilityInteractionMode[];
+    capabilities: string[];
+  };
   permissions: ZenXCapabilityPermission[];
   tools: ZenXCapabilityTool[];
   resources: ZenXCapabilityResource[];
@@ -54,9 +68,11 @@ export interface ZenXCapabilityGrant {
 export interface ZenXCapabilityAuditRecord {
   id: string;
   capabilityId: string;
+  providerId: string;
   toolName: string;
   callId: string;
   cwd: string;
+  interactionMode: ZenXCapabilityInteractionMode;
   startedAt: string;
   completedAt?: string;
   status: "running" | "completed" | "failed" | "cancelled";
@@ -68,8 +84,11 @@ export interface ZenXCapabilitySummary {
     resources: Array<Omit<ZenXCapabilityResource, "content">>;
   };
   source: "bundled" | "local";
+  available: boolean;
+  unavailableReason?: string;
   granted: ZenXCapabilityGrant[];
   enabledTools: string[];
+  blockedTools: string[];
 }
 
 export interface ZenXCapabilitySnapshot {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+
+import type { ToolInvocation } from "../../../../src/tool.js";
+import {
+  BrowserZenXCapabilityPackage,
+  ElectronBrowserBackend,
+  type ZenXBrowserBackend,
+} from "./capabilities/browser-provider.js";
+import {
+  ComputerZenXCapabilityPackage,
+  ElectronMacComputerBackend,
+  type ZenXComputerBackend,
+} from "./capabilities/computer-provider.js";
+import { JsonZenXCapabilityGrantStore } from "./capabilities/grant-store.js";
+import { discoverLocalCapabilityPackages } from "./capabilities/local-package.js";
+import { ZenXCapabilityRegistry } from "./capabilities/registry.js";
+import type {
+  ZenXCapabilityGrantStore,
+  ZenXCapabilityHost,
+  ZenXCapabilityHostSnapshot,
+  ZenXCapabilityPackage,
+  ZenXCapabilitySnapshot,
+} from "./capabilities/types.js";
+
+export class ZenXCapabilityService implements ZenXCapabilityHost {
+  readonly #registry: ZenXCapabilityRegistry;
+  readonly #localDirectory: string;
+  readonly #browserBackend: ZenXBrowserBackend;
+  readonly #computerBackend: ZenXComputerBackend;
+
+  constructor(options: {
+    userDataDirectory: string;
+    grantStore?: ZenXCapabilityGrantStore;
+    localDirectory?: string;
+    browserBackend?: ZenXBrowserBackend;
+    computerBackend?: ZenXComputerBackend;
+  }) {
+    this.#registry = new ZenXCapabilityRegistry(
+      options.grantStore ??
+        new JsonZenXCapabilityGrantStore(
+          path.join(options.userDataDirectory, "capability-grants.json"),
+        ),
+    );
+    this.#localDirectory =
+      options.localDirectory ??
+      path.join(options.userDataDirectory, "capabilities");
+    this.#browserBackend =
+      options.browserBackend ?? new ElectronBrowserBackend();
+    this.#computerBackend =
+      options.computerBackend ?? new ElectronMacComputerBackend();
+  }
+
+  async initialize(): Promise<void> {
+    await this.#registry.initialize();
+    this.#registry.register(
+      new BrowserZenXCapabilityPackage(this.#browserBackend),
+      "bundled",
+    );
+    this.#registry.register(
+      new ComputerZenXCapabilityPackage(this.#computerBackend),
+      "bundled",
+    );
+    const discovered = await discoverLocalCapabilityPackages(
+      this.#localDirectory,
+    );
+    for (const capabilityPackage of discovered.packages) {
+      try {
+        this.#registry.register(capabilityPackage, "local");
+      } catch (error) {
+        this.#registry.recordDiscoveryError(describeError(error));
+      }
+    }
+    for (const error of discovered.errors) {
+      this.#registry.recordDiscoveryError(error);
+    }
+  }
+
+  snapshot(): ZenXCapabilitySnapshot {
+    return this.#registry.snapshot();
+  }
+
+  register(
+    capabilityPackage: ZenXCapabilityPackage,
+    source: "bundled" | "local" = "bundled",
+  ): void {
+    this.#registry.register(capabilityPackage, source);
+  }
+
+  async unregister(capabilityId: string): Promise<void> {
+    await this.#registry.unregister(capabilityId);
+  }
+
+  hostSnapshot(): ZenXCapabilityHostSnapshot {
+    return this.#registry.hostSnapshot();
+  }
+
+  async execute(invocation: ToolInvocation) {
+    return await this.#registry.execute(invocation);
+  }
+
+  async grant(
+    capabilityId: string,
+    permissionIds?: readonly string[],
+  ): Promise<ZenXCapabilitySnapshot> {
+    await this.#registry.grant(capabilityId, permissionIds);
+    return this.snapshot();
+  }
+
+  async revoke(
+    capabilityId: string,
+    permissionIds?: readonly string[],
+  ): Promise<ZenXCapabilitySnapshot> {
+    await this.#registry.revoke(capabilityId, permissionIds);
+    return this.snapshot();
+  }
+
+  onChange(listener: (snapshot: ZenXCapabilitySnapshot) => void): () => void {
+    return this.#registry.onChange(listener);
+  }
+
+  async close(): Promise<void> {
+    await this.#registry.close();
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+
+import { app } from "electron";
+
+import {
+  BrowserZenXCapabilityPackage,
+  ElectronBrowserBackend,
+  type BrowserInspection,
+} from "./capabilities/browser-provider.js";
+import {
+  ComputerZenXCapabilityPackage,
+  ElectronMacComputerBackend,
+} from "./capabilities/computer-provider.js";
+import { MemoryZenXCapabilityGrantStore } from "./capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "./capabilities/registry.js";
+
+const web = createServer((request, response) => {
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  if (request.url === "/next") {
+    response.end(
+      "<!doctype html><title>Next</title><main>Navigation complete</main>",
+    );
+    return;
+  }
+  response.end(`<!doctype html>
+    <title>ZenX capability smoke</title>
+    <input id="name" aria-label="Name">
+    <button id="mark" onclick="document.querySelector('output').textContent = 'Marked ' + document.querySelector('#name').value">Mark</button>
+    <output></output>
+    <a id="next" href="/next">Next</a>`);
+});
+
+void app.whenReady().then(async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  try {
+    const port = await listen();
+    await registry.initialize();
+    registry.register(
+      new BrowserZenXCapabilityPackage(new ElectronBrowserBackend()),
+    );
+    registry.register(
+      new ComputerZenXCapabilityPackage(new ElectronMacComputerBackend()),
+    );
+    await registry.grant("browser");
+    await registry.grant("computer");
+
+    const opened = await invoke(registry, "browser_open", {
+      sessionId: "desktop-smoke",
+      url: `http://127.0.0.1:${String(port)}/`,
+    });
+    const tabId = requiredResultString(opened, "tabId");
+    let inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    assert.match(inspected.visibleText, /Mark/u);
+    await invoke(registry, "browser_type", {
+      sessionId: "desktop-smoke",
+      tabId,
+      selector: "#name",
+      text: "Browser",
+    });
+    await invoke(registry, "browser_click", {
+      sessionId: "desktop-smoke",
+      tabId,
+      selector: "#mark",
+    });
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    assert.match(inspected.visibleText, /Marked Browser/u);
+    await invoke(registry, "browser_navigate", {
+      sessionId: "desktop-smoke",
+      tabId,
+      url: `http://127.0.0.1:${String(port)}/next`,
+    });
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    assert.match(inspected.visibleText, /Navigation complete/u);
+
+    const computer = await invoke(registry, "computer_inspect", {});
+    assert.equal((computer as { platform: string }).platform, "darwin");
+    const screenshot = await invoke(registry, "computer_screenshot", {});
+    assert.ok((screenshot as { bytes: number }).bytes > 0);
+
+    if (process.env["ZENX_SMOKE_COMPUTER_INPUT"] === "1") {
+      await invoke(registry, "browser_navigate", {
+        sessionId: "desktop-smoke",
+        tabId,
+        url: `http://127.0.0.1:${String(port)}/`,
+      });
+      const targetInspection = (await invoke(registry, "browser_inspect", {
+        sessionId: "desktop-smoke",
+        tabId,
+      })) as BrowserInspection;
+      const input = targetInspection.targets.find(
+        (target) => target.selector === "#name",
+      );
+      if (input?.screenPoint === undefined) {
+        throw new Error("Browser smoke input did not expose a screen target");
+      }
+      await invoke(registry, "computer_click", {
+        ...input.screenPoint,
+        context: "ZenX Browser / capability smoke / Name input",
+      });
+      await invoke(registry, "computer_type", {
+        text: "Computer",
+        context: "ZenX Browser / capability smoke / Name input",
+      });
+      const afterInput = (await invoke(registry, "browser_inspect", {
+        sessionId: "desktop-smoke",
+        tabId,
+      })) as BrowserInspection;
+      assert.equal(
+        afterInput.targets.find((target) => target.selector === "#name")?.value,
+        "Computer",
+      );
+    }
+
+    console.log(
+      `ZenX capability desktop smoke passed: browser open/inspect/navigate/click/type; computer inspect/screenshot${
+        process.env["ZENX_SMOKE_COMPUTER_INPUT"] === "1" ? "/click/type" : ""
+      }`,
+    );
+  } catch (error) {
+    console.error("ZenX capability desktop smoke failed", error);
+    process.exitCode = 1;
+  } finally {
+    await registry.close();
+    await closeWeb();
+    app.quit();
+  }
+});
+
+async function invoke(
+  registry: ZenXCapabilityRegistry,
+  name: string,
+  arguments_: Record<string, unknown>,
+): Promise<unknown> {
+  const result = await registry.execute({
+    callId: `smoke-${name}`,
+    name,
+    arguments: arguments_,
+    cwd: process.cwd(),
+    signal: new AbortController().signal,
+  });
+  const parsed = JSON.parse(result.output) as { result?: unknown };
+  if (parsed.result === undefined) {
+    throw new Error(`${name} returned no structured result`);
+  }
+  return parsed.result;
+}
+
+function requiredResultString(value: unknown, key: string): string {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof (value as Record<string, unknown>)[key] !== "string"
+  ) {
+    throw new Error(`Smoke result is missing ${key}`);
+  }
+  return (value as Record<string, string>)[key]!;
+}
+
+async function listen(): Promise<number> {
+  await new Promise<void>((resolve, reject) => {
+    web.once("error", reject);
+    web.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = web.address();
+  if (typeof address !== "object" || address === null) {
+    throw new Error("Smoke HTTP server did not bind a TCP port");
+  }
+  return address.port;
+}
+
+async function closeWeb(): Promise<void> {
+  if (!web.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    web.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 
-import { app } from "electron";
+import { app, screen } from "electron";
 
 import {
   BrowserZenXCapabilityPackage,
@@ -23,15 +23,41 @@ const web = createServer((request, response) => {
     );
     return;
   }
+  if (request.url === "/storage-seed") {
+    response.end(`<!doctype html><title>Storage seed</title>
+      <main>Storage seeded</main>
+      <script>
+        document.cookie = "zenx_smoke_cookie=present; SameSite=Lax";
+        sessionStorage.setItem("zenx_smoke_session", "present");
+      </script>`);
+    return;
+  }
+  if (request.url === "/storage-check") {
+    response.end(`<!doctype html><title>Storage check</title>
+      <main></main>
+      <script>
+        const cookieLeaked = document.cookie.includes("zenx_smoke_cookie=present");
+        const sessionLeaked = sessionStorage.getItem("zenx_smoke_session") === "present";
+        document.querySelector("main").textContent = cookieLeaked || sessionLeaked ? "Storage leaked" : "Storage clean";
+      </script>`);
+    return;
+  }
   response.end(`<!doctype html>
     <title>ZenX capability smoke</title>
     <input id="name" aria-label="Name">
+    <input id="password" type="password" aria-label="Password" value="must-not-leak">
+    <button id="hidden" hidden>Hidden</button>
     <button id="mark" onclick="document.querySelector('output').textContent = 'Marked ' + document.querySelector('#name').value">Mark</button>
+    <button id="volatile">Original identity</button>
     <output></output>
-    <a id="next" href="/next">Next</a>`);
+    <a id="next" href="/next">Next</a>
+    <script>setTimeout(() => document.querySelector('#volatile').textContent = 'Changed identity', 5000)</script>`);
 });
 
+app.commandLine.appendSwitch("force-renderer-accessibility");
+
 void app.whenReady().then(async () => {
+  app.setAccessibilitySupportEnabled(true);
   const registry = new ZenXCapabilityRegistry(
     new MemoryZenXCapabilityGrantStore(),
   );
@@ -41,11 +67,13 @@ void app.whenReady().then(async () => {
     registry.register(
       new BrowserZenXCapabilityPackage(new ElectronBrowserBackend()),
     );
-    registry.register(
-      new ComputerZenXCapabilityPackage(new ElectronMacComputerBackend()),
-    );
+    const computerBackend = new ElectronMacComputerBackend();
+    await computerBackend.prepareForegroundInput(new AbortController().signal);
+    registry.register(new ComputerZenXCapabilityPackage(computerBackend));
     await registry.grant("browser");
     await registry.grant("computer");
+    const cursorBefore = screen.getCursorScreenPoint();
+    const foregroundBefore = await computerBackend.desktopContext();
 
     const opened = await invoke(registry, "browser_open", {
       sessionId: "desktop-smoke",
@@ -57,76 +85,158 @@ void app.whenReady().then(async () => {
       tabId,
     })) as BrowserInspection;
     assert.match(inspected.visibleText, /Mark/u);
+    assert.equal(
+      inspected.targets.some(({ name }) => name === "Hidden"),
+      false,
+    );
+    const password = inspected.targets.find(({ name }) => name === "Password");
+    assert.equal(password?.secure, true);
+    assert.equal(password?.value, undefined);
+    assert.equal(password?.actions.includes("type"), false);
+    if (password !== undefined) {
+      await assert.rejects(
+        invoke(registry, "browser_type", {
+          sessionId: "desktop-smoke",
+          tabId,
+          observationId: inspected.observationId,
+          targetId: password.targetId,
+          text: "not-a-secret",
+        }),
+        /password or secure controls/u,
+      );
+    }
+    const input = requiredBrowserTarget(inspected, "Name", "type");
     await invoke(registry, "browser_type", {
       sessionId: "desktop-smoke",
       tabId,
-      selector: "#name",
+      observationId: inspected.observationId,
+      targetId: input.targetId,
       text: "Browser",
     });
+    await assert.rejects(
+      invoke(registry, "browser_click", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: input.targetId,
+      }),
+      /stale or unknown/u,
+    );
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    await assert.rejects(
+      invoke(registry, "browser_click", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: "forged-target",
+      }),
+      /forged/u,
+    );
+    const mark = requiredBrowserTarget(inspected, "Mark", "click");
     await invoke(registry, "browser_click", {
       sessionId: "desktop-smoke",
       tabId,
-      selector: "#mark",
+      observationId: inspected.observationId,
+      targetId: mark.targetId,
     });
     inspected = (await invoke(registry, "browser_inspect", {
       sessionId: "desktop-smoke",
       tabId,
     })) as BrowserInspection;
     assert.match(inspected.visibleText, /Marked Browser/u);
+    const volatile = requiredBrowserTarget(
+      inspected,
+      "Original identity",
+      "click",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 5200));
+    await assert.rejects(
+      invoke(registry, "browser_click", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: volatile.targetId,
+      }),
+      /identity-changed/u,
+    );
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    const staleNavigationTarget = requiredBrowserTarget(
+      inspected,
+      "Next",
+      "click",
+    );
     await invoke(registry, "browser_navigate", {
       sessionId: "desktop-smoke",
       tabId,
       url: `http://127.0.0.1:${String(port)}/next`,
     });
+    await assert.rejects(
+      invoke(registry, "browser_click", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: staleNavigationTarget.targetId,
+      }),
+      /stale or unknown/u,
+    );
     inspected = (await invoke(registry, "browser_inspect", {
       sessionId: "desktop-smoke",
       tabId,
     })) as BrowserInspection;
     assert.match(inspected.visibleText, /Navigation complete/u);
 
-    const computer = await invoke(registry, "computer_inspect", {});
-    assert.equal((computer as { platform: string }).platform, "darwin");
-    const screenshot = await invoke(registry, "computer_screenshot", {});
-    assert.ok((screenshot as { bytes: number }).bytes > 0);
+    await invoke(registry, "browser_navigate", {
+      sessionId: "desktop-smoke",
+      tabId,
+      url: `http://127.0.0.1:${String(port)}/storage-seed`,
+    });
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
+    assert.match(inspected.visibleText, /Storage seeded/u);
+    const closedSeedSession = await invoke(registry, "browser_close_session", {
+      sessionId: "desktop-smoke",
+    });
+    assert.equal((closedSeedSession as { closedTabs: number }).closedTabs, 1);
+    const remainingTabs = (await invoke(registry, "browser_list_tabs", {
+      sessionId: "desktop-smoke",
+    })) as unknown[];
+    assert.deepEqual(remainingTabs, []);
 
-    if (process.env["ZENX_SMOKE_COMPUTER_INPUT"] === "1") {
-      await invoke(registry, "browser_navigate", {
-        sessionId: "desktop-smoke",
-        tabId,
-        url: `http://127.0.0.1:${String(port)}/`,
-      });
-      const targetInspection = (await invoke(registry, "browser_inspect", {
-        sessionId: "desktop-smoke",
-        tabId,
-      })) as BrowserInspection;
-      const input = targetInspection.targets.find(
-        (target) => target.selector === "#name",
-      );
-      if (input?.screenPoint === undefined) {
-        throw new Error("Browser smoke input did not expose a screen target");
-      }
-      await invoke(registry, "computer_click", {
-        ...input.screenPoint,
-        context: "ZenX Browser / capability smoke / Name input",
-      });
-      await invoke(registry, "computer_type", {
-        text: "Computer",
-        context: "ZenX Browser / capability smoke / Name input",
-      });
-      const afterInput = (await invoke(registry, "browser_inspect", {
-        sessionId: "desktop-smoke",
-        tabId,
-      })) as BrowserInspection;
-      assert.equal(
-        afterInput.targets.find((target) => target.selector === "#name")?.value,
-        "Computer",
-      );
-    }
+    const reopened = await invoke(registry, "browser_open", {
+      sessionId: "desktop-smoke",
+      url: `http://127.0.0.1:${String(port)}/storage-check`,
+    });
+    const reopenedTabId = requiredResultString(reopened, "tabId");
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId: reopenedTabId,
+    })) as BrowserInspection;
+    assert.match(inspected.visibleText, /Storage clean/u);
+    assert.doesNotMatch(inspected.visibleText, /Storage leaked/u);
+    await invoke(registry, "browser_close", {
+      sessionId: "desktop-smoke",
+      tabId: reopenedTabId,
+    });
+    const closedSession = await invoke(registry, "browser_close_session", {
+      sessionId: "desktop-smoke",
+    });
+    assert.equal((closedSession as { closedTabs: number }).closedTabs, 0);
+    const cursorAfter = screen.getCursorScreenPoint();
+    const foregroundAfter = await computerBackend.desktopContext();
+    assert.deepEqual(cursorAfter, cursorBefore);
+    assert.equal(foregroundAfter.pid, foregroundBefore.pid);
+    assert.equal(foregroundAfter.bundleId, foregroundBefore.bundleId);
 
     console.log(
-      `ZenX capability desktop smoke passed: browser open/inspect/navigate/click/type; computer inspect/screenshot${
-        process.env["ZENX_SMOKE_COMPUTER_INPUT"] === "1" ? "/click/type" : ""
-      }`,
+      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, changed, and password targets; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
     );
   } catch (error) {
     console.error("ZenX capability desktop smoke failed", error);
@@ -166,6 +276,23 @@ function requiredResultString(value: unknown, key: string): string {
     throw new Error(`Smoke result is missing ${key}`);
   }
   return (value as Record<string, string>)[key]!;
+}
+
+function requiredBrowserTarget(
+  inspection: BrowserInspection,
+  name: string,
+  action: "click" | "type",
+): BrowserInspection["targets"][number] {
+  const target = inspection.targets.find(
+    (candidate) =>
+      candidate.name === name && candidate.actions.includes(action),
+  );
+  if (target === undefined) {
+    throw new Error(
+      `Smoke inspection did not return ${action} target ${name}: ${JSON.stringify(inspection.targets)}`,
+    );
+  }
+  return target;
 }
 
 async function listen(): Promise<number> {

--- a/apps/zenx/src/main/capability-tool-executor.ts
+++ b/apps/zenx/src/main/capability-tool-executor.ts
@@ -1,0 +1,103 @@
+import type {
+  ToolExecutionResult,
+  ToolExecutor,
+  ToolInvocation,
+} from "../../../../src/tool.js";
+import { ShellToolExecutor } from "../../../../src/tool.js";
+import type { CapabilityResultCommand, HostEvent } from "./host-messages.js";
+import type { ZenXCapabilityHostSnapshot } from "./capabilities/types.js";
+
+interface PendingInvocation {
+  resolve(result: ToolExecutionResult): void;
+  reject(error: Error): void;
+  signal: AbortSignal;
+  abort(): void;
+}
+
+export class ZenXHostToolExecutor implements ToolExecutor {
+  readonly definitions;
+  readonly #shell: ShellToolExecutor;
+  readonly #capabilityNames: Set<string>;
+  readonly #send: (event: HostEvent) => void;
+  readonly #pending = new Map<string, PendingInvocation>();
+
+  constructor(options: {
+    capabilities: ZenXCapabilityHostSnapshot;
+    blockedEnvironmentVariables?: readonly string[];
+    redactedValues?: readonly string[];
+    send: (event: HostEvent) => void;
+  }) {
+    this.#shell = new ShellToolExecutor({
+      blockedEnvironmentVariables: options.blockedEnvironmentVariables,
+      redactedValues: options.redactedValues,
+    });
+    this.#capabilityNames = new Set(
+      options.capabilities.definitions.map((definition) => definition.name),
+    );
+    this.definitions = [
+      ...this.#shell.definitions,
+      ...options.capabilities.definitions,
+    ];
+    this.#send = options.send;
+  }
+
+  async execute(invocation: ToolInvocation): Promise<ToolExecutionResult> {
+    if (invocation.name === "shell")
+      return await this.#shell.execute(invocation);
+    if (!this.#capabilityNames.has(invocation.name)) {
+      throw new Error(`Unsupported tool: ${invocation.name}`);
+    }
+    invocation.signal.throwIfAborted();
+    const invocationId = `${process.pid}:${invocation.callId}:${String(Date.now())}`;
+    return await new Promise<ToolExecutionResult>((resolve, reject) => {
+      const abort = (): void => {
+        this.#pending.delete(invocationId);
+        this.#send({ type: "capability/cancel", invocationId });
+        reject(
+          invocation.signal.reason ??
+            new DOMException("The operation was aborted", "AbortError"),
+        );
+      };
+      this.#pending.set(invocationId, {
+        resolve,
+        reject,
+        signal: invocation.signal,
+        abort,
+      });
+      invocation.signal.addEventListener("abort", abort, { once: true });
+      this.#send({
+        type: "capability/invoke",
+        invocationId,
+        invocation: {
+          callId: invocation.callId,
+          name: invocation.name,
+          arguments: invocation.arguments,
+          cwd: invocation.cwd,
+        },
+      });
+    });
+  }
+
+  handleResult(command: CapabilityResultCommand): void {
+    const pending = this.#pending.get(command.invocationId);
+    if (pending === undefined) return;
+    this.#pending.delete(command.invocationId);
+    pending.signal.removeEventListener("abort", pending.abort);
+    if (command.error === undefined) {
+      pending.resolve({
+        output: command.output ?? "",
+        exitCode: command.exitCode ?? 1,
+      });
+    } else {
+      pending.reject(new Error(command.error));
+    }
+  }
+
+  close(reason = "ZenX capability bridge closed"): void {
+    for (const pending of this.#pending.values()) {
+      pending.signal.removeEventListener("abort", pending.abort);
+      pending.reject(new Error(reason));
+    }
+    this.#pending.clear();
+  }
+}

--- a/apps/zenx/src/main/host-messages.ts
+++ b/apps/zenx/src/main/host-messages.ts
@@ -1,4 +1,5 @@
 import type { ZenHostOptions } from "../../../../apps/cli/src/host.js";
+import type { ZenXCapabilityHostSnapshot } from "./capabilities/types.js";
 
 export type ZenXHostConfig = Omit<ZenHostOptions, "journal" | "threadMetadata">;
 
@@ -7,27 +8,60 @@ export type HostCommand =
       type: "start";
       config: ZenXHostConfig;
       bearerToken: string;
+      capabilities: ZenXCapabilityHostSnapshot;
     }
-  | { type: "shutdown" };
+  | { type: "shutdown" }
+  | CapabilityResultCommand;
+
+export interface CapabilityResultCommand {
+  type: "capability/result";
+  invocationId: string;
+  output?: string;
+  exitCode?: number;
+  error?: string;
+}
 
 export type HostEvent =
-  { type: "ready"; url: string } | { type: "error"; message: string };
+  | { type: "ready"; url: string }
+  | { type: "error"; message: string }
+  | {
+      type: "capability/invoke";
+      invocationId: string;
+      invocation: {
+        callId: string;
+        name: string;
+        arguments: Record<string, unknown>;
+        cwd: string;
+      };
+    }
+  | { type: "capability/cancel"; invocationId: string };
 
 export function isHostCommand(value: unknown): value is HostCommand {
   if (typeof value !== "object" || value === null || !("type" in value)) {
     return false;
   }
   const type = (value as { type?: unknown }).type;
-  return type === "start" || type === "shutdown";
+  return (
+    type === "start" || type === "shutdown" || type === "capability/result"
+  );
 }
 
 export function isHostEvent(value: unknown): value is HostEvent {
   if (typeof value !== "object" || value === null || !("type" in value)) {
     return false;
   }
-  const event = value as { type?: unknown; url?: unknown; message?: unknown };
+  const event = value as {
+    type?: unknown;
+    url?: unknown;
+    message?: unknown;
+    invocationId?: unknown;
+    invocation?: unknown;
+  };
   return (
     (event.type === "ready" && typeof event.url === "string") ||
-    (event.type === "error" && typeof event.message === "string")
+    (event.type === "error" && typeof event.message === "string") ||
+    ((event.type === "capability/invoke" ||
+      event.type === "capability/cancel") &&
+      typeof event.invocationId === "string")
   );
 }

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -16,10 +16,12 @@ import type {
   CreateTriggerInput,
   RoomMember,
 } from "./trigger-types.js";
+import { ZenXCapabilityService } from "./capability-service.js";
 
 let appServerManager: AppServerManager | undefined;
 let settingsService: ZenXSettingsService | undefined;
 let triggerService: ZenXTriggerService | undefined;
+let capabilityService: ZenXCapabilityService | undefined;
 let quitting = false;
 
 function createWindow(): BrowserWindow {
@@ -69,6 +71,8 @@ app.whenReady().then(async () => {
     ),
   });
   try {
+    capabilityService = new ZenXCapabilityService({ userDataDirectory });
+    await capabilityService.initialize();
     await settingsService.initialize(process.env);
     let startupError: unknown;
     let hostConfig;
@@ -90,8 +94,10 @@ app.whenReady().then(async () => {
       tokenFile,
       hostConfig,
       execPath: process.execPath,
+      capabilityHost: capabilityService,
     });
     installProtocolIpc(appServerManager);
+    installCapabilityIpc(capabilityService, appServerManager);
     triggerService = new ZenXTriggerService(
       appServerManager,
       new ZenXTriggerStore(join(userDataDirectory, "trigger-registry.json")),
@@ -118,6 +124,7 @@ app.whenReady().then(async () => {
         tokenFile,
         hostConfig,
         execPath: process.execPath,
+        capabilityHost: capabilityService,
       });
       await appServerManager.start();
     } else {
@@ -136,7 +143,10 @@ app.on("before-quit", (event) => {
   event.preventDefault();
   quitting = true;
   triggerService?.stop();
-  void appServerManager.stop().finally(() => app.quit());
+  void appServerManager
+    .stop()
+    .then(async () => await capabilityService?.close())
+    .finally(() => app.quit());
 });
 
 app.on("window-all-closed", () => {
@@ -316,6 +326,56 @@ function installTriggerIpc(triggers: ZenXTriggerService): void {
     for (const window of BrowserWindow.getAllWindows())
       window.webContents.send(ipcChannels.triggersChanged, snapshot);
   });
+}
+
+function installCapabilityIpc(
+  capabilities: ZenXCapabilityService,
+  manager: AppServerManager,
+): void {
+  ipcMain.handle(ipcChannels.capabilitiesGet, () => capabilities.snapshot());
+  ipcMain.handle(
+    ipcChannels.capabilitiesGrant,
+    async (_event, capabilityId: unknown, permissionIds: unknown) => {
+      const parsed = capabilityPermissionRequest(capabilityId, permissionIds);
+      await capabilities.grant(parsed.capabilityId, parsed.permissionIds);
+      await manager.restartCapabilities();
+      return capabilities.snapshot();
+    },
+  );
+  ipcMain.handle(
+    ipcChannels.capabilitiesRevoke,
+    async (_event, capabilityId: unknown, permissionIds: unknown) => {
+      const parsed = capabilityPermissionRequest(capabilityId, permissionIds);
+      await capabilities.revoke(parsed.capabilityId, parsed.permissionIds);
+      await manager.restartCapabilities();
+      return capabilities.snapshot();
+    },
+  );
+  capabilities.onChange((snapshot) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      window.webContents.send(ipcChannels.capabilitiesChanged, snapshot);
+    }
+  });
+}
+
+function capabilityPermissionRequest(
+  capabilityId: unknown,
+  permissionIds: unknown,
+): { capabilityId: string; permissionIds?: string[] } {
+  if (typeof capabilityId !== "string" || capabilityId.length === 0) {
+    throw new Error("Invalid capability ID");
+  }
+  if (permissionIds === undefined) return { capabilityId };
+  if (
+    !Array.isArray(permissionIds) ||
+    permissionIds.some(
+      (permissionId) =>
+        typeof permissionId !== "string" || permissionId.length === 0,
+    )
+  ) {
+    throw new Error("Invalid capability permission list");
+  }
+  return { capabilityId, permissionIds };
 }
 
 function isApprovalDecision(value: unknown): value is ApprovalDecision {

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -24,6 +24,7 @@ import type {
   RoomMember,
   TriggerSnapshot,
 } from "../main/trigger-types.js";
+import type { ZenXCapabilitySnapshot } from "../main/capabilities/types.js";
 
 contextBridge.exposeInMainWorld("zenx", {
   platform: process.platform,
@@ -145,6 +146,38 @@ contextBridge.exposeInMainWorld("zenx", {
       ) => listener(snapshot);
       ipcRenderer.on(ipcChannels.triggersChanged, wrapped);
       return () => ipcRenderer.off(ipcChannels.triggersChanged, wrapped);
+    },
+  },
+  capabilities: {
+    get: async (): Promise<ZenXCapabilitySnapshot> =>
+      await ipcRenderer.invoke(ipcChannels.capabilitiesGet),
+    grant: async (
+      capabilityId: string,
+      permissionIds?: string[],
+    ): Promise<ZenXCapabilitySnapshot> =>
+      await ipcRenderer.invoke(
+        ipcChannels.capabilitiesGrant,
+        capabilityId,
+        permissionIds,
+      ),
+    revoke: async (
+      capabilityId: string,
+      permissionIds?: string[],
+    ): Promise<ZenXCapabilitySnapshot> =>
+      await ipcRenderer.invoke(
+        ipcChannels.capabilitiesRevoke,
+        capabilityId,
+        permissionIds,
+      ),
+    onChange: (
+      listener: (snapshot: ZenXCapabilitySnapshot) => void,
+    ): (() => void) => {
+      const wrapped = (
+        _event: Electron.IpcRendererEvent,
+        snapshot: ZenXCapabilitySnapshot,
+      ) => listener(snapshot);
+      ipcRenderer.on(ipcChannels.capabilitiesChanged, wrapped);
+      return () => ipcRenderer.off(ipcChannels.capabilitiesChanged, wrapped);
     },
   },
 });

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -22,4 +22,8 @@ export const ipcChannels = {
   roomsAddMember: "zenx:rooms:add-member",
   roomsRemoveMember: "zenx:rooms:remove-member",
   roomsPost: "zenx:rooms:post",
+  capabilitiesGet: "zenx:capabilities:get",
+  capabilitiesGrant: "zenx:capabilities:grant",
+  capabilitiesRevoke: "zenx:capabilities:revoke",
+  capabilitiesChanged: "zenx:capabilities:changed",
 } as const;

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from "react";
+
+import type {
+  ZenXCapabilitySnapshot,
+  ZenXCapabilitySummary,
+} from "../../main/capabilities/types.js";
+import { Icon } from "./icons.js";
+
+export function CapabilitySettings() {
+  const [snapshot, setSnapshot] = useState<ZenXCapabilitySnapshot | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const dispose = window.zenx.capabilities.onChange((value) => {
+      if (active) setSnapshot(value);
+    });
+    void window.zenx.capabilities
+      .get()
+      .then((value) => active && setSnapshot(value))
+      .catch((reason: unknown) => active && setError(describeError(reason)));
+    return () => {
+      active = false;
+      dispose();
+    };
+  }, []);
+
+  const setGranted = async (
+    capability: ZenXCapabilitySummary,
+    grant: boolean,
+  ) => {
+    setBusy(capability.manifest.id);
+    setError(null);
+    try {
+      const next = grant
+        ? await window.zenx.capabilities.grant(capability.manifest.id)
+        : await window.zenx.capabilities.revoke(capability.manifest.id);
+      setSnapshot(next);
+    } catch (reason) {
+      setError(describeError(reason));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (snapshot === null) {
+    return (
+      <div className="settings-card capability-settings">
+        <h2>Agent capabilities</h2>
+        <p className="settings-note">{error ?? "Loading capabilities…"}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-card capability-settings">
+      <div className="capability-heading">
+        <div>
+          <h2>Agent capabilities</h2>
+          <p className="settings-note">
+            Grants control which structured tools the Agent can discover and
+            execute. Per-call approval and the execution sandbox remain
+            separate.
+          </p>
+        </div>
+        <span>{snapshot.capabilities.length} installed</span>
+      </div>
+      <div className="capability-list">
+        {snapshot.capabilities.map((capability) => {
+          const granted =
+            capability.manifest.permissions.length ===
+            capability.granted.length;
+          return (
+            <article className="capability-card" key={capability.manifest.id}>
+              <header>
+                <div>
+                  <strong>{capability.manifest.displayName}</strong>
+                  <span>
+                    {capability.source} · v{capability.manifest.version}
+                  </span>
+                </div>
+                <button
+                  className={granted ? "danger-button" : "primary-button"}
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() => void setGranted(capability, !granted)}
+                >
+                  {busy === capability.manifest.id
+                    ? "Restarting host…"
+                    : granted
+                      ? "Revoke"
+                      : "Grant"}
+                </button>
+              </header>
+              <p>{capability.manifest.description}</p>
+              <ul>
+                {capability.manifest.permissions.map((permission) => {
+                  const allowed = capability.granted.some(
+                    (grant) => grant.permissionId === permission.id,
+                  );
+                  return (
+                    <li key={permission.id}>
+                      <Icon name={allowed ? "check" : "warning"} size={12} />
+                      <span>
+                        <strong>{permission.title}</strong>
+                        <small>
+                          {permission.scope} · {permission.description}
+                        </small>
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+              <footer>
+                {capability.enabledTools.length} of{" "}
+                {capability.manifest.tools.length} tools exposed ·{" "}
+                {capability.manifest.resources.length} instruction resources
+              </footer>
+            </article>
+          );
+        })}
+      </div>
+      {snapshot.recentInvocations.length === 0 ? null : (
+        <div className="capability-audit">
+          <h3>Recent capability use</h3>
+          {snapshot.recentInvocations.slice(0, 8).map((invocation) => (
+            <div key={invocation.id}>
+              <Icon
+                name={invocation.status === "completed" ? "check" : "warning"}
+                size={12}
+              />
+              <code>{invocation.toolName}</code>
+              <span>{invocation.status}</span>
+              <time>{new Date(invocation.startedAt).toLocaleTimeString()}</time>
+            </div>
+          ))}
+        </div>
+      )}
+      {snapshot.discoveryErrors.map((message) => (
+        <div className="settings-error" role="alert" key={message}>
+          <Icon name="warning" size={14} />
+          Local capability: {message}
+        </div>
+      ))}
+      {error === null ? null : (
+        <div className="settings-error" role="alert">
+          <Icon name="warning" size={14} />
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -61,7 +61,9 @@ export function CapabilitySettings() {
           <p className="settings-note">
             Grants control which structured tools the Agent can discover and
             execute. Per-call approval and the execution sandbox remain
-            separate.
+            separate. Foreground-required tools are labeled because they may
+            temporarily take over pointer, keyboard, or focus; Stop cancels a
+            running operation.
           </p>
         </div>
         <span>{snapshot.capabilities.length} installed</span>
@@ -79,11 +81,18 @@ export function CapabilitySettings() {
                   <span>
                     {capability.source} · v{capability.manifest.version}
                   </span>
+                  <span>
+                    {capability.manifest.provider.id} ·{" "}
+                    {capability.manifest.provider.platforms.join(", ")}
+                  </span>
+                  {capability.available ? null : (
+                    <span>{capability.unavailableReason}</span>
+                  )}
                 </div>
                 <button
                   className={granted ? "danger-button" : "primary-button"}
                   type="button"
-                  disabled={busy !== null}
+                  disabled={busy !== null || !capability.available}
                   onClick={() => void setGranted(capability, !granted)}
                 >
                   {busy === capability.manifest.id
@@ -112,10 +121,37 @@ export function CapabilitySettings() {
                   );
                 })}
               </ul>
+              <ul>
+                {capability.manifest.tools.map((tool) => (
+                  <li key={tool.name}>
+                    <Icon
+                      name={
+                        tool.interactionMode !== "foreground_required"
+                          ? "check"
+                          : "warning"
+                      }
+                      size={12}
+                    />
+                    <span>
+                      <strong>{tool.name}</strong>
+                      <small>
+                        {tool.interactionMode} · {tool.capabilities.join(", ")}
+                      </small>
+                    </span>
+                  </li>
+                ))}
+              </ul>
               <footer>
                 {capability.enabledTools.length} of{" "}
                 {capability.manifest.tools.length} tools exposed ·{" "}
-                {capability.manifest.resources.length} instruction resources
+                {
+                  capability.manifest.tools.filter(
+                    (tool) => tool.interactionMode === "background_safe",
+                  ).length
+                }{" "}
+                background-safe · {capability.blockedTools.length} foreground
+                blocked · {capability.manifest.resources.length} instruction
+                resources
               </footer>
             </article>
           );
@@ -131,6 +167,7 @@ export function CapabilitySettings() {
                 size={12}
               />
               <code>{invocation.toolName}</code>
+              <span>{invocation.interactionMode}</span>
               <span>{invocation.status}</span>
               <time>{new Date(invocation.startedAt).toLocaleTimeString()}</time>
             </div>

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -6,6 +6,7 @@ import type {
   ZenXProviderProfile,
 } from "../../main/host-profile.js";
 import { Icon } from "./icons.js";
+import { CapabilitySettings } from "./CapabilitySettings.js";
 
 export function SettingsView({ onClose }: { onClose(): void }) {
   const [settings, setSettings] = useState<PublicHostSettings | null>(null);
@@ -284,6 +285,7 @@ export function SettingsView({ onClose }: { onClose(): void }) {
             their ZAS-authoritative model until you change it explicitly.
           </p>
         </div>
+        <CapabilitySettings />
         {error === null ? null : (
           <div className="settings-error" role="alert">
             <Icon name="warning" size={14} />

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -503,6 +503,7 @@ function CommandItemView({
 }: {
   item: Extract<ThreadItem, { type: "commandExecution" }>;
 }) {
+  const capabilityTool = capabilityToolName(item.command);
   return (
     <article className={`command-item ${item.status}`}>
       <div className="command-heading">
@@ -514,7 +515,7 @@ function CommandItemView({
             size={13}
           />
         )}
-        <strong>shell</strong>
+        <strong>{capabilityTool ?? "shell"}</strong>
         <code>{item.command}</code>
         <span>{commandStatus(item.status)}</span>
       </div>
@@ -524,6 +525,13 @@ function CommandItemView({
       )}
     </article>
   );
+}
+
+export function capabilityToolName(command: string): string | null {
+  const candidate = command.split(" ", 1)[0] ?? "";
+  return /^(?:browser_|computer_|zenx_capability_)/u.test(candidate)
+    ? candidate
+    : null;
 }
 
 function turnLabel(turn: Turn): string {

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -504,6 +504,7 @@ function CommandItemView({
   item: Extract<ThreadItem, { type: "commandExecution" }>;
 }) {
   const capabilityTool = capabilityToolName(item.command);
+  const foregroundTakeover = isForegroundTakeoverTool(item.command);
   return (
     <article className={`command-item ${item.status}`}>
       <div className="command-heading">
@@ -519,6 +520,12 @@ function CommandItemView({
         <code>{item.command}</code>
         <span>{commandStatus(item.status)}</span>
       </div>
+      {foregroundTakeover ? (
+        <p className="command-impact-warning" role="status">
+          Foreground takeover: this operation can move the real pointer, type
+          into the focused app, or scroll it. Use Stop to cancel immediately.
+        </p>
+      ) : null}
       {item.aggregatedOutput === null ||
       item.aggregatedOutput.length === 0 ? null : (
         <pre>{item.aggregatedOutput}</pre>
@@ -532,6 +539,12 @@ export function capabilityToolName(command: string): string | null {
   return /^(?:browser_|computer_|zenx_capability_)/u.test(candidate)
     ? candidate
     : null;
+}
+
+export function isForegroundTakeoverTool(command: string): boolean {
+  return (
+    capabilityToolName(command)?.startsWith("computer_foreground_") ?? false
+  );
 }
 
 function turnLabel(turn: Turn): string {

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -21,6 +21,7 @@ import type {
   RoomMember,
   TriggerSnapshot,
 } from "../../main/trigger-types.js";
+import type { ZenXCapabilitySnapshot } from "../../main/capabilities/types.js";
 
 declare global {
   interface Window {
@@ -82,6 +83,20 @@ declare global {
           text: string,
         ): Promise<TriggerSnapshot>;
         onChange(listener: (snapshot: TriggerSnapshot) => void): () => void;
+      };
+      capabilities: {
+        get(): Promise<ZenXCapabilitySnapshot>;
+        grant(
+          capabilityId: string,
+          permissionIds?: string[],
+        ): Promise<ZenXCapabilitySnapshot>;
+        revoke(
+          capabilityId: string,
+          permissionIds?: string[],
+        ): Promise<ZenXCapabilitySnapshot>;
+        onChange(
+          listener: (snapshot: ZenXCapabilitySnapshot) => void,
+        ): () => void;
       };
     };
   }

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1438,6 +1438,16 @@ summary:focus-visible {
   white-space: nowrap;
 }
 
+.command-impact-warning {
+  margin: 0;
+  padding: 9px 12px;
+  border-top: 1px solid rgba(244, 184, 96, 0.3);
+  color: var(--color-warning, #f4b860);
+  background: rgba(244, 184, 96, 0.08);
+  font-size: var(--font-size-xs);
+  line-height: 1.45;
+}
+
 .command-item pre {
   max-height: 280px;
   margin: 0;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -909,6 +909,99 @@ summary:focus-visible {
   padding-top: 5px;
 }
 
+.capability-heading,
+.capability-card header,
+.capability-card li,
+.capability-audit > div {
+  display: flex;
+  align-items: center;
+}
+
+.capability-heading,
+.capability-card header {
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.capability-heading > span,
+.capability-card header span,
+.capability-card footer,
+.capability-card small,
+.capability-audit span,
+.capability-audit time {
+  color: var(--color-text-muted);
+  font-size: 12px;
+}
+
+.capability-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.capability-card {
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 14px;
+  background: color-mix(in srgb, var(--color-panel) 86%, white 2%);
+}
+
+.capability-card header > div,
+.capability-card li > span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.capability-card > p {
+  color: var(--color-text-muted);
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.capability-card ul {
+  display: grid;
+  gap: 9px;
+  margin: 12px 0;
+  padding: 0;
+  list-style: none;
+}
+
+.capability-card li {
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.capability-audit {
+  margin-top: 18px;
+  border-top: 1px solid var(--color-border);
+  padding-top: 14px;
+}
+
+.capability-audit h3 {
+  margin: 0 0 10px;
+  font-size: 13px;
+}
+
+.capability-audit > div {
+  gap: 9px;
+  min-height: 28px;
+}
+
+.capability-audit time {
+  margin-left: auto;
+}
+
+.danger-button {
+  border: 1px solid color-mix(in srgb, var(--color-red) 42%, transparent);
+  border-radius: var(--radius-sm);
+  padding: 6px 11px;
+  color: var(--color-red);
+  background: var(--color-red-dim);
+  cursor: pointer;
+}
+
 .messages {
   min-height: 0;
   flex: 1;

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -8,6 +8,7 @@ import {
   AppServerManager,
   type AppServerHostStatus,
 } from "../src/main/app-server-manager.js";
+import type { ZenXCapabilityHost } from "../src/main/capabilities/types.js";
 
 function managerFor(directory: string): AppServerManager {
   return new AppServerManager({
@@ -91,6 +92,94 @@ test("projects outer-host startup failures as a visible terminal status", () => 
     type: "error",
     message: "ZenX trigger registry has an invalid entry shape",
   });
+});
+
+test("bridges a granted structured capability through the real App Server host", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-capability-host-"),
+  );
+  const invocations: string[] = [];
+  const capabilityHost: ZenXCapabilityHost = {
+    hostSnapshot: () => ({
+      definitions: [
+        {
+          name: "demo_inspect",
+          description: "Inspect the demo provider",
+          inputSchema: {
+            type: "object",
+            properties: { target: { type: "string" } },
+            required: ["target"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    }),
+    execute: async (invocation) => {
+      invocations.push(
+        `${invocation.name}:${String(invocation.arguments.target)}`,
+      );
+      return { output: '{"visible":"bounded"}', exitCode: 0 };
+    },
+  };
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "always",
+      provider: { type: "fake" },
+    },
+    capabilityHost,
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+  try {
+    await manager.start();
+    const completed = deferred<void>();
+    const approvals: string[] = [];
+    manager.onApprovalRequest((request) => {
+      approvals.push(request.params.command);
+      manager.respondToApproval(request.requestId, "accept");
+    });
+    manager.onNotification((method) => {
+      if (method === "turn/completed") completed.resolve();
+    });
+    const started = await manager.request("thread/start", {
+      approvalPolicy: "on-request",
+      sandbox: "danger-full-access",
+    });
+    await manager.request("turn/start", {
+      threadId: started.thread.id,
+      input: [
+        {
+          type: "text",
+          text: '!tool demo_inspect {"target":"tab-1"}',
+        },
+      ],
+    });
+    await within(completed.promise);
+    assert.deepEqual(invocations, ["demo_inspect:tab-1"]);
+    assert.deepEqual(approvals, ['demo_inspect {"target":"tab-1"}']);
+    const read = await manager.request("thread/read", {
+      threadId: started.thread.id,
+      includeTurns: true,
+    });
+    const command = read.thread.turns[0]?.items.find(
+      (item) => item.type === "commandExecution",
+    );
+    assert.equal(command?.type, "commandExecution");
+    if (command?.type === "commandExecution") {
+      assert.match(command.command, /^demo_inspect /u);
+      assert.equal(command.aggregatedOutput, '{"visible":"bounded"}');
+      assert.equal(command.status, "completed");
+    }
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 function deferred<T>() {

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -2,9 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  assertBrowserTabCapacity,
   BrowserZenXCapabilityPackage,
+  browserCapabilityManifest,
+  browserPartitionName,
+  MAX_BROWSER_TABS_GLOBAL,
+  MAX_BROWSER_TABS_PER_SESSION,
+  resolveBrowserObservedTarget,
   type BrowserInspection,
+  type BrowserObservation,
   type BrowserTabSummary,
+  type BrowserTargetFingerprint,
   type ZenXBrowserBackend,
 } from "../src/main/capabilities/browser-provider.js";
 
@@ -29,28 +37,133 @@ test("browser vertical slice targets one session/tab through structured operatio
     "browser_inspect",
     invocation({ sessionId: "research", tabId: "tab-1" }),
   )) as BrowserInspection;
-  assert.equal(inspection.targets[0]?.selector, "#go");
+  assert.equal(inspection.observationId, "observation-1");
+  assert.deepEqual(
+    inspection.targets.map(({ targetId }) => targetId),
+    ["target-go", "target-query"],
+  );
   await capability.invoke(
     "browser_click",
-    invocation({ sessionId: "research", tabId: "tab-1", selector: "#go" }),
+    invocation({
+      sessionId: "research",
+      tabId: "tab-1",
+      observationId: inspection.observationId,
+      targetId: "target-go",
+    }),
   );
+  const nextInspection = (await capability.invoke(
+    "browser_inspect",
+    invocation({ sessionId: "research", tabId: "tab-1" }),
+  )) as BrowserInspection;
   await capability.invoke(
     "browser_type",
     invocation({
       sessionId: "research",
       tabId: "tab-1",
-      selector: "#query",
+      observationId: nextInspection.observationId,
+      targetId: "target-query",
       text: "Zen",
       submit: true,
     }),
+  );
+  await capability.invoke(
+    "browser_close",
+    invocation({ sessionId: "research", tabId: "tab-1" }),
+  );
+  await capability.invoke(
+    "browser_close_session",
+    invocation({ sessionId: "research" }),
   );
   assert.deepEqual(calls, [
     "open:research:https://example.com/start",
     "navigate:research:tab-1:https://example.com/next",
     "inspect:research:tab-1",
-    "click:research:tab-1:#go",
-    "type:research:tab-1:#query:3:true",
+    "click:research:tab-1:observation-1:target-go",
+    "inspect:research:tab-1",
+    "type:research:tab-1:observation-1:target-query:3:true",
+    "close:research:tab-1",
+    "close-session:research",
   ]);
+});
+
+test("browser rejects stale, forged, and secure opaque targets", () => {
+  const editable = fingerprint({ actions: ["click", "type"] });
+  const password = fingerprint({
+    type: "password",
+    secure: true,
+    actions: ["click"],
+  });
+  const observation: BrowserObservation = {
+    id: "observation-1",
+    documentVersion: 7,
+    targets: new Map([
+      ["editable", editable],
+      ["password", password],
+    ]),
+  };
+  assert.equal(
+    resolveBrowserObservedTarget(
+      observation,
+      7,
+      "observation-1",
+      "editable",
+      "type",
+    ),
+    editable,
+  );
+  assert.throws(
+    () =>
+      resolveBrowserObservedTarget(
+        observation,
+        8,
+        "observation-1",
+        "editable",
+        "click",
+      ),
+    /stale or unknown/u,
+  );
+  assert.throws(
+    () =>
+      resolveBrowserObservedTarget(
+        observation,
+        7,
+        "observation-1",
+        "forged",
+        "click",
+      ),
+    /forged/u,
+  );
+  assert.throws(
+    () =>
+      resolveBrowserObservedTarget(
+        observation,
+        7,
+        "observation-1",
+        "password",
+        "type",
+      ),
+    /password or secure controls/u,
+  );
+});
+
+test("browser enforces per-session and global tab limits", () => {
+  assert.doesNotThrow(() => assertBrowserTabCapacity(0, 0));
+  assert.throws(
+    () => assertBrowserTabCapacity(1, MAX_BROWSER_TABS_PER_SESSION),
+    /session tab limit/u,
+  );
+  assert.throws(
+    () => assertBrowserTabCapacity(MAX_BROWSER_TABS_GLOBAL, 0),
+    /global tab limit/u,
+  );
+});
+
+test("same logical session uses a fresh partition generation after close", () => {
+  const first = browserPartitionName("research", 1);
+  const reopened = browserPartitionName("research", 2);
+  assert.notEqual(reopened, first);
+  assert.match(first, /zenx-capability-research-1$/u);
+  assert.match(reopened, /zenx-capability-research-2$/u);
 });
 
 test("browser refuses credential-bearing and sensitive URLs before provider use", async () => {
@@ -74,6 +187,24 @@ test("browser refuses credential-bearing and sensitive URLs before provider use"
       }),
     ),
     /sensitive query parameter/u,
+  );
+});
+
+test("browser advertises a cross-platform dedicated background-safe provider", () => {
+  assert.deepEqual(browserCapabilityManifest.provider.platforms, [
+    "darwin",
+    "win32",
+    "linux",
+  ]);
+  assert.ok(
+    browserCapabilityManifest.tools.every(
+      (tool) => tool.interactionMode === "background_safe",
+    ),
+  );
+  assert.ok(
+    browserCapabilityManifest.tools.every((tool) =>
+      tool.capabilities.includes("dedicated_profile"),
+    ),
   );
 });
 
@@ -102,21 +233,62 @@ function browserBackend(calls: string[]): ZenXBrowserBackend {
       calls.push(`inspect:${sessionId}:${tabId}`);
       return {
         ...summary,
+        observationId: "observation-1",
+        documentVersion: 1,
         visibleText: "Fixture page",
-        targets: [{ selector: "#go", role: "button", name: "Go" }],
+        targets: [
+          {
+            targetId: "target-go",
+            role: "button",
+            name: "Go",
+            actions: ["click"],
+          },
+          {
+            targetId: "target-query",
+            role: "input",
+            name: "Query",
+            actions: ["click", "type"],
+          },
+        ],
       };
     },
-    click: async (sessionId, tabId, selector) => {
-      calls.push(`click:${sessionId}:${tabId}:${selector}`);
+    click: async (sessionId, tabId, observationId, targetId) => {
+      calls.push(`click:${sessionId}:${tabId}:${observationId}:${targetId}`);
       return summary;
     },
-    type: async (sessionId, tabId, selector, text, submit) => {
+    type: async (sessionId, tabId, observationId, targetId, text, submit) => {
       calls.push(
-        `type:${sessionId}:${tabId}:${selector}:${String(text.length)}:${String(submit)}`,
+        `type:${sessionId}:${tabId}:${observationId}:${targetId}:${String(text.length)}:${String(submit)}`,
       );
       return summary;
     },
+    closeTab: (sessionId, tabId) => {
+      calls.push(`close:${sessionId}:${tabId}`);
+    },
+    closeSession: (sessionId) => {
+      calls.push(`close-session:${sessionId}`);
+      return 0;
+    },
     close: () => undefined,
+  };
+}
+
+function fingerprint(
+  overrides: Partial<BrowserTargetFingerprint> = {},
+): BrowserTargetFingerprint {
+  return {
+    selector: "#target",
+    tag: "input",
+    role: "input",
+    name: "Target",
+    type: "text",
+    id: "target",
+    fieldName: "target",
+    autocomplete: "off",
+    href: "",
+    secure: false,
+    actions: ["click"],
+    ...overrides,
   };
 }
 

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BrowserZenXCapabilityPackage,
+  type BrowserInspection,
+  type BrowserTabSummary,
+  type ZenXBrowserBackend,
+} from "../src/main/capabilities/browser-provider.js";
+
+test("browser vertical slice targets one session/tab through structured operations", async () => {
+  const calls: string[] = [];
+  const backend = browserBackend(calls);
+  const capability = new BrowserZenXCapabilityPackage(backend);
+  const opened = await capability.invoke(
+    "browser_open",
+    invocation({ sessionId: "research", url: "https://example.com/start" }),
+  );
+  assert.equal((opened as BrowserTabSummary).tabId, "tab-1");
+  await capability.invoke(
+    "browser_navigate",
+    invocation({
+      sessionId: "research",
+      tabId: "tab-1",
+      url: "https://example.com/next",
+    }),
+  );
+  const inspection = (await capability.invoke(
+    "browser_inspect",
+    invocation({ sessionId: "research", tabId: "tab-1" }),
+  )) as BrowserInspection;
+  assert.equal(inspection.targets[0]?.selector, "#go");
+  await capability.invoke(
+    "browser_click",
+    invocation({ sessionId: "research", tabId: "tab-1", selector: "#go" }),
+  );
+  await capability.invoke(
+    "browser_type",
+    invocation({
+      sessionId: "research",
+      tabId: "tab-1",
+      selector: "#query",
+      text: "Zen",
+      submit: true,
+    }),
+  );
+  assert.deepEqual(calls, [
+    "open:research:https://example.com/start",
+    "navigate:research:tab-1:https://example.com/next",
+    "inspect:research:tab-1",
+    "click:research:tab-1:#go",
+    "type:research:tab-1:#query:3:true",
+  ]);
+});
+
+test("browser refuses credential-bearing and sensitive URLs before provider use", async () => {
+  const capability = new BrowserZenXCapabilityPackage(browserBackend([]));
+  await assert.rejects(
+    capability.invoke(
+      "browser_open",
+      invocation({
+        sessionId: "research",
+        url: "https://user:password@example.com/",
+      }),
+    ),
+    /must not contain credentials/u,
+  );
+  await assert.rejects(
+    capability.invoke(
+      "browser_open",
+      invocation({
+        sessionId: "research",
+        url: "https://example.com/?access_token=private",
+      }),
+    ),
+    /sensitive query parameter/u,
+  );
+});
+
+function browserBackend(calls: string[]): ZenXBrowserBackend {
+  const summary: BrowserTabSummary = {
+    sessionId: "research",
+    tabId: "tab-1",
+    title: "Fixture",
+    url: "https://example.com/",
+    loading: false,
+  };
+  return {
+    listTabs: async (sessionId) => {
+      calls.push(`list:${sessionId}`);
+      return [summary];
+    },
+    open: async (sessionId, url) => {
+      calls.push(`open:${sessionId}:${url.replace(/\/$/u, "")}`);
+      return summary;
+    },
+    navigate: async (sessionId, tabId, url) => {
+      calls.push(`navigate:${sessionId}:${tabId}:${url.replace(/\/$/u, "")}`);
+      return summary;
+    },
+    inspect: async (sessionId, tabId) => {
+      calls.push(`inspect:${sessionId}:${tabId}`);
+      return {
+        ...summary,
+        visibleText: "Fixture page",
+        targets: [{ selector: "#go", role: "button", name: "Go" }],
+      };
+    },
+    click: async (sessionId, tabId, selector) => {
+      calls.push(`click:${sessionId}:${tabId}:${selector}`);
+      return summary;
+    },
+    type: async (sessionId, tabId, selector, text, submit) => {
+      calls.push(
+        `type:${sessionId}:${tabId}:${selector}:${String(text.length)}:${String(submit)}`,
+      );
+      return summary;
+    },
+    close: () => undefined,
+  };
+}
+
+function invocation(arguments_: Record<string, unknown>) {
+  return {
+    callId: "call-1",
+    name: "test",
+    arguments: arguments_,
+    cwd: "/workspace",
+    signal: new AbortController().signal,
+  };
+}

--- a/apps/zenx/test/capability-grant-store.test.ts
+++ b/apps/zenx/test/capability-grant-store.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { JsonZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+
+test("persists only explicit capability permission grants", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-grants-"));
+  const filePath = path.join(directory, "grants.json");
+  const store = new JsonZenXCapabilityGrantStore(filePath);
+  try {
+    assert.deepEqual(await store.load(), {});
+    await store.save({
+      browser: [
+        { permissionId: "browser.tabs.read", scope: "browser-session" },
+      ],
+    });
+    assert.deepEqual(await store.load(), {
+      browser: [
+        { permissionId: "browser.tabs.read", scope: "browser-session" },
+      ],
+    });
+    const raw = await readFile(filePath, "utf8");
+    assert.doesNotMatch(raw, /cookie|credential|token/iu);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/apps/zenx/test/capability-registry.test.ts
+++ b/apps/zenx/test/capability-registry.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import {
+  CAPABILITY_RESOURCE_TOOL,
+  ZenXCapabilityRegistry,
+} from "../src/main/capabilities/registry.js";
+import type {
+  ZenXCapabilityManifest,
+  ZenXCapabilityPackage,
+} from "../src/main/capabilities/types.js";
+
+const manifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: "fixture",
+  displayName: "Fixture",
+  version: "1.0.0",
+  description: "Test capability",
+  permissions: [
+    {
+      id: "fixture.read",
+      title: "Read",
+      description: "Read fixture state",
+      scope: "workspace",
+    },
+    {
+      id: "fixture.write",
+      title: "Write",
+      description: "Write fixture state",
+      scope: "workspace",
+    },
+  ],
+  tools: [
+    {
+      name: "fixture_inspect",
+      description: "Inspect fixture",
+      inputSchema: { type: "object", additionalProperties: false },
+      permissions: ["fixture.read"],
+      maxOutputBytes: 1024,
+    },
+    {
+      name: "fixture_change",
+      description: "Change fixture",
+      inputSchema: { type: "object", additionalProperties: true },
+      permissions: ["fixture.write"],
+    },
+  ],
+  resources: [
+    {
+      id: "fixture-skill",
+      kind: "skill",
+      title: "Fixture skill",
+      description: "How to use the fixture",
+      content: "Inspect before changing the fixture.",
+    },
+  ],
+};
+
+test("registers, grants, revokes, and unregisters package contributions", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  registry.register(packageFixture(async () => ({ ok: true })));
+
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  await registry.grant("fixture", ["fixture.read"]);
+  assert.deepEqual(
+    registry.hostSnapshot().definitions.map((tool) => tool.name),
+    ["fixture_inspect"],
+  );
+  await registry.grant("fixture", ["fixture.write"]);
+  assert.deepEqual(
+    registry.hostSnapshot().definitions.map((tool) => tool.name),
+    ["fixture_inspect", "fixture_change", CAPABILITY_RESOURCE_TOOL],
+  );
+
+  const resource = await registry.execute(
+    invocation(CAPABILITY_RESOURCE_TOOL, {
+      capabilityId: "fixture",
+      resourceId: "fixture-skill",
+    }),
+  );
+  assert.match(resource.output, /Inspect before changing/u);
+
+  await registry.revoke("fixture", ["fixture.write"]);
+  assert.deepEqual(
+    registry.hostSnapshot().definitions.map((tool) => tool.name),
+    ["fixture_inspect"],
+  );
+  await assert.rejects(
+    registry.execute(invocation("fixture_change", {})),
+    /not granted/u,
+  );
+
+  await registry.unregister("fixture");
+  assert.deepEqual(registry.snapshot().capabilities, []);
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+});
+
+test("bounds and redacts provider output and projects invocation audit", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  registry.register(
+    packageFixture(async () => ({
+      cookie: "session=private",
+      authorization: "Bearer private",
+      nested: { token: "private-token" },
+      diagnostic:
+        "Authorization failed for Bearer visible-secret access_token=query-secret",
+      visible: "x".repeat(8_000),
+    })),
+  );
+  await registry.grant("fixture", ["fixture.read"]);
+
+  const result = await registry.execute(invocation("fixture_inspect", {}));
+  assert.ok(Buffer.byteLength(result.output, "utf8") <= 1024);
+  assert.doesNotMatch(result.output, /private/u);
+  assert.doesNotMatch(result.output, /visible-secret|query-secret/u);
+  assert.match(result.output, /truncated/u);
+  const [audit] = registry.snapshot().recentInvocations;
+  assert.equal(audit?.capabilityId, "fixture");
+  assert.equal(audit?.toolName, "fixture_inspect");
+  assert.equal(audit?.status, "completed");
+});
+
+test("rejects duplicate tool ownership", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  registry.register(packageFixture(async () => null));
+  assert.throws(
+    () =>
+      registry.register({
+        ...packageFixture(async () => null),
+        manifest: { ...manifest, id: "other" },
+      }),
+    /already registered/u,
+  );
+});
+
+test("projects an invocation cancelled while its provider is finishing", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  const controller = new AbortController();
+  await registry.initialize();
+  registry.register(
+    packageFixture(async () => {
+      controller.abort(new DOMException("stopped", "AbortError"));
+      return { late: true };
+    }),
+  );
+  await registry.grant("fixture", ["fixture.read"]);
+  await assert.rejects(
+    registry.execute({
+      ...invocation("fixture_inspect", {}),
+      signal: controller.signal,
+    }),
+    /stopped/u,
+  );
+  assert.equal(registry.snapshot().recentInvocations[0]?.status, "cancelled");
+});
+
+function packageFixture(
+  invoke: ZenXCapabilityPackage["invoke"],
+): ZenXCapabilityPackage {
+  return { manifest: structuredClone(manifest), invoke };
+}
+
+function invocation(name: string, arguments_: Record<string, unknown>) {
+  return {
+    callId: "call-1",
+    name,
+    arguments: arguments_,
+    cwd: "/workspace",
+    signal: new AbortController().signal,
+  };
+}

--- a/apps/zenx/test/capability-registry.test.ts
+++ b/apps/zenx/test/capability-registry.test.ts
@@ -17,6 +17,12 @@ const manifest: ZenXCapabilityManifest = {
   displayName: "Fixture",
   version: "1.0.0",
   description: "Test capability",
+  provider: {
+    id: "fixture-provider",
+    platforms: [process.platform],
+    interactionModes: ["background_safe", "foreground_required"],
+    capabilities: ["fixture.read", "fixture.write"],
+  },
   permissions: [
     {
       id: "fixture.read",
@@ -37,6 +43,8 @@ const manifest: ZenXCapabilityManifest = {
       description: "Inspect fixture",
       inputSchema: { type: "object", additionalProperties: false },
       permissions: ["fixture.read"],
+      interactionMode: "background_safe",
+      capabilities: ["fixture.read"],
       maxOutputBytes: 1024,
     },
     {
@@ -44,6 +52,8 @@ const manifest: ZenXCapabilityManifest = {
       description: "Change fixture",
       inputSchema: { type: "object", additionalProperties: true },
       permissions: ["fixture.write"],
+      interactionMode: "foreground_required",
+      capabilities: ["fixture.write", "global_input"],
     },
   ],
   resources: [
@@ -75,6 +85,7 @@ test("registers, grants, revokes, and unregisters package contributions", async 
     registry.hostSnapshot().definitions.map((tool) => tool.name),
     ["fixture_inspect", "fixture_change", CAPABILITY_RESOURCE_TOOL],
   );
+  assert.deepEqual(registry.snapshot().capabilities[0]?.blockedTools, []);
 
   const resource = await registry.execute(
     invocation(CAPABILITY_RESOURCE_TOOL, {
@@ -83,6 +94,8 @@ test("registers, grants, revokes, and unregisters package contributions", async 
     }),
   );
   assert.match(resource.output, /Inspect before changing/u);
+  assert.match(resource.output, /"interactionMode":"background_safe"/u);
+  assert.match(resource.output, /"id":"fixture-provider"/u);
 
   await registry.revoke("fixture", ["fixture.write"]);
   assert.deepEqual(
@@ -123,8 +136,82 @@ test("bounds and redacts provider output and projects invocation audit", async (
   assert.match(result.output, /truncated/u);
   const [audit] = registry.snapshot().recentInvocations;
   assert.equal(audit?.capabilityId, "fixture");
+  assert.equal(audit?.providerId, "fixture-provider");
   assert.equal(audit?.toolName, "fixture_inspect");
   assert.equal(audit?.status, "completed");
+  assert.equal(audit?.interactionMode, "background_safe");
+});
+
+test("rejects unsafe output bounds and still bounds oversized metadata", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  for (const maxOutputBytes of [-1, 512, 1024.5, 1024 * 1024 + 1]) {
+    const invalid = structuredClone(manifest);
+    invalid.id = `invalid-${String(maxOutputBytes).replace(/\W/gu, "-")}`;
+    invalid.tools[0]!.maxOutputBytes = maxOutputBytes;
+    assert.throws(
+      () =>
+        registry.register({
+          manifest: invalid,
+          invoke: async () => null,
+        }),
+      /maxOutputBytes must be an integer between 1024 and 1048576/u,
+    );
+  }
+
+  const metadataHeavy = structuredClone(manifest);
+  metadataHeavy.id = "metadata-heavy";
+  metadataHeavy.provider.id = "provider-" + "p".repeat(4_000);
+  metadataHeavy.tools[0]!.capabilities = ["c".repeat(4_000)];
+  registry.register({
+    manifest: metadataHeavy,
+    invoke: async () => ({ ok: true }),
+  });
+  await registry.grant("metadata-heavy", ["fixture.read"]);
+  const result = await registry.execute(invocation("fixture_inspect", {}));
+  assert.ok(Buffer.byteLength(result.output, "utf8") <= 1024);
+  assert.match(result.output, /metadata exceeded the configured output bound/u);
+});
+
+test("can restrict foreground-required tools without conflating restriction with grants", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+    { allowForegroundRequired: false },
+  );
+  await registry.initialize();
+  registry.register(packageFixture(async () => ({ changed: true })));
+  await registry.grant("fixture", ["fixture.write"]);
+  assert.deepEqual(
+    registry.hostSnapshot().definitions.map((tool) => tool.name),
+    [],
+  );
+  assert.deepEqual(registry.snapshot().capabilities[0]?.blockedTools, [
+    "fixture_change",
+  ]);
+  await assert.rejects(
+    registry.execute(invocation("fixture_change", {})),
+    /foreground_required.*background-safe execution only/u,
+  );
+});
+
+test("negotiates provider platforms without leaking platform types into tools", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+    { platform: "unsupported-test-platform" },
+  );
+  await registry.initialize();
+  registry.register(packageFixture(async () => ({ ok: true })));
+  await registry.grant("fixture", ["fixture.read"]);
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  const capability = registry.snapshot().capabilities[0];
+  assert.equal(capability?.available, false);
+  assert.match(capability?.unavailableReason ?? "", /does not support/u);
+  await assert.rejects(
+    registry.execute(invocation("fixture_inspect", {})),
+    /does not support unsupported-test-platform/u,
+  );
 });
 
 test("rejects duplicate tool ownership", async () => {

--- a/apps/zenx/test/capability-tool-executor.test.ts
+++ b/apps/zenx/test/capability-tool-executor.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ZenXHostToolExecutor } from "../src/main/capability-tool-executor.js";
+import type { HostEvent } from "../src/main/host-messages.js";
+
+test("exposes capability definitions and resolves main-process execution", async () => {
+  const events: HostEvent[] = [];
+  const executor = new ZenXHostToolExecutor({
+    capabilities: {
+      definitions: [
+        {
+          name: "fixture_inspect",
+          description: "Inspect",
+          inputSchema: { type: "object" },
+        },
+      ],
+    },
+    send: (event) => events.push(event),
+  });
+  assert.deepEqual(
+    executor.definitions.map((definition) => definition.name),
+    ["shell", "fixture_inspect"],
+  );
+  const execution = executor.execute({
+    callId: "call-1",
+    name: "fixture_inspect",
+    arguments: { target: "one" },
+    cwd: "/workspace",
+    signal: new AbortController().signal,
+  });
+  const request = events.find((event) => event.type === "capability/invoke");
+  assert.equal(request?.type, "capability/invoke");
+  if (request?.type !== "capability/invoke") throw new Error("missing request");
+  executor.handleResult({
+    type: "capability/result",
+    invocationId: request.invocationId,
+    output: "bounded",
+    exitCode: 0,
+  });
+  assert.deepEqual(await execution, { output: "bounded", exitCode: 0 });
+});
+
+test("propagates cancellation to the main-process provider", async () => {
+  const events: HostEvent[] = [];
+  const executor = new ZenXHostToolExecutor({
+    capabilities: {
+      definitions: [
+        {
+          name: "fixture_wait",
+          description: "Wait",
+          inputSchema: { type: "object" },
+        },
+      ],
+    },
+    send: (event) => events.push(event),
+  });
+  const controller = new AbortController();
+  const execution = executor.execute({
+    callId: "call-2",
+    name: "fixture_wait",
+    arguments: {},
+    cwd: "/workspace",
+    signal: controller.signal,
+  });
+  controller.abort(new DOMException("stop", "AbortError"));
+  await assert.rejects(execution, /stop/u);
+  assert.equal(events.at(-1)?.type, "capability/cancel");
+});

--- a/apps/zenx/test/computer-capability.test.ts
+++ b/apps/zenx/test/computer-capability.test.ts
@@ -2,127 +2,252 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  computerCapabilityManifest,
+  ComputerObservationLedger,
   ComputerZenXCapabilityPackage,
-  type ComputerState,
+  type ComputerControlSelector,
+  type ComputerInspection,
+  type ComputerTarget,
   type ZenXComputerBackend,
 } from "../src/main/capabilities/computer-provider.js";
 
-test("computer vertical slice audits explicit target context without echoing typed text", async () => {
+const target: ComputerTarget = { pid: 42, windowTitle: "Smoke" };
+const fieldControl: ComputerControlSelector = {
+  observationId: "observation-1",
+  targetId: "field",
+};
+const buttonControl: ComputerControlSelector = {
+  observationId: "observation-1",
+  targetId: "button",
+};
+
+test("computer vertical slice uses only targeted AX operations and does not echo set values", async () => {
   const calls: string[] = [];
   const capability = new ComputerZenXCapabilityPackage(computerBackend(calls));
   const inspected = (await capability.invoke(
     "computer_inspect",
-    invocation({}),
-  )) as ComputerState;
-  assert.equal(inspected.frontmostApplication, "ZenX");
-  const clicked = await capability.invoke(
-    "computer_click",
-    invocation({ x: 120, y: 80, context: "ZenX / Smoke / Continue" }),
+    invocation({ target }),
+  )) as ComputerInspection;
+  assert.equal(inspected.target.applicationName, "Fixture");
+  const pressed = await capability.invoke(
+    "computer_press",
+    invocation({ target, control: buttonControl }),
   );
-  assert.deepEqual((clicked as { action: unknown }).action, {
-    x: 120,
-    y: 80,
-    button: "left",
-    context: "ZenX / Smoke / Continue",
-  });
-  const typed = await capability.invoke(
-    "computer_type",
+  assert.deepEqual((pressed as { control: unknown }).control, buttonControl);
+  await capability.invoke("computer_inspect", invocation({ target }));
+  const set = await capability.invoke(
+    "computer_set_value",
     invocation({
-      text: "private deliberate text",
-      context: "ZenX / Smoke / Name",
+      target,
+      control: fieldControl,
+      value: "private deliberate text",
     }),
   );
-  assert.deepEqual((typed as { action: unknown }).action, {
-    characterCount: 23,
-    context: "ZenX / Smoke / Name",
-  });
-  assert.doesNotMatch(JSON.stringify(typed), /private deliberate/u);
-  await capability.invoke(
-    "computer_key_press",
-    invocation({ key: "enter", context: "ZenX / Smoke / Name" }),
-  );
-  await capability.invoke(
-    "computer_scroll",
-    invocation({ deltaY: 500, context: "ZenX / Smoke / List" }),
-  );
+  assert.equal((set as { characterCount: number }).characterCount, 23);
+  assert.doesNotMatch(JSON.stringify(set), /private deliberate/u);
   assert.deepEqual(calls, [
-    "inspect",
-    "click:120:80:left",
-    "type:23",
-    "key:enter",
-    "scroll:500",
+    "inspect:42",
+    "press:button",
+    "inspect:42",
+    "set:field:23",
   ]);
 });
 
-test("computer input requires explicit context and bounded operations", async () => {
-  const capability = new ComputerZenXCapabilityPackage(computerBackend([]));
-  await assert.rejects(
-    capability.invoke("computer_click", invocation({ x: 1, y: 2 })),
-    /context/u,
+test("computer observation IDs are target-scoped, latest-only, and reject secure values", () => {
+  const ledger = new ComputerObservationLedger();
+  const first = ledger.observe("app-a", [
+    {
+      role: "AXButton",
+      title: "Mark",
+      frame: "10.0,10.0,20.0,20.0",
+      secure: false,
+      actions: ["AXPress"],
+    },
+  ]);
+  const firstControl = first.selectors[0]!;
+  const second = ledger.observe("app-a", [
+    {
+      role: "AXButton",
+      title: "Mark",
+      frame: "20.0,10.0,20.0,20.0",
+      secure: false,
+      actions: ["AXPress"],
+    },
+  ]);
+  assert.throws(
+    () => ledger.consume("app-a", firstControl, "press"),
+    /stale, unknown/u,
   );
-  await assert.rejects(
-    capability.invoke(
-      "computer_scroll",
-      invocation({ deltaY: 20_000, context: "target" }),
-    ),
-    /between -10000 and 10000/u,
+  assert.throws(
+    () =>
+      ledger.consume(
+        "app-a",
+        { ...second.selectors[0]!, targetId: "forged" },
+        "press",
+      ),
+    /forged/u,
+  );
+  assert.throws(
+    () => ledger.consume("app-b", second.selectors[0]!, "press"),
+    /another target/u,
+  );
+
+  const secure = ledger.observe("app-a", [
+    {
+      role: "AXTextField",
+      subrole: "AXSecureTextField",
+      frame: "10.0,40.0,100.0,20.0",
+      secure: true,
+      actions: ["AXSetValue"],
+    },
+  ]);
+  assert.throws(
+    () => ledger.consume("app-a", secure.selectors[0]!, "set_value"),
+    /rejects password or secure controls/u,
   );
 });
 
+test("declares background-safe semantics separately from foreground takeover", async () => {
+  const modes = Object.fromEntries(
+    computerCapabilityManifest.tools.map((tool) => [
+      tool.name,
+      tool.interactionMode,
+    ]),
+  );
+  assert.equal(modes.computer_inspect, "background_safe");
+  assert.equal(modes.computer_press, "background_safe");
+  assert.equal(modes.computer_set_value, "background_safe");
+  assert.equal(modes.computer_foreground_click, "foreground_required");
+  assert.equal(modes.computer_foreground_type, undefined);
+
+  const capability = new ComputerZenXCapabilityPackage(computerBackend([]));
+  await assert.rejects(
+    capability.invoke(
+      "computer_set_value",
+      invocation({ target, control: fieldControl, value: "x".repeat(4_001) }),
+    ),
+    /limited to 4000/u,
+  );
+  await assert.rejects(
+    capability.invoke(
+      "computer_screenshot",
+      invocation({ target: { pid: 42 } }),
+    ),
+    /windowTitle/u,
+  );
+  await assert.rejects(
+    capability.invoke("computer_inspect", invocation({ target: { pid: 42 } })),
+    /cannot inspect or act across sibling windows/u,
+  );
+});
+
+test("cancels foreground takeover before global input begins", async () => {
+  const calls: string[] = [];
+  const capability = new ComputerZenXCapabilityPackage(computerBackend(calls));
+  const controller = new AbortController();
+  controller.abort(new DOMException("stopped", "AbortError"));
+  await assert.rejects(
+    capability.invoke(
+      "computer_foreground_click",
+      invocation({ x: 10, y: 20 }, controller.signal),
+    ),
+    /stopped/u,
+  );
+  assert.deepEqual(calls, []);
+});
+
+test("executes the explicitly labeled foreground baseline after its cancellation window", async () => {
+  const calls: string[] = [];
+  const capability = new ComputerZenXCapabilityPackage(computerBackend(calls));
+  const result = await capability.invoke(
+    "computer_foreground_click",
+    invocation({ x: 10, y: 20, button: "right" }),
+  );
+  assert.deepEqual(result, {
+    action: "click",
+    x: 10,
+    y: 20,
+    button: "right",
+    impact: "foreground_takeover",
+  });
+  assert.deepEqual(calls, ["foreground-click:10:20:right"]);
+});
+
 function computerBackend(calls: string[]): ZenXComputerBackend {
-  const state: ComputerState = {
-    platform: "darwin",
-    frontmostApplication: "ZenX",
-    frontmostWindowTitle: "Smoke",
-    cursor: { x: 10, y: 10 },
-    displays: [
-      {
-        id: "1",
-        bounds: { x: 0, y: 0, width: 1440, height: 900 },
-        scaleFactor: 2,
-      },
-    ],
+  const resolvedTarget = {
+    pid: 42,
+    bundleId: "dev.zen.fixture",
+    applicationName: "Fixture",
+    windowTitle: "Smoke",
   };
   return {
-    inspect: async () => {
-      calls.push("inspect");
-      return state;
+    inspect: async (inspectedTarget) => {
+      calls.push(`inspect:${String(inspectedTarget.pid)}`);
+      return {
+        platform: "darwin",
+        observationId: "observation-1",
+        target: resolvedTarget,
+        controls: [
+          {
+            selector: buttonControl,
+            role: "AXButton",
+            title: "Mark",
+            enabled: true,
+            actions: ["AXPress"],
+          },
+          {
+            selector: fieldControl,
+            role: "AXTextField",
+            title: "Name",
+            enabled: true,
+            actions: ["AXSetValue"],
+          },
+        ],
+        truncated: false,
+      };
+    },
+    press: async (_target, selected) => {
+      calls.push(`press:${selected.targetId}`);
+      return { target: resolvedTarget, control: selected };
+    },
+    setValue: async (_target, selected, value) => {
+      calls.push(`set:${selected.targetId}:${String(value.length)}`);
+      return {
+        target: resolvedTarget,
+        control: selected,
+        characterCount: value.length,
+      };
     },
     screenshot: async () => ({
       artifactPath: "/private/tmp/fixture.png",
-      sourceId: "screen:1",
-      sourceName: "Display 1",
+      target: resolvedTarget,
       width: 1200,
       height: 800,
       bytes: 100,
       expiresAt: new Date(0).toISOString(),
     }),
-    click: async (x, y, button) => {
-      calls.push(`click:${String(x)}:${String(y)}:${button}`);
-      return state;
+    foregroundClick: async (x, y, button) => {
+      calls.push(`foreground-click:${String(x)}:${String(y)}:${button}`);
     },
-    type: async (text) => {
-      calls.push(`type:${String(text.length)}`);
-      return state;
+    foregroundKeyPress: async (key) => {
+      calls.push(`foreground-key:${key}`);
     },
-    keyPress: async (key) => {
-      calls.push(`key:${key}`);
-      return state;
-    },
-    scroll: async (deltaY) => {
-      calls.push(`scroll:${String(deltaY)}`);
-      return state;
+    foregroundScroll: async (deltaY) => {
+      calls.push(`foreground-scroll:${String(deltaY)}`);
     },
     close: () => undefined,
   };
 }
 
-function invocation(arguments_: Record<string, unknown>) {
+function invocation(
+  arguments_: Record<string, unknown>,
+  signal = new AbortController().signal,
+) {
   return {
     callId: "call-1",
     name: "test",
     arguments: arguments_,
     cwd: "/workspace",
-    signal: new AbortController().signal,
+    signal,
   };
 }

--- a/apps/zenx/test/computer-capability.test.ts
+++ b/apps/zenx/test/computer-capability.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ComputerZenXCapabilityPackage,
+  type ComputerState,
+  type ZenXComputerBackend,
+} from "../src/main/capabilities/computer-provider.js";
+
+test("computer vertical slice audits explicit target context without echoing typed text", async () => {
+  const calls: string[] = [];
+  const capability = new ComputerZenXCapabilityPackage(computerBackend(calls));
+  const inspected = (await capability.invoke(
+    "computer_inspect",
+    invocation({}),
+  )) as ComputerState;
+  assert.equal(inspected.frontmostApplication, "ZenX");
+  const clicked = await capability.invoke(
+    "computer_click",
+    invocation({ x: 120, y: 80, context: "ZenX / Smoke / Continue" }),
+  );
+  assert.deepEqual((clicked as { action: unknown }).action, {
+    x: 120,
+    y: 80,
+    button: "left",
+    context: "ZenX / Smoke / Continue",
+  });
+  const typed = await capability.invoke(
+    "computer_type",
+    invocation({
+      text: "private deliberate text",
+      context: "ZenX / Smoke / Name",
+    }),
+  );
+  assert.deepEqual((typed as { action: unknown }).action, {
+    characterCount: 23,
+    context: "ZenX / Smoke / Name",
+  });
+  assert.doesNotMatch(JSON.stringify(typed), /private deliberate/u);
+  await capability.invoke(
+    "computer_key_press",
+    invocation({ key: "enter", context: "ZenX / Smoke / Name" }),
+  );
+  await capability.invoke(
+    "computer_scroll",
+    invocation({ deltaY: 500, context: "ZenX / Smoke / List" }),
+  );
+  assert.deepEqual(calls, [
+    "inspect",
+    "click:120:80:left",
+    "type:23",
+    "key:enter",
+    "scroll:500",
+  ]);
+});
+
+test("computer input requires explicit context and bounded operations", async () => {
+  const capability = new ComputerZenXCapabilityPackage(computerBackend([]));
+  await assert.rejects(
+    capability.invoke("computer_click", invocation({ x: 1, y: 2 })),
+    /context/u,
+  );
+  await assert.rejects(
+    capability.invoke(
+      "computer_scroll",
+      invocation({ deltaY: 20_000, context: "target" }),
+    ),
+    /between -10000 and 10000/u,
+  );
+});
+
+function computerBackend(calls: string[]): ZenXComputerBackend {
+  const state: ComputerState = {
+    platform: "darwin",
+    frontmostApplication: "ZenX",
+    frontmostWindowTitle: "Smoke",
+    cursor: { x: 10, y: 10 },
+    displays: [
+      {
+        id: "1",
+        bounds: { x: 0, y: 0, width: 1440, height: 900 },
+        scaleFactor: 2,
+      },
+    ],
+  };
+  return {
+    inspect: async () => {
+      calls.push("inspect");
+      return state;
+    },
+    screenshot: async () => ({
+      artifactPath: "/private/tmp/fixture.png",
+      sourceId: "screen:1",
+      sourceName: "Display 1",
+      width: 1200,
+      height: 800,
+      bytes: 100,
+      expiresAt: new Date(0).toISOString(),
+    }),
+    click: async (x, y, button) => {
+      calls.push(`click:${String(x)}:${String(y)}:${button}`);
+      return state;
+    },
+    type: async (text) => {
+      calls.push(`type:${String(text.length)}`);
+      return state;
+    },
+    keyPress: async (key) => {
+      calls.push(`key:${key}`);
+      return state;
+    },
+    scroll: async (deltaY) => {
+      calls.push(`scroll:${String(deltaY)}`);
+      return state;
+    },
+    close: () => undefined,
+  };
+}
+
+function invocation(arguments_: Record<string, unknown>) {
+  return {
+    callId: "call-1",
+    name: "test",
+    arguments: arguments_,
+    cwd: "/workspace",
+    signal: new AbortController().signal,
+  };
+}

--- a/apps/zenx/test/local-capability.test.ts
+++ b/apps/zenx/test/local-capability.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { discoverLocalCapabilityPackages } from "../src/main/capabilities/local-package.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
+
+test("discovers and executes a local process package with a minimal JSON contract", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-local-capability-"),
+  );
+  const executable = path.join(directory, "provider.mjs");
+  try {
+    await writeFile(
+      executable,
+      `#!/usr/bin/env node
+let input = "";
+for await (const chunk of process.stdin) input += chunk;
+const request = JSON.parse(input);
+process.stdout.write(JSON.stringify({ tool: request.tool, value: request.arguments.value, leakedEnvironment: process.env.OPENAI_API_KEY ?? null }));
+`,
+      "utf8",
+    );
+    await chmod(executable, 0o700);
+    await writeFile(
+      path.join(directory, "fixture.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: "local-fixture",
+        displayName: "Local fixture",
+        version: "1.0.0",
+        description: "Local process fixture",
+        permissions: [
+          {
+            id: "local-fixture.run",
+            title: "Run fixture",
+            description: "Run the local fixture",
+            scope: "workspace",
+          },
+        ],
+        tools: [
+          {
+            name: "local_fixture_run",
+            description: "Run fixture",
+            inputSchema: { type: "object" },
+            permissions: ["local-fixture.run"],
+          },
+        ],
+        resources: [],
+        runtime: { type: "process", command: "./provider.mjs" },
+      }),
+      "utf8",
+    );
+    process.env.OPENAI_API_KEY = "must-not-cross-boundary";
+    const discovered = await discoverLocalCapabilityPackages(directory);
+    assert.deepEqual(discovered.errors, []);
+    assert.equal(discovered.packages.length, 1);
+    const registry = new ZenXCapabilityRegistry(
+      new MemoryZenXCapabilityGrantStore(),
+    );
+    await registry.initialize();
+    registry.register(discovered.packages[0]!, "local");
+    await registry.grant("local-fixture");
+    const result = await registry.execute({
+      callId: "call-local",
+      name: "local_fixture_run",
+      arguments: { value: "ok" },
+      cwd: "/workspace",
+      signal: new AbortController().signal,
+    });
+    assert.match(result.output, /"value":"ok"/u);
+    assert.match(result.output, /"leakedEnvironment":null/u);
+    assert.doesNotMatch(result.output, /must-not-cross-boundary/u);
+  } finally {
+    delete process.env.OPENAI_API_KEY;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("reports malformed local manifests without hiding other packages", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-local-invalid-"),
+  );
+  try {
+    await writeFile(path.join(directory, "bad.json"), "{}", "utf8");
+    const discovered = await discoverLocalCapabilityPackages(directory);
+    assert.equal(discovered.packages.length, 0);
+    assert.match(discovered.errors[0] ?? "", /manifest shape is invalid/u);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/apps/zenx/test/local-capability.test.ts
+++ b/apps/zenx/test/local-capability.test.ts
@@ -33,6 +33,12 @@ process.stdout.write(JSON.stringify({ tool: request.tool, value: request.argumen
         displayName: "Local fixture",
         version: "1.0.0",
         description: "Local process fixture",
+        provider: {
+          id: "fixture-process",
+          platforms: [process.platform],
+          interactionModes: ["background_safe"],
+          capabilities: ["fixture.run"],
+        },
         permissions: [
           {
             id: "local-fixture.run",
@@ -47,6 +53,8 @@ process.stdout.write(JSON.stringify({ tool: request.tool, value: request.argumen
             description: "Run fixture",
             inputSchema: { type: "object" },
             permissions: ["local-fixture.run"],
+            interactionMode: "background_safe",
+            capabilities: ["fixture.run"],
           },
         ],
         resources: [],
@@ -86,9 +94,45 @@ test("reports malformed local manifests without hiding other packages", async ()
   );
   try {
     await writeFile(path.join(directory, "bad.json"), "{}", "utf8");
+    await writeFile(
+      path.join(directory, "bad-output-bound.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: "bad-output-bound",
+        displayName: "Bad output bound",
+        version: "1.0.0",
+        description: "Invalid local output bound",
+        provider: {
+          id: "fixture",
+          platforms: [process.platform],
+          interactionModes: ["background_safe"],
+          capabilities: ["fixture.run"],
+        },
+        permissions: [],
+        tools: [
+          {
+            name: "bad_output_bound",
+            description: "Invalid",
+            inputSchema: { type: "object" },
+            permissions: [],
+            interactionMode: "background_safe",
+            capabilities: ["fixture.run"],
+            maxOutputBytes: -1,
+          },
+        ],
+        resources: [],
+        runtime: { type: "process", command: "./missing" },
+      }),
+      "utf8",
+    );
     const discovered = await discoverLocalCapabilityPackages(directory);
     assert.equal(discovered.packages.length, 0);
-    assert.match(discovered.errors[0] ?? "", /manifest shape is invalid/u);
+    assert.equal(discovered.errors.length, 2);
+    assert.ok(
+      discovered.errors.every((error) =>
+        /manifest shape is invalid/u.test(error),
+      ),
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -12,6 +12,7 @@ import {
   type ComposerState,
 } from "../src/renderer/src/composer-state.js";
 import { ThreadView } from "../src/renderer/src/ThreadView.js";
+import { capabilityToolName } from "../src/renderer/src/ThreadView.js";
 
 const noop = async () => undefined;
 
@@ -62,6 +63,14 @@ test("pending submission fences duplicate actions without locking the editor", (
   assert.doesNotMatch(html, /<textarea[^>]*disabled/);
   assert.match(html, /<button[^>]*disabled[^>]*>.*Steering…/s);
   assert.match(html, /Adding guidance to the current turn/);
+});
+
+test("labels capability audit cards separately from shell commands", () => {
+  assert.equal(
+    capabilityToolName('browser_inspect {"sessionId":"one"}'),
+    "browser_inspect",
+  );
+  assert.equal(capabilityToolName("printf hello"), null);
 });
 
 function render(

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -12,7 +12,10 @@ import {
   type ComposerState,
 } from "../src/renderer/src/composer-state.js";
 import { ThreadView } from "../src/renderer/src/ThreadView.js";
-import { capabilityToolName } from "../src/renderer/src/ThreadView.js";
+import {
+  capabilityToolName,
+  isForegroundTakeoverTool,
+} from "../src/renderer/src/ThreadView.js";
 
 const noop = async () => undefined;
 
@@ -71,6 +74,11 @@ test("labels capability audit cards separately from shell commands", () => {
     "browser_inspect",
   );
   assert.equal(capabilityToolName("printf hello"), null);
+  assert.equal(
+    isForegroundTakeoverTool('computer_foreground_click {"x":1,"y":2}'),
+    true,
+  );
+  assert.equal(isForegroundTakeoverTool("computer_press {}"), false);
 });
 
 function render(

--- a/src/model.ts
+++ b/src/model.ts
@@ -286,6 +286,46 @@ export class FakeModel implements ModelAdapter {
       };
       return;
     }
+    if (text.startsWith("!tool ")) {
+      const invocation = text.slice("!tool ".length);
+      const separator = invocation.indexOf(" ");
+      const name = separator < 0 ? invocation : invocation.slice(0, separator);
+      const definition = request.tools.find((tool) => tool.name === name);
+      if (definition === undefined) {
+        yield* streamWords(`Unknown fake tool: ${name}`, request.signal);
+        return;
+      }
+      const rawArguments =
+        separator < 0 ? "{}" : invocation.slice(separator + 1);
+      let arguments_: unknown;
+      try {
+        arguments_ = JSON.parse(rawArguments);
+      } catch {
+        yield* streamWords(
+          `Invalid fake tool arguments for ${name}`,
+          request.signal,
+        );
+        return;
+      }
+      if (
+        typeof arguments_ !== "object" ||
+        arguments_ === null ||
+        Array.isArray(arguments_)
+      ) {
+        yield* streamWords(
+          `Invalid fake tool arguments for ${name}`,
+          request.signal,
+        );
+        return;
+      }
+      yield {
+        type: "tool_call",
+        callId: `fake_${Date.now().toString(36)}`,
+        name,
+        arguments: arguments_ as Record<string, unknown>,
+      };
+      return;
+    }
 
     yield* streamWords(`Echo: ${text}`, request.signal);
     yield {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -482,12 +482,12 @@ function readCommand(toolCall: {
   arguments: Record<string, unknown>;
 }): string {
   if (
-    toolCall.name !== "shell" ||
-    typeof toolCall.arguments.command !== "string"
+    toolCall.name === "shell" &&
+    typeof toolCall.arguments.command === "string"
   ) {
-    throw new Error(`Unsupported tool call: ${toolCall.name}`);
+    return toolCall.arguments.command;
   }
-  return toolCall.arguments.command;
+  return `${toolCall.name} ${JSON.stringify(toolCall.arguments)}`;
 }
 
 function isAbortError(error: unknown): boolean {


### PR DESCRIPTION
Closes #36

Depends on #34; this PR is based on `codex/zenx-desktop-vertical-slice`.

## What changed

- adds a ZenX-owned bundled/local capability manifest, registry, grant store, skill/prompt resources, structured execution bridge, bounded/redacted results, and in-memory audit projection
- adds provider/platform negotiation plus per-tool `background_safe`, `foreground_required`, and future `isolated` interaction metadata; grants, approval, and execution restrictions remain separate
- adds hidden dedicated Chromium incarnation partitions controlled through CDP for bounded browser list/open/navigate/inspect/click/type/close operations, with per-session/global tab caps
- binds browser actions to the latest `{sessionId, tabId, documentVersion, observationId, targetId}` observation; raw CSS selectors stay provider-private, and actions revalidate visibility, action support, and semantic identity before consuming the observation
- omits password values and rejects secure browser/computer value targets; `browser_type` and `computer_set_value` are explicitly non-secret-only because their text is persisted in canonical tool-call arguments
- adds a macOS computer tracer bullet with exact-window AX inspection, opaque latest-observation target IDs, AXPress/AXValue semantic actions, scoped short-lived capture, and separately named foreground click/key/scroll operations
- replaces short-lived-process BFS element indices with semantic fingerprints including role/identifier/title/description/geometry; moved, stale, forged, missing, and ambiguous controls fail closed
- validates local/bundled `maxOutputBytes` to 1 KiB–1 MiB and guarantees the final envelope respects the bound even when metadata alone is oversized
- keeps the public capability contract platform-neutral so Windows UIA/WGC/SendInput and future providers do not leak HWND/UIA or AX/CGEvent types

## Interaction impact and fallback

The product route is background-first, then explicit foreground takeover when needed. Foreground takeover remains available and does not block #36. Background-safe operations never silently fall back to CGEvent/global input; unsupported semantics fail explicitly. Full arbitrary non-interfering automation remains a future isolated desktop/VM/remote-host provider.

The browser provider does not attach to the user's Chrome profile or existing tabs. That would be a separate explicit opt-in provider with different privacy and interaction impact.

## Provider reuse decisions

- **Browser:** directly uses Electron's bundled Chromium CDP path and an in-memory partition. The provider seam can later use an isolated Playwright `BrowserContext`; Playwright is not added as a dependency in this tracer bullet.
- **macOS:** evaluated MIT-licensed [OpenClaw Peekaboo](https://github.com/openclaw/Peekaboo) and aligned with observe → opaque target → native semantic action → explicit foreground fallback. Peekaboo is not bundled yet because ZenX still needs pinned JSON compatibility and deliberate packaging/signing/permission onboarding. The minimal Swift AX/CGEvent helper is provisional.
- **Windows:** the minimum follow-up is a thin optional adapter over Microsoft's MIT/Public Preview [winapp CLI UI automation](https://github.com/microsoft/winappCli/blob/main/docs/ui-automation.md): UIA/WGC map to background-safe operations; click/drag/SendInput map to foreground-required operations. Windows computer execution currently negotiates unavailable.
- **Isolated desktop:** [OSWorld](https://github.com/xlang-ai/OSWorld)'s VMware/VirtualBox/Docker/cloud provider separation is the future reference; no VM lifecycle is implemented here.

No third-party automation source was copied into this PR.

## Boundaries

- Zen Core, Thread, ItemList, and `src/protocol/codex` remain free of plugin semantics.
- ZenX owns discovery/registration, grants/UI, provider execution, audit projection, and skill/prompt exposure.
- Provider credentials, cookies, storage state, and raw browser sessions are not journaled. User-supplied non-secret typing text is a canonical tool-call argument; this PR does not claim arbitrary typed credentials stay out of the journal.
- Computer inspection requires an exact window title, returns at most 32 controls, and never falls back from scoped AX actions to global input.
- Marketplace/distribution and ZenX project/thread self-control tools are out of scope.

## Review fixes

- regression coverage for stale/forged/secure browser IDs, DOM identity changes, hidden targets, navigation invalidation, close cleanup, and tab caps
- regression coverage for latest-only/target-scoped/forged/secure computer IDs; index-only selectors are no longer accepted
- output-bound validation in local discovery and registry registration, plus oversized-metadata bounding
- `browser_close_session` now destroys every window, awaits storage/cache/auth cleanup, and invalidates the incarnation partition; same-ID reopen is verified free of prior cookies/session storage, while active generation bookkeeping is released when no tabs or opens remain
- removed untargeted `computer_foreground_type`: it cannot establish that the focused field is non-secret; allowlisted foreground key presses remain explicit takeover operations

## Verification

- `npm --workspace apps/zenx run check` — ZenX 83 passed plus typecheck and production build
- `npm test` — Node 87 passed; IMZen 38 passed
- `npm run check` — format, lint, typecheck, Node 87, IMZen 38 passed
- `npm --workspace apps/zenx run smoke:capabilities` — real hidden browser open/inspect/type/click/navigate/close; forged/stale/changed/hidden/password rejection; cookie/session-storage seed → close-session → same-ID clean reopen; foreground helper compilation without input injection; cursor position and foreground app unchanged

## Current limitations

- bundled computer execution is implemented on macOS only; Windows is the next provider adapter and Linux computer control is unsupported
- AXPress/AXValue depend on exact-window accessibility semantics; arbitrary GUI work may require explicit foreground takeover
- scoped capture requires an on-screen resolvable window plus Screen Recording permission
- foreground takeover intentionally affects the live pointer/focused app; it is labeled and cancellable, but is not exercised against the user's desktop in automated smoke
- the packaged smoke proves the dedicated browser background-safe path leaves pointer/focus unchanged and compiles both macOS helpers; live third-party AX window/action smoke remains target/permission dependent, while opaque latest-observation, stale/forged/secure, fingerprint, and ambiguity behavior is covered at the provider/test boundary

## Coordination seam for #35

#35 can register a separate ZenX-owned package through `ZenXCapabilityPackage` / `ZenXCapabilityRegistry.register()`, declare permissions/tools/resources/interaction metadata, and rely on the existing host bridge. It should not add project/thread semantics to Zen Core or modify browser/computer providers.
