### PR TITLE
Add Windows WinApp computer provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
     timeout-minutes: 20
     env:
       WINAPP_CLI_UPDATE_CHECK: "0"
+      WINAPP_CLI_TELEMETRY_OPTOUT: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,24 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:capabilities
+
+  zenx-windows-computer-smoke:
+    name: ZenX Windows WinApp adapter smoke
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      WINAPP_CLI_UPDATE_CHECK: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install Microsoft WinApp CLI
+        uses: microsoft/setup-WinAppCli@b93bbddc1f7abc061ca0d3a8119e3a0c7dd71495 # v0.2
+        with:
+          version: v0.3.1
+      - name: Report WinApp CLI version
+        run: winapp --version
+      - run: npm ci
+      - run: npm --workspace apps/zenx run smoke:windows-computer

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,6 +76,9 @@
   协商实际影响且禁止静默降级。
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
   重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
+- **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
+  投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
+  不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -122,7 +122,9 @@ uses UIA `invoke` / `set-value`, and captures with the default WGC/PrintWindow
 path. It never passes `--focus` or `--capture-screen` and never silently falls
 back to `click`, `send-keys`, or other global input injection. WinApp command
 output, errors, duration, and artifacts are bounded; cancellation terminates the
-child process, and screenshots expire after five minutes. WinApp CLI 0.3.1's
+child process, and screenshots expire after five minutes. Set-value completion is
+confirmed by WinApp CLI's bounded native `wait-for --value` assertion without
+projecting the value back to the Agent. WinApp CLI 0.3.1's
 inspect JSON does not expose a stable password-state field, so ZenX conservatively
 rejects controls whose control type, name, automation ID, or class name looks
 secret-bearing; regardless of that heuristic, all `computer_set_value` calls are
@@ -245,7 +247,7 @@ On Windows, `smoke:windows-computer` launches a deterministic WinForms fixture
 with a real UIA-editable control and drives the real
 `WinAppCliComputerBackend` through `ComputerZenXCapabilityPackage` and the
 capability registry, verifying exact PID/title→HWND resolution, bounded semantic
-inspection, UIA set-value with internal readback verification, a post-action
+inspection, UIA set-value with a bounded native value assertion, a post-action
 re-inspection, and WGC-default scoped capture without `--focus`
 or `--capture-screen`. GitHub CI runs that path on `windows-latest` with Microsoft's
 official setup action. The cross-platform fixture suite validates the same WinApp

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -95,7 +95,7 @@ automation product.
 
 The computer contract is platform-neutral: tools describe semantic observation,
 press/value/capture operations and their interaction impact, while a platform
-provider reports what it implements. The current macOS provider offers targeted
+provider reports what it implements. The macOS provider offers targeted
 AXUIElement inspect/AXPress/AXValue and window-scoped capture as
 `background_safe`; these operations require an exact window title, expose at
 most 32 controls, issue short-lived opaque IDs, and revalidate semantic identity
@@ -112,9 +112,18 @@ reported as unsupported/foreground-required.
 
 The macOS provider requires Accessibility permission; window capture also
 requires Screen Recording, and first-use helper compilation requires Apple
-Command Line Tools. A Windows provider remains required after this tracer bullet
-and can implement the same semantic backend with UI Automation, Windows Graphics
-Capture, and SendInput. Linux is currently unsupported for computer control.
+Command Line Tools. On Windows, ZenX selects an optional thin adapter over
+Microsoft's Public Preview `winapp` CLI. Install it explicitly with
+`winget install Microsoft.winappcli --source winget`; ZenX probes `winapp
+--version` at startup and reports an actionable discovery diagnostic when it is
+missing. The adapter resolves an exact title to one HWND with `ui list-windows
+--json`, maps bounded `ui inspect --json` results to ZenX opaque observation IDs,
+uses UIA `invoke` / `set-value`, and captures with the default WGC/PrintWindow
+path. It never passes `--focus` or `--capture-screen` and never silently falls
+back to `click`, `send-keys`, or other global input injection. WinApp command
+output, errors, duration, and artifacts are bounded; cancellation terminates the
+child process, secure-looking controls reject value setting, and screenshots
+expire after five minutes. Linux is currently unsupported for computer control.
 Full arbitrary GUI automation cannot always be background-safe; an isolated
 macOS/Windows session, VM, or remote host is the intended route to arbitrary
 control without disturbing the user's desktop.
@@ -133,11 +142,12 @@ mature external implementations while retaining a runnable bundled baseline:
   is therefore provisional rather than a claim that ZenX should maintain a
   complete macOS automation stack. See
   <https://github.com/openclaw/Peekaboo>.
-- Windows should begin as a thin optional adapter over Microsoft's MIT-licensed,
-  Public Preview `winapp` CLI. UIA inspect/search/get/set-value/invoke/wait and
-  WGC capture map to background-safe semantic tools; click/drag/SendInput map to
-  foreground-required tools. Provider-private HWND/UIA values must be translated
-  to observation-scoped opaque ZenX target IDs/results. See
+- Windows is a thin optional adapter over Microsoft's MIT-licensed, Public
+  Preview `winapp` CLI. UIA inspect/set-value/invoke and default WGC capture map
+  to background-safe semantic tools; provider-private HWND/UIA selectors are
+  translated to observation-scoped opaque ZenX target IDs/results. WinApp's
+  input-injecting verbs are deliberately not exposed by the current unscoped
+  ZenX foreground contract. See
   <https://github.com/microsoft/winappCli/blob/main/docs/ui-automation.md>.
 - Browser automation currently uses the bundled Chromium CDP path and an
   ephemeral partition. A Playwright adapter should preserve the same tools while
@@ -204,6 +214,8 @@ or distribution layer.
 npm --workspace apps/zenx run check
 npm run check
 npm --workspace apps/zenx run smoke:capabilities
+# Windows only, after installing Microsoft WinApp CLI:
+npm --workspace apps/zenx run smoke:windows-computer
 ```
 
 The automated integration suite runs the timer → wakeup → App Server Turn →
@@ -225,6 +237,13 @@ third-party AX window/action smoke remains permission- and target-dependent; its
 opaque latest-observation and forged/stale/secure paths are unit-covered. The
 compiled helper enforces semantic fingerprint/geometry revalidation and rejects
 ambiguous matches, but that path is not claimed as a live third-party-app smoke.
+On Windows, `smoke:windows-computer` launches Notepad and verifies exact
+PID/title→HWND resolution, bounded semantic inspection, UIA set-value, and
+WGC-default scoped capture without `--focus` or `--capture-screen`. The
+cross-platform fixture suite validates the same WinApp JSON mapping, secure and
+stale target rejection, pre-action semantic revalidation, diagnostic behavior,
+timeout/cancellation, output bounds, and exact-value error redaction when a
+Windows host is not available.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -113,17 +113,21 @@ reported as unsupported/foreground-required.
 The macOS provider requires Accessibility permission; window capture also
 requires Screen Recording, and first-use helper compilation requires Apple
 Command Line Tools. On Windows, ZenX selects an optional thin adapter over
-Microsoft's Public Preview `winapp` CLI. Install it explicitly with
+Microsoft's Public Preview `winapp` CLI 0.3.1 or newer. Install it explicitly with
 `winget install Microsoft.winappcli --source winget`; ZenX probes `winapp
---version` at startup and reports an actionable discovery diagnostic when it is
-missing. The adapter resolves an exact title to one HWND with `ui list-windows
+--version` plus a read-only JSON schema probe at startup and does not expose the
+provider when it is missing, too old, or schema-incompatible. The adapter resolves an exact title to one HWND with `ui list-windows
 --json`, maps bounded `ui inspect --json` results to ZenX opaque observation IDs,
 uses UIA `invoke` / `set-value`, and captures with the default WGC/PrintWindow
 path. It never passes `--focus` or `--capture-screen` and never silently falls
 back to `click`, `send-keys`, or other global input injection. WinApp command
 output, errors, duration, and artifacts are bounded; cancellation terminates the
-child process, secure-looking controls reject value setting, and screenshots
-expire after five minutes. Linux is currently unsupported for computer control.
+child process, and screenshots expire after five minutes. WinApp CLI 0.3.1's
+inspect JSON does not expose a stable password-state field, so ZenX conservatively
+rejects controls whose control type, name, automation ID, or class name looks
+secret-bearing; regardless of that heuristic, all `computer_set_value` calls are
+explicitly non-secret-only because their text is journaled. Linux is currently
+unsupported for computer control.
 Full arbitrary GUI automation cannot always be background-safe; an isolated
 macOS/Windows session, VM, or remote host is the intended route to arbitrary
 control without disturbing the user's desktop.
@@ -237,11 +241,16 @@ third-party AX window/action smoke remains permission- and target-dependent; its
 opaque latest-observation and forged/stale/secure paths are unit-covered. The
 compiled helper enforces semantic fingerprint/geometry revalidation and rejects
 ambiguous matches, but that path is not claimed as a live third-party-app smoke.
-On Windows, `smoke:windows-computer` launches Notepad and verifies exact
-PID/title→HWND resolution, bounded semantic inspection, UIA set-value, and
-WGC-default scoped capture without `--focus` or `--capture-screen`. The
-cross-platform fixture suite validates the same WinApp JSON mapping, secure and
-stale target rejection, pre-action semantic revalidation, diagnostic behavior,
+On Windows, `smoke:windows-computer` launches a deterministic WinForms fixture
+with a real UIA-editable control and drives the real
+`WinAppCliComputerBackend` through `ComputerZenXCapabilityPackage` and the
+capability registry, verifying exact PID/title→HWND resolution, bounded semantic
+inspection, UIA set-value with internal readback verification, a post-action
+re-inspection, and WGC-default scoped capture without `--focus`
+or `--capture-screen`. GitHub CI runs that path on `windows-latest` with Microsoft's
+official setup action. The cross-platform fixture suite validates the same WinApp
+0.3.1 JSON mapping, conservative secure-control heuristic, stale target rejection,
+pre-action semantic revalidation, startup version/schema diagnostics,
 timeout/cancellation, output bounds, and exact-value error redaction when a
 Windows host is not available.
 It does

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -11,6 +11,7 @@
     "test": "tsx --test test/**/*.test.ts",
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
+    "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
     "check": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {

--- a/apps/zenx/scripts/windows-winapp-smoke.ps1
+++ b/apps/zenx/scripts/windows-winapp-smoke.ps1
@@ -8,65 +8,49 @@ if (-not (Get-Command winapp -ErrorAction SilentlyContinue)) {
   throw "WinApp CLI is missing. Install it with: winget install Microsoft.winappcli --source winget"
 }
 
-$artifactDirectory = Join-Path $env:TEMP ("zenx-winapp-smoke-" + [guid]::NewGuid().ToString("N"))
-New-Item -ItemType Directory -Path $artifactDirectory | Out-Null
-$notepad = $null
+$fixture = $null
+$fixtureScript = Join-Path $env:TEMP ("zenx-winapp-fixture-" + [guid]::NewGuid().ToString("N") + ".ps1")
+$fixtureTitle = "ZenX WinApp Smoke " + [guid]::NewGuid().ToString("N")
 
 try {
-  $notepad = Start-Process notepad.exe -PassThru
+  @'
+param([string] $Title)
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$form = New-Object System.Windows.Forms.Form
+$form.Text = $Title
+$form.Width = 640
+$form.Height = 360
+$editor = New-Object System.Windows.Forms.TextBox
+$editor.Name = "ZenXSmokeEditor"
+$editor.AccessibleName = "ZenX smoke editor"
+$editor.Multiline = $true
+$editor.SetBounds(24, 24, 560, 220)
+$form.Controls.Add($editor)
+[System.Windows.Forms.Application]::Run($form)
+'@ | Set-Content -LiteralPath $fixtureScript -Encoding UTF8
+  $fixture = Start-Process powershell.exe -ArgumentList @(
+    "-NoProfile",
+    "-ExecutionPolicy", "Bypass",
+    "-STA",
+    "-File", ('"' + $fixtureScript + '"'),
+    "-Title", ('"' + $fixtureTitle + '"')
+  ) -PassThru
   $deadline = [DateTime]::UtcNow.AddSeconds(15)
   do {
     Start-Sleep -Milliseconds 250
-    $notepad.Refresh()
-  } while ([string]::IsNullOrWhiteSpace($notepad.MainWindowTitle) -and [DateTime]::UtcNow -lt $deadline)
+    $fixture.Refresh()
+  } while ($fixture.MainWindowTitle -ne $fixtureTitle -and [DateTime]::UtcNow -lt $deadline)
 
-  if ([string]::IsNullOrWhiteSpace($notepad.MainWindowTitle)) {
-    throw "Notepad did not expose a window title before the smoke timeout."
+  if ($fixture.MainWindowTitle -ne $fixtureTitle) {
+    throw "The deterministic WinForms fixture did not expose its window before the smoke timeout."
   }
 
-  $windows = @(winapp ui list-windows --app $notepad.Id --json | ConvertFrom-Json)
-  $target = @($windows | Where-Object {
-    $_.processId -eq $notepad.Id -and $_.title -eq $notepad.MainWindowTitle
-  })
-  if ($target.Count -ne 1) {
-    throw "Expected one exact Notepad HWND; found $($target.Count)."
+  & npx --no-install tsx ./src/main/windows-computer-smoke.ts --pid $fixture.Id --title $fixtureTitle
+  if ($LASTEXITCODE -ne 0) {
+    throw "The ZenX WinApp adapter/registry smoke failed with exit code $LASTEXITCODE."
   }
-
-  $inspection = winapp ui inspect --window $target[0].hwnd --depth 8 --hide-disabled --hide-offscreen --json | ConvertFrom-Json
-  if (@($inspection.windows).Count -ne 1) {
-    throw "WinApp inspect did not return the exact Notepad window."
-  }
-
-  function Expand-WinAppElement([object[]] $roots) {
-    $pending = [Collections.Generic.Stack[object]]::new()
-    for ($index = $roots.Count - 1; $index -ge 0; $index--) { $pending.Push($roots[$index]) }
-    while ($pending.Count -gt 0) {
-      $element = $pending.Pop()
-      $element
-      $children = @($element.children)
-      for ($index = $children.Count - 1; $index -ge 0; $index--) { $pending.Push($children[$index]) }
-    }
-  }
-
-  $elements = @(Expand-WinAppElement @($inspection.windows[0].elements))
-  $editor = $elements | Where-Object {
-    $_.selector -and $_.type -match "Edit|TextBox|Document"
-  } | Select-Object -First 1
-  if (-not $editor) {
-    throw "No semantic Notepad editor selector was found."
-  }
-
-  $probeText = "ZenX WinApp smoke " + [DateTime]::UtcNow.ToString("O")
-  winapp ui set-value $editor.selector $probeText --window $target[0].hwnd --json | ConvertFrom-Json | Out-Null
-
-  $screenshotPath = Join-Path $artifactDirectory "notepad.png"
-  $capture = winapp ui screenshot --window $target[0].hwnd --output $screenshotPath --json | ConvertFrom-Json
-  if ($capture.hwnd -ne $target[0].hwnd -or -not (Test-Path $screenshotPath)) {
-    throw "The scoped screenshot did not confirm its HWND and artifact."
-  }
-
-  Write-Host "ZenX WinApp smoke passed: inspect, semantic set-value, and WGC-default scoped capture."
 } finally {
-  if ($notepad -and -not $notepad.HasExited) { Stop-Process -Id $notepad.Id -Force }
-  Remove-Item -LiteralPath $artifactDirectory -Recurse -Force -ErrorAction SilentlyContinue
+  if ($fixture -and -not $fixture.HasExited) { Stop-Process -Id $fixture.Id -Force }
+  Remove-Item -LiteralPath $fixtureScript -Force -ErrorAction SilentlyContinue
 }

--- a/apps/zenx/scripts/windows-winapp-smoke.ps1
+++ b/apps/zenx/scripts/windows-winapp-smoke.ps1
@@ -1,0 +1,72 @@
+$ErrorActionPreference = "Stop"
+
+if (-not $IsWindows) {
+  throw "This smoke test must run on Windows."
+}
+
+if (-not (Get-Command winapp -ErrorAction SilentlyContinue)) {
+  throw "WinApp CLI is missing. Install it with: winget install Microsoft.winappcli --source winget"
+}
+
+$artifactDirectory = Join-Path $env:TEMP ("zenx-winapp-smoke-" + [guid]::NewGuid().ToString("N"))
+New-Item -ItemType Directory -Path $artifactDirectory | Out-Null
+$notepad = $null
+
+try {
+  $notepad = Start-Process notepad.exe -PassThru
+  $deadline = [DateTime]::UtcNow.AddSeconds(15)
+  do {
+    Start-Sleep -Milliseconds 250
+    $notepad.Refresh()
+  } while ([string]::IsNullOrWhiteSpace($notepad.MainWindowTitle) -and [DateTime]::UtcNow -lt $deadline)
+
+  if ([string]::IsNullOrWhiteSpace($notepad.MainWindowTitle)) {
+    throw "Notepad did not expose a window title before the smoke timeout."
+  }
+
+  $windows = @(winapp ui list-windows --app $notepad.Id --json | ConvertFrom-Json)
+  $target = @($windows | Where-Object {
+    $_.processId -eq $notepad.Id -and $_.title -eq $notepad.MainWindowTitle
+  })
+  if ($target.Count -ne 1) {
+    throw "Expected one exact Notepad HWND; found $($target.Count)."
+  }
+
+  $inspection = winapp ui inspect --window $target[0].hwnd --depth 8 --hide-disabled --hide-offscreen --json | ConvertFrom-Json
+  if (@($inspection.windows).Count -ne 1) {
+    throw "WinApp inspect did not return the exact Notepad window."
+  }
+
+  function Expand-WinAppElement([object[]] $roots) {
+    $pending = [Collections.Generic.Stack[object]]::new()
+    for ($index = $roots.Count - 1; $index -ge 0; $index--) { $pending.Push($roots[$index]) }
+    while ($pending.Count -gt 0) {
+      $element = $pending.Pop()
+      $element
+      $children = @($element.children)
+      for ($index = $children.Count - 1; $index -ge 0; $index--) { $pending.Push($children[$index]) }
+    }
+  }
+
+  $elements = @(Expand-WinAppElement @($inspection.windows[0].elements))
+  $editor = $elements | Where-Object {
+    $_.selector -and $_.type -match "Edit|TextBox|Document"
+  } | Select-Object -First 1
+  if (-not $editor) {
+    throw "No semantic Notepad editor selector was found."
+  }
+
+  $probeText = "ZenX WinApp smoke " + [DateTime]::UtcNow.ToString("O")
+  winapp ui set-value $editor.selector $probeText --window $target[0].hwnd --json | ConvertFrom-Json | Out-Null
+
+  $screenshotPath = Join-Path $artifactDirectory "notepad.png"
+  $capture = winapp ui screenshot --window $target[0].hwnd --output $screenshotPath --json | ConvertFrom-Json
+  if ($capture.hwnd -ne $target[0].hwnd -or -not (Test-Path $screenshotPath)) {
+    throw "The scoped screenshot did not confirm its HWND and artifact."
+  }
+
+  Write-Host "ZenX WinApp smoke passed: inspect, semantic set-value, and WGC-default scoped capture."
+} finally {
+  if ($notepad -and -not $notepad.HasExited) { Stop-Process -Id $notepad.Id -Force }
+  Remove-Item -LiteralPath $artifactDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/apps/zenx/scripts/windows-winapp-smoke.ps1
+++ b/apps/zenx/scripts/windows-winapp-smoke.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = "Stop"
 
-if (-not $IsWindows) {
+if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
   throw "This smoke test must run on Windows."
 }
 

--- a/apps/zenx/src/main/capabilities/computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/computer-provider.ts
@@ -9,6 +9,7 @@ import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
 
 export interface ComputerTarget {
   pid?: number;
+  applicationId?: string;
   bundleId?: string;
   windowTitle?: string;
 }
@@ -23,7 +24,8 @@ export interface ComputerInspection {
   observationId: string;
   target: {
     pid: number;
-    bundleId: string;
+    applicationId?: string;
+    bundleId?: string;
     applicationName: string;
     windowTitle?: string;
   };
@@ -39,10 +41,14 @@ export interface ComputerInspection {
 }
 
 export interface ZenXComputerBackend {
-  inspect(target: ComputerTarget): Promise<ComputerInspection>;
+  inspect(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<ComputerInspection>;
   press(
     target: ComputerTarget,
     control: ComputerControlSelector,
+    signal?: AbortSignal,
   ): Promise<{
     target: ComputerInspection["target"];
     control: ComputerControlSelector;
@@ -51,12 +57,16 @@ export interface ZenXComputerBackend {
     target: ComputerTarget,
     control: ComputerControlSelector,
     value: string,
+    signal?: AbortSignal,
   ): Promise<{
     target: ComputerInspection["target"];
     control: ComputerControlSelector;
     characterCount: number;
   }>;
-  screenshot(target: ComputerTarget): Promise<{
+  screenshot(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<{
     artifactPath: string;
     target: ComputerInspection["target"];
     width: number;
@@ -87,6 +97,8 @@ export type ComputerKey =
   | "arrowRight";
 
 export const MAX_COMPUTER_INSPECTION_CONTROLS = 32;
+export const COMPUTER_ACTION_PRESS = "press";
+export const COMPUTER_ACTION_SET_VALUE = "set_value";
 
 export const computerCapabilityManifest: ZenXCapabilityManifest = {
   schemaVersion: 1,
@@ -121,7 +133,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
       id: "computer.accessibility.act",
       title: "Act on a targeted control",
       description:
-        "Perform AXPress or set AXValue on an explicitly selected accessibility control without global input.",
+        "Perform a semantic press or set a semantic value on an explicitly selected accessibility control without global input.",
       scope: "local-device",
     },
     {
@@ -143,7 +155,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "computer_inspect",
       description:
-        "Inspect at most 32 accessibility controls in one exact app window target without activating it or reading sibling windows. target.windowTitle is required.",
+        "Inspect at most 32 semantic accessibility controls in one exact app window target without activating it or reading sibling windows. target.windowTitle is required.",
       inputSchema: objectSchema({ target: targetSchema() }, ["target"]),
       permissions: ["computer.accessibility.inspect"],
       interactionMode: "background_safe",
@@ -157,7 +169,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "computer_press",
       description:
-        "Perform AXPress on one control returned by computer_inspect. Does not move the pointer, type keys, or activate the target app.",
+        "Perform a native semantic press on one control returned by computer_inspect. Does not move the pointer, type keys, or activate the target app.",
       inputSchema: objectSchema(
         { target: targetSchema(), control: controlSchema() },
         ["target", "control"],
@@ -169,7 +181,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "computer_set_value",
       description:
-        "Set a non-secret AXValue on one editable opaque target from the latest computer_inspect observation. Secure/password controls are rejected; supplied text is a canonical journaled tool argument.",
+        "Set a non-secret semantic value on one editable opaque target from the latest computer_inspect observation. Secure/password controls are rejected; supplied text is a canonical journaled tool argument.",
       inputSchema: objectSchema(
         {
           target: targetSchema(),
@@ -208,11 +220,15 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
 };
 
 export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
-  readonly manifest = computerCapabilityManifest;
+  readonly manifest: ZenXCapabilityManifest;
   readonly #backend: ZenXComputerBackend;
 
-  constructor(backend: ZenXComputerBackend) {
+  constructor(
+    backend: ZenXComputerBackend,
+    manifest = computerCapabilityManifest,
+  ) {
     this.#backend = backend;
+    this.manifest = manifest;
   }
 
   async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
@@ -223,12 +239,13 @@ export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
     switch (toolName) {
       case "computer_inspect":
         requireScopedWindow(target, "computer_inspect");
-        return await this.#backend.inspect(target);
+        return await this.#backend.inspect(target, invocation.signal);
       case "computer_press":
         requireScopedWindow(target, "computer_press");
         return await this.#backend.press(
           target,
           requiredControl(invocation.arguments),
+          invocation.signal,
         );
       case "computer_set_value": {
         requireScopedWindow(target, "computer_set_value");
@@ -240,13 +257,14 @@ export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
           target,
           requiredControl(invocation.arguments),
           value,
+          invocation.signal,
         );
       }
       case "computer_screenshot":
         if (target.windowTitle === undefined) {
           throw new Error("computer_screenshot requires target.windowTitle");
         }
-        return await this.#backend.screenshot(target);
+        return await this.#backend.screenshot(target, invocation.signal);
       default:
         throw new Error(`Unsupported computer tool: ${toolName}`);
     }
@@ -347,9 +365,12 @@ export class ComputerObservationLedger {
     if (fingerprint === undefined) {
       throw new Error("Computer target ID is forged, stale, or unknown");
     }
-    if (action === "press" && !fingerprint.actions.includes("AXPress")) {
+    if (
+      action === "press" &&
+      !fingerprint.actions.includes(COMPUTER_ACTION_PRESS)
+    ) {
       throw new Error(
-        "Control does not support background-safe semantic press; foreground_required",
+        "Control no longer supports background-safe semantic press; foreground_required",
       );
     }
     if (action === "set_value") {
@@ -358,9 +379,9 @@ export class ComputerObservationLedger {
           "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
         );
       }
-      if (!fingerprint.actions.includes("AXSetValue")) {
+      if (!fingerprint.actions.includes(COMPUTER_ACTION_SET_VALUE)) {
         throw new Error(
-          "Control does not support background-safe semantic set value; foreground_required",
+          "Control no longer supports background-safe semantic set value; foreground_required",
         );
       }
     }
@@ -401,8 +422,15 @@ function rawControlFingerprint(
   return {
     ...control.selector,
     secure: control.secure === true,
-    actions: [...control.actions],
+    actions: canonicalMacActions(control.actions),
   };
+}
+
+function canonicalMacActions(actions: readonly string[]): string[] {
+  return [
+    ...(actions.includes("AXPress") ? [COMPUTER_ACTION_PRESS] : []),
+    ...(actions.includes("AXSetValue") ? [COMPUTER_ACTION_SET_VALUE] : []),
+  ];
 }
 
 function semanticControlSelector(
@@ -415,6 +443,7 @@ function semanticControlSelector(
 function computerTargetKey(target: ComputerTarget): string {
   return JSON.stringify({
     pid: target.pid ?? null,
+    applicationId: target.applicationId ?? null,
     bundleId: target.bundleId ?? null,
     windowTitle: target.windowTitle ?? null,
   });
@@ -461,7 +490,7 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
         role: control.role,
         title: control.title,
         enabled: control.enabled,
-        actions: control.actions,
+        actions: rawControlFingerprint(control).actions,
         ...(control.secure ? { secure: true } : {}),
       })),
       truncated:
@@ -1150,16 +1179,28 @@ function foregroundTools(): ZenXCapabilityManifest["tools"] {
 function requiredTarget(arguments_: Record<string, unknown>): ComputerTarget {
   const raw = requiredObject(arguments_, "target");
   const pid = optionalPositiveInteger(raw, "pid");
+  const applicationId = optionalString(raw, "applicationId");
   const bundleId = optionalString(raw, "bundleId");
   const windowTitle = optionalString(raw, "windowTitle");
-  if (pid === undefined && bundleId === undefined) {
-    throw new Error("target requires pid or bundleId");
+  if (
+    pid === undefined &&
+    applicationId === undefined &&
+    bundleId === undefined
+  ) {
+    throw new Error("target requires pid, applicationId, or bundleId");
   }
   if (windowTitle !== undefined && windowTitle.length > 256) {
     throw new Error("target.windowTitle is limited to 256 characters");
   }
+  if (applicationId !== undefined && applicationId.length > 256) {
+    throw new Error("target.applicationId is limited to 256 characters");
+  }
+  if (bundleId !== undefined && bundleId.length > 256) {
+    throw new Error("target.bundleId is limited to 256 characters");
+  }
   return {
     ...(pid === undefined ? {} : { pid }),
+    ...(applicationId === undefined ? {} : { applicationId }),
     ...(bundleId === undefined ? {} : { bundleId }),
     ...(windowTitle === undefined ? {} : { windowTitle }),
   };
@@ -1289,11 +1330,16 @@ function targetSchema(): Record<string, unknown> {
     type: "object",
     properties: {
       pid: { type: "integer", minimum: 1 },
+      applicationId: stringSchema(),
       bundleId: stringSchema(),
       windowTitle: stringSchema(),
     },
     additionalProperties: false,
-    anyOf: [{ required: ["pid"] }, { required: ["bundleId"] }],
+    anyOf: [
+      { required: ["pid"] },
+      { required: ["applicationId"] },
+      { required: ["bundleId"] },
+    ],
   };
 }
 

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -39,7 +39,7 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
       "uia.inspect",
       "uia.invoke",
       "uia.set_value",
-      "uia.get_value.verify",
+      "uia.wait_for.verify",
       "wgc.capture",
       "cancellable",
       "bounded_output",
@@ -112,7 +112,7 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
     executable: "winapp",
     installCommand: WINAPP_INSTALL_COMMAND,
     jsonContract:
-      "ui list-windows/inspect/invoke/set-value/get-value/screenshot --json",
+      "ui list-windows/inspect/invoke/set-value/wait-for/screenshot --json",
     minimumVersion: MINIMUM_WINAPP_CLI_VERSION,
     docs: "https://learn.microsoft.com/windows/apps/dev-tools/winapp-cli/ui-automation",
   },
@@ -420,19 +420,36 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       [value],
     );
     requireConfirmedHwnd(result.hwnd, window.hwnd, "set-value");
-    const readback = await this.#json<{ elementId?: string; text?: unknown }>(
-      ["ui", "get-value", selector, "--window", window.hwnd, "--json"],
-      10_000,
+    const verification = await this.#json<{
+      found?: boolean;
+      timedOut?: boolean;
+      waitedMs?: number;
+    }>(
+      [
+        "ui",
+        "wait-for",
+        selector,
+        "--window",
+        window.hwnd,
+        "--value",
+        value,
+        "--timeout",
+        "3000",
+        "--json",
+      ],
+      5_000,
       signal,
       [value],
     );
     if (
-      readback.elementId !== selector ||
-      typeof readback.text !== "string" ||
-      normalizeUiText(readback.text) !== normalizeUiText(value)
+      verification.found !== true ||
+      verification.timedOut === true ||
+      !Number.isSafeInteger(verification.waitedMs) ||
+      (verification.waitedMs as number) < 0 ||
+      (verification.waitedMs as number) > 3_500
     ) {
       throw new Error(
-        "WinApp CLI set-value did not produce the expected UI Automation readback",
+        "WinApp CLI set-value did not satisfy the bounded UI Automation value assertion",
       );
     }
     const refreshedWindow = await this.#refreshWindow(window, signal);
@@ -879,10 +896,6 @@ function winAppControlType(element: WinAppElement): string | undefined {
   return element.controlType ?? element.type;
 }
 
-function normalizeUiText(value: string): string {
-  return value.replaceAll("\r", "").replace(/\n$/u, "");
-}
-
 function parseWinAppVersion(output: string): string | undefined {
   const match = output
     .trim()
@@ -946,12 +959,12 @@ function validateCliSchema(stdout: string, detectedVersion: string): void {
   const ui = nestedCommand(root, "subcommands", "ui");
   const subcommands = commandMap(ui.subcommands, "ui subcommands");
   const required = [
-    "get-value",
     "inspect",
     "invoke",
     "list-windows",
     "screenshot",
     "set-value",
+    "wait-for",
   ];
   const missing = required.filter(
     (command) => subcommands[command] === undefined,

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -24,6 +24,7 @@ const MAX_WINAPP_STDOUT_BYTES = 2 * 1024 * 1024;
 const MAX_WINAPP_STDERR_BYTES = 16 * 1024;
 const WINAPP_INSTALL_COMMAND =
   "winget install Microsoft.winappcli --source winget";
+export const MINIMUM_WINAPP_CLI_VERSION = "0.3.1";
 
 export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
   ...structuredClone(computerCapabilityManifest),
@@ -38,6 +39,7 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
       "uia.inspect",
       "uia.invoke",
       "uia.set_value",
+      "uia.get_value.verify",
       "wgc.capture",
       "cancellable",
       "bounded_output",
@@ -109,7 +111,9 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
     dependency: "Microsoft WinApp CLI (Public Preview)",
     executable: "winapp",
     installCommand: WINAPP_INSTALL_COMMAND,
-    jsonContract: "ui list-windows/inspect/invoke/set-value/screenshot --json",
+    jsonContract:
+      "ui list-windows/inspect/invoke/set-value/get-value/screenshot --json",
+    minimumVersion: MINIMUM_WINAPP_CLI_VERSION,
     docs: "https://learn.microsoft.com/windows/apps/dev-tools/winapp-cli/ui-automation",
   },
 };
@@ -119,6 +123,8 @@ export interface WinAppCliDiagnostic {
   platform: NodeJS.Platform;
   executable: string;
   version?: string;
+  requiredVersion: string;
+  schemaCompatible: boolean;
   installCommand: string;
   message: string;
 }
@@ -145,7 +151,7 @@ export interface WinAppCliRunner {
 }
 
 interface WinAppWindow {
-  hwnd: number;
+  hwnd: string;
   processId: number;
   processName: string;
   title?: string;
@@ -154,6 +160,7 @@ interface WinAppWindow {
 }
 
 interface WinAppElement {
+  controlType?: string;
   type?: string;
   name?: string;
   automationId?: string;
@@ -172,8 +179,12 @@ interface WinAppElement {
 }
 
 interface WinAppInspectEnvelope {
+  depth?: number;
+  interactive?: boolean;
+  hideDisabled?: boolean;
+  hideOffscreen?: boolean;
   windows?: Array<{
-    hwnd?: number;
+    hwnd?: unknown;
     title?: string;
     elementCount?: number;
     elements?: WinAppElement[];
@@ -186,7 +197,7 @@ interface WinAppScreenshotEnvelope {
   height?: number;
   processId?: number;
   windowTitle?: string;
-  hwnd?: number;
+  hwnd?: unknown;
 }
 
 export class SpawnWinAppCliRunner implements WinAppCliRunner {
@@ -229,10 +240,13 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
         ready: false,
         platform: this.#platform,
         executable: this.#command,
+        requiredVersion: MINIMUM_WINAPP_CLI_VERSION,
+        schemaCompatible: false,
         installCommand: WINAPP_INSTALL_COMMAND,
         message: "Microsoft WinApp CLI is only available on Windows",
       };
     }
+    let detectedVersion: string | undefined;
     try {
       const result = await this.#runner.run(this.#command, ["--version"], {
         timeoutMs: 5_000,
@@ -240,22 +254,73 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
         maxStdoutBytes: 4 * 1024,
         maxStderrBytes: 4 * 1024,
       });
-      const version = result.stdout.trim().slice(0, 128);
+      const version = parseWinAppVersion(result.stdout);
+      if (version === undefined) {
+        return {
+          ready: false,
+          platform: this.#platform,
+          executable: this.#command,
+          requiredVersion: MINIMUM_WINAPP_CLI_VERSION,
+          schemaCompatible: false,
+          installCommand: WINAPP_INSTALL_COMMAND,
+          message: `Microsoft WinApp CLI version is unknown; ${MINIMUM_WINAPP_CLI_VERSION} or newer is required`,
+        };
+      }
+      if (compareVersions(version, MINIMUM_WINAPP_CLI_VERSION) < 0) {
+        return {
+          ready: false,
+          platform: this.#platform,
+          executable: this.#command,
+          version,
+          requiredVersion: MINIMUM_WINAPP_CLI_VERSION,
+          schemaCompatible: false,
+          installCommand: WINAPP_INSTALL_COMMAND,
+          message: `Microsoft WinApp CLI ${version} is incompatible; ${MINIMUM_WINAPP_CLI_VERSION} or newer is required`,
+        };
+      }
+      detectedVersion = version;
+      const cliSchemaResult = await this.#runner.run(
+        this.#command,
+        ["--cli-schema"],
+        {
+          timeoutMs: 5_000,
+          signal,
+          maxStdoutBytes: 512 * 1024,
+          maxStderrBytes: 4 * 1024,
+        },
+      );
+      validateCliSchema(cliSchemaResult.stdout, version);
+      const probe = await this.#runner.run(
+        this.#command,
+        ["ui", "list-windows", "--json"],
+        {
+          timeoutMs: 5_000,
+          signal,
+          maxStdoutBytes: 256 * 1024,
+          maxStderrBytes: 4 * 1024,
+        },
+      );
+      validateWindowListProbe(probe.stdout);
       return {
         ready: true,
         platform: this.#platform,
         executable: this.#command,
-        ...(version.length === 0 ? {} : { version }),
+        version,
+        requiredVersion: MINIMUM_WINAPP_CLI_VERSION,
+        schemaCompatible: true,
         installCommand: WINAPP_INSTALL_COMMAND,
-        message: "Microsoft WinApp CLI is ready",
+        message: `Microsoft WinApp CLI ${version} is ready (requires ${MINIMUM_WINAPP_CLI_VERSION}+)`,
       };
     } catch (error) {
       return {
         ready: false,
         platform: this.#platform,
         executable: this.#command,
+        ...(detectedVersion === undefined ? {} : { version: detectedVersion }),
+        requiredVersion: MINIMUM_WINAPP_CLI_VERSION,
+        schemaCompatible: false,
         installCommand: WINAPP_INSTALL_COMMAND,
-        message: `${describeError(error)}. Install with: ${WINAPP_INSTALL_COMMAND}`,
+        message: `${describeError(error)} (detected ${detectedVersion ?? "unknown"}; requires ${MINIMUM_WINAPP_CLI_VERSION}+). Install with: ${WINAPP_INSTALL_COMMAND}`,
       };
     }
   }
@@ -282,7 +347,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       target: resolvedTarget(window),
       controls: controls.map((control, index) => ({
         selector: observation.selectors[index]!,
-        role: boundedText(control.type ?? "Control", 80),
+        role: boundedText(winAppControlType(control) ?? "Control", 80),
         title: boundedText(control.name ?? control.automationId ?? "", 256),
         enabled: control.isEnabled !== false,
         actions: fingerprints[index]!.actions,
@@ -312,7 +377,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     const selector = requiredProviderSelector(fingerprint);
     const window = await this.#resolveWindow(target, signal);
     await this.#revalidateControl(window, fingerprint, "press", signal);
-    const result = await this.#json<{ hwnd?: number }>(
+    const result = await this.#json<{ hwnd?: unknown }>(
       ["ui", "invoke", selector, "--window", String(window.hwnd), "--json"],
       10_000,
       signal,
@@ -340,7 +405,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     const selector = requiredProviderSelector(fingerprint);
     const window = await this.#resolveWindow(target, signal);
     await this.#revalidateControl(window, fingerprint, "set_value", signal);
-    const result = await this.#json<{ hwnd?: number }>(
+    const result = await this.#json<{ hwnd?: unknown }>(
       [
         "ui",
         "set-value",
@@ -355,8 +420,24 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       [value],
     );
     requireConfirmedHwnd(result.hwnd, window.hwnd, "set-value");
+    const readback = await this.#json<{ elementId?: string; text?: unknown }>(
+      ["ui", "get-value", selector, "--window", window.hwnd, "--json"],
+      10_000,
+      signal,
+      [value],
+    );
+    if (
+      readback.elementId !== selector ||
+      typeof readback.text !== "string" ||
+      normalizeUiText(readback.text) !== normalizeUiText(value)
+    ) {
+      throw new Error(
+        "WinApp CLI set-value did not produce the expected UI Automation readback",
+      );
+    }
+    const refreshedWindow = await this.#refreshWindow(window, signal);
     return {
-      target: resolvedTarget(window),
+      target: resolvedTarget(refreshedWindow),
       control,
       characterCount: value.length,
     };
@@ -400,7 +481,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       throw error;
     }
     if (
-      result.hwnd !== window.hwnd ||
+      !sameHwnd(result.hwnd, window.hwnd) ||
       path.resolve(result.filePath ?? "") !== path.resolve(artifactPath)
     ) {
       await rm(artifactPath, { force: true });
@@ -487,6 +568,33 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     return matches[0]!;
   }
 
+  async #refreshWindow(
+    previous: WinAppWindow,
+    signal?: AbortSignal,
+  ): Promise<WinAppWindow> {
+    const result = await this.#json<unknown>(
+      ["ui", "list-windows", "--app", String(previous.processId), "--json"],
+      10_000,
+      signal,
+    );
+    if (!Array.isArray(result)) {
+      throw new Error("WinApp CLI list-windows returned an invalid JSON shape");
+    }
+    const matches = result
+      .map(parseWindow)
+      .filter(
+        (candidate) =>
+          candidate.processId === previous.processId &&
+          candidate.hwnd === previous.hwnd,
+      );
+    if (matches.length !== 1) {
+      throw new Error(
+        "The targeted Windows HWND changed or became ambiguous after set-value",
+      );
+    }
+    return matches[0]!;
+  }
+
   async #inspectWindow(
     window: WinAppWindow,
     signal?: AbortSignal,
@@ -506,8 +614,9 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       DEFAULT_TIMEOUT_MS,
       signal,
     );
-    const inspectedWindow = envelope.windows?.find(
-      (candidate) => candidate.hwnd === window.hwnd,
+    validateInspectEnvelope(envelope);
+    const inspectedWindow = envelope.windows?.find((candidate) =>
+      sameHwnd(candidate.hwnd, window.hwnd),
     );
     if (inspectedWindow === undefined) {
       throw new Error(
@@ -692,7 +801,7 @@ function winAppFingerprint(element: WinAppElement): ComputerControlFingerprint {
   }
   return {
     identifier: element.selector,
-    role: element.type,
+    role: winAppControlType(element),
     title: boundedText(element.name ?? "", 256),
     description: boundedText(element.automationId ?? "", 256),
     frame: [element.x, element.y, element.width, element.height]
@@ -720,13 +829,18 @@ function sameSemanticFingerprint(
 function isEditableElement(element: WinAppElement): boolean {
   if (element.value !== undefined && element.value !== null) return true;
   return /(?:edit|textbox|document|combobox|spinner|slider)/iu.test(
-    `${element.type ?? ""} ${element.className ?? ""}`,
+    `${winAppControlType(element) ?? ""} ${element.className ?? ""}`,
   );
 }
 
 function isSecureElement(element: WinAppElement): boolean {
   return /(?:password|passwd|passcode|pin|secret|secure|credential|token)/iu.test(
-    [element.type, element.name, element.automationId, element.className]
+    [
+      winAppControlType(element),
+      element.name,
+      element.automationId,
+      element.className,
+    ]
       .filter((value): value is string => typeof value === "string")
       .join(" "),
   );
@@ -761,13 +875,187 @@ function computerTargetKey(target: ComputerTarget): string {
   });
 }
 
+function winAppControlType(element: WinAppElement): string | undefined {
+  return element.controlType ?? element.type;
+}
+
+function normalizeUiText(value: string): string {
+  return value.replaceAll("\r", "").replace(/\n$/u, "");
+}
+
+function parseWinAppVersion(output: string): string | undefined {
+  const match = output
+    .trim()
+    .match(
+      /(?:^|[^0-9])(\d+)\.(\d+)\.(\d+)(?:[-+][0-9A-Za-z.-]+)?(?:$|[^0-9])/u,
+    );
+  if (match === null) return undefined;
+  return `${match[1]}.${match[2]}.${match[3]}`;
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0);
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function validateWindowListProbe(stdout: string): void {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `Microsoft WinApp CLI ${MINIMUM_WINAPP_CLI_VERSION}+ JSON schema probe returned malformed JSON`,
+    );
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(
+      `Microsoft WinApp CLI ${MINIMUM_WINAPP_CLI_VERSION}+ JSON schema probe returned an incompatible list-windows shape`,
+    );
+  }
+  for (const entry of value) parseWindow(entry);
+}
+
+function validateCliSchema(stdout: string, detectedVersion: string): void {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      "Microsoft WinApp CLI --cli-schema returned malformed JSON",
+    );
+  }
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Microsoft WinApp CLI returned an incompatible CLI schema");
+  }
+  const root = value as Record<string, unknown>;
+  const schemaVersion = root.schemaVersion;
+  const schemaCliVersion =
+    typeof root.version === "string"
+      ? parseWinAppVersion(root.version)
+      : undefined;
+  if (schemaVersion !== "1.0" || schemaCliVersion !== detectedVersion) {
+    throw new Error(
+      `Microsoft WinApp CLI schema/version mismatch (schema ${String(schemaVersion)}, CLI ${schemaCliVersion ?? "unknown"})`,
+    );
+  }
+  const ui = nestedCommand(root, "subcommands", "ui");
+  const subcommands = commandMap(ui.subcommands, "ui subcommands");
+  const required = [
+    "get-value",
+    "inspect",
+    "invoke",
+    "list-windows",
+    "screenshot",
+    "set-value",
+  ];
+  const missing = required.filter(
+    (command) => subcommands[command] === undefined,
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `Microsoft WinApp CLI schema is missing required UI commands: ${missing.join(", ")}`,
+    );
+  }
+}
+
+function nestedCommand(
+  parent: Record<string, unknown>,
+  collectionKey: string,
+  command: string,
+): Record<string, unknown> {
+  const commands = commandMap(parent[collectionKey], collectionKey);
+  const value = commands[command];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(
+      `Microsoft WinApp CLI schema is missing required command ${command}`,
+    );
+  }
+  return value as Record<string, unknown>;
+}
+
+function commandMap(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Microsoft WinApp CLI returned invalid ${label}`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function validateInspectEnvelope(
+  envelope: WinAppInspectEnvelope,
+): asserts envelope is WinAppInspectEnvelope & {
+  windows: Array<{
+    hwnd: unknown;
+    title?: string;
+    elementCount?: number;
+    elements?: WinAppElement[];
+  }>;
+} {
+  if (
+    typeof envelope !== "object" ||
+    envelope === null ||
+    !Array.isArray(envelope.windows)
+  ) {
+    throw new Error(
+      `WinApp CLI inspect returned an incompatible JSON shape; ${MINIMUM_WINAPP_CLI_VERSION}+ is required`,
+    );
+  }
+  for (const window of envelope.windows) {
+    if (typeof window !== "object" || window === null) {
+      throw new Error("WinApp CLI inspect returned an invalid window entry");
+    }
+    normalizeHwnd(window.hwnd, "inspect window hwnd");
+    if (window.elements !== undefined) {
+      if (!Array.isArray(window.elements)) {
+        throw new Error("WinApp CLI inspect returned invalid elements");
+      }
+      validateElements(window.elements);
+    }
+  }
+}
+
+function validateElements(elements: readonly WinAppElement[]): void {
+  const stack = [...elements];
+  let visited = 0;
+  while (stack.length > 0) {
+    const element = stack.pop();
+    if (typeof element !== "object" || element === null) {
+      throw new Error("WinApp CLI inspect returned an invalid element");
+    }
+    visited += 1;
+    if (visited > 4_096) {
+      throw new Error(
+        "WinApp CLI inspect exceeded its schema validation bound",
+      );
+    }
+    if (
+      element.selector !== undefined &&
+      typeof winAppControlType(element) !== "string"
+    ) {
+      throw new Error(
+        `WinApp CLI inspect uses an incompatible element schema; ${MINIMUM_WINAPP_CLI_VERSION}+ element type metadata is required`,
+      );
+    }
+    if (element.children !== undefined) {
+      if (!Array.isArray(element.children)) {
+        throw new Error("WinApp CLI inspect returned invalid element children");
+      }
+      stack.push(...element.children);
+    }
+  }
+}
+
 function parseWindow(value: unknown): WinAppWindow {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("WinApp CLI returned an invalid window entry");
   }
   const record = value as Record<string, unknown>;
   return {
-    hwnd: positiveInteger(record.hwnd, "window hwnd"),
+    hwnd: normalizeHwnd(record.hwnd, "window hwnd"),
     processId: positiveInteger(record.processId, "window processId"),
     processName: requiredBoundedString(record.processName, "processName", 256),
     ...(typeof record.title === "string"
@@ -796,14 +1084,38 @@ function positiveInteger(value: unknown, label: string): number {
 
 function requireConfirmedHwnd(
   actual: unknown,
-  expected: number,
+  expected: string,
   action: string,
 ): void {
-  if (actual !== expected) {
+  if (!sameHwnd(actual, expected)) {
     throw new Error(
       `WinApp CLI ${action} did not confirm the explicitly targeted HWND`,
     );
   }
+}
+
+function sameHwnd(actual: unknown, expected: string): boolean {
+  try {
+    return normalizeHwnd(actual, "HWND") === expected;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeHwnd(value: unknown, label: string): string {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`WinApp CLI returned an invalid ${label}`);
+    }
+    return String(value);
+  }
+  if (typeof value !== "string") {
+    throw new Error(`WinApp CLI returned an invalid ${label}`);
+  }
+  const normalized = value.trim().toLowerCase();
+  if (/^0x[0-9a-f]+$/u.test(normalized)) return normalized;
+  if (/^[1-9][0-9]*$/u.test(normalized)) return normalized;
+  throw new Error(`WinApp CLI returned an invalid ${label}`);
 }
 
 function nonNegativeInteger(value: unknown, label: string): number {

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -497,13 +497,15 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       await rm(artifactPath, { force: true });
       throw error;
     }
-    if (
-      !sameHwnd(result.hwnd, window.hwnd) ||
-      path.resolve(result.filePath ?? "") !== path.resolve(artifactPath)
-    ) {
+    const hwndConfirmed = sameHwnd(result.hwnd, window.hwnd);
+    const artifactConfirmed = sameWindowsPath(
+      result.filePath ?? "",
+      artifactPath,
+    );
+    if (!hwndConfirmed || !artifactConfirmed) {
       await rm(artifactPath, { force: true });
       throw new Error(
-        "WinApp CLI screenshot did not confirm the explicitly targeted window and artifact path",
+        `WinApp CLI screenshot did not confirm the explicitly targeted window and artifact path (HWND confirmed: ${String(hwndConfirmed)}; artifact confirmed: ${String(artifactConfirmed)})`,
       );
     }
     const metadata = await stat(artifactPath);
@@ -1126,9 +1128,20 @@ function normalizeHwnd(value: unknown, label: string): string {
     throw new Error(`WinApp CLI returned an invalid ${label}`);
   }
   const normalized = value.trim().toLowerCase();
-  if (/^0x[0-9a-f]+$/u.test(normalized)) return normalized;
-  if (/^[1-9][0-9]*$/u.test(normalized)) return normalized;
+  if (/^0x[0-9a-f]+$/u.test(normalized)) {
+    return BigInt(normalized).toString(10);
+  }
+  if (/^[1-9][0-9]*$/u.test(normalized)) {
+    return BigInt(normalized).toString(10);
+  }
   throw new Error(`WinApp CLI returned an invalid ${label}`);
+}
+
+function sameWindowsPath(actual: string, expected: string): boolean {
+  if (actual.length === 0) return false;
+  const normalize = (value: string): string =>
+    path.resolve(value).replace(/^\\\\\?\\/u, "").toLocaleLowerCase("en-US");
+  return normalize(actual) === normalize(expected);
 }
 
 function nonNegativeInteger(value: unknown, label: string): number {

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, realpath, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -498,7 +498,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       throw error;
     }
     const hwndConfirmed = sameHwnd(result.hwnd, window.hwnd);
-    const artifactConfirmed = sameWindowsPath(
+    const artifactConfirmed = await sameWindowsFile(
       result.filePath ?? "",
       artifactPath,
     );
@@ -1137,11 +1137,25 @@ function normalizeHwnd(value: unknown, label: string): string {
   throw new Error(`WinApp CLI returned an invalid ${label}`);
 }
 
-function sameWindowsPath(actual: string, expected: string): boolean {
+async function sameWindowsFile(
+  actual: string,
+  expected: string,
+): Promise<boolean> {
   if (actual.length === 0) return false;
-  const normalize = (value: string): string =>
-    path.resolve(value).replace(/^\\\\\?\\/u, "").toLocaleLowerCase("en-US");
-  return normalize(actual) === normalize(expected);
+  try {
+    const [actualRealPath, expectedRealPath] = await Promise.all([
+      realpath(actual),
+      realpath(expected),
+    ]);
+    const normalize = (value: string): string =>
+      path
+        .resolve(value)
+        .replace(/^\\\\\?\\/u, "")
+        .toLocaleLowerCase("en-US");
+    return normalize(actualRealPath) === normalize(expectedRealPath);
+  } catch {
+    return false;
+  }
 }
 
 function nonNegativeInteger(value: unknown, label: string): number {

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -1,0 +1,856 @@
+import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { mkdir, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  COMPUTER_ACTION_PRESS,
+  COMPUTER_ACTION_SET_VALUE,
+  computerCapabilityManifest,
+  ComputerObservationLedger,
+  type ComputerControlFingerprint,
+  type ComputerControlSelector,
+  type ComputerInspection,
+  type ComputerKey,
+  type ComputerTarget,
+  MAX_COMPUTER_INSPECTION_CONTROLS,
+  type ZenXComputerBackend,
+} from "./computer-provider.js";
+import type { ZenXCapabilityManifest } from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_WINAPP_STDOUT_BYTES = 2 * 1024 * 1024;
+const MAX_WINAPP_STDERR_BYTES = 16 * 1024;
+const WINAPP_INSTALL_COMMAND =
+  "winget install Microsoft.winappcli --source winget";
+
+export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
+  ...structuredClone(computerCapabilityManifest),
+  version: "1.1.0",
+  description:
+    "Optional Windows desktop operations backed by Microsoft's WinApp CLI: targeted UI Automation and WGC capture stay background-safe; unsupported global input never silently substitutes for them.",
+  provider: {
+    id: "microsoft-winapp-cli",
+    platforms: ["win32"],
+    interactionModes: ["background_safe"],
+    capabilities: [
+      "uia.inspect",
+      "uia.invoke",
+      "uia.set_value",
+      "wgc.capture",
+      "cancellable",
+      "bounded_output",
+    ],
+  },
+  permissions: computerCapabilityManifest.permissions.map((permission) => {
+    if (permission.id === "computer.accessibility.act") {
+      return {
+        ...permission,
+        description:
+          "Invoke or set a value through Windows UI Automation on an explicitly selected control.",
+      };
+    }
+    if (permission.id === "computer.window.capture") {
+      return {
+        ...permission,
+        description:
+          "Capture one explicitly targeted HWND through WinApp CLI's background-safe default capture path.",
+      };
+    }
+    return permission;
+  }),
+  tools: computerCapabilityManifest.tools
+    .filter((tool) => tool.interactionMode === "background_safe")
+    .map((tool) => {
+      switch (tool.name) {
+        case "computer_inspect":
+          return {
+            ...tool,
+            description:
+              "Inspect at most 32 semantic UI Automation controls in one exact Windows HWND without activating it or reading sibling windows. target.windowTitle is required.",
+            capabilities: ["uia.inspect", "app_targeted", "no_global_input"],
+          };
+        case "computer_press":
+          return {
+            ...tool,
+            description:
+              "Invoke one opaque control from the latest computer_inspect through Windows UI Automation. The provider revalidates selector, semantics, geometry, secure state, and action immediately before invoking.",
+            capabilities: ["uia.invoke", "app_targeted", "no_global_input"],
+          };
+        case "computer_set_value":
+          return {
+            ...tool,
+            description:
+              "Set a non-secret value on one opaque editable control through Windows UI Automation. The provider revalidates selector, semantics, geometry, secure state, and action; supplied text is a canonical journaled tool argument.",
+            capabilities: ["uia.set_value", "app_targeted", "no_global_input"],
+          };
+        default:
+          return {
+            ...tool,
+            description:
+              "Capture one exact Windows HWND through WinApp CLI's default WGC/PrintWindow path to a private five-minute PNG artifact. Returns metadata/path, never pixels in the Thread journal.",
+            capabilities: ["wgc.capture", "app_targeted", "no_global_input"],
+          };
+      }
+    }),
+  resources: [
+    {
+      id: "windows-computer-use",
+      kind: "skill",
+      title: "Targeted Windows computer use",
+      description:
+        "Use Microsoft WinApp CLI UI Automation through ZenX's opaque observe-before-act contract.",
+      content:
+        "Target one Windows application by pid or applicationId plus an exact windowTitle. Inspect first, then use only the observationId and targetId returned by the latest computer_inspect. Re-inspect after every action. Semantic invoke and set-value use UI Automation and do not inject global input. computer_set_value is non-secret-only because tool arguments are journaled; secure-looking controls are rejected. Window capture uses WinApp CLI's default WGC/PrintWindow path and never opts into --capture-screen or --focus. If UIA semantics are insufficient, report foreground_required; this provider does not silently inject pointer or keyboard input.",
+    },
+  ],
+  settings: {
+    dependency: "Microsoft WinApp CLI (Public Preview)",
+    executable: "winapp",
+    installCommand: WINAPP_INSTALL_COMMAND,
+    jsonContract: "ui list-windows/inspect/invoke/set-value/screenshot --json",
+    docs: "https://learn.microsoft.com/windows/apps/dev-tools/winapp-cli/ui-automation",
+  },
+};
+
+export interface WinAppCliDiagnostic {
+  ready: boolean;
+  platform: NodeJS.Platform;
+  executable: string;
+  version?: string;
+  installCommand: string;
+  message: string;
+}
+
+export interface WinAppCliRunOptions {
+  timeoutMs: number;
+  signal?: AbortSignal;
+  maxStdoutBytes?: number;
+  maxStderrBytes?: number;
+  redactions?: readonly string[];
+}
+
+export interface WinAppCliRunResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface WinAppCliRunner {
+  run(
+    executable: string,
+    args: readonly string[],
+    options: WinAppCliRunOptions,
+  ): Promise<WinAppCliRunResult>;
+}
+
+interface WinAppWindow {
+  hwnd: number;
+  processId: number;
+  processName: string;
+  title?: string;
+  width: number;
+  height: number;
+}
+
+interface WinAppElement {
+  type?: string;
+  name?: string;
+  automationId?: string;
+  className?: string;
+  isEnabled?: boolean;
+  isOffscreen?: boolean;
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  selector?: string;
+  value?: unknown;
+  isInvokable?: boolean;
+  hasMoreChildren?: boolean;
+  children?: WinAppElement[];
+}
+
+interface WinAppInspectEnvelope {
+  windows?: Array<{
+    hwnd?: number;
+    title?: string;
+    elementCount?: number;
+    elements?: WinAppElement[];
+  }>;
+}
+
+interface WinAppScreenshotEnvelope {
+  filePath?: string;
+  width?: number;
+  height?: number;
+  processId?: number;
+  windowTitle?: string;
+  hwnd?: number;
+}
+
+export class SpawnWinAppCliRunner implements WinAppCliRunner {
+  async run(
+    executable: string,
+    args: readonly string[],
+    options: WinAppCliRunOptions,
+  ): Promise<WinAppCliRunResult> {
+    return await runBoundedProcess(executable, args, options);
+  }
+}
+
+export class WinAppCliComputerBackend implements ZenXComputerBackend {
+  readonly #artifactDirectory: string;
+  readonly #command: string;
+  readonly #expiryTimers = new Set<NodeJS.Timeout>();
+  readonly #observations = new ComputerObservationLedger();
+  readonly #platform: NodeJS.Platform;
+  readonly #runner: WinAppCliRunner;
+
+  constructor(
+    options: {
+      artifactDirectory?: string;
+      command?: string;
+      platform?: NodeJS.Platform;
+      runner?: WinAppCliRunner;
+    } = {},
+  ) {
+    this.#artifactDirectory =
+      options.artifactDirectory ??
+      path.join(os.tmpdir(), `zenx-winapp-artifacts-${String(process.pid)}`);
+    this.#command = options.command ?? "winapp";
+    this.#platform = options.platform ?? process.platform;
+    this.#runner = options.runner ?? new SpawnWinAppCliRunner();
+  }
+
+  async diagnose(signal?: AbortSignal): Promise<WinAppCliDiagnostic> {
+    if (this.#platform !== "win32") {
+      return {
+        ready: false,
+        platform: this.#platform,
+        executable: this.#command,
+        installCommand: WINAPP_INSTALL_COMMAND,
+        message: "Microsoft WinApp CLI is only available on Windows",
+      };
+    }
+    try {
+      const result = await this.#runner.run(this.#command, ["--version"], {
+        timeoutMs: 5_000,
+        signal,
+        maxStdoutBytes: 4 * 1024,
+        maxStderrBytes: 4 * 1024,
+      });
+      const version = result.stdout.trim().slice(0, 128);
+      return {
+        ready: true,
+        platform: this.#platform,
+        executable: this.#command,
+        ...(version.length === 0 ? {} : { version }),
+        installCommand: WINAPP_INSTALL_COMMAND,
+        message: "Microsoft WinApp CLI is ready",
+      };
+    } catch (error) {
+      return {
+        ready: false,
+        platform: this.#platform,
+        executable: this.#command,
+        installCommand: WINAPP_INSTALL_COMMAND,
+        message: `${describeError(error)}. Install with: ${WINAPP_INSTALL_COMMAND}`,
+      };
+    }
+  }
+
+  async inspect(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<ComputerInspection> {
+    this.#requireWindows();
+    const window = await this.#resolveWindow(target, signal);
+    const inspectedWindow = await this.#inspectWindow(window, signal);
+    const flattened = flattenElements(inspectedWindow.elements ?? []);
+    const controls = flattened
+      .filter((element) => usableSelector(element.selector))
+      .slice(0, MAX_COMPUTER_INSPECTION_CONTROLS);
+    const fingerprints = controls.map(winAppFingerprint);
+    const observation = this.#observations.observe(
+      computerTargetKey(target),
+      fingerprints,
+    );
+    return {
+      platform: "win32",
+      observationId: observation.observationId,
+      target: resolvedTarget(window),
+      controls: controls.map((control, index) => ({
+        selector: observation.selectors[index]!,
+        role: boundedText(control.type ?? "Control", 80),
+        title: boundedText(control.name ?? control.automationId ?? "", 256),
+        enabled: control.isEnabled !== false,
+        actions: fingerprints[index]!.actions,
+        ...(fingerprints[index]!.secure ? { secure: true } : {}),
+      })),
+      truncated:
+        flattened.length > MAX_COMPUTER_INSPECTION_CONTROLS ||
+        flattened.some((element) => element.hasMoreChildren === true) ||
+        (inspectedWindow.elementCount ?? flattened.length) > flattened.length,
+    };
+  }
+
+  async press(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    signal?: AbortSignal,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+  }> {
+    this.#requireWindows();
+    const fingerprint = this.#observations.consume(
+      computerTargetKey(target),
+      control,
+      "press",
+    );
+    const selector = requiredProviderSelector(fingerprint);
+    const window = await this.#resolveWindow(target, signal);
+    await this.#revalidateControl(window, fingerprint, "press", signal);
+    const result = await this.#json<{ hwnd?: number }>(
+      ["ui", "invoke", selector, "--window", String(window.hwnd), "--json"],
+      10_000,
+      signal,
+    );
+    requireConfirmedHwnd(result.hwnd, window.hwnd, "invoke");
+    return { target: resolvedTarget(window), control };
+  }
+
+  async setValue(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    value: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+    characterCount: number;
+  }> {
+    this.#requireWindows();
+    const fingerprint = this.#observations.consume(
+      computerTargetKey(target),
+      control,
+      "set_value",
+    );
+    const selector = requiredProviderSelector(fingerprint);
+    const window = await this.#resolveWindow(target, signal);
+    await this.#revalidateControl(window, fingerprint, "set_value", signal);
+    const result = await this.#json<{ hwnd?: number }>(
+      [
+        "ui",
+        "set-value",
+        selector,
+        value,
+        "--window",
+        String(window.hwnd),
+        "--json",
+      ],
+      10_000,
+      signal,
+      [value],
+    );
+    requireConfirmedHwnd(result.hwnd, window.hwnd, "set-value");
+    return {
+      target: resolvedTarget(window),
+      control,
+      characterCount: value.length,
+    };
+  }
+
+  async screenshot(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<{
+    artifactPath: string;
+    target: ComputerInspection["target"];
+    width: number;
+    height: number;
+    bytes: number;
+    expiresAt: string;
+  }> {
+    this.#requireWindows();
+    const window = await this.#resolveWindow(target, signal);
+    await mkdir(this.#artifactDirectory, { recursive: true, mode: 0o700 });
+    const artifactPath = path.join(
+      this.#artifactDirectory,
+      `${randomUUID()}.png`,
+    );
+    let result: WinAppScreenshotEnvelope;
+    try {
+      result = await this.#json<WinAppScreenshotEnvelope>(
+        [
+          "ui",
+          "screenshot",
+          "--window",
+          String(window.hwnd),
+          "--output",
+          artifactPath,
+          "--json",
+        ],
+        20_000,
+        signal,
+      );
+    } catch (error) {
+      await rm(artifactPath, { force: true });
+      throw error;
+    }
+    if (
+      result.hwnd !== window.hwnd ||
+      path.resolve(result.filePath ?? "") !== path.resolve(artifactPath)
+    ) {
+      await rm(artifactPath, { force: true });
+      throw new Error(
+        "WinApp CLI screenshot did not confirm the explicitly targeted window and artifact path",
+      );
+    }
+    const metadata = await stat(artifactPath);
+    const expiresAt = new Date(Date.now() + 5 * 60_000);
+    const timer = setTimeout(() => {
+      this.#expiryTimers.delete(timer);
+      void rm(artifactPath, { force: true });
+    }, 5 * 60_000);
+    timer.unref();
+    this.#expiryTimers.add(timer);
+    return {
+      artifactPath,
+      target: resolvedTarget(window),
+      width: positiveInteger(result.width, "screenshot width"),
+      height: positiveInteger(result.height, "screenshot height"),
+      bytes: metadata.size,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  async foregroundClick(): Promise<void> {
+    throw unsupportedForeground();
+  }
+
+  async foregroundKeyPress(_key: ComputerKey): Promise<void> {
+    throw unsupportedForeground();
+  }
+
+  async foregroundScroll(): Promise<void> {
+    throw unsupportedForeground();
+  }
+
+  async close(): Promise<void> {
+    this.#observations.clear();
+    for (const timer of this.#expiryTimers) clearTimeout(timer);
+    this.#expiryTimers.clear();
+    await rm(this.#artifactDirectory, { recursive: true, force: true });
+  }
+
+  async #resolveWindow(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<WinAppWindow> {
+    if (target.windowTitle === undefined) {
+      throw new Error(
+        "Windows computer operations require target.windowTitle for exact HWND scoping",
+      );
+    }
+    const app =
+      target.pid ?? target.applicationId ?? target.bundleId ?? undefined;
+    if (app === undefined) {
+      throw new Error("Windows target requires pid or applicationId");
+    }
+    const result = await this.#json<unknown>(
+      ["ui", "list-windows", "--app", String(app), "--json"],
+      10_000,
+      signal,
+    );
+    if (!Array.isArray(result)) {
+      throw new Error("WinApp CLI list-windows returned an invalid JSON shape");
+    }
+    const matches = result
+      .map(parseWindow)
+      .filter(
+        (candidate) =>
+          candidate.title === target.windowTitle &&
+          (target.pid === undefined || candidate.processId === target.pid),
+      );
+    if (matches.length === 0) {
+      throw new Error(
+        "The exact Windows app/window target was not found; run computer_inspect again with a current pid/applicationId and windowTitle",
+      );
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        "The Windows app/window target is ambiguous; use the exact process pid and windowTitle",
+      );
+    }
+    return matches[0]!;
+  }
+
+  async #inspectWindow(
+    window: WinAppWindow,
+    signal?: AbortSignal,
+  ): Promise<NonNullable<WinAppInspectEnvelope["windows"]>[number]> {
+    const envelope = await this.#json<WinAppInspectEnvelope>(
+      [
+        "ui",
+        "inspect",
+        "--window",
+        String(window.hwnd),
+        "--depth",
+        "8",
+        "--hide-disabled",
+        "--hide-offscreen",
+        "--json",
+      ],
+      DEFAULT_TIMEOUT_MS,
+      signal,
+    );
+    const inspectedWindow = envelope.windows?.find(
+      (candidate) => candidate.hwnd === window.hwnd,
+    );
+    if (inspectedWindow === undefined) {
+      throw new Error(
+        "WinApp CLI inspect returned no data for the explicitly targeted window",
+      );
+    }
+    return inspectedWindow;
+  }
+
+  async #revalidateControl(
+    window: WinAppWindow,
+    expected: ComputerControlFingerprint,
+    action: "press" | "set_value",
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const selector = requiredProviderSelector(expected);
+    const inspectedWindow = await this.#inspectWindow(window, signal);
+    const matches = flattenElements(inspectedWindow.elements ?? []).filter(
+      (element) => element.selector === selector,
+    );
+    if (matches.length !== 1) {
+      throw new Error(
+        "The WinApp control is stale, missing, or ambiguous; inspect the target again",
+      );
+    }
+    const actual = winAppFingerprint(matches[0]!);
+    if (action === "set_value" && actual.secure) {
+      throw new Error(
+        "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
+      );
+    }
+    if (!sameSemanticFingerprint(expected, actual)) {
+      throw new Error(
+        "The WinApp control changed since the observation; inspect the target again",
+      );
+    }
+    const requiredAction =
+      action === "press" ? COMPUTER_ACTION_PRESS : COMPUTER_ACTION_SET_VALUE;
+    if (!actual.actions.includes(requiredAction)) {
+      throw new Error(
+        `The WinApp control no longer supports ${requiredAction}; inspect the target again`,
+      );
+    }
+  }
+
+  async #json<T>(
+    args: readonly string[],
+    timeoutMs: number,
+    signal?: AbortSignal,
+    redactions?: readonly string[],
+  ): Promise<T> {
+    const result = await this.#runner.run(this.#command, args, {
+      timeoutMs,
+      signal,
+      maxStdoutBytes: MAX_WINAPP_STDOUT_BYTES,
+      maxStderrBytes: MAX_WINAPP_STDERR_BYTES,
+      redactions,
+    });
+    try {
+      return JSON.parse(result.stdout) as T;
+    } catch {
+      throw new Error("WinApp CLI returned malformed JSON");
+    }
+  }
+
+  #requireWindows(): void {
+    if (this.#platform !== "win32") {
+      throw new Error(
+        "Microsoft WinApp CLI computer provider requires Windows",
+      );
+    }
+  }
+}
+
+export async function runBoundedProcess(
+  executable: string,
+  args: readonly string[],
+  options: WinAppCliRunOptions,
+): Promise<WinAppCliRunResult> {
+  options.signal?.throwIfAborted();
+  return await new Promise<WinAppCliRunResult>((resolve, reject) => {
+    const child = spawn(executable, args, {
+      shell: false,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let settled = false;
+    const maxStdout = options.maxStdoutBytes ?? MAX_WINAPP_STDOUT_BYTES;
+    const maxStderr = options.maxStderrBytes ?? MAX_WINAPP_STDERR_BYTES;
+    const finish = (callback: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      options.signal?.removeEventListener("abort", abort);
+      callback();
+    };
+    const failAndKill = (error: Error): void => {
+      child.kill("SIGKILL");
+      finish(() => reject(error));
+    };
+    const timer = setTimeout(() => {
+      failAndKill(
+        new Error(
+          `${path.basename(executable)} timed out after ${String(options.timeoutMs)}ms`,
+        ),
+      );
+    }, options.timeoutMs);
+    const abort = (): void => {
+      failAndKill(
+        options.signal?.reason instanceof Error
+          ? options.signal.reason
+          : new DOMException("WinApp CLI operation cancelled", "AbortError"),
+      );
+    };
+    options.signal?.addEventListener("abort", abort, { once: true });
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes > maxStdout) {
+        failAndKill(new Error("WinApp CLI stdout exceeded its bounded limit"));
+        return;
+      }
+      stdout.push(chunk);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderrBytes += chunk.length;
+      if (stderrBytes > maxStderr) {
+        failAndKill(new Error("WinApp CLI stderr exceeded its bounded limit"));
+        return;
+      }
+      stderr.push(chunk);
+    });
+    child.once("error", (error) => finish(() => reject(error)));
+    child.once("close", (code, exitSignal) => {
+      finish(() => {
+        if (code === 0) {
+          resolve({
+            stdout: Buffer.concat(stdout).toString("utf8"),
+            stderr: Buffer.concat(stderr).toString("utf8"),
+          });
+          return;
+        }
+        const detail = redactDiagnostic(
+          `${Buffer.concat(stderr).toString("utf8")} ${Buffer.concat(stdout).toString("utf8")}`,
+          options.redactions,
+        );
+        reject(
+          new Error(
+            `${path.basename(executable)} failed (${exitSignal ?? String(code)}): ${detail}`,
+          ),
+        );
+      });
+    });
+    if (options.signal?.aborted === true) abort();
+  });
+}
+
+function flattenElements(roots: readonly WinAppElement[]): WinAppElement[] {
+  const result: WinAppElement[] = [];
+  const stack = [...roots].reverse();
+  while (stack.length > 0) {
+    const element = stack.pop()!;
+    result.push(element);
+    if (result.length >= 512) break;
+    const children = element.children ?? [];
+    for (let index = children.length - 1; index >= 0; index -= 1) {
+      stack.push(children[index]!);
+    }
+  }
+  return result;
+}
+
+function winAppFingerprint(element: WinAppElement): ComputerControlFingerprint {
+  const secure = isSecureElement(element);
+  const actions: string[] = [];
+  if (element.isInvokable === true) actions.push(COMPUTER_ACTION_PRESS);
+  if (!secure && isEditableElement(element)) {
+    actions.push(COMPUTER_ACTION_SET_VALUE);
+  }
+  return {
+    identifier: element.selector,
+    role: element.type,
+    title: boundedText(element.name ?? "", 256),
+    description: boundedText(element.automationId ?? "", 256),
+    frame: [element.x, element.y, element.width, element.height]
+      .map((value) => (Number.isFinite(value) ? String(value) : ""))
+      .join(","),
+    secure,
+    actions,
+  };
+}
+
+function sameSemanticFingerprint(
+  expected: ComputerControlFingerprint,
+  actual: ComputerControlFingerprint,
+): boolean {
+  return (
+    expected.identifier === actual.identifier &&
+    expected.role === actual.role &&
+    expected.title === actual.title &&
+    expected.description === actual.description &&
+    expected.frame === actual.frame &&
+    expected.secure === actual.secure
+  );
+}
+
+function isEditableElement(element: WinAppElement): boolean {
+  if (element.value !== undefined && element.value !== null) return true;
+  return /(?:edit|textbox|document|combobox|spinner|slider)/iu.test(
+    `${element.type ?? ""} ${element.className ?? ""}`,
+  );
+}
+
+function isSecureElement(element: WinAppElement): boolean {
+  return /(?:password|passwd|passcode|pin|secret|secure|credential|token)/iu.test(
+    [element.type, element.name, element.automationId, element.className]
+      .filter((value): value is string => typeof value === "string")
+      .join(" "),
+  );
+}
+
+function requiredProviderSelector(
+  fingerprint: ComputerControlFingerprint,
+): string {
+  if (!usableSelector(fingerprint.identifier)) {
+    throw new Error(
+      "The WinApp CLI selector is unavailable; inspect the target again",
+    );
+  }
+  return fingerprint.identifier;
+}
+
+function usableSelector(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 256 &&
+    !/[\u0000-\u001f\u007f]/u.test(value)
+  );
+}
+
+function computerTargetKey(target: ComputerTarget): string {
+  return JSON.stringify({
+    pid: target.pid ?? null,
+    applicationId: target.applicationId ?? null,
+    bundleId: target.bundleId ?? null,
+    windowTitle: target.windowTitle ?? null,
+  });
+}
+
+function parseWindow(value: unknown): WinAppWindow {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("WinApp CLI returned an invalid window entry");
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    hwnd: positiveInteger(record.hwnd, "window hwnd"),
+    processId: positiveInteger(record.processId, "window processId"),
+    processName: requiredBoundedString(record.processName, "processName", 256),
+    ...(typeof record.title === "string"
+      ? { title: boundedText(record.title, 256) }
+      : {}),
+    width: nonNegativeInteger(record.width, "window width"),
+    height: nonNegativeInteger(record.height, "window height"),
+  };
+}
+
+function resolvedTarget(window: WinAppWindow): ComputerInspection["target"] {
+  return {
+    pid: window.processId,
+    applicationId: window.processName,
+    applicationName: window.processName,
+    ...(window.title === undefined ? {} : { windowTitle: window.title }),
+  };
+}
+
+function positiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new Error(`WinApp CLI returned an invalid ${label}`);
+  }
+  return value as number;
+}
+
+function requireConfirmedHwnd(
+  actual: unknown,
+  expected: number,
+  action: string,
+): void {
+  if (actual !== expected) {
+    throw new Error(
+      `WinApp CLI ${action} did not confirm the explicitly targeted HWND`,
+    );
+  }
+}
+
+function nonNegativeInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new Error(`WinApp CLI returned an invalid ${label}`);
+  }
+  return value as number;
+}
+
+function requiredBoundedString(
+  value: unknown,
+  label: string,
+  limit: number,
+): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`WinApp CLI returned an invalid ${label}`);
+  }
+  return boundedText(value, limit);
+}
+
+function boundedText(value: string, limit: number): string {
+  return value.replace(/[\u0000-\u001f\u007f]/gu, " ").slice(0, limit);
+}
+
+function redactDiagnostic(
+  value: string,
+  exactValues: readonly string[] = [],
+): string {
+  let redacted = value;
+  for (const exact of exactValues) {
+    if (exact.length > 0) redacted = redacted.replaceAll(exact, "[REDACTED]");
+  }
+  return redacted
+    .replace(
+      /("?(?:password|secret|token|credential|authorization)"?\s*[:=]\s*)("[^"]*"|\S+)/giu,
+      "$1[REDACTED]",
+    )
+    .trim()
+    .slice(0, 2_048);
+}
+
+function unsupportedForeground(): Error {
+  return new Error(
+    "The Microsoft WinApp CLI provider does not expose ZenX's unscoped foreground tools; use background-safe UIA operations or a future explicitly app-targeted foreground contract",
+  );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -7,6 +7,7 @@ import {
   type ZenXBrowserBackend,
 } from "./capabilities/browser-provider.js";
 import {
+  computerCapabilityManifest,
   ComputerZenXCapabilityPackage,
   ElectronMacComputerBackend,
   type ZenXComputerBackend,
@@ -20,13 +21,19 @@ import type {
   ZenXCapabilityHostSnapshot,
   ZenXCapabilityPackage,
   ZenXCapabilitySnapshot,
+  ZenXCapabilityManifest,
 } from "./capabilities/types.js";
+import {
+  windowsComputerCapabilityManifest,
+  WinAppCliComputerBackend,
+} from "./capabilities/windows-computer-provider.js";
 
 export class ZenXCapabilityService implements ZenXCapabilityHost {
   readonly #registry: ZenXCapabilityRegistry;
   readonly #localDirectory: string;
   readonly #browserBackend: ZenXBrowserBackend;
   readonly #computerBackend: ZenXComputerBackend;
+  readonly #computerManifest: ZenXCapabilityManifest;
 
   constructor(options: {
     userDataDirectory: string;
@@ -34,6 +41,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     localDirectory?: string;
     browserBackend?: ZenXBrowserBackend;
     computerBackend?: ZenXComputerBackend;
+    computerManifest?: ZenXCapabilityManifest;
   }) {
     this.#registry = new ZenXCapabilityRegistry(
       options.grantStore ??
@@ -46,8 +54,13 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
       path.join(options.userDataDirectory, "capabilities");
     this.#browserBackend =
       options.browserBackend ?? new ElectronBrowserBackend();
-    this.#computerBackend =
-      options.computerBackend ?? new ElectronMacComputerBackend();
+    const bundledComputer = defaultComputerProvider();
+    this.#computerBackend = options.computerBackend ?? bundledComputer.backend;
+    this.#computerManifest =
+      options.computerManifest ??
+      (options.computerBackend === undefined
+        ? bundledComputer.manifest
+        : computerCapabilityManifest);
   }
 
   async initialize(): Promise<void> {
@@ -57,9 +70,20 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
       "bundled",
     );
     this.#registry.register(
-      new ComputerZenXCapabilityPackage(this.#computerBackend),
+      new ComputerZenXCapabilityPackage(
+        this.#computerBackend,
+        this.#computerManifest,
+      ),
       "bundled",
     );
+    if (this.#computerBackend instanceof WinAppCliComputerBackend) {
+      const diagnostic = await this.#computerBackend.diagnose();
+      if (!diagnostic.ready) {
+        this.#registry.recordDiscoveryError(
+          `Windows computer provider: ${diagnostic.message}`,
+        );
+      }
+    }
     const discovered = await discoverLocalCapabilityPackages(
       this.#localDirectory,
     );
@@ -121,6 +145,21 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
   async close(): Promise<void> {
     await this.#registry.close();
   }
+}
+
+function defaultComputerProvider(): {
+  backend: ZenXComputerBackend;
+  manifest: ZenXCapabilityManifest;
+} {
+  return process.platform === "win32"
+    ? {
+        backend: new WinAppCliComputerBackend(),
+        manifest: windowsComputerCapabilityManifest,
+      }
+    : {
+        backend: new ElectronMacComputerBackend(),
+        manifest: computerCapabilityManifest,
+      };
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -34,6 +34,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
   readonly #browserBackend: ZenXBrowserBackend;
   readonly #computerBackend: ZenXComputerBackend;
   readonly #computerManifest: ZenXCapabilityManifest;
+  #computerRegistered = false;
 
   constructor(options: {
     userDataDirectory: string;
@@ -69,20 +70,25 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
       new BrowserZenXCapabilityPackage(this.#browserBackend),
       "bundled",
     );
-    this.#registry.register(
-      new ComputerZenXCapabilityPackage(
-        this.#computerBackend,
-        this.#computerManifest,
-      ),
-      "bundled",
-    );
+    let registerComputer = true;
     if (this.#computerBackend instanceof WinAppCliComputerBackend) {
       const diagnostic = await this.#computerBackend.diagnose();
       if (!diagnostic.ready) {
+        registerComputer = false;
         this.#registry.recordDiscoveryError(
           `Windows computer provider: ${diagnostic.message}`,
         );
       }
+    }
+    if (registerComputer) {
+      this.#registry.register(
+        new ComputerZenXCapabilityPackage(
+          this.#computerBackend,
+          this.#computerManifest,
+        ),
+        "bundled",
+      );
+      this.#computerRegistered = true;
     }
     const discovered = await discoverLocalCapabilityPackages(
       this.#localDirectory,
@@ -144,6 +150,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
 
   async close(): Promise<void> {
     await this.#registry.close();
+    if (!this.#computerRegistered) await this.#computerBackend.close();
   }
 }
 

--- a/apps/zenx/src/main/windows-computer-smoke.ts
+++ b/apps/zenx/src/main/windows-computer-smoke.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from "node:crypto";
+import { stat } from "node:fs/promises";
+
+import type { ToolInvocation } from "../../../../src/tool.js";
+import {
+  ComputerZenXCapabilityPackage,
+  type ComputerInspection,
+} from "./capabilities/computer-provider.js";
+import { ZenXCapabilityRegistry } from "./capabilities/registry.js";
+import { MemoryZenXCapabilityGrantStore } from "./capabilities/grant-store.js";
+import {
+  windowsComputerCapabilityManifest,
+  WinAppCliComputerBackend,
+} from "./capabilities/windows-computer-provider.js";
+
+const arguments_ = parseArguments(process.argv.slice(2));
+const target = {
+  pid: requiredPositiveInteger(arguments_.pid, "--pid"),
+  windowTitle: requiredString(arguments_.title, "--title"),
+};
+const controller = new AbortController();
+const timeout = setTimeout(() => {
+  controller.abort(
+    new DOMException("Windows adapter smoke timed out", "AbortError"),
+  );
+}, 60_000);
+timeout.unref();
+
+const grantStore = new MemoryZenXCapabilityGrantStore();
+const registry = new ZenXCapabilityRegistry(grantStore, {
+  platform: "win32",
+  allowForegroundRequired: false,
+});
+const backend = new WinAppCliComputerBackend({ platform: "win32" });
+
+try {
+  const diagnostic = await backend.diagnose(controller.signal);
+  if (!diagnostic.ready) throw new Error(diagnostic.message);
+
+  await registry.initialize();
+  registry.register(
+    new ComputerZenXCapabilityPackage(
+      backend,
+      windowsComputerCapabilityManifest,
+    ),
+    "bundled",
+  );
+  await registry.grant(windowsComputerCapabilityManifest.id);
+
+  const first = await execute<ComputerInspection>(
+    registry,
+    "computer_inspect",
+    { target },
+    controller.signal,
+  );
+  const editor = first.controls.find(
+    (control) =>
+      control.enabled &&
+      control.secure !== true &&
+      control.actions.includes("set_value"),
+  );
+  if (editor === undefined) {
+    throw new Error(
+      "ZenX adapter found no non-secret editable fixture control",
+    );
+  }
+
+  const probeText = `ZenX WinApp adapter smoke ${new Date().toISOString()}`;
+  const setResult = await execute<{
+    target: ComputerInspection["target"];
+    characterCount: number;
+  }>(
+    registry,
+    "computer_set_value",
+    { target, control: editor.selector, value: probeText },
+    controller.signal,
+  );
+  if (setResult.characterCount !== probeText.length) {
+    throw new Error(
+      "ZenX adapter did not confirm the complete set-value input",
+    );
+  }
+  const refreshedTarget = {
+    pid: setResult.target.pid,
+    applicationId: setResult.target.applicationId,
+    windowTitle: setResult.target.windowTitle,
+  };
+
+  const second = await execute<ComputerInspection>(
+    registry,
+    "computer_inspect",
+    { target: refreshedTarget },
+    controller.signal,
+  );
+  if (second.controls.length === 0) {
+    throw new Error(
+      "ZenX adapter could not re-inspect the fixture after set-value",
+    );
+  }
+
+  const screenshot = await execute<{
+    artifactPath: string;
+    bytes: number;
+    width: number;
+    height: number;
+  }>(
+    registry,
+    "computer_screenshot",
+    { target: refreshedTarget },
+    controller.signal,
+  );
+  const metadata = await stat(screenshot.artifactPath);
+  if (
+    metadata.size <= 0 ||
+    screenshot.bytes !== metadata.size ||
+    screenshot.width <= 0 ||
+    screenshot.height <= 0
+  ) {
+    throw new Error("ZenX adapter returned an invalid screenshot artifact");
+  }
+
+  console.log(
+    `ZenX WinApp adapter smoke passed with WinApp CLI ${diagnostic.version}: inspect -> opaque observation -> set_value with UIA readback -> re-inspect -> scoped screenshot.`,
+  );
+} finally {
+  clearTimeout(timeout);
+  await registry.close();
+}
+
+async function execute<T>(
+  registry_: ZenXCapabilityRegistry,
+  name: string,
+  args: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<T> {
+  const invocation: ToolInvocation = {
+    callId: randomUUID(),
+    name,
+    arguments: args,
+    cwd: process.cwd(),
+    signal,
+  };
+  const execution = await registry_.execute(invocation);
+  if (execution.exitCode !== 0) {
+    throw new Error(
+      `${name} failed with exit code ${String(execution.exitCode)}`,
+    );
+  }
+  const envelope = JSON.parse(execution.output) as {
+    result?: T;
+    truncated?: boolean;
+  };
+  if (envelope.truncated === true || envelope.result === undefined) {
+    throw new Error(`${name} returned no complete result through the registry`);
+  }
+  return envelope.result;
+}
+
+function parseArguments(values: readonly string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (let index = 0; index < values.length; index += 2) {
+    const key = values[index];
+    const value = values[index + 1];
+    if (key === undefined || !key.startsWith("--") || value === undefined) {
+      throw new Error("Expected --pid <number> --title <exact-title>");
+    }
+    result[key.slice(2)] = value;
+  }
+  return result;
+}
+
+function requiredString(value: string | undefined, flag: string): string {
+  if (value === undefined || value.trim().length === 0) {
+    throw new Error(`${flag} is required`);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(
+  value: string | undefined,
+  flag: string,
+): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${flag} must be a positive integer`);
+  }
+  return parsed;
+}

--- a/apps/zenx/src/main/windows-computer-smoke.ts
+++ b/apps/zenx/src/main/windows-computer-smoke.ts
@@ -120,7 +120,7 @@ try {
   }
 
   console.log(
-    `ZenX WinApp adapter smoke passed with WinApp CLI ${diagnostic.version}: inspect -> opaque observation -> set_value with UIA readback -> re-inspect -> scoped screenshot.`,
+    `ZenX WinApp adapter smoke passed with WinApp CLI ${diagnostic.version}: inspect -> opaque observation -> set_value with bounded UIA assertion -> re-inspect -> scoped screenshot.`,
   );
 } finally {
   clearTimeout(timeout);

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -177,7 +177,7 @@ export function CapabilitySettings() {
       {snapshot.discoveryErrors.map((message) => (
         <div className="settings-error" role="alert" key={message}>
           <Icon name="warning" size={14} />
-          Local capability: {message}
+          Capability: {message}
         </div>
       ))}
       {error === null ? null : (

--- a/apps/zenx/test/computer-capability.test.ts
+++ b/apps/zenx/test/computer-capability.test.ts
@@ -61,7 +61,7 @@ test("computer observation IDs are target-scoped, latest-only, and reject secure
       title: "Mark",
       frame: "10.0,10.0,20.0,20.0",
       secure: false,
-      actions: ["AXPress"],
+      actions: ["press"],
     },
   ]);
   const firstControl = first.selectors[0]!;
@@ -71,7 +71,7 @@ test("computer observation IDs are target-scoped, latest-only, and reject secure
       title: "Mark",
       frame: "20.0,10.0,20.0,20.0",
       secure: false,
-      actions: ["AXPress"],
+      actions: ["press"],
     },
   ]);
   assert.throws(
@@ -98,7 +98,7 @@ test("computer observation IDs are target-scoped, latest-only, and reject secure
       subrole: "AXSecureTextField",
       frame: "10.0,40.0,100.0,20.0",
       secure: true,
-      actions: ["AXSetValue"],
+      actions: ["set_value"],
     },
   ]);
   assert.throws(
@@ -193,14 +193,14 @@ function computerBackend(calls: string[]): ZenXComputerBackend {
             role: "AXButton",
             title: "Mark",
             enabled: true,
-            actions: ["AXPress"],
+            actions: ["press"],
           },
           {
             selector: fieldControl,
             role: "AXTextField",
             title: "Name",
             enabled: true,
-            actions: ["AXSetValue"],
+            actions: ["set_value"],
           },
         ],
         truncated: false,

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -391,9 +391,13 @@ class FixtureWinAppRunner implements WinAppCliRunner {
       this.writtenValue = args[3] ?? "";
       return output(JSON.stringify({ elementId: args[2], hwnd: "0x2329" }));
     }
-    if (args[1] === "get-value") {
+    if (args[1] === "wait-for") {
       return output(
-        JSON.stringify({ elementId: args[2], text: this.writtenValue }),
+        JSON.stringify({
+          found: args.includes(this.writtenValue),
+          timedOut: false,
+          waitedMs: 100,
+        }),
       );
     }
     if (args[1] === "screenshot") {
@@ -435,12 +439,12 @@ function fixtureCliSchema(version: string) {
       ui: {
         subcommands: Object.fromEntries(
           [
-            "get-value",
             "inspect",
             "invoke",
             "list-windows",
             "screenshot",
             "set-value",
+            "wait-for",
           ].map((name) => [name, { description: name }]),
         ),
       },

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -76,7 +76,7 @@ test("Windows provider maps WinApp JSON into opaque bounded UIA controls", async
     "invoke",
     "provider-button-selector",
     "--window",
-    "0x2329",
+    "9001",
     "--json",
   ]);
   const setCommand = runner.commands.find((args) => args[1] === "set-value");
@@ -106,7 +106,7 @@ test("Windows provider captures only the exact HWND through WGC-default screensh
       "ui",
       "screenshot",
       "--window",
-      "0x2329",
+      "9001",
       "--output",
     ]);
     assert.equal(screenshotCommand.includes("--capture-screen"), false);
@@ -383,7 +383,7 @@ class FixtureWinAppRunner implements WinAppCliRunner {
         JSON.stringify({
           elementId: args[2],
           pattern: "Invoke",
-          hwnd: "0x2329",
+          hwnd: 9001,
         }),
       );
     }

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -8,6 +8,8 @@ import {
   ComputerZenXCapabilityPackage,
   type ComputerInspection,
 } from "../src/main/capabilities/computer-provider.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityService } from "../src/main/capability-service.js";
 import {
   runBoundedProcess,
   windowsComputerCapabilityManifest,
@@ -74,7 +76,7 @@ test("Windows provider maps WinApp JSON into opaque bounded UIA controls", async
     "invoke",
     "provider-button-selector",
     "--window",
-    "9001",
+    "0x2329",
     "--json",
   ]);
   const setCommand = runner.commands.find((args) => args[1] === "set-value");
@@ -104,7 +106,7 @@ test("Windows provider captures only the exact HWND through WGC-default screensh
       "ui",
       "screenshot",
       "--window",
-      "9001",
+      "0x2329",
       "--output",
     ]);
     assert.equal(screenshotCommand.includes("--capture-screen"), false);
@@ -172,6 +174,19 @@ test("Windows provider revalidates secure state and semantic identity immediatel
   );
 });
 
+test("Windows provider rejects legacy inspect envelopes instead of silently misparsing them", async () => {
+  const runner = new FixtureWinAppRunner();
+  runner.legacyInspectEnvelope = true;
+  const backend = new WinAppCliComputerBackend({
+    platform: "win32",
+    runner,
+  });
+  await assert.rejects(
+    backend.inspect(target),
+    /incompatible JSON shape.*0\.3\.1/u,
+  );
+});
+
 test("Windows manifest exposes background-safe WinApp operations without unscoped input injection", () => {
   assert.equal(
     windowsComputerCapabilityManifest.provider.id,
@@ -201,7 +216,44 @@ test("WinApp diagnostic is actionable without installing on non-Windows test hos
     runner: new FixtureWinAppRunner(),
   }).diagnose();
   assert.equal(ready.ready, true);
-  assert.equal(ready.version, "1.2.3-preview");
+  assert.equal(ready.version, "1.2.3");
+  assert.equal(ready.requiredVersion, "0.3.1");
+  assert.equal(ready.schemaCompatible, true);
+
+  const oldRunner = new FixtureWinAppRunner();
+  oldRunner.versionOutput = "winapp 0.3.0\n";
+  const old = await new WinAppCliComputerBackend({
+    platform: "win32",
+    runner: oldRunner,
+  }).diagnose();
+  assert.equal(old.ready, false);
+  assert.equal(old.version, "0.3.0");
+  assert.match(old.message, /0\.3\.0.*0\.3\.1/u);
+  assert.equal(
+    oldRunner.commands.some((args) => args[1] === "list-windows"),
+    false,
+  );
+
+  const unknownRunner = new FixtureWinAppRunner();
+  unknownRunner.versionOutput = "WinApp CLI public preview\n";
+  const unknown = await new WinAppCliComputerBackend({
+    platform: "win32",
+    runner: unknownRunner,
+  }).diagnose();
+  assert.equal(unknown.ready, false);
+  assert.equal(unknown.version, undefined);
+  assert.match(unknown.message, /unknown.*0\.3\.1/u);
+
+  const incompatibleSchemaRunner = new FixtureWinAppRunner();
+  incompatibleSchemaRunner.schemaProbeOutput = '{"elements":[]}';
+  const incompatibleSchema = await new WinAppCliComputerBackend({
+    platform: "win32",
+    runner: incompatibleSchemaRunner,
+  }).diagnose();
+  assert.equal(incompatibleSchema.ready, false);
+  assert.equal(incompatibleSchema.version, "1.2.3");
+  assert.equal(incompatibleSchema.schemaCompatible, false);
+  assert.match(incompatibleSchema.message, /incompatible.*detected 1\.2\.3/u);
 
   const unavailable = await new WinAppCliComputerBackend({
     platform: "darwin",
@@ -209,6 +261,46 @@ test("WinApp diagnostic is actionable without installing on non-Windows test hos
   assert.equal(unavailable.ready, false);
   assert.match(unavailable.message, /only available on Windows/u);
   assert.match(unavailable.installCommand, /winget install/u);
+});
+
+test("ZenX startup does not expose an incompatible WinApp provider", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-winapp-startup-"),
+  );
+  const runner = new FixtureWinAppRunner();
+  runner.versionOutput = "winapp 0.3.0\n";
+  const service = new ZenXCapabilityService({
+    userDataDirectory: directory,
+    localDirectory: path.join(directory, "no-local-capabilities"),
+    grantStore: new MemoryZenXCapabilityGrantStore(),
+    computerBackend: new WinAppCliComputerBackend({
+      platform: "win32",
+      runner,
+    }),
+    computerManifest: windowsComputerCapabilityManifest,
+  });
+  try {
+    await service.initialize();
+    const snapshot = service.snapshot();
+    assert.equal(
+      snapshot.capabilities.some(
+        (capability) => capability.manifest.id === "computer",
+      ),
+      false,
+    );
+    assert.match(snapshot.discoveryErrors.join("\n"), /0\.3\.0.*0\.3\.1/u);
+    assert.equal(
+      service
+        .hostSnapshot()
+        .definitions.some((definition) =>
+          definition.name.startsWith("computer_"),
+        ),
+      false,
+    );
+  } finally {
+    await service.close();
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("WinApp process runner enforces cancellation, timeout, and output bounds", async () => {
@@ -251,6 +343,10 @@ class FixtureWinAppRunner implements WinAppCliRunner {
   ambiguous = false;
   buttonX = 10;
   secureField = false;
+  legacyInspectEnvelope = false;
+  schemaProbeOutput: string | undefined;
+  versionOutput = "winapp 1.2.3-preview\n";
+  writtenValue = "";
 
   async run(
     _executable: string,
@@ -259,14 +355,25 @@ class FixtureWinAppRunner implements WinAppCliRunner {
   ): Promise<WinAppCliRunResult> {
     this.commands.push([...args]);
     if (args[0] === "--version") {
-      return output("1.2.3-preview\n");
+      return output(this.versionOutput);
+    }
+    if (args[0] === "--cli-schema") {
+      const version =
+        this.versionOutput.match(/\d+\.\d+\.\d+/u)?.[0] ?? "0.0.0";
+      return output(JSON.stringify(fixtureCliSchema(version)));
     }
     if (args[1] === "list-windows") {
+      if (!args.includes("--app") && this.schemaProbeOutput !== undefined) {
+        return output(this.schemaProbeOutput);
+      }
       const windows = [fixtureWindow()];
       if (this.ambiguous) windows.push(fixtureWindow());
       return output(JSON.stringify(windows));
     }
     if (args[1] === "inspect") {
+      if (this.legacyInspectEnvelope) {
+        return output(JSON.stringify({ elements: [] }));
+      }
       return output(
         JSON.stringify(fixtureInspection(this.buttonX, this.secureField)),
       );
@@ -276,12 +383,18 @@ class FixtureWinAppRunner implements WinAppCliRunner {
         JSON.stringify({
           elementId: args[2],
           pattern: "Invoke",
-          hwnd: 9001,
+          hwnd: "0x2329",
         }),
       );
     }
     if (args[1] === "set-value") {
-      return output(JSON.stringify({ elementId: args[2], hwnd: 9001 }));
+      this.writtenValue = args[3] ?? "";
+      return output(JSON.stringify({ elementId: args[2], hwnd: "0x2329" }));
+    }
+    if (args[1] === "get-value") {
+      return output(
+        JSON.stringify({ elementId: args[2], text: this.writtenValue }),
+      );
     }
     if (args[1] === "screenshot") {
       const outputIndex = args.indexOf("--output");
@@ -294,7 +407,7 @@ class FixtureWinAppRunner implements WinAppCliRunner {
           height: 720,
           processId: 4242,
           windowTitle: "Fixture Window",
-          hwnd: 9001,
+          hwnd: "0x2329",
         }),
       );
     }
@@ -304,12 +417,34 @@ class FixtureWinAppRunner implements WinAppCliRunner {
 
 function fixtureWindow() {
   return {
-    hwnd: 9001,
+    hwnd: "0x2329",
     processId: 4242,
     processName: "FixtureApp",
     title: "Fixture Window",
     width: 1280,
     height: 720,
+  };
+}
+
+function fixtureCliSchema(version: string) {
+  return {
+    name: "winapp",
+    version,
+    schemaVersion: "1.0",
+    subcommands: {
+      ui: {
+        subcommands: Object.fromEntries(
+          [
+            "get-value",
+            "inspect",
+            "invoke",
+            "list-windows",
+            "screenshot",
+            "set-value",
+          ].map((name) => [name, { description: name }]),
+        ),
+      },
+    },
   };
 }
 
@@ -321,7 +456,7 @@ function fixtureInspection(buttonX = 10, secureField = false) {
     hideOffscreen: true,
     windows: [
       {
-        hwnd: 9001,
+        hwnd: "0x2329",
         title: "Fixture Window",
         elementCount: 3,
         elements: [

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  ComputerZenXCapabilityPackage,
+  type ComputerInspection,
+} from "../src/main/capabilities/computer-provider.js";
+import {
+  runBoundedProcess,
+  windowsComputerCapabilityManifest,
+  WinAppCliComputerBackend,
+  type WinAppCliRunner,
+  type WinAppCliRunOptions,
+  type WinAppCliRunResult,
+} from "../src/main/capabilities/windows-computer-provider.js";
+
+const target = {
+  pid: 4242,
+  applicationId: "FixtureApp",
+  windowTitle: "Fixture Window",
+};
+
+test("Windows provider maps WinApp JSON into opaque bounded UIA controls", async () => {
+  const runner = new FixtureWinAppRunner();
+  const backend = new WinAppCliComputerBackend({
+    platform: "win32",
+    runner,
+  });
+  const capability = new ComputerZenXCapabilityPackage(
+    backend,
+    windowsComputerCapabilityManifest,
+  );
+
+  const inspected = (await capability.invoke(
+    "computer_inspect",
+    invocation({ target }),
+  )) as ComputerInspection;
+  assert.equal(inspected.platform, "win32");
+  assert.equal(inspected.target.applicationId, "FixtureApp");
+  assert.equal(inspected.controls.length, 3);
+  assert.equal(inspected.controls[0]?.title, "Save");
+  assert.deepEqual(inspected.controls[0]?.actions, ["press"]);
+  assert.deepEqual(inspected.controls[1]?.actions, ["set_value"]);
+  assert.equal(inspected.controls[2]?.secure, true);
+  assert.deepEqual(inspected.controls[2]?.actions, []);
+  assert.doesNotMatch(JSON.stringify(inspected), /existing private value/u);
+  assert.doesNotMatch(JSON.stringify(inspected), /provider-button-selector/u);
+
+  await capability.invoke(
+    "computer_press",
+    invocation({ target, control: inspected.controls[0]!.selector }),
+  );
+  const refreshed = (await capability.invoke(
+    "computer_inspect",
+    invocation({ target }),
+  )) as ComputerInspection;
+  const set = await capability.invoke(
+    "computer_set_value",
+    invocation({
+      target,
+      control: refreshed.controls[1]!.selector,
+      value: "deliberate non-secret text",
+    }),
+  );
+  assert.equal((set as { characterCount: number }).characterCount, 26);
+  assert.doesNotMatch(JSON.stringify(set), /deliberate non-secret/u);
+
+  const invokeCommand = runner.commands.find((args) => args[1] === "invoke");
+  assert.deepEqual(invokeCommand, [
+    "ui",
+    "invoke",
+    "provider-button-selector",
+    "--window",
+    "9001",
+    "--json",
+  ]);
+  const setCommand = runner.commands.find((args) => args[1] === "set-value");
+  assert.deepEqual(setCommand?.slice(0, 3), [
+    "ui",
+    "set-value",
+    "provider-field-selector",
+  ]);
+});
+
+test("Windows provider captures only the exact HWND through WGC-default screenshot", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-winapp-test-"));
+  try {
+    const runner = new FixtureWinAppRunner();
+    const backend = new WinAppCliComputerBackend({
+      artifactDirectory: directory,
+      platform: "win32",
+      runner,
+    });
+    const result = await backend.screenshot(target);
+    assert.equal(result.target.windowTitle, "Fixture Window");
+    assert.equal(result.width, 1280);
+    assert.equal(result.height, 720);
+    assert.equal(result.bytes, 7);
+    const screenshotCommand = runner.commands.at(-1)!;
+    assert.deepEqual(screenshotCommand.slice(0, 5), [
+      "ui",
+      "screenshot",
+      "--window",
+      "9001",
+      "--output",
+    ]);
+    assert.equal(screenshotCommand.includes("--capture-screen"), false);
+    assert.equal(screenshotCommand.includes("--focus"), false);
+    await backend.close();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Windows provider rejects ambiguous windows, stale selectors, and secure controls", async () => {
+  const runner = new FixtureWinAppRunner();
+  const backend = new WinAppCliComputerBackend({
+    platform: "win32",
+    runner,
+  });
+  const inspected = await backend.inspect(target);
+  const secure = inspected.controls.find((control) => control.secure)!;
+  await assert.rejects(
+    backend.setValue(target, secure.selector, "must-not-run"),
+    /rejects password or secure controls/u,
+  );
+  assert.equal(
+    runner.commands.some((args) => args.includes("must-not-run")),
+    false,
+  );
+
+  const first = inspected.controls[0]!.selector;
+  await backend.inspect(target);
+  await assert.rejects(backend.press(target, first), /stale, unknown/u);
+
+  runner.ambiguous = true;
+  await assert.rejects(backend.inspect(target), /ambiguous/u);
+});
+
+test("Windows provider revalidates secure state and semantic identity immediately before acting", async () => {
+  const runner = new FixtureWinAppRunner();
+  const backend = new WinAppCliComputerBackend({
+    platform: "win32",
+    runner,
+  });
+  const first = await backend.inspect(target);
+  runner.secureField = true;
+  await assert.rejects(
+    backend.setValue(target, first.controls[1]!.selector, "must-not-run"),
+    /rejects password or secure controls/u,
+  );
+  assert.equal(
+    runner.commands.some(
+      (args) => args[1] === "set-value" && args.includes("must-not-run"),
+    ),
+    false,
+  );
+
+  runner.secureField = false;
+  const second = await backend.inspect(target);
+  runner.buttonX = 99;
+  await assert.rejects(
+    backend.press(target, second.controls[0]!.selector),
+    /changed since the observation/u,
+  );
+  assert.equal(
+    runner.commands.some((args) => args[1] === "invoke"),
+    false,
+  );
+});
+
+test("Windows manifest exposes background-safe WinApp operations without unscoped input injection", () => {
+  assert.equal(
+    windowsComputerCapabilityManifest.provider.id,
+    "microsoft-winapp-cli",
+  );
+  assert.deepEqual(windowsComputerCapabilityManifest.provider.platforms, [
+    "win32",
+  ]);
+  assert.equal(
+    windowsComputerCapabilityManifest.tools.every(
+      (tool) => tool.interactionMode === "background_safe",
+    ),
+    true,
+  );
+  assert.equal(
+    windowsComputerCapabilityManifest.tools.some((tool) =>
+      tool.name.startsWith("computer_foreground_"),
+    ),
+    false,
+  );
+});
+
+test("WinApp diagnostic is actionable without installing on non-Windows test hosts", async () => {
+  const ready = await new WinAppCliComputerBackend({
+    platform: "win32",
+    command: "fixture-winapp",
+    runner: new FixtureWinAppRunner(),
+  }).diagnose();
+  assert.equal(ready.ready, true);
+  assert.equal(ready.version, "1.2.3-preview");
+
+  const unavailable = await new WinAppCliComputerBackend({
+    platform: "darwin",
+  }).diagnose();
+  assert.equal(unavailable.ready, false);
+  assert.match(unavailable.message, /only available on Windows/u);
+  assert.match(unavailable.installCommand, /winget install/u);
+});
+
+test("WinApp process runner enforces cancellation, timeout, and output bounds", async () => {
+  const controller = new AbortController();
+  const cancelled = runBoundedProcess(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 1000)"],
+    { timeoutMs: 5_000, signal: controller.signal },
+  );
+  controller.abort(new DOMException("stopped", "AbortError"));
+  await assert.rejects(cancelled, /stopped/u);
+
+  await assert.rejects(
+    runBoundedProcess(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      timeoutMs: 25,
+    }),
+    /timed out/u,
+  );
+  await assert.rejects(
+    runBoundedProcess(process.execPath, ["-e", "console.log('x'.repeat(99))"], {
+      timeoutMs: 1_000,
+      maxStdoutBytes: 16,
+    }),
+    /stdout exceeded/u,
+  );
+  const sensitiveFailure = await runBoundedProcess(
+    process.execPath,
+    ["-e", "console.error('exact-private-value'); process.exit(2)"],
+    {
+      timeoutMs: 1_000,
+      redactions: ["exact-private-value"],
+    },
+  ).catch((error: unknown) => error);
+  assert.match(String(sensitiveFailure), /\[REDACTED\]/u);
+  assert.doesNotMatch(String(sensitiveFailure), /exact-private-value/u);
+});
+
+class FixtureWinAppRunner implements WinAppCliRunner {
+  readonly commands: string[][] = [];
+  ambiguous = false;
+  buttonX = 10;
+  secureField = false;
+
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: WinAppCliRunOptions,
+  ): Promise<WinAppCliRunResult> {
+    this.commands.push([...args]);
+    if (args[0] === "--version") {
+      return output("1.2.3-preview\n");
+    }
+    if (args[1] === "list-windows") {
+      const windows = [fixtureWindow()];
+      if (this.ambiguous) windows.push(fixtureWindow());
+      return output(JSON.stringify(windows));
+    }
+    if (args[1] === "inspect") {
+      return output(
+        JSON.stringify(fixtureInspection(this.buttonX, this.secureField)),
+      );
+    }
+    if (args[1] === "invoke") {
+      return output(
+        JSON.stringify({
+          elementId: args[2],
+          pattern: "Invoke",
+          hwnd: 9001,
+        }),
+      );
+    }
+    if (args[1] === "set-value") {
+      return output(JSON.stringify({ elementId: args[2], hwnd: 9001 }));
+    }
+    if (args[1] === "screenshot") {
+      const outputIndex = args.indexOf("--output");
+      const artifactPath = args[outputIndex + 1]!;
+      await writeFile(artifactPath, "fixture", "utf8");
+      return output(
+        JSON.stringify({
+          filePath: artifactPath,
+          width: 1280,
+          height: 720,
+          processId: 4242,
+          windowTitle: "Fixture Window",
+          hwnd: 9001,
+        }),
+      );
+    }
+    throw new Error(`Unexpected fixture command: ${args.join(" ")}`);
+  }
+}
+
+function fixtureWindow() {
+  return {
+    hwnd: 9001,
+    processId: 4242,
+    processName: "FixtureApp",
+    title: "Fixture Window",
+    width: 1280,
+    height: 720,
+  };
+}
+
+function fixtureInspection(buttonX = 10, secureField = false) {
+  return {
+    depth: 8,
+    interactive: false,
+    hideDisabled: true,
+    hideOffscreen: true,
+    windows: [
+      {
+        hwnd: 9001,
+        title: "Fixture Window",
+        elementCount: 3,
+        elements: [
+          {
+            type: "Button",
+            name: "Save",
+            automationId: "SaveButton",
+            selector: "provider-button-selector",
+            isEnabled: true,
+            isOffscreen: false,
+            isInvokable: true,
+            x: buttonX,
+            y: 10,
+            width: 80,
+            height: 30,
+          },
+          {
+            type: secureField ? "PasswordBox" : "TextBox",
+            name: secureField ? "Password" : "Notes",
+            automationId: secureField ? "PasswordField" : "NotesField",
+            selector: "provider-field-selector",
+            value: "existing private value",
+            isEnabled: true,
+            isOffscreen: false,
+            x: 10,
+            y: 50,
+            width: 200,
+            height: 30,
+          },
+          {
+            type: "PasswordBox",
+            name: "Password",
+            automationId: "PasswordField",
+            selector: "provider-password-selector",
+            value: "never-project-this",
+            isEnabled: true,
+            isOffscreen: false,
+            x: 10,
+            y: 90,
+            width: 200,
+            height: 30,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function output(stdout: string): WinAppCliRunResult {
+  return { stdout, stderr: "" };
+}
+
+function invocation(arguments_: Record<string, unknown>) {
+  return {
+    callId: "call-1",
+    name: "test",
+    arguments: arguments_,
+    cwd: "C:\\workspace",
+    signal: new AbortController().signal,
+  };
+}

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -111,6 +111,35 @@ test("Windows provider captures only the exact HWND through WGC-default screensh
     ]);
     assert.equal(screenshotCommand.includes("--capture-screen"), false);
     assert.equal(screenshotCommand.includes("--focus"), false);
+    await backend.close();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Windows provider confirms a screenshot through its real file identity", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-winapp-test-"));
+  const artifactDirectory = path.join(directory, "artifacts");
+  const aliasDirectory = path.join(directory, "artifact-alias");
+  try {
+    await mkdir(artifactDirectory);
+    await symlink(
+      artifactDirectory,
+      aliasDirectory,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const runner = new FixtureWinAppRunner();
+    runner.screenshotPath = (artifactPath) =>
+      path.join(aliasDirectory, path.basename(artifactPath));
+    const backend = new WinAppCliComputerBackend({
+      artifactDirectory,
+      platform: "win32",
+      runner,
+    });
+
+    const result = await backend.screenshot(target);
+
+    assert.equal(path.dirname(result.artifactPath), artifactDirectory);
     await backend.close();
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -347,6 +376,7 @@ class FixtureWinAppRunner implements WinAppCliRunner {
   schemaProbeOutput: string | undefined;
   versionOutput = "winapp 1.2.3-preview\n";
   writtenValue = "";
+  screenshotPath: ((artifactPath: string) => string) | undefined;
 
   async run(
     _executable: string,
@@ -406,7 +436,7 @@ class FixtureWinAppRunner implements WinAppCliRunner {
       await writeFile(artifactPath, "fixture", "utf8");
       return output(
         JSON.stringify({
-          filePath: artifactPath,
+          filePath: this.screenshotPath?.(artifactPath) ?? artifactPath,
           width: 1280,
           height: 720,
           processId: 4242,


### PR DESCRIPTION
Closes #41.

## What changed

- selects an optional Microsoft WinApp CLI provider on Windows while keeping the platform-neutral ZenX capability contract and Zen Core unchanged
- requires WinApp CLI 0.3.1+, validates `--version`, the machine-readable `--cli-schema`, and read-only `list-windows --json`, and does not register or expose tools when startup compatibility checks fail
- resolves exact PID/application + window title targets to one HWND, accepts the official versioned HWND/element JSON shapes, and rejects legacy inspect envelopes instead of silently misparsing them
- projects bounded UIA inspection into observation-scoped opaque ZenX control IDs, then revalidates semantic identity, geometry, secure heuristic, and supported action immediately before acting
- drives UIA invoke/set-value and default WGC/PrintWindow capture without `--focus`, `--capture-screen`, pointer injection, or keyboard injection; set-value is verified through a bounded native UIA wait-for value assertion that never projects the value to Agent output
- adds a real Windows tracer bullet through `WinAppCliComputerBackend` → `ComputerZenXCapabilityPackage` → capability registry using a deterministic WinForms fixture
- adds `windows-latest` CI using the official Microsoft setup action v0.2 pinned by commit and WinApp CLI v0.3.1

## Why

ZenX needs a Windows computer-use route without maintaining another UI Automation implementation. Microsoft WinApp CLI already provides UIA and Windows Graphics Capture with explicit JSON and input-impact boundaries, so the ZenX adapter remains thin and optional.

## User impact

On Windows, install the Public Preview CLI with:

```powershell
winget install Microsoft.winappcli --source winget
```

ZenX exposes the same semantic `computer_*` tools used on macOS. The Windows provider currently exposes only background-safe operations; the existing unscoped foreground tools are not advertised because WinApp input-injection verbs would affect the live desktop.

WinApp CLI 0.3.1 inspect JSON has no stable password-state field. ZenX therefore uses a conservative control-type/name/automation-ID/class-name heuristic and keeps every `computer_set_value` call explicitly non-secret-only because its input is journaled. This is not claimed as a strong upstream password signal.

## Validation

- `npm run check` — Core/CLI 87 tests and IMZen 38 tests passed
- `npm --workspace apps/zenx run check` — typecheck, 108 tests, and production Electron/Vite build passed
- fixture tests cover official v0.3.1 JSON, old/unknown/current version diagnostics, CLI/schema mismatch, legacy inspect rejection, stale/forged/secure controls, pre-action changes, exact HWND confirmation, timeout/cancellation, bounds, and redaction
- `npm --workspace apps/zenx run smoke:windows-computer` launches a deterministic WinForms UI and traverses the real adapter/registry inspect → opaque target → set-value/bounded assertion → re-inspect → scoped screenshot path
- GitHub `windows-latest` runs the real smoke with the official WinApp binary; it does not substitute mocks

## Upstream contracts checked

- Microsoft Learn: https://learn.microsoft.com/windows/apps/dev-tools/winapp-cli/
- Microsoft UI automation docs/source: https://github.com/microsoft/winappCli
- Microsoft setup action: https://github.com/microsoft/setup-WinAppCli