### PR TITLE
ZenX: integrate mature browser and computer providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,24 @@ jobs:
         run: winapp --version
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:windows-computer
+
+  zenx-playwright-provider-smoke:
+    name: ZenX real Playwright provider smoke
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Install the official Playwright CLI and Chromium
+        run: |
+          npm install --global @playwright/cli@0.1.18
+          playwright-cli install-browser
+      - name: Exercise provider selection and the real CLI adapter
+        env:
+          CI: "1"
+          ZENX_REQUIRE_PLAYWRIGHT: "1"
+        run: npm --workspace apps/zenx run smoke:providers

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,6 +79,8 @@
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。
+- **ZenXCapabilityProviderCatalog** — ZenX 产品层探测并诊断可选的成熟外部执行后端，按显式优先级选择
+  Playwright、Peekaboo、WinApp 或适用平台的 bundled fallback；版本、权限与可用性只属于 host 配置和瞬时诊断，不进入 Zen Core。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -19,9 +19,11 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
 Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
-首批 browser provider 以独立临时 profile/session 暴露跨平台有界 DOM 操作，computer
+首批 browser provider 优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
+回落到 bundled Electron/CDP 临时 profile；两者都只暴露有界 DOM 操作。computer
 公共 contract 暴露语义动作、平台能力与 background-safe/foreground-required 影响协商；
-当前 macOS provider 以 AX/窗口定向截图和明确提示、可取消的前台输入形成 tracer bullet，
+当前 macOS provider 优先复用 Peekaboo 3.x 的 background-first 操作，缺失或不兼容时以 bundled
+AX/窗口定向截图和明确提示、可取消的前台输入形成基线；
 后续 Windows provider 可用 UIA/Windows Graphics Capture/SendInput 接入同一 seam；manifest、权限、
 provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协议。上述外层配置
 和调度状态不进入 Zen Core，命中 Trigger 仍只通过 App Server 发起普通 Turn；在真实

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -139,27 +139,35 @@ control without disturbing the user's desktop.
 This tracer bullet deliberately keeps the provider boundary compatible with
 mature external implementations while retaining a runnable bundled baseline:
 
-- macOS follows Peekaboo's observe → opaque observation element ID → native semantic action
-  → explicit foreground fallback layering. Peekaboo is MIT and is the preferred
-  next adapter, but it is not bundled here: the CLI is not currently a ZenX
-  dependency, its released/source toolchain and permission-onboarding lifecycle
-  must be packaged and signed deliberately, and its JSON compatibility must be
-  pinned before ZenX can rely on it. The current minimal Swift AX/CGEvent helper
-  is therefore provisional rather than a claim that ZenX should maintain a
-  complete macOS automation stack. See
-  <https://github.com/openclaw/Peekaboo>.
-- Windows is a thin optional adapter over Microsoft's MIT-licensed, Public
+- macOS now discovers an optional Peekaboo 3.x CLI and pins its JSON envelope,
+  permission probe, snapshot and action assumptions. It uses a fresh exact-window
+  `see` before every semantic action, revalidates identity/security/actions, and
+  invokes background `click` or `set-value` with the fresh snapshot and element
+  IDs. Foreground pointer/key/scroll remains explicitly labeled. Missing,
+  incompatible, or malformed Peekaboo installations produce terminal provider
+  diagnostics and select the bundled Swift AX/CGEvent baseline; they never cause
+  a background operation to become foreground. Install Peekaboo separately or
+  set `ZENX_PEEKABOO_CLI` to an exact executable. See the upstream command and
+  background validation contracts at <https://github.com/openclaw/Peekaboo/blob/main/docs/cli-command-reference.md>
+  and <https://github.com/openclaw/Peekaboo/blob/main/docs/testing/background-computer-use.md>.
+- Windows uses a thin optional adapter over Microsoft's MIT-licensed, Public
   Preview `winapp` CLI. UIA inspect/set-value/invoke and default WGC capture map
   to background-safe semantic tools; provider-private HWND/UIA selectors are
-  translated to observation-scoped opaque ZenX target IDs/results. WinApp's
-  input-injecting verbs are deliberately not exposed by the current unscoped
-  ZenX foreground contract. See
+  translated to observation-scoped opaque ZenX target IDs/results. Startup pins
+  the supported version/schema and required commands before registration.
+  WinApp input-injecting verbs are deliberately not exposed by the current
+  unscoped ZenX foreground contract. See
   <https://github.com/microsoft/winappCli/blob/main/docs/ui-automation.md>.
-- Browser automation currently uses the bundled Chromium CDP path and an
-  ephemeral partition. A Playwright adapter should preserve the same tools while
-  using isolated non-persistent `BrowserContext`s; attaching an existing user
-  profile remains a separate opt-in provider. See
-  <https://playwright.dev/docs/api/class-browsercontext>.
+- Browser automation now prefers an optional compatible Playwright CLI (currently
+  pinned to `>=0.1.0 <0.2.0`) and validates its `--json` version/list schema
+  before selection. Its default headless session is reported as `isolated`, and
+  every action re-snapshots and revalidates Playwright ref plus DOM
+  role/name/type/security/visibility/action fingerprint. Missing or incompatible
+  CLI installations remain explicit in provider diagnostics and use the existing
+  bundled Chromium CDP ephemeral-partition provider. Install `@playwright/cli`
+  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; attaching a user
+  profile is still unsupported. See <https://playwright.dev/agent-cli/introduction>
+  and <https://playwright.dev/docs/api/class-browsercontext>.
 - A future `isolated` interaction mode/provider can place arbitrary control in a
   VM, cloud desktop, or remote host. OSWorld's provider separation across
   VMware/VirtualBox/Docker/cloud is a useful reference, but no VM lifecycle is
@@ -222,6 +230,7 @@ npm run check
 npm --workspace apps/zenx run smoke:capabilities
 # Windows only, after installing Microsoft WinApp CLI:
 npm --workspace apps/zenx run smoke:windows-computer
+npm --workspace apps/zenx run smoke:providers
 ```
 
 The automated integration suite runs the timer → wakeup → App Server Turn →
@@ -255,6 +264,12 @@ official setup action. The cross-platform fixture suite validates the same WinAp
 pre-action semantic revalidation, startup version/schema diagnostics,
 timeout/cancellation, output bounds, and exact-value error redaction when a
 Windows host is not available.
+The provider smoke exercises the selected Playwright-or-Electron browser against
+a local page through open → inspect → action → verify → close and prints bounded
+provider/version/permission diagnostics. CI installs the pinned official
+`@playwright/cli` and requires that provider to be selected; a local run may
+exercise the Electron fallback when the CLI is absent. The smoke only probes
+Peekaboo availability and permissions; it never sends desktop input.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
             "src/main/capability-smoke.ts",
           ),
           "real-smoke": resolve(__dirname, "src/main/real-smoke.ts"),
+          "provider-smoke": resolve(__dirname, "src/main/provider-smoke.ts"),
         },
       },
     },

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -12,6 +12,7 @@
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
+    "smoke:providers": "npm run build && electron ./out/main/provider-smoke.js",
     "check": "npm run typecheck && npm test && npm run build"
   },
   "dependencies": {

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -28,19 +28,32 @@ export interface BrowserInspection extends BrowserTabSummary {
 }
 
 export interface ZenXBrowserBackend {
-  listTabs(sessionId: string): Promise<BrowserTabSummary[]>;
-  open(sessionId: string, url: string): Promise<BrowserTabSummary>;
+  listTabs(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary[]>;
+  open(
+    sessionId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary>;
   navigate(
     sessionId: string,
     tabId: string,
     url: string,
+    signal?: AbortSignal,
   ): Promise<BrowserTabSummary>;
-  inspect(sessionId: string, tabId: string): Promise<BrowserInspection>;
+  inspect(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserInspection>;
   click(
     sessionId: string,
     tabId: string,
     observationId: string,
     targetId: string,
+    signal?: AbortSignal,
   ): Promise<BrowserTabSummary>;
   type(
     sessionId: string,
@@ -49,9 +62,17 @@ export interface ZenXBrowserBackend {
     targetId: string,
     text: string,
     submit: boolean,
+    signal?: AbortSignal,
   ): Promise<BrowserTabSummary>;
-  closeTab(sessionId: string, tabId: string): Promise<void> | void;
-  closeSession(sessionId: string): Promise<number> | number;
+  closeTab(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<void> | void;
+  closeSession(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<number> | number;
   close(): Promise<void> | void;
 }
 
@@ -209,33 +230,40 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
 };
 
 export class BrowserZenXCapabilityPackage implements ZenXCapabilityPackage {
-  readonly manifest = browserCapabilityManifest;
+  readonly manifest: ZenXCapabilityManifest;
   readonly #backend: ZenXBrowserBackend;
 
-  constructor(backend: ZenXBrowserBackend) {
+  constructor(
+    backend: ZenXBrowserBackend,
+    manifest: ZenXCapabilityManifest = browserCapabilityManifest,
+  ) {
     this.#backend = backend;
+    this.manifest = manifest;
   }
 
   async invoke(toolName: string, invocation: ToolInvocation): Promise<unknown> {
     const sessionId = requiredTargetId(invocation.arguments, "sessionId");
     switch (toolName) {
       case "browser_list_tabs":
-        return await this.#backend.listTabs(sessionId);
+        return await this.#backend.listTabs(sessionId, invocation.signal);
       case "browser_open":
         return await this.#backend.open(
           sessionId,
           safeBrowserUrl(requiredString(invocation.arguments, "url")),
+          invocation.signal,
         );
       case "browser_navigate":
         return await this.#backend.navigate(
           sessionId,
           requiredTargetId(invocation.arguments, "tabId"),
           safeBrowserUrl(requiredString(invocation.arguments, "url")),
+          invocation.signal,
         );
       case "browser_inspect":
         return await this.#backend.inspect(
           sessionId,
           requiredTargetId(invocation.arguments, "tabId"),
+          invocation.signal,
         );
       case "browser_click":
         return await this.#backend.click(
@@ -243,6 +271,7 @@ export class BrowserZenXCapabilityPackage implements ZenXCapabilityPackage {
           requiredTargetId(invocation.arguments, "tabId"),
           requiredTargetId(invocation.arguments, "observationId"),
           requiredTargetId(invocation.arguments, "targetId"),
+          invocation.signal,
         );
       case "browser_type":
         return await this.#backend.type(
@@ -252,15 +281,19 @@ export class BrowserZenXCapabilityPackage implements ZenXCapabilityPackage {
           requiredTargetId(invocation.arguments, "targetId"),
           requiredString(invocation.arguments, "text", true),
           optionalBoolean(invocation.arguments, "submit") ?? false,
+          invocation.signal,
         );
       case "browser_close": {
         const tabId = requiredTargetId(invocation.arguments, "tabId");
-        await this.#backend.closeTab(sessionId, tabId);
+        await this.#backend.closeTab(sessionId, tabId, invocation.signal);
         return { closed: true, sessionId, tabId };
       }
       case "browser_close_session":
         return {
-          closedTabs: await this.#backend.closeSession(sessionId),
+          closedTabs: await this.#backend.closeSession(
+            sessionId,
+            invocation.signal,
+          ),
           sessionId,
         };
       default:

--- a/apps/zenx/src/main/capabilities/computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/computer-provider.ts
@@ -19,6 +19,11 @@ export interface ComputerControlSelector {
   targetId: string;
 }
 
+export const COMPUTER_ACTION_PRESS = "press";
+export const COMPUTER_ACTION_SET_VALUE = "set_value";
+export type ComputerControlAction =
+  typeof COMPUTER_ACTION_PRESS | typeof COMPUTER_ACTION_SET_VALUE;
+
 export interface ComputerInspection {
   platform: NodeJS.Platform;
   observationId: string;
@@ -34,7 +39,7 @@ export interface ComputerInspection {
     role: string;
     title: string;
     enabled: boolean;
-    actions: string[];
+    actions: ComputerControlAction[];
     secure?: true;
   }>;
   truncated: boolean;
@@ -97,8 +102,6 @@ export type ComputerKey =
   | "arrowRight";
 
 export const MAX_COMPUTER_INSPECTION_CONTROLS = 32;
-export const COMPUTER_ACTION_PRESS = "press";
-export const COMPUTER_ACTION_SET_VALUE = "set_value";
 
 export const computerCapabilityManifest: ZenXCapabilityManifest = {
   schemaVersion: 1,
@@ -225,7 +228,7 @@ export class ComputerZenXCapabilityPackage implements ZenXCapabilityPackage {
 
   constructor(
     backend: ZenXComputerBackend,
-    manifest = computerCapabilityManifest,
+    manifest: ZenXCapabilityManifest = computerCapabilityManifest,
   ) {
     this.#backend = backend;
     this.manifest = manifest;
@@ -321,7 +324,7 @@ export interface ComputerControlFingerprint {
   description?: string;
   frame?: string;
   secure: boolean;
-  actions: string[];
+  actions: ComputerControlAction[];
 }
 
 interface ComputerObservation {
@@ -350,7 +353,7 @@ export class ComputerObservationLedger {
   consume(
     targetKey: string,
     selector: ComputerControlSelector,
-    action: "press" | "set_value",
+    action: ComputerControlAction,
   ): ComputerControlFingerprint {
     const observation = this.#latest.get(targetKey);
     if (
@@ -366,14 +369,14 @@ export class ComputerObservationLedger {
       throw new Error("Computer target ID is forged, stale, or unknown");
     }
     if (
-      action === "press" &&
+      action === COMPUTER_ACTION_PRESS &&
       !fingerprint.actions.includes(COMPUTER_ACTION_PRESS)
     ) {
       throw new Error(
         "Control no longer supports background-safe semantic press; foreground_required",
       );
     }
-    if (action === "set_value") {
+    if (action === COMPUTER_ACTION_SET_VALUE) {
       if (fingerprint.secure) {
         throw new Error(
           "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
@@ -422,15 +425,19 @@ function rawControlFingerprint(
   return {
     ...control.selector,
     secure: control.secure === true,
-    actions: canonicalMacActions(control.actions),
+    actions: canonicalComputerActions(control.actions),
   };
 }
 
-function canonicalMacActions(actions: readonly string[]): string[] {
-  return [
-    ...(actions.includes("AXPress") ? [COMPUTER_ACTION_PRESS] : []),
-    ...(actions.includes("AXSetValue") ? [COMPUTER_ACTION_SET_VALUE] : []),
-  ];
+function canonicalComputerActions(
+  actions: readonly string[],
+): ComputerControlAction[] {
+  const canonical: ComputerControlAction[] = [];
+  if (actions.includes("AXPress")) canonical.push(COMPUTER_ACTION_PRESS);
+  if (actions.includes("AXSetValue")) {
+    canonical.push(COMPUTER_ACTION_SET_VALUE);
+  }
+  return canonical;
 }
 
 function semanticControlSelector(
@@ -527,7 +534,7 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
     const fingerprint = this.#observations.consume(
       computerTargetKey(target),
       control,
-      "press",
+      COMPUTER_ACTION_PRESS,
     );
     const response = (await this.#accessibility.run({
       operation: "press",
@@ -550,7 +557,7 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
     const fingerprint = this.#observations.consume(
       computerTargetKey(target),
       control,
-      "set_value",
+      COMPUTER_ACTION_SET_VALUE,
     );
     const response = (await this.#accessibility.run({
       operation: "setValue",

--- a/apps/zenx/src/main/capabilities/external-provider.ts
+++ b/apps/zenx/src/main/capabilities/external-provider.ts
@@ -1,0 +1,263 @@
+import { spawn } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface ExternalProviderProcessResult {
+  stdout: string;
+  stderr: string;
+}
+
+export interface ExternalProviderProcessRunner {
+  run(
+    executable: string,
+    args: readonly string[],
+    options: {
+      cwd?: string;
+      timeoutMs: number;
+      signal?: AbortSignal;
+      maxOutputBytes?: number;
+    },
+  ): Promise<ExternalProviderProcessResult>;
+}
+
+const DEFAULT_MAX_PROCESS_OUTPUT_BYTES = 1024 * 1024;
+
+export class SystemExternalProviderProcessRunner implements ExternalProviderProcessRunner {
+  async run(
+    executable: string,
+    args: readonly string[],
+    options: {
+      cwd?: string;
+      timeoutMs: number;
+      signal?: AbortSignal;
+      maxOutputBytes?: number;
+    },
+  ): Promise<ExternalProviderProcessResult> {
+    options.signal?.throwIfAborted();
+    const maxOutputBytes =
+      options.maxOutputBytes ?? DEFAULT_MAX_PROCESS_OUTPUT_BYTES;
+    const invocation = await resolveExternalProviderInvocation(
+      executable,
+      process.env,
+    );
+    return await new Promise((resolve, reject) => {
+      const child = spawn(
+        invocation.executable,
+        [...invocation.argumentPrefix, ...args],
+        {
+          cwd: options.cwd,
+          env: providerProcessEnvironment(process.env),
+          shell: false,
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+        },
+      );
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let totalBytes = 0;
+      let settled = false;
+      const finish = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        options.signal?.removeEventListener("abort", abort);
+        callback();
+      };
+      const fail = (error: unknown): void => {
+        child.kill("SIGKILL");
+        finish(() => reject(error));
+      };
+      const collect = (target: Buffer[], chunk: Buffer): void => {
+        totalBytes += chunk.length;
+        if (totalBytes > maxOutputBytes) {
+          fail(
+            new Error(
+              `${path.basename(executable)} exceeded the ${String(maxOutputBytes)} byte output limit`,
+            ),
+          );
+          return;
+        }
+        target.push(chunk);
+      };
+      const timer = setTimeout(() => {
+        fail(
+          new Error(
+            `${path.basename(executable)} timed out after ${String(options.timeoutMs)}ms`,
+          ),
+        );
+      }, options.timeoutMs);
+      timer.unref();
+      const abort = (): void => {
+        fail(
+          options.signal?.reason ??
+            new DOMException("External provider call cancelled", "AbortError"),
+        );
+      };
+      options.signal?.addEventListener("abort", abort, { once: true });
+      child.stdout?.on("data", (chunk: Buffer) => collect(stdout, chunk));
+      child.stderr?.on("data", (chunk: Buffer) => collect(stderr, chunk));
+      child.once("error", (error) => fail(error));
+      child.once("close", (code, signal) => {
+        finish(() => {
+          const output = Buffer.concat(stdout).toString("utf8");
+          const diagnostic = Buffer.concat(stderr).toString("utf8");
+          if (code === 0) {
+            resolve({ stdout: output, stderr: diagnostic });
+            return;
+          }
+          reject(
+            new Error(
+              `${path.basename(executable)} failed (${signal ?? String(code)}): ${redactExternalDiagnostic(diagnostic || output)}`,
+            ),
+          );
+        });
+      });
+      if (options.signal?.aborted === true) abort();
+    });
+  }
+}
+
+interface ExternalProviderInvocation {
+  executable: string;
+  argumentPrefix: string[];
+}
+
+async function resolveExternalProviderInvocation(
+  executable: string,
+  environment: NodeJS.ProcessEnv,
+): Promise<ExternalProviderInvocation> {
+  if (
+    process.platform !== "win32" ||
+    path.extname(executable).toLowerCase() !== ".cmd"
+  ) {
+    return { executable, argumentPrefix: [] };
+  }
+  const source = await readFile(executable, "utf8");
+  const entry = parseWindowsNpmShimEntry(source);
+  if (entry === undefined) {
+    throw new Error(
+      `${path.basename(executable)} is not a supported npm Node command shim`,
+    );
+  }
+  const segments = entry.split(/[\\/]+/u);
+  if (
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    )
+  ) {
+    throw new Error(
+      `${path.basename(executable)} contains an unsafe shim entry`,
+    );
+  }
+  const script = path.resolve(path.dirname(executable), ...segments);
+  const relative = path.relative(path.dirname(executable), script);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(
+      `${path.basename(executable)} resolves outside its npm prefix`,
+    );
+  }
+  await access(script);
+  const siblingNode = path.join(path.dirname(executable), "node.exe");
+  const nodeExecutable = (await isExecutable(siblingNode))
+    ? siblingNode
+    : await discoverExecutable("node", {
+        environment,
+        platform: "win32",
+      });
+  if (nodeExecutable === undefined) {
+    throw new Error(
+      `Cannot execute ${path.basename(executable)} without node.exe`,
+    );
+  }
+  return { executable: nodeExecutable, argumentPrefix: [script] };
+}
+
+export function parseWindowsNpmShimEntry(source: string): string | undefined {
+  return source.match(/%dp0%[\\/]([^"\r\n]+?\.js)(?:"|\s|$)/iu)?.[1];
+}
+
+export async function discoverExecutable(
+  command: string,
+  options: {
+    environment?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+  } = {},
+): Promise<string | undefined> {
+  if (path.isAbsolute(command) || command.includes(path.sep)) {
+    return (await isExecutable(command)) ? command : undefined;
+  }
+  const environment = options.environment ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const directories = (environment.PATH ?? "")
+    .split(path.delimiter)
+    .filter((entry) => entry.length > 0);
+  const extensions =
+    platform === "win32"
+      ? (environment.PATHEXT ?? ".EXE;.CMD;.BAT").split(";").filter(Boolean)
+      : [""];
+  for (const directory of directories) {
+    for (const extension of extensions) {
+      const candidate = path.join(directory, `${command}${extension}`);
+      if (await isExecutable(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function parseExternalJson(
+  provider: string,
+  output: string,
+): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new Error(`${provider} returned invalid JSON`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${provider} returned a non-object JSON response`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function providerProcessEnvironment(
+  source: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const keys = [
+    "PATH",
+    "HOME",
+    "TMPDIR",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "SystemRoot",
+    "WINDIR",
+    "LOCALAPPDATA",
+    "USERPROFILE",
+  ];
+  return Object.fromEntries(
+    keys.flatMap((key) =>
+      source[key] === undefined ? [] : [[key, source[key]]],
+    ),
+  );
+}
+
+function redactExternalDiagnostic(value: string): string {
+  return value
+    .trim()
+    .slice(0, 2048)
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [REDACTED]")
+    .replace(
+      /\b((?:api[_-]?key|access[_-]?token|password|secret))=\S+/giu,
+      "$1=[REDACTED]",
+    );
+}
+
+async function isExecutable(candidate: string): Promise<boolean> {
+  try {
+    await access(candidate, process.platform === "win32" ? undefined : 0o1);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/zenx/src/main/capabilities/peekaboo-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/peekaboo-computer-provider.ts
@@ -1,0 +1,592 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  ComputerControlSelector,
+  ComputerInspection,
+  ComputerKey,
+  ComputerTarget,
+  ZenXComputerBackend,
+} from "./computer-provider.js";
+import {
+  COMPUTER_ACTION_PRESS,
+  COMPUTER_ACTION_SET_VALUE,
+  type ComputerControlAction,
+} from "./computer-provider.js";
+import {
+  type ExternalProviderProcessRunner,
+  parseExternalJson,
+} from "./external-provider.js";
+
+const PEEKABOO_TIMEOUT_MS = 25_000;
+const MAX_PEEKABOO_CONTROLS = 32;
+
+interface PeekabooElement {
+  id: string;
+  role: string;
+  title?: string;
+  label?: string;
+  description?: string;
+  identifier?: string;
+  is_actionable: boolean;
+}
+
+interface PeekabooObservedTarget {
+  rawElementId: string;
+  snapshotId: string;
+  actions: ComputerControlAction[];
+  secure: boolean;
+  fingerprint: string;
+}
+
+interface PeekabooObservation {
+  observationId: string;
+  targetKey: string;
+  snapshotId: string;
+  targets: Map<string, PeekabooObservedTarget>;
+}
+
+export class PeekabooComputerBackend implements ZenXComputerBackend {
+  readonly #executable: string;
+  readonly #runner: ExternalProviderProcessRunner;
+  readonly #artifactDirectory: string;
+  readonly #observations = new Map<string, PeekabooObservation>();
+  readonly #snapshotIds = new Set<string>();
+
+  constructor(options: {
+    executable: string;
+    runner: ExternalProviderProcessRunner;
+    artifactDirectory?: string;
+  }) {
+    this.#executable = options.executable;
+    this.#runner = options.runner;
+    this.#artifactDirectory =
+      options.artifactDirectory ??
+      path.join(os.tmpdir(), `zenx-peekaboo-${String(process.pid)}`);
+  }
+
+  async inspect(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<ComputerInspection> {
+    const response = await this.#run(
+      [
+        "see",
+        ...peekabooTargetArguments(target),
+        "--max-elements",
+        "128",
+        "--timeout-seconds",
+        "20",
+      ],
+      signal,
+    );
+    const data = requirePeekabooData(response, "see");
+    const snapshotId = requiredString(data, "snapshot_id", "see.data");
+    this.#snapshotIds.add(snapshotId);
+    const elements = requiredArray(data, "ui_elements", "see.data").map(
+      requirePeekabooElement,
+    );
+    const selected = elements.slice(0, MAX_PEEKABOO_CONTROLS);
+    const observationId = randomUUID();
+    const targets = new Map<string, PeekabooObservedTarget>();
+    const controls = selected.map((element) => {
+      const targetId = randomUUID();
+      const secure = isSecurePeekabooElement(element);
+      const actions = peekabooElementActions(element, secure);
+      targets.set(targetId, {
+        rawElementId: element.id,
+        snapshotId,
+        actions,
+        secure,
+        fingerprint: peekabooElementFingerprint(element),
+      });
+      return {
+        selector: { observationId, targetId },
+        role: element.role,
+        title: element.label ?? element.title ?? element.description ?? "",
+        enabled: element.is_actionable,
+        actions,
+        ...(secure ? { secure: true as const } : {}),
+      };
+    });
+    const key = computerTargetKey(target);
+    const prior = this.#observations.get(key);
+    if (prior !== undefined) {
+      await this.#cleanSnapshot(prior.snapshotId);
+    }
+    this.#observations.set(key, {
+      observationId,
+      targetKey: key,
+      snapshotId,
+      targets,
+    });
+    return {
+      platform: "darwin",
+      observationId,
+      target: targetSummary(target, data),
+      controls,
+      truncated: elements.length > selected.length || data.truncation != null,
+    };
+  }
+
+  async press(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    signal?: AbortSignal,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+  }> {
+    const observed = this.#consume(target, control, COMPUTER_ACTION_PRESS);
+    let fresh: { rawElementId: string; snapshotId: string } | undefined;
+    try {
+      fresh = await this.#revalidate(target, observed, signal);
+      await this.#run(
+        [
+          "click",
+          "--on",
+          fresh.rawElementId,
+          "--snapshot",
+          fresh.snapshotId,
+          ...peekabooTargetArguments(target),
+        ],
+        signal,
+      );
+    } finally {
+      await this.#cleanSnapshot(observed.snapshotId);
+      if (fresh !== undefined) await this.#cleanSnapshot(fresh.snapshotId);
+    }
+    return { target: targetSummary(target), control };
+  }
+
+  async setValue(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    value: string,
+    signal?: AbortSignal,
+  ): Promise<{
+    target: ComputerInspection["target"];
+    control: ComputerControlSelector;
+    characterCount: number;
+  }> {
+    const observed = this.#consume(target, control, COMPUTER_ACTION_SET_VALUE);
+    let fresh: { rawElementId: string; snapshotId: string } | undefined;
+    try {
+      fresh = await this.#revalidate(target, observed, signal);
+      await this.#run(
+        [
+          "set-value",
+          value,
+          "--on",
+          fresh.rawElementId,
+          "--snapshot",
+          fresh.snapshotId,
+        ],
+        signal,
+      );
+    } finally {
+      await this.#cleanSnapshot(observed.snapshotId);
+      if (fresh !== undefined) await this.#cleanSnapshot(fresh.snapshotId);
+    }
+    return {
+      target: targetSummary(target),
+      control,
+      characterCount: value.length,
+    };
+  }
+
+  async screenshot(
+    target: ComputerTarget,
+    signal?: AbortSignal,
+  ): Promise<{
+    artifactPath: string;
+    target: ComputerInspection["target"];
+    width: number;
+    height: number;
+    bytes: number;
+    expiresAt: string;
+  }> {
+    await mkdir(this.#artifactDirectory, { recursive: true, mode: 0o700 });
+    const artifactPath = path.join(
+      this.#artifactDirectory,
+      `${randomUUID()}.png`,
+    );
+    const response = await this.#run(
+      [
+        "image",
+        ...peekabooTargetArguments(target),
+        "--capture-focus",
+        "background",
+        "--format",
+        "png",
+        "--path",
+        artifactPath,
+      ],
+      signal,
+    );
+    requirePeekabooData(response, "image");
+    const file = await readFile(artifactPath);
+    const dimensions = pngDimensions(file);
+    const expiresAt = new Date(Date.now() + 5 * 60_000);
+    const timer = setTimeout(
+      () => void rm(artifactPath, { force: true }),
+      5 * 60_000,
+    );
+    timer.unref();
+    return {
+      artifactPath,
+      target: targetSummary(target),
+      width: dimensions.width,
+      height: dimensions.height,
+      bytes: (await stat(artifactPath)).size,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  async foregroundClick(
+    x: number,
+    y: number,
+    button: "left" | "right",
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.#run(
+      [
+        "click",
+        "--coords",
+        `${String(Math.round(x))},${String(Math.round(y))}`,
+        "--global-coords",
+        "--foreground",
+        ...(button === "right" ? ["--right"] : []),
+      ],
+      signal,
+    );
+  }
+
+  async foregroundKeyPress(
+    key: ComputerKey,
+    signal: AbortSignal,
+  ): Promise<void> {
+    await this.#run(["press", peekabooKey(key), "--foreground"], signal);
+  }
+
+  async foregroundScroll(deltaY: number, signal: AbortSignal): Promise<void> {
+    await this.#run(
+      [
+        "scroll",
+        "--direction",
+        deltaY > 0 ? "down" : "up",
+        "--amount",
+        String(Math.max(1, Math.min(100, Math.round(Math.abs(deltaY) / 100)))),
+        "--foreground",
+      ],
+      signal,
+    );
+  }
+
+  async close(): Promise<void> {
+    this.#observations.clear();
+    for (const snapshotId of [...this.#snapshotIds]) {
+      await this.#cleanSnapshot(snapshotId);
+    }
+    await rm(this.#artifactDirectory, { recursive: true, force: true });
+  }
+
+  #consume(
+    target: ComputerTarget,
+    control: ComputerControlSelector,
+    action: ComputerControlAction,
+  ): PeekabooObservedTarget {
+    const key = computerTargetKey(target);
+    const observation = this.#observations.get(key);
+    if (
+      observation === undefined ||
+      observation.targetKey !== key ||
+      observation.observationId !== control.observationId
+    ) {
+      throw new Error(
+        "Computer observation is stale, unknown, or scoped to another target; inspect again",
+      );
+    }
+    const selected = observation.targets.get(control.targetId);
+    if (selected === undefined) {
+      throw new Error("Computer target ID is forged, stale, or unknown");
+    }
+    if (!selected.actions.includes(action)) {
+      throw new Error(`Computer target does not support ${action}`);
+    }
+    if (action === COMPUTER_ACTION_SET_VALUE && selected.secure) {
+      throw new Error(
+        "computer_set_value rejects password or secure controls because supplied text is journaled",
+      );
+    }
+    this.#observations.delete(key);
+    return selected;
+  }
+
+  async #revalidate(
+    target: ComputerTarget,
+    observed: PeekabooObservedTarget,
+    signal?: AbortSignal,
+  ): Promise<{ rawElementId: string; snapshotId: string }> {
+    const response = await this.#run(
+      [
+        "see",
+        ...peekabooTargetArguments(target),
+        "--max-elements",
+        "128",
+        "--timeout-seconds",
+        "20",
+      ],
+      signal,
+    );
+    const data = requirePeekabooData(response, "see");
+    const snapshotId = requiredString(data, "snapshot_id", "see.data");
+    this.#snapshotIds.add(snapshotId);
+    const matches = requiredArray(data, "ui_elements", "see.data")
+      .map(requirePeekabooElement)
+      .filter(
+        (element) =>
+          peekabooElementFingerprint(element) === observed.fingerprint &&
+          isSecurePeekabooElement(element) === observed.secure &&
+          sameActions(
+            peekabooElementActions(element, observed.secure),
+            observed.actions,
+          ),
+      );
+    if (matches.length !== 1) {
+      throw new Error(
+        "Peekaboo target identity changed, disappeared, or became ambiguous; inspect again",
+      );
+    }
+    return { rawElementId: matches[0]!.id, snapshotId };
+  }
+
+  async #cleanSnapshot(snapshotId: string): Promise<void> {
+    if (snapshotId.length === 0) return;
+    if (!this.#snapshotIds.delete(snapshotId)) return;
+    await this.#runner
+      .run(this.#executable, ["clean", "--snapshot", snapshotId, "--json"], {
+        timeoutMs: 5_000,
+        maxOutputBytes: 64 * 1024,
+      })
+      .catch(() => undefined);
+  }
+
+  async #run(
+    args: readonly string[],
+    signal?: AbortSignal,
+  ): Promise<Record<string, unknown>> {
+    const result = await this.#runner.run(
+      this.#executable,
+      [...args, "--json"],
+      {
+        timeoutMs: PEEKABOO_TIMEOUT_MS,
+        signal,
+        maxOutputBytes: 512 * 1024,
+      },
+    );
+    const response = parseExternalJson("peekaboo", result.stdout);
+    if (response.success !== true) {
+      const error = asRecord(response.error);
+      throw new Error(
+        `peekaboo: ${String(error?.message ?? "unknown provider error")}`,
+      );
+    }
+    return response;
+  }
+}
+
+function requirePeekabooData(
+  response: Record<string, unknown>,
+  operation: string,
+): Record<string, unknown> {
+  const data = asRecord(response.data);
+  if (data === undefined) {
+    throw new Error(
+      `Unsupported Peekaboo 3.x JSON schema: ${operation}.data must be an object`,
+    );
+  }
+  return data;
+}
+
+function requirePeekabooElement(value: unknown): PeekabooElement {
+  const element = asRecord(value);
+  if (
+    element === undefined ||
+    typeof element.id !== "string" ||
+    typeof element.role !== "string" ||
+    typeof element.is_actionable !== "boolean"
+  ) {
+    throw new Error(
+      "Unsupported Peekaboo 3.x JSON schema: invalid ui_elements entry",
+    );
+  }
+  return {
+    id: element.id,
+    role: element.role,
+    is_actionable: element.is_actionable,
+    ...optionalTextProperties(element, [
+      "title",
+      "label",
+      "description",
+      "identifier",
+    ]),
+  };
+}
+
+function optionalTextProperties(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): Record<string, string> {
+  return Object.fromEntries(
+    keys.flatMap((key) =>
+      typeof value[key] === "string" ? [[key, value[key]]] : [],
+    ),
+  );
+}
+
+function peekabooTargetArguments(target: ComputerTarget): string[] {
+  const application = target.bundleId ?? target.applicationId;
+  if (target.pid === undefined && application === undefined) {
+    throw new Error("Peekaboo target requires pid, bundleId, or applicationId");
+  }
+  const selector =
+    target.pid === undefined && application !== undefined
+      ? ["--app", application]
+      : ["--pid", String(target.pid)];
+  return [
+    ...selector,
+    ...(target.windowTitle === undefined
+      ? []
+      : ["--window-title", target.windowTitle]),
+  ];
+}
+
+function computerTargetKey(target: ComputerTarget): string {
+  return JSON.stringify({
+    pid: target.pid ?? null,
+    applicationId: target.applicationId ?? null,
+    bundleId: target.bundleId ?? null,
+    windowTitle: target.windowTitle ?? null,
+  });
+}
+
+function targetSummary(
+  target: ComputerTarget,
+  data: Record<string, unknown> = {},
+): ComputerInspection["target"] {
+  return {
+    pid: target.pid ?? 0,
+    ...(target.applicationId === undefined
+      ? {}
+      : { applicationId: target.applicationId }),
+    ...(target.bundleId === undefined ? {} : { bundleId: target.bundleId }),
+    applicationName:
+      typeof data.application_name === "string"
+        ? data.application_name
+        : (target.bundleId ??
+          target.applicationId ??
+          `PID ${String(target.pid ?? "unknown")}`),
+    ...(target.windowTitle === undefined
+      ? {}
+      : { windowTitle: target.windowTitle }),
+  };
+}
+
+function isSecurePeekabooElement(element: PeekabooElement): boolean {
+  return /secure|password/iu.test(
+    `${element.role} ${element.title ?? ""} ${element.label ?? ""} ${element.description ?? ""}`,
+  );
+}
+
+function peekabooElementActions(
+  element: PeekabooElement,
+  secure: boolean,
+): ComputerControlAction[] {
+  const editable = /text|search|combo/iu.test(element.role);
+  const actions: ComputerControlAction[] = [];
+  if (element.is_actionable) actions.push(COMPUTER_ACTION_PRESS);
+  if (editable && !secure) actions.push(COMPUTER_ACTION_SET_VALUE);
+  return actions;
+}
+
+function peekabooElementFingerprint(element: PeekabooElement): string {
+  return JSON.stringify({
+    role: element.role,
+    identifier: element.identifier ?? null,
+    title: element.title ?? null,
+    label: element.label ?? null,
+    description: element.description ?? null,
+  });
+}
+
+function sameActions(
+  left: readonly ComputerControlAction[],
+  right: readonly ComputerControlAction[],
+): boolean {
+  return (
+    left.length === right.length && left.every((value) => right.includes(value))
+  );
+}
+
+function peekabooKey(key: ComputerKey): string {
+  return (
+    {
+      enter: "return",
+      escape: "escape",
+      tab: "tab",
+      backspace: "delete",
+      space: "space",
+      arrowUp: "up",
+      arrowDown: "down",
+      arrowLeft: "left",
+      arrowRight: "right",
+    } as const
+  )[key];
+}
+
+function pngDimensions(buffer: Buffer): { width: number; height: number } {
+  if (
+    buffer.length < 24 ||
+    !buffer
+      .subarray(0, 8)
+      .equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+  ) {
+    throw new Error("Peekaboo screenshot is not a valid PNG");
+  }
+  return { width: buffer.readUInt32BE(16), height: buffer.readUInt32BE(20) };
+}
+
+function requiredString(
+  value: Record<string, unknown>,
+  key: string,
+  owner: string,
+): string {
+  if (typeof value[key] !== "string" || value[key].length === 0) {
+    throw new Error(
+      `Unsupported Peekaboo 3.x JSON schema: ${owner}.${key} must be a string`,
+    );
+  }
+  return value[key];
+}
+
+function requiredArray(
+  value: Record<string, unknown>,
+  key: string,
+  owner: string,
+): unknown[] {
+  if (!Array.isArray(value[key])) {
+    throw new Error(
+      `Unsupported Peekaboo 3.x JSON schema: ${owner}.${key} must be an array`,
+    );
+  }
+  return value[key];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -1,0 +1,805 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type {
+  BrowserInspection,
+  BrowserTabSummary,
+  BrowserTargetFingerprint,
+  ZenXBrowserBackend,
+} from "./browser-provider.js";
+import {
+  type ExternalProviderProcessRunner,
+  parseExternalJson,
+} from "./external-provider.js";
+
+const PLAYWRIGHT_PROVIDER_TIMEOUT_MS = 30_000;
+const PLAYWRIGHT_CLOSE_TIMEOUT_MS = 10_000;
+const MAX_PLAYWRIGHT_VISIBLE_TEXT = 8_000;
+const MAX_PLAYWRIGHT_TARGETS = 128;
+
+interface PlaywrightTabState {
+  tabId: string;
+  index: number;
+  documentVersion: number;
+  observation?: PlaywrightObservation;
+}
+
+interface PlaywrightSessionState {
+  sessionId: string;
+  cliSessionName: string;
+  opened: boolean;
+  tabs: Map<string, PlaywrightTabState>;
+}
+
+interface PlaywrightObservation {
+  id: string;
+  documentVersion: number;
+  targets: Map<
+    string,
+    BrowserTargetFingerprint & { ref: string; disabled: boolean }
+  >;
+}
+
+interface PlaywrightPageState {
+  index: number;
+  title: string;
+  url: string;
+  current: boolean;
+}
+
+interface PlaywrightAriaNode {
+  role: string;
+  name?: string;
+  ref?: string;
+  disabled?: true;
+  cursor?: "pointer";
+  url?: string;
+  placeholder?: string;
+  text?: string;
+  children?: Array<PlaywrightAriaNode | string>;
+}
+
+interface PlaywrightDomMetadata {
+  ref: string;
+  count: 1;
+  visible: boolean;
+  tag: string;
+  type: string;
+  id: string;
+  fieldName: string;
+  autocomplete: string;
+  href: string;
+}
+
+export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
+  readonly #executable: string;
+  readonly #runner: ExternalProviderProcessRunner;
+  readonly #cwd: string;
+  readonly #sessions = new Map<string, PlaywrightSessionState>();
+
+  constructor(options: {
+    executable: string;
+    runner: ExternalProviderProcessRunner;
+    cwd: string;
+  }) {
+    this.#executable = options.executable;
+    this.#runner = options.runner;
+    this.#cwd = options.cwd;
+  }
+
+  async listTabs(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary[]> {
+    const session = this.#requireSession(sessionId);
+    const pages = await this.#pageStates(session, signal);
+    this.#reconcileTabs(session, pages);
+    return pages.map((page) => {
+      const state = [...session.tabs.values()].find(
+        (candidate) => candidate.index === page.index,
+      );
+      if (state === undefined) {
+        throw new Error("Playwright tab reconciliation failed");
+      }
+      return pageSummary(sessionId, state.tabId, page);
+    });
+  }
+
+  async open(
+    sessionId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const session = this.#session(sessionId);
+    if (!session.opened) {
+      const response = await this.#run(
+        session,
+        ["open", url],
+        signal,
+        PLAYWRIGHT_PROVIDER_TIMEOUT_MS,
+      );
+      requirePlaywrightOpenEnvelope(response, session.cliSessionName);
+      session.opened = true;
+    } else {
+      await this.#run(session, ["tab-new", url], signal);
+    }
+    const pages = await this.#pageStates(session, signal);
+    this.#reconcileTabs(session, pages);
+    const current = pages.find((page) => page.current) ?? pages.at(-1);
+    if (current === undefined)
+      throw new Error("Playwright opened no browser tab");
+    const state = [...session.tabs.values()].find(
+      (candidate) => candidate.index === current.index,
+    );
+    if (state === undefined)
+      throw new Error("Playwright tab mapping is missing");
+    return pageSummary(sessionId, state.tabId, current);
+  }
+
+  async navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const { session, tab } = this.#requireTab(sessionId, tabId);
+    await this.#select(session, tab, signal);
+    this.#invalidate(tab);
+    await this.#run(session, ["goto", url], signal);
+    return await this.#summary(sessionId, session, tab, signal);
+  }
+
+  async inspect(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserInspection> {
+    const { session, tab } = this.#requireTab(sessionId, tabId);
+    await this.#select(session, tab, signal);
+    const snapshot = await this.#snapshot(session, signal);
+    const observationId = randomUUID();
+    const targets = new Map<
+      string,
+      BrowserTargetFingerprint & { ref: string; disabled: boolean }
+    >();
+    const visible: string[] = [];
+    const nodes: PlaywrightAriaNode[] = [];
+    walkAriaSnapshot(snapshot, (node) => {
+      appendVisibleText(visible, node);
+      if (node.ref !== undefined && nodes.length < MAX_PLAYWRIGHT_TARGETS) {
+        nodes.push(node);
+      }
+    });
+    const metadata = await this.#domMetadata(
+      session,
+      nodes.flatMap((node) => (node.ref === undefined ? [] : [node.ref])),
+      signal,
+    );
+    for (const node of nodes) {
+      const dom = node.ref === undefined ? undefined : metadata.get(node.ref);
+      if (node.ref === undefined || dom === undefined || !dom.visible) continue;
+      const fingerprint = playwrightTargetFingerprint(node, dom);
+      const actions = fingerprint.actions;
+      if (actions.length === 0) continue;
+      const targetId = randomUUID();
+      targets.set(targetId, {
+        ref: node.ref,
+        ...fingerprint,
+        disabled: node.disabled === true,
+      });
+    }
+    tab.observation = {
+      id: observationId,
+      documentVersion: tab.documentVersion,
+      targets,
+    };
+    const summary = await this.#summary(sessionId, session, tab, signal);
+    return {
+      ...summary,
+      observationId,
+      documentVersion: tab.documentVersion,
+      visibleText: visible.join("\n").slice(0, MAX_PLAYWRIGHT_VISIBLE_TEXT),
+      targets: [...targets].map(([targetId, target]) => ({
+        targetId,
+        role: target.role,
+        name: target.name,
+        actions: [...target.actions],
+        ...(target.secure ? { secure: true as const } : {}),
+      })),
+    };
+  }
+
+  async click(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const { session, tab } = this.#requireTab(sessionId, tabId);
+    const target = requireObservedTarget(tab, observationId, targetId, "click");
+    await this.#select(session, tab, signal);
+    await this.#revalidateTarget(session, target, "click", signal);
+    this.#invalidate(tab);
+    await this.#run(session, ["click", target.ref], signal);
+    return await this.#summary(sessionId, session, tab, signal);
+  }
+
+  async type(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const { session, tab } = this.#requireTab(sessionId, tabId);
+    const target = requireObservedTarget(tab, observationId, targetId, "type");
+    await this.#select(session, tab, signal);
+    await this.#revalidateTarget(session, target, "type", signal);
+    this.#invalidate(tab);
+    await this.#run(session, ["fill", target.ref, text], signal);
+    if (submit) await this.#run(session, ["press", "Enter"], signal);
+    return await this.#summary(sessionId, session, tab, signal);
+  }
+
+  async closeTab(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const { session, tab } = this.#requireTab(sessionId, tabId);
+    await this.#run(session, ["tab-close", String(tab.index)], signal);
+    session.tabs.delete(tabId);
+    for (const candidate of session.tabs.values()) {
+      if (candidate.index > tab.index) candidate.index -= 1;
+    }
+  }
+
+  async closeSession(sessionId: string, signal?: AbortSignal): Promise<number> {
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined) return 0;
+    const closedTabs = session.tabs.size;
+    try {
+      if (session.opened) {
+        await this.#run(
+          session,
+          ["close"],
+          signal,
+          PLAYWRIGHT_CLOSE_TIMEOUT_MS,
+        );
+      }
+    } finally {
+      session.tabs.clear();
+      session.opened = false;
+      this.#sessions.delete(sessionId);
+    }
+    return closedTabs;
+  }
+
+  async close(): Promise<void> {
+    for (const sessionId of [...this.#sessions.keys()]) {
+      await this.closeSession(sessionId).catch(() => undefined);
+    }
+  }
+
+  async #run(
+    session: PlaywrightSessionState,
+    args: readonly string[],
+    signal?: AbortSignal,
+    timeoutMs = PLAYWRIGHT_PROVIDER_TIMEOUT_MS,
+  ): Promise<Record<string, unknown>> {
+    try {
+      const result = await this.#runner.run(
+        this.#executable,
+        ["--json", `-s=${session.cliSessionName}`, ...args],
+        {
+          cwd: this.#cwd,
+          timeoutMs,
+          signal,
+          maxOutputBytes: 512 * 1024,
+        },
+      );
+      const response = parseExternalJson("playwright-cli", result.stdout);
+      if (response.isError === true) {
+        throw new Error(
+          `playwright-cli: ${String(response.error ?? "unknown provider error")}`,
+        );
+      }
+      return response;
+    } catch (error) {
+      if (signal?.aborted === true || isAbortError(error)) {
+        if (this.#sessions.get(session.sessionId) === session) {
+          this.#sessions.delete(session.sessionId);
+        }
+        session.opened = false;
+        session.tabs.clear();
+        void this.#bestEffortCancel(session);
+      }
+      throw error;
+    }
+  }
+
+  async #bestEffortCancel(session: PlaywrightSessionState): Promise<void> {
+    await this.#runner
+      .run(
+        this.#executable,
+        ["--json", `-s=${session.cliSessionName}`, "close"],
+        { cwd: this.#cwd, timeoutMs: PLAYWRIGHT_CLOSE_TIMEOUT_MS },
+      )
+      .catch(() => undefined);
+  }
+
+  async #pageStates(
+    session: PlaywrightSessionState,
+    signal?: AbortSignal,
+  ): Promise<PlaywrightPageState[]> {
+    if (!session.opened) return [];
+    const response = await this.#run(
+      session,
+      [
+        "run-code",
+        "async page => await Promise.all(page.context().pages().map(async (candidate, index) => ({ index, title: await candidate.title(), url: candidate.url(), current: candidate === page })))",
+      ],
+      signal,
+    );
+    if (typeof response.result !== "string") {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: run-code result must be a JSON string",
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(response.result);
+    } catch {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: run-code result is not JSON",
+      );
+    }
+    if (!Array.isArray(parsed) || !parsed.every(isPlaywrightPageState)) {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: invalid page state result",
+      );
+    }
+    return parsed;
+  }
+
+  async #snapshot(
+    session: PlaywrightSessionState,
+    signal?: AbortSignal,
+  ): Promise<PlaywrightAriaNode[]> {
+    const response = await this.#run(
+      session,
+      ["snapshot", "--depth=12"],
+      signal,
+    );
+    return requireAriaSnapshot(response);
+  }
+
+  async #revalidateTarget(
+    session: PlaywrightSessionState,
+    target: BrowserTargetFingerprint & {
+      ref: string;
+      disabled: boolean;
+    },
+    action: "click" | "type",
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const snapshot = await this.#snapshot(session, signal);
+    const matches: PlaywrightAriaNode[] = [];
+    walkAriaSnapshot(snapshot, (node) => {
+      if (node.ref === target.ref) matches.push(node);
+    });
+    if (matches.length !== 1) {
+      throw new Error(
+        "Playwright target is stale, hidden, missing, or ambiguous; inspect again",
+      );
+    }
+    const node = matches[0]!;
+    const metadata = await this.#domMetadata(session, [target.ref], signal);
+    const dom = metadata.get(target.ref);
+    if (dom === undefined || !dom.visible) {
+      throw new Error(
+        "Playwright target is stale, hidden, missing, or ambiguous; inspect again",
+      );
+    }
+    const fingerprint = playwrightTargetFingerprint(node, dom);
+    if (
+      fingerprint.selector !== target.selector ||
+      fingerprint.tag !== target.tag ||
+      fingerprint.role !== target.role ||
+      fingerprint.name !== target.name ||
+      fingerprint.type !== target.type ||
+      fingerprint.id !== target.id ||
+      fingerprint.fieldName !== target.fieldName ||
+      fingerprint.autocomplete !== target.autocomplete ||
+      fingerprint.href !== target.href ||
+      fingerprint.secure !== target.secure ||
+      (node.disabled === true) !== target.disabled ||
+      fingerprint.actions.length !== target.actions.length ||
+      !fingerprint.actions.every((candidate) =>
+        target.actions.includes(candidate),
+      ) ||
+      !fingerprint.actions.includes(action)
+    ) {
+      throw new Error(
+        "Playwright target identity, security, visibility, or actions changed; inspect again",
+      );
+    }
+  }
+
+  async #domMetadata(
+    session: PlaywrightSessionState,
+    refs: readonly string[],
+    signal?: AbortSignal,
+  ): Promise<Map<string, PlaywrightDomMetadata>> {
+    if (refs.length === 0) return new Map();
+    const code = `async page => await Promise.all(${JSON.stringify(refs)}.map(async ref => {
+      const locator = page.locator('aria-ref=' + ref);
+      const count = await locator.count();
+      if (count !== 1) return { ref, count };
+      const visible = await locator.isVisible();
+      const attributes = await locator.evaluate(element => ({
+        tag: element.tagName.toLowerCase(),
+        type: element.getAttribute('type') || '',
+        id: element.id || '',
+        fieldName: element.getAttribute('name') || '',
+        autocomplete: element.getAttribute('autocomplete') || '',
+        href: element.getAttribute('href') || ''
+      }));
+      return { ref, count, visible, ...attributes };
+    }))`;
+    const response = await this.#run(session, ["run-code", code], signal);
+    if (typeof response.result !== "string") {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: DOM metadata result must be a JSON string",
+      );
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(response.result);
+    } catch {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: DOM metadata result is not JSON",
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: DOM metadata must be an array",
+      );
+    }
+    const result = new Map<string, PlaywrightDomMetadata>();
+    for (const entry of parsed) {
+      if (isPlaywrightDomMetadata(entry)) result.set(entry.ref, entry);
+      else if (!isMissingPlaywrightDomMetadata(entry)) {
+        throw new Error(
+          "Unsupported playwright-cli JSON schema: invalid DOM metadata entry",
+        );
+      }
+    }
+    return result;
+  }
+
+  #reconcileTabs(
+    session: PlaywrightSessionState,
+    pages: PlaywrightPageState[],
+  ): void {
+    const indexes = new Set(pages.map((page) => page.index));
+    for (const [tabId, tab] of session.tabs) {
+      if (!indexes.has(tab.index)) session.tabs.delete(tabId);
+    }
+    for (const page of pages) {
+      if (![...session.tabs.values()].some((tab) => tab.index === page.index)) {
+        const tabId = randomUUID();
+        session.tabs.set(tabId, {
+          tabId,
+          index: page.index,
+          documentVersion: 0,
+        });
+      }
+    }
+  }
+
+  async #select(
+    session: PlaywrightSessionState,
+    tab: PlaywrightTabState,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await this.#run(session, ["tab-select", String(tab.index)], signal);
+  }
+
+  async #summary(
+    sessionId: string,
+    session: PlaywrightSessionState,
+    tab: PlaywrightTabState,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const pages = await this.#pageStates(session, signal);
+    const page = pages.find((candidate) => candidate.index === tab.index);
+    if (page === undefined)
+      throw new Error("Playwright browser tab was closed");
+    return pageSummary(sessionId, tab.tabId, page);
+  }
+
+  #session(sessionId: string): PlaywrightSessionState {
+    let session = this.#sessions.get(sessionId);
+    if (session !== undefined) return session;
+    session = {
+      sessionId,
+      cliSessionName: `${playwrightSessionName(sessionId)}-${randomUUID().slice(0, 8)}`,
+      opened: false,
+      tabs: new Map(),
+    };
+    this.#sessions.set(sessionId, session);
+    return session;
+  }
+
+  #requireSession(sessionId: string): PlaywrightSessionState {
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined || !session.opened) {
+      throw new Error(`Unknown Playwright browser session: ${sessionId}`);
+    }
+    return session;
+  }
+
+  #requireTab(
+    sessionId: string,
+    tabId: string,
+  ): { session: PlaywrightSessionState; tab: PlaywrightTabState } {
+    const session = this.#requireSession(sessionId);
+    const tab = session.tabs.get(tabId);
+    if (tab === undefined) {
+      throw new Error("Browser tab is unknown or scoped to another session");
+    }
+    return { session, tab };
+  }
+
+  #invalidate(tab: PlaywrightTabState): void {
+    tab.documentVersion += 1;
+    tab.observation = undefined;
+  }
+}
+
+function requirePlaywrightOpenEnvelope(
+  response: Record<string, unknown>,
+  expectedSession: string,
+): void {
+  if (
+    response.session !== expectedSession ||
+    typeof response.result !== "object" ||
+    response.result === null
+  ) {
+    throw new Error(
+      "Unsupported playwright-cli JSON schema: invalid open envelope",
+    );
+  }
+}
+
+function requireAriaSnapshot(
+  response: Record<string, unknown>,
+): PlaywrightAriaNode[] {
+  if (!Array.isArray(response.snapshot)) {
+    throw new Error(
+      "Unsupported playwright-cli JSON schema: snapshot must be an array",
+    );
+  }
+  if (!response.snapshot.every(isPlaywrightAriaNode)) {
+    throw new Error(
+      "Unsupported playwright-cli JSON schema: invalid ARIA snapshot node",
+    );
+  }
+  return response.snapshot;
+}
+
+function isPlaywrightAriaNode(value: unknown): value is PlaywrightAriaNode {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const node = value as Record<string, unknown>;
+  if (typeof node.role !== "string") return false;
+  if (node.ref !== undefined && typeof node.ref !== "string") return false;
+  if (
+    node.children !== undefined &&
+    (!Array.isArray(node.children) ||
+      !node.children.every(
+        (child) => typeof child === "string" || isPlaywrightAriaNode(child),
+      ))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function walkAriaSnapshot(
+  nodes: readonly PlaywrightAriaNode[],
+  visit: (node: PlaywrightAriaNode) => void,
+): void {
+  const queue = [...nodes];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    visit(node);
+    for (const child of node.children ?? []) {
+      if (typeof child !== "string") queue.push(child);
+    }
+  }
+}
+
+function appendVisibleText(target: string[], node: PlaywrightAriaNode): void {
+  if (target.join("\n").length >= MAX_PLAYWRIGHT_VISIBLE_TEXT) return;
+  const text = node.text ?? node.name;
+  if (typeof text === "string" && text.trim().length > 0) {
+    target.push(text.trim().slice(0, 512));
+  }
+  for (const child of node.children ?? []) {
+    if (typeof child === "string" && child.trim().length > 0) {
+      target.push(child.trim().slice(0, 512));
+    }
+  }
+}
+
+function playwrightTargetFingerprint(
+  node: PlaywrightAriaNode,
+  dom: PlaywrightDomMetadata,
+): BrowserTargetFingerprint {
+  const secure = isSecurePlaywrightNode(node, dom);
+  return {
+    selector: node.ref!,
+    tag: dom.tag,
+    role: node.role,
+    name: node.name ?? node.placeholder ?? "",
+    type: dom.type,
+    id: dom.id,
+    fieldName: dom.fieldName,
+    autocomplete: dom.autocomplete,
+    href: dom.href || node.url || "",
+    secure,
+    actions: playwrightNodeActions(node, dom, secure),
+  };
+}
+
+function playwrightNodeActions(
+  node: PlaywrightAriaNode,
+  dom: PlaywrightDomMetadata,
+  secure: boolean,
+): Array<"click" | "type"> {
+  if (node.disabled === true) return [];
+  const clickRoles = new Set([
+    "button",
+    "checkbox",
+    "combobox",
+    "link",
+    "menuitem",
+    "option",
+    "radio",
+    "switch",
+    "tab",
+    "searchbox",
+    "textbox",
+  ]);
+  const typeRoles = new Set(["combobox", "searchbox", "textbox"]);
+  const nonTypeableInput = new Set([
+    "button",
+    "checkbox",
+    "file",
+    "hidden",
+    "image",
+    "radio",
+    "reset",
+    "submit",
+  ]);
+  return [
+    ...(clickRoles.has(node.role) || node.cursor === "pointer"
+      ? (["click"] as const)
+      : []),
+    ...(!secure &&
+    typeRoles.has(node.role) &&
+    !(dom.tag === "input" && nonTypeableInput.has(dom.type.toLowerCase()))
+      ? (["type"] as const)
+      : []),
+  ];
+}
+
+function isSecurePlaywrightNode(
+  node: PlaywrightAriaNode,
+  dom: PlaywrightDomMetadata,
+): boolean {
+  const semantics = `${node.role} ${node.name ?? ""} ${node.placeholder ?? ""}`;
+  return (
+    dom.type.toLowerCase() === "password" ||
+    /(?:^|-)password$/iu.test(dom.autocomplete) ||
+    /password|secure/iu.test(semantics)
+  );
+}
+
+function isPlaywrightDomMetadata(
+  value: unknown,
+): value is PlaywrightDomMetadata {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.ref === "string" &&
+    entry.count === 1 &&
+    typeof entry.visible === "boolean" &&
+    typeof entry.tag === "string" &&
+    typeof entry.type === "string" &&
+    typeof entry.id === "string" &&
+    typeof entry.fieldName === "string" &&
+    typeof entry.autocomplete === "string" &&
+    typeof entry.href === "string"
+  );
+}
+
+function isMissingPlaywrightDomMetadata(value: unknown): boolean {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return typeof entry.ref === "string" && entry.count !== 1;
+}
+
+function requireObservedTarget(
+  tab: PlaywrightTabState,
+  observationId: string,
+  targetId: string,
+  action: "click" | "type",
+): BrowserTargetFingerprint & { ref: string; disabled: boolean } {
+  const observation = tab.observation;
+  if (
+    observation === undefined ||
+    observation.id !== observationId ||
+    observation.documentVersion !== tab.documentVersion
+  ) {
+    throw new Error("Browser observation is stale or unknown; inspect again");
+  }
+  const target = observation.targets.get(targetId);
+  if (target === undefined) {
+    throw new Error("Browser target ID is forged, stale, or unknown");
+  }
+  if (target.disabled || !target.actions.includes(action)) {
+    throw new Error(`Browser target does not support ${action}`);
+  }
+  if (action === "type" && target.secure) {
+    throw new Error(
+      "browser_type rejects password or secure controls because supplied text is journaled",
+    );
+  }
+  return target;
+}
+
+function isPlaywrightPageState(value: unknown): value is PlaywrightPageState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const page = value as Record<string, unknown>;
+  return (
+    Number.isSafeInteger(page.index) &&
+    typeof page.title === "string" &&
+    typeof page.url === "string" &&
+    typeof page.current === "boolean"
+  );
+}
+
+function pageSummary(
+  sessionId: string,
+  tabId: string,
+  page: PlaywrightPageState,
+): BrowserTabSummary {
+  return {
+    sessionId,
+    tabId,
+    title: page.title,
+    url: page.url,
+    loading: false,
+  };
+}
+
+export function playwrightSessionName(sessionId: string): string {
+  const digest = createHash("sha256").update(sessionId).digest("hex");
+  return `zenx-${digest.slice(0, 24)}`;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -1,0 +1,573 @@
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+
+import {
+  browserCapabilityManifest,
+  ElectronBrowserBackend,
+  type ZenXBrowserBackend,
+} from "./browser-provider.js";
+import {
+  computerCapabilityManifest,
+  ElectronMacComputerBackend,
+  type ZenXComputerBackend,
+} from "./computer-provider.js";
+import {
+  discoverExecutable,
+  type ExternalProviderProcessRunner,
+  parseExternalJson,
+  SystemExternalProviderProcessRunner,
+} from "./external-provider.js";
+import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
+import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
+import {
+  windowsComputerCapabilityManifest,
+  WinAppCliComputerBackend,
+} from "./windows-computer-provider.js";
+import type {
+  ZenXCapabilityManifest,
+  ZenXCapabilityProviderDiagnostic,
+} from "./types.js";
+
+export interface ZenXCapabilityProviderSelection<T> {
+  backend: T;
+  manifest: ZenXCapabilityManifest;
+  diagnostics: ZenXCapabilityProviderDiagnostic[];
+}
+
+export interface ZenXOptionalCapabilityProviderSelection<T> {
+  backend?: T;
+  manifest: ZenXCapabilityManifest;
+  diagnostics: ZenXCapabilityProviderDiagnostic[];
+}
+
+export interface ZenXCapabilityProviderCatalogOptions {
+  userDataDirectory: string;
+  environment?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  runner?: ExternalProviderProcessRunner;
+}
+
+// @playwright/cli has its own 0.1.x package version. It embeds Playwright
+// 1.62+, but `playwright-cli --json --version` intentionally reports the CLI
+// package version, not the embedded engine version.
+const MIN_PLAYWRIGHT_CLI = [0, 1, 0] as const;
+const MAX_PLAYWRIGHT_CLI_EXCLUSIVE = [0, 2, 0] as const;
+const MIN_PEEKABOO = [3, 0, 0] as const;
+const MAX_PEEKABOO_EXCLUSIVE = [4, 0, 0] as const;
+
+export async function selectBrowserProvider(
+  options: ZenXCapabilityProviderCatalogOptions,
+): Promise<ZenXCapabilityProviderSelection<ZenXBrowserBackend>> {
+  const runner = options.runner ?? new SystemExternalProviderProcessRunner();
+  const environment = options.environment ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const configured = environment.ZENX_PLAYWRIGHT_CLI;
+  const executable = await discoverExecutable(configured ?? "playwright-cli", {
+    environment,
+    platform,
+  });
+  const fallbackDiagnostic = electronBrowserDiagnostic(
+    executable === undefined ? "fallback" : "available",
+  );
+  if (executable === undefined) {
+    return {
+      backend: new ElectronBrowserBackend(),
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "browser",
+          "playwright-cli",
+          ["isolated"],
+          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+          configured === undefined
+            ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
+            : `Configured Playwright CLI is not executable: ${configured}`,
+        ),
+        fallbackDiagnostic,
+      ],
+    };
+  }
+  try {
+    const version = await probePlaywrightCli(executable, runner);
+    const playwrightDirectory = path.join(
+      options.userDataDirectory,
+      "playwright",
+    );
+    await mkdir(playwrightDirectory, { recursive: true, mode: 0o700 });
+    return {
+      backend: new PlaywrightCliBrowserBackend({
+        executable,
+        runner,
+        cwd: playwrightDirectory,
+      }),
+      manifest: playwrightBrowserManifest(),
+      diagnostics: [
+        {
+          capabilityId: "browser",
+          providerId: "playwright-cli",
+          status: "selected",
+          interactionModes: ["isolated"],
+          capabilities: [
+            "headless",
+            "browser_context",
+            "aria_snapshot",
+            "auto_wait",
+            "cross_platform",
+          ],
+          executable,
+          version,
+          permissionSummary:
+            "Isolated in-memory Playwright session; no foreground desktop input",
+        },
+        fallbackDiagnostic,
+      ],
+    };
+  } catch (error) {
+    return {
+      backend: new ElectronBrowserBackend(),
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "browser",
+          "playwright-cli",
+          ["isolated"],
+          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+          describeError(error),
+          executable,
+        ),
+        electronBrowserDiagnostic("fallback"),
+      ],
+    };
+  }
+}
+
+export async function selectComputerProvider(
+  options: ZenXCapabilityProviderCatalogOptions,
+): Promise<ZenXOptionalCapabilityProviderSelection<ZenXComputerBackend>> {
+  const runner = options.runner ?? new SystemExternalProviderProcessRunner();
+  const environment = options.environment ?? process.env;
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    const backend = new WinAppCliComputerBackend();
+    const diagnostic = await backend.diagnose();
+    if (!diagnostic.ready) {
+      await backend.close();
+      return {
+        manifest: windowsComputerCapabilityManifest,
+        diagnostics: [
+          unavailableDiagnostic(
+            "computer",
+            "microsoft-winapp-cli",
+            ["background_safe"],
+            ["uia.inspect", "uia.invoke", "uia.set_value", "wgc.capture"],
+            diagnostic.message,
+            diagnostic.executable,
+          ),
+        ],
+      };
+    }
+    return {
+      backend,
+      manifest: windowsComputerCapabilityManifest,
+      diagnostics: [
+        {
+          capabilityId: "computer",
+          providerId: "microsoft-winapp-cli",
+          status: "selected",
+          interactionModes: ["background_safe"],
+          capabilities: [
+            "uia.inspect",
+            "uia.invoke",
+            "uia.set_value",
+            "wgc.capture",
+          ],
+          executable: diagnostic.executable,
+          ...(diagnostic.version === undefined
+            ? {}
+            : { version: diagnostic.version }),
+          permissionSummary:
+            "Exact-window UI Automation and WGC capture; no global input injection",
+        },
+      ],
+    };
+  }
+  if (platform !== "darwin") {
+    return {
+      manifest: computerCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "computer",
+          "peekaboo-cli",
+          ["background_safe", "foreground_required"],
+          ["accessibility", "window.capture", "global_input"],
+          "No computer provider is available for this platform",
+        ),
+        macBundledDiagnostic("unavailable", "Bundled provider is macOS-only"),
+      ],
+    };
+  }
+  const configured = environment.ZENX_PEEKABOO_CLI;
+  const executable = await discoverExecutable(configured ?? "peekaboo", {
+    environment,
+    platform,
+  });
+  if (executable === undefined) {
+    return {
+      backend: new ElectronMacComputerBackend(),
+      manifest: computerCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "computer",
+          "peekaboo-cli",
+          ["background_safe", "foreground_required"],
+          ["accessibility", "window.capture", "global_input"],
+          configured === undefined
+            ? "Peekaboo 3.x is not installed; install its CLI or set ZENX_PEEKABOO_CLI"
+            : `Configured Peekaboo CLI is not executable: ${configured}`,
+        ),
+        macBundledDiagnostic("fallback"),
+      ],
+    };
+  }
+  try {
+    const probe = await probePeekabooCli(executable, runner);
+    return {
+      backend: new PeekabooComputerBackend({ executable, runner }),
+      manifest: peekabooComputerManifest(),
+      diagnostics: [
+        {
+          capabilityId: "computer",
+          providerId: "peekaboo-cli",
+          status: "selected",
+          interactionModes: ["background_safe", "foreground_required"],
+          capabilities: [
+            "accessibility.inspect",
+            "background.semantic_action",
+            "window.capture",
+            "foreground.global_input",
+          ],
+          executable,
+          version: probe.version,
+          permissionSummary: probe.permissionSummary,
+        },
+        macBundledDiagnostic("available"),
+      ],
+    };
+  } catch (error) {
+    return {
+      backend: new ElectronMacComputerBackend(),
+      manifest: computerCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "computer",
+          "peekaboo-cli",
+          ["background_safe", "foreground_required"],
+          ["accessibility", "window.capture", "global_input"],
+          describeError(error),
+          executable,
+        ),
+        macBundledDiagnostic("fallback"),
+      ],
+    };
+  }
+}
+
+export async function probePlaywrightCli(
+  executable: string,
+  runner: ExternalProviderProcessRunner,
+): Promise<string> {
+  const versionResult = await runner.run(executable, ["--json", "--version"], {
+    timeoutMs: 5_000,
+    maxOutputBytes: 32 * 1024,
+  });
+  const versionEnvelope = parseExternalJson(
+    "playwright-cli",
+    versionResult.stdout,
+  );
+  const version = requiredVersion(versionEnvelope.version, "playwright-cli");
+  assertSupportedVersion(
+    version,
+    MIN_PLAYWRIGHT_CLI,
+    MAX_PLAYWRIGHT_CLI_EXCLUSIVE,
+    "playwright-cli",
+  );
+  const listResult = await runner.run(executable, ["--json", "list"], {
+    timeoutMs: 5_000,
+    maxOutputBytes: 64 * 1024,
+  });
+  const listEnvelope = parseExternalJson("playwright-cli", listResult.stdout);
+  if (
+    !Array.isArray(listEnvelope.browsers) ||
+    !listEnvelope.browsers.every(isPlaywrightBrowserDiagnostic)
+  ) {
+    throw new Error(
+      "Unsupported playwright-cli JSON schema: list.browsers is invalid",
+    );
+  }
+  return version;
+}
+
+export async function probePeekabooCli(
+  executable: string,
+  runner: ExternalProviderProcessRunner,
+): Promise<{ version: string; permissionSummary: string }> {
+  const versionResult = await runner.run(executable, ["--version"], {
+    timeoutMs: 5_000,
+    maxOutputBytes: 32 * 1024,
+  });
+  const version = versionResult.stdout.match(/\b(\d+\.\d+\.\d+)\b/u)?.[1];
+  if (version === undefined) {
+    throw new Error("Peekaboo --version did not contain a semantic version");
+  }
+  assertSupportedVersion(
+    version,
+    MIN_PEEKABOO,
+    MAX_PEEKABOO_EXCLUSIVE,
+    "Peekaboo",
+  );
+  const toolsResult = await runner.run(executable, ["tools", "--json"], {
+    timeoutMs: 10_000,
+    maxOutputBytes: 128 * 1024,
+  });
+  const toolsEnvelope = parseExternalJson("peekaboo", toolsResult.stdout);
+  const toolsData = asRecord(toolsEnvelope.data);
+  const tools = toolsData?.tools;
+  if (
+    toolsEnvelope.success !== true ||
+    !Array.isArray(tools) ||
+    !tools.every(isPeekabooTool)
+  ) {
+    throw new Error(
+      "Unsupported Peekaboo 3.x JSON schema: tools envelope is invalid",
+    );
+  }
+  const toolNames = new Set(tools.map((tool) => tool.name));
+  for (const required of ["see", "click", "set_value", "image"]) {
+    if (!toolNames.has(required)) {
+      throw new Error(`Peekaboo 3.x is missing required tool ${required}`);
+    }
+  }
+  const permissionsResult = await runner.run(
+    executable,
+    ["permissions", "status", "--json"],
+    { timeoutMs: 10_000, maxOutputBytes: 128 * 1024 },
+  );
+  const envelope = parseExternalJson("peekaboo", permissionsResult.stdout);
+  const data = asRecord(envelope.data);
+  const permissions = data?.permissions;
+  if (
+    envelope.success !== true ||
+    !Array.isArray(permissions) ||
+    !permissions.every(isPeekabooPermission)
+  ) {
+    throw new Error(
+      "Unsupported Peekaboo 3.x JSON schema: permissions status envelope is invalid",
+    );
+  }
+  return {
+    version,
+    permissionSummary: permissions
+      .map(
+        (permission) =>
+          `${String(permission.name)}=${permission.isGranted === true ? "granted" : "missing"}`,
+      )
+      .join(", "),
+  };
+}
+
+function playwrightBrowserManifest(): ZenXCapabilityManifest {
+  return {
+    ...structuredClone(browserCapabilityManifest),
+    description:
+      "A cross-platform isolated Playwright CLI browser session with bounded ARIA inspection and native auto-waiting actions.",
+    provider: {
+      id: "playwright-cli",
+      platforms: ["darwin", "win32", "linux"],
+      interactionModes: ["isolated"],
+      capabilities: [
+        "headless",
+        "browser_context",
+        "aria_snapshot",
+        "auto_wait",
+        "dom.navigate",
+        "dom.interact",
+      ],
+    },
+    tools: browserCapabilityManifest.tools.map((tool) => ({
+      ...structuredClone(tool),
+      interactionMode: "isolated",
+      capabilities: [
+        "playwright_cli",
+        "headless",
+        "browser_context",
+        ...tool.capabilities.filter(
+          (capability) =>
+            capability !== "dedicated_profile" && capability !== "cdp",
+        ),
+      ],
+    })),
+  };
+}
+
+function peekabooComputerManifest(): ZenXCapabilityManifest {
+  return {
+    ...structuredClone(computerCapabilityManifest),
+    description:
+      "Peekaboo 3.x background-first macOS automation with bounded snapshots, explicit permissions, and foreground input only through labeled takeover tools.",
+    provider: {
+      id: "peekaboo-cli",
+      platforms: ["darwin"],
+      interactionModes: ["background_safe", "foreground_required"],
+      capabilities: [
+        "peekaboo.snapshot",
+        "accessibility.inspect",
+        "background.semantic_action",
+        "window.capture",
+        "foreground.global_input",
+      ],
+    },
+    tools: computerCapabilityManifest.tools.map((tool) => ({
+      ...structuredClone(tool),
+      permissions:
+        tool.name === "computer_inspect"
+          ? [...tool.permissions, "computer.window.capture"]
+          : [...tool.permissions],
+      capabilities: ["peekaboo_cli", ...tool.capabilities],
+    })),
+  };
+}
+
+function electronBrowserDiagnostic(
+  status: ZenXCapabilityProviderDiagnostic["status"],
+): ZenXCapabilityProviderDiagnostic {
+  return {
+    capabilityId: "browser",
+    providerId: "electron-dedicated-browser",
+    status,
+    interactionModes: ["background_safe"],
+    capabilities: ["dedicated_profile", "cdp", "dom.inspect", "dom.interact"],
+    permissionSummary: "Bundled hidden ephemeral Electron partition",
+  };
+}
+
+function macBundledDiagnostic(
+  status: ZenXCapabilityProviderDiagnostic["status"],
+  reason?: string,
+): ZenXCapabilityProviderDiagnostic {
+  return {
+    capabilityId: "computer",
+    providerId: "macos-desktop",
+    status,
+    interactionModes: ["background_safe", "foreground_required"],
+    capabilities: [
+      "accessibility.inspect",
+      "semantic.press",
+      "semantic.set_value",
+      "window.capture",
+      "global_input",
+    ],
+    ...(reason === undefined ? {} : { reason }),
+  };
+}
+
+function unavailableDiagnostic(
+  capabilityId: string,
+  providerId: string,
+  interactionModes: ZenXCapabilityProviderDiagnostic["interactionModes"],
+  capabilities: string[],
+  reason: string,
+  executable?: string,
+): ZenXCapabilityProviderDiagnostic {
+  return {
+    capabilityId,
+    providerId,
+    status: "unavailable",
+    interactionModes,
+    capabilities,
+    reason,
+    ...(executable === undefined ? {} : { executable }),
+  };
+}
+
+function requiredVersion(value: unknown, provider: string): string {
+  if (typeof value !== "string" || !/^\d+\.\d+\.\d+(?:[-+].*)?$/u.test(value)) {
+    throw new Error(
+      `Unsupported ${provider} JSON schema: version must be semantic`,
+    );
+  }
+  return value;
+}
+
+function assertSupportedVersion(
+  version: string,
+  minimum: readonly [number, number, number],
+  maximumExclusive: readonly [number, number, number],
+  provider: string,
+): void {
+  const parsed = version
+    .split(/[.+-]/u, 3)
+    .map((part) => Number.parseInt(part, 10)) as [number, number, number];
+  const belowMinimum =
+    parsed[0] < minimum[0] ||
+    (parsed[0] === minimum[0] && parsed[1] < minimum[1]) ||
+    (parsed[0] === minimum[0] &&
+      parsed[1] === minimum[1] &&
+      parsed[2] < minimum[2]);
+  const atOrAboveMaximum =
+    parsed[0] > maximumExclusive[0] ||
+    (parsed[0] === maximumExclusive[0] && parsed[1] > maximumExclusive[1]) ||
+    (parsed[0] === maximumExclusive[0] &&
+      parsed[1] === maximumExclusive[1] &&
+      parsed[2] >= maximumExclusive[2]);
+  if (atOrAboveMaximum || belowMinimum) {
+    throw new Error(
+      `${provider} ${version} is unsupported; expected >=${minimum.join(".")} and <${maximumExclusive.join(".")}`,
+    );
+  }
+}
+
+function isPlaywrightBrowserDiagnostic(value: unknown): boolean {
+  const browser = asRecord(value);
+  return (
+    browser !== undefined &&
+    typeof browser.name === "string" &&
+    (browser.status === "open" || browser.status === "closed") &&
+    typeof browser.version === "string"
+  );
+}
+
+function isPeekabooPermission(value: unknown): value is {
+  name: string;
+  isRequired: boolean;
+  isGranted: boolean;
+} {
+  const permission = asRecord(value);
+  return (
+    permission !== undefined &&
+    typeof permission.name === "string" &&
+    typeof permission.isRequired === "boolean" &&
+    typeof permission.isGranted === "boolean"
+  );
+}
+
+function isPeekabooTool(value: unknown): value is {
+  name: string;
+  description: string;
+} {
+  const tool = asRecord(value);
+  return (
+    tool !== undefined &&
+    typeof tool.name === "string" &&
+    typeof tool.description === "string"
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -14,6 +14,7 @@ import type {
   ZenXCapabilityHostSnapshot,
   ZenXCapabilityManifest,
   ZenXCapabilityPackage,
+  ZenXCapabilityProviderDiagnostic,
   ZenXCapabilitySnapshot,
   ZenXCapabilityTool,
   ZenXCapabilityInteractionMode,
@@ -43,6 +44,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   >();
   readonly #listeners = new Set<(snapshot: ZenXCapabilitySnapshot) => void>();
   readonly #audit: ZenXCapabilityAuditRecord[] = [];
+  readonly #providerDiagnostics: ZenXCapabilityProviderDiagnostic[] = [];
   readonly #discoveryErrors: string[] = [];
   readonly #options: ZenXCapabilityRegistryOptions;
   #grants: Record<string, ZenXCapabilityGrant[]> = {};
@@ -99,6 +101,18 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
 
   recordDiscoveryError(message: string): void {
     this.#discoveryErrors.push(message);
+    this.#emit();
+  }
+
+  recordProviderDiagnostic(diagnostic: ZenXCapabilityProviderDiagnostic): void {
+    const index = this.#providerDiagnostics.findIndex(
+      (candidate) =>
+        candidate.capabilityId === diagnostic.capabilityId &&
+        candidate.providerId === diagnostic.providerId,
+    );
+    if (index === -1)
+      this.#providerDiagnostics.push(structuredClone(diagnostic));
+    else this.#providerDiagnostics[index] = structuredClone(diagnostic);
     this.#emit();
   }
 
@@ -194,6 +208,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         };
       }),
       recentInvocations: structuredClone(this.#audit),
+      providerDiagnostics: structuredClone(this.#providerDiagnostics),
       discoveryErrors: [...this.#discoveryErrors],
     };
   }

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -79,6 +79,18 @@ export interface ZenXCapabilityAuditRecord {
   summary?: string;
 }
 
+export interface ZenXCapabilityProviderDiagnostic {
+  capabilityId: string;
+  providerId: string;
+  status: "available" | "fallback" | "selected" | "unavailable";
+  interactionModes: ZenXCapabilityInteractionMode[];
+  capabilities: string[];
+  executable?: string;
+  version?: string;
+  permissionSummary?: string;
+  reason?: string;
+}
+
 export interface ZenXCapabilitySummary {
   manifest: Omit<ZenXCapabilityManifest, "resources"> & {
     resources: Array<Omit<ZenXCapabilityResource, "content">>;
@@ -94,6 +106,7 @@ export interface ZenXCapabilitySummary {
 export interface ZenXCapabilitySnapshot {
   capabilities: ZenXCapabilitySummary[];
   recentInvocations: ZenXCapabilityAuditRecord[];
+  providerDiagnostics: ZenXCapabilityProviderDiagnostic[];
   discoveryErrors: string[];
 }
 

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -9,6 +9,7 @@ import {
   COMPUTER_ACTION_SET_VALUE,
   computerCapabilityManifest,
   ComputerObservationLedger,
+  type ComputerControlAction,
   type ComputerControlFingerprint,
   type ComputerControlSelector,
   type ComputerInspection,
@@ -813,7 +814,7 @@ function flattenElements(roots: readonly WinAppElement[]): WinAppElement[] {
 
 function winAppFingerprint(element: WinAppElement): ComputerControlFingerprint {
   const secure = isSecureElement(element);
-  const actions: string[] = [];
+  const actions: ComputerControlAction[] = [];
   if (element.isInvokable === true) actions.push(COMPUTER_ACTION_PRESS);
   if (!secure && isEditableElement(element)) {
     actions.push(COMPUTER_ACTION_SET_VALUE);

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -3,18 +3,20 @@ import path from "node:path";
 import type { ToolInvocation } from "../../../../src/tool.js";
 import {
   BrowserZenXCapabilityPackage,
-  ElectronBrowserBackend,
   type ZenXBrowserBackend,
 } from "./capabilities/browser-provider.js";
 import {
-  computerCapabilityManifest,
   ComputerZenXCapabilityPackage,
-  ElectronMacComputerBackend,
   type ZenXComputerBackend,
 } from "./capabilities/computer-provider.js";
 import { JsonZenXCapabilityGrantStore } from "./capabilities/grant-store.js";
 import { discoverLocalCapabilityPackages } from "./capabilities/local-package.js";
 import { ZenXCapabilityRegistry } from "./capabilities/registry.js";
+import {
+  selectBrowserProvider,
+  selectComputerProvider,
+} from "./capabilities/provider-catalog.js";
+import { WinAppCliComputerBackend } from "./capabilities/windows-computer-provider.js";
 import type {
   ZenXCapabilityGrantStore,
   ZenXCapabilityHost,
@@ -23,17 +25,14 @@ import type {
   ZenXCapabilitySnapshot,
   ZenXCapabilityManifest,
 } from "./capabilities/types.js";
-import {
-  windowsComputerCapabilityManifest,
-  WinAppCliComputerBackend,
-} from "./capabilities/windows-computer-provider.js";
 
 export class ZenXCapabilityService implements ZenXCapabilityHost {
   readonly #registry: ZenXCapabilityRegistry;
+  readonly #userDataDirectory: string;
   readonly #localDirectory: string;
-  readonly #browserBackend: ZenXBrowserBackend;
-  readonly #computerBackend: ZenXComputerBackend;
-  readonly #computerManifest: ZenXCapabilityManifest;
+  readonly #browserBackend?: ZenXBrowserBackend;
+  readonly #computerBackend?: ZenXComputerBackend;
+  readonly #computerManifest?: ZenXCapabilityManifest;
   #computerRegistered = false;
 
   constructor(options: {
@@ -50,29 +49,50 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
           path.join(options.userDataDirectory, "capability-grants.json"),
         ),
     );
+    this.#userDataDirectory = options.userDataDirectory;
     this.#localDirectory =
       options.localDirectory ??
       path.join(options.userDataDirectory, "capabilities");
-    this.#browserBackend =
-      options.browserBackend ?? new ElectronBrowserBackend();
-    const bundledComputer = defaultComputerProvider();
-    this.#computerBackend = options.computerBackend ?? bundledComputer.backend;
-    this.#computerManifest =
-      options.computerManifest ??
-      (options.computerBackend === undefined
-        ? bundledComputer.manifest
-        : computerCapabilityManifest);
+    this.#browserBackend = options.browserBackend;
+    this.#computerBackend = options.computerBackend;
+    this.#computerManifest = options.computerManifest;
   }
 
   async initialize(): Promise<void> {
     await this.#registry.initialize();
+    const browser =
+      this.#browserBackend === undefined
+        ? await selectBrowserProvider({
+            userDataDirectory: this.#userDataDirectory,
+          })
+        : {
+            backend: this.#browserBackend,
+            manifest: undefined,
+            diagnostics: [],
+          };
     this.#registry.register(
-      new BrowserZenXCapabilityPackage(this.#browserBackend),
+      new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
       "bundled",
     );
-    let registerComputer = true;
-    if (this.#computerBackend instanceof WinAppCliComputerBackend) {
-      const diagnostic = await this.#computerBackend.diagnose();
+    for (const diagnostic of browser.diagnostics) {
+      this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+    const computer =
+      this.#computerBackend === undefined
+        ? await selectComputerProvider({
+            userDataDirectory: this.#userDataDirectory,
+          })
+        : {
+            backend: this.#computerBackend,
+            manifest: this.#computerManifest,
+            diagnostics: [],
+          };
+    let registerComputer = computer.backend !== undefined;
+    if (
+      this.#computerBackend !== undefined &&
+      computer.backend instanceof WinAppCliComputerBackend
+    ) {
+      const diagnostic = await computer.backend.diagnose();
       if (!diagnostic.ready) {
         registerComputer = false;
         this.#registry.recordDiscoveryError(
@@ -80,15 +100,23 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
         );
       }
     }
-    if (registerComputer) {
+    if (registerComputer && computer.backend !== undefined) {
       this.#registry.register(
-        new ComputerZenXCapabilityPackage(
-          this.#computerBackend,
-          this.#computerManifest,
-        ),
+        new ComputerZenXCapabilityPackage(computer.backend, computer.manifest),
         "bundled",
       );
       this.#computerRegistered = true;
+    }
+    for (const diagnostic of computer.diagnostics) {
+      this.#registry.recordProviderDiagnostic(diagnostic);
+      if (
+        diagnostic.providerId === "microsoft-winapp-cli" &&
+        diagnostic.status === "unavailable"
+      ) {
+        this.#registry.recordDiscoveryError(
+          `Windows computer provider: ${diagnostic.reason ?? "unavailable"}`,
+        );
+      }
     }
     const discovered = await discoverLocalCapabilityPackages(
       this.#localDirectory,
@@ -150,23 +178,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
 
   async close(): Promise<void> {
     await this.#registry.close();
-    if (!this.#computerRegistered) await this.#computerBackend.close();
+    if (!this.#computerRegistered) await this.#computerBackend?.close();
   }
-}
-
-function defaultComputerProvider(): {
-  backend: ZenXComputerBackend;
-  manifest: ZenXCapabilityManifest;
-} {
-  return process.platform === "win32"
-    ? {
-        backend: new WinAppCliComputerBackend(),
-        manifest: windowsComputerCapabilityManifest,
-      }
-    : {
-        backend: new ElectronMacComputerBackend(),
-        manifest: computerCapabilityManifest,
-      };
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/provider-smoke.ts
+++ b/apps/zenx/src/main/provider-smoke.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { app } from "electron";
+
+import {
+  selectBrowserProvider,
+  selectComputerProvider,
+} from "./capabilities/provider-catalog.js";
+
+const web = createServer((_request, response) => {
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.end(
+    "<!doctype html><title>Provider smoke</title><main><button onclick=\"this.textContent='Clicked target'\">Smoke target</button></main>",
+  );
+});
+
+void app.whenReady().then(async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-provider-smoke-"),
+  );
+  try {
+    const port = await listen();
+    const browser = await selectBrowserProvider({
+      userDataDirectory: directory,
+    });
+    const selectedBrowser = browser.diagnostics.find(
+      (diagnostic) => diagnostic.status === "selected",
+    );
+    if (process.env.ZENX_REQUIRE_PLAYWRIGHT === "1") {
+      assert.equal(
+        selectedBrowser?.providerId,
+        "playwright-cli",
+        `Expected Playwright provider, got ${JSON.stringify(browser.diagnostics)}`,
+      );
+    }
+    const opened = await browser.backend.open(
+      "provider-smoke",
+      `http://127.0.0.1:${String(port)}/`,
+    );
+    const inspection = await browser.backend.inspect(
+      "provider-smoke",
+      opened.tabId,
+    );
+    assert.match(inspection.visibleText, /Smoke target/u);
+    const target = inspection.targets.find(
+      (candidate) =>
+        candidate.name === "Smoke target" &&
+        candidate.actions.includes("click"),
+    );
+    assert.ok(target, "Expected an inspectable click target");
+    await browser.backend.click(
+      "provider-smoke",
+      opened.tabId,
+      inspection.observationId,
+      target.targetId,
+    );
+    const verified = await browser.backend.inspect(
+      "provider-smoke",
+      opened.tabId,
+    );
+    assert.match(verified.visibleText, /Clicked target/u);
+    await browser.backend.closeSession("provider-smoke");
+    await browser.backend.close();
+
+    const computer = await selectComputerProvider({
+      userDataDirectory: directory,
+    });
+    await computer.backend?.close();
+    console.log(
+      JSON.stringify(
+        {
+          passed: true,
+          browser: browser.diagnostics,
+          computer: computer.diagnostics,
+          note: "Computer discovery/permission probe only; this smoke never sends desktop input.",
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.error("ZenX provider smoke failed", error);
+    process.exitCode = 1;
+  } finally {
+    await closeWeb();
+    await rm(directory, { recursive: true, force: true });
+    app.quit();
+  }
+});
+
+async function listen(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    web.once("error", reject);
+    web.listen(0, "127.0.0.1", () => {
+      web.removeListener("error", reject);
+      const address = web.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("Provider smoke server did not bind a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+async function closeWeb(): Promise<void> {
+  if (!web.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    web.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -157,6 +157,31 @@ export function CapabilitySettings() {
           );
         })}
       </div>
+      {snapshot.providerDiagnostics.length === 0 ? null : (
+        <div className="capability-audit">
+          <h3>Execution providers</h3>
+          {snapshot.providerDiagnostics.map((provider) => (
+            <div
+              key={`${provider.capabilityId}:${provider.providerId}`}
+              title={provider.reason ?? provider.permissionSummary}
+            >
+              <Icon
+                name={
+                  provider.status === "selected" ||
+                  provider.status === "available"
+                    ? "check"
+                    : "warning"
+                }
+                size={12}
+              />
+              <code>{provider.providerId}</code>
+              <span>{provider.status}</span>
+              <span>{provider.interactionModes.join(", ")}</span>
+              <span>{provider.version ?? "bundled"}</span>
+            </div>
+          ))}
+        </div>
+      )}
       {snapshot.recentInvocations.length === 0 ? null : (
         <div className="capability-audit">
           <h3>Recent capability use</h3>

--- a/apps/zenx/test/external-provider.test.ts
+++ b/apps/zenx/test/external-provider.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseWindowsNpmShimEntry,
+  SystemExternalProviderProcessRunner,
+} from "../src/main/capabilities/external-provider.js";
+
+test("external provider runner enforces bounded output and timeout", async () => {
+  const runner = new SystemExternalProviderProcessRunner();
+  await assert.rejects(
+    runner.run(process.execPath, ["-e", "console.log('x'.repeat(4096))"], {
+      timeoutMs: 5_000,
+      maxOutputBytes: 1024,
+    }),
+    /output limit/u,
+  );
+  await assert.rejects(
+    runner.run(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+      timeoutMs: 50,
+      maxOutputBytes: 1024,
+    }),
+    /timed out after 50ms/u,
+  );
+});
+
+test("external provider runner cancels the child process", async () => {
+  const runner = new SystemExternalProviderProcessRunner();
+  const controller = new AbortController();
+  const pending = runner.run(
+    process.execPath,
+    ["-e", "setInterval(() => {}, 1000)"],
+    {
+      timeoutMs: 5_000,
+      signal: controller.signal,
+      maxOutputBytes: 1024,
+    },
+  );
+  controller.abort(new DOMException("provider stopped", "AbortError"));
+  await assert.rejects(pending, /provider stopped/u);
+});
+
+test("parses only the Node entry from a standard Windows npm command shim", () => {
+  assert.equal(
+    parseWindowsNpmShimEntry(
+      '@ECHO off\r\n"%_prog%" "%dp0%\\node_modules\\@playwright\\cli\\playwright-cli.js" %*\r\n',
+    ),
+    "node_modules\\@playwright\\cli\\playwright-cli.js",
+  );
+  assert.equal(
+    parseWindowsNpmShimEntry("@ECHO off\r\nunknown %*\r\n"),
+    undefined,
+  );
+});

--- a/apps/zenx/test/peekaboo-computer-provider.test.ts
+++ b/apps/zenx/test/peekaboo-computer-provider.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ExternalProviderProcessResult,
+  ExternalProviderProcessRunner,
+} from "../src/main/capabilities/external-provider.js";
+import { PeekabooComputerBackend } from "../src/main/capabilities/peekaboo-computer-provider.js";
+
+const target = {
+  pid: 42,
+  bundleId: "dev.zen.fixture",
+  windowTitle: "Fixture",
+};
+
+test("Peekaboo provider keeps semantic actions background-first and opaque", async () => {
+  const runner = new FakePeekabooRunner();
+  const backend = new PeekabooComputerBackend({
+    executable: "/opt/peekaboo",
+    runner,
+  });
+  const inspection = await backend.inspect(target);
+  assert.equal(inspection.controls.length, 3);
+  assert.equal(inspection.controls[2]?.secure, true);
+  assert.deepEqual(inspection.controls[2]?.actions, ["press"]);
+  const button = inspection.controls[0];
+  assert.ok(button);
+  await backend.press(target, button.selector);
+  const click = runner.calls.find((args) => args[0] === "click");
+  assert.ok(click);
+  assert.equal(click.includes("--foreground"), false);
+  assert.ok(click.includes("--snapshot"));
+  assert.equal(click.at(-1), "--json");
+  await assert.rejects(
+    backend.press(target, button.selector),
+    /stale, unknown/u,
+  );
+});
+
+test("Peekaboo foreground baseline is explicit in the invoked command", async () => {
+  const runner = new FakePeekabooRunner();
+  const backend = new PeekabooComputerBackend({
+    executable: "/opt/peekaboo",
+    runner,
+  });
+  await backend.foregroundClick(100, 200, "left", new AbortController().signal);
+  assert.deepEqual(runner.calls[0], [
+    "click",
+    "--coords",
+    "100,200",
+    "--global-coords",
+    "--foreground",
+    "--json",
+  ]);
+});
+
+test("Peekaboo provider re-observes and rejects changed element identity", async () => {
+  const runner = new FakePeekabooRunner();
+  const backend = new PeekabooComputerBackend({
+    executable: "/opt/peekaboo",
+    runner,
+  });
+  const inspection = await backend.inspect(target);
+  const button = inspection.controls[0];
+  assert.ok(button);
+  runner.changeIdentity = true;
+  await assert.rejects(
+    backend.press(target, button.selector),
+    /identity changed/u,
+  );
+  assert.equal(runner.calls.filter((args) => args[0] === "click").length, 0);
+});
+
+test("Peekaboo accepts an applicationId-only target without an undefined CLI argument", async () => {
+  const runner = new FakePeekabooRunner();
+  const backend = new PeekabooComputerBackend({
+    executable: "/opt/peekaboo",
+    runner,
+  });
+  const applicationTarget = {
+    applicationId: "Fixture Application",
+    windowTitle: "Fixture",
+  };
+  const inspection = await backend.inspect(applicationTarget);
+  assert.equal(inspection.target.applicationId, "Fixture Application");
+  assert.equal(inspection.target.applicationName, "Fixture");
+  const see = runner.calls.find((args) => args[0] === "see");
+  assert.ok(see);
+  const appIndex = see.indexOf("--app");
+  assert.notEqual(appIndex, -1);
+  assert.equal(see[appIndex + 1], "Fixture Application");
+  assert.equal(
+    see.some((argument) => argument === undefined),
+    false,
+  );
+});
+
+class FakePeekabooRunner implements ExternalProviderProcessRunner {
+  readonly calls: string[][] = [];
+  changeIdentity = false;
+  #seeCount = 0;
+
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: { timeoutMs: number },
+  ): Promise<ExternalProviderProcessResult> {
+    this.calls.push([...args]);
+    if (args[0] === "see") this.#seeCount += 1;
+    const data =
+      args[0] === "see"
+        ? {
+            snapshot_id: "snapshot-1",
+            application_name: "Fixture",
+            window_title: "Fixture",
+            ui_elements: [
+              {
+                id: "B1",
+                role: "AXButton",
+                label:
+                  this.changeIdentity && this.#seeCount > 1 ? "Changed" : "Run",
+                is_actionable: true,
+              },
+              {
+                id: "T1",
+                role: "AXTextField",
+                label: "Name",
+                is_actionable: true,
+              },
+              {
+                id: "S1",
+                role: "AXSecureTextField",
+                label: "Password",
+                is_actionable: true,
+              },
+            ],
+          }
+        : {};
+    return {
+      stdout: JSON.stringify({ success: true, data }),
+      stderr: "",
+    };
+  }
+}

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ExternalProviderProcessResult,
+  ExternalProviderProcessRunner,
+} from "../src/main/capabilities/external-provider.js";
+import { PlaywrightCliBrowserBackend } from "../src/main/capabilities/playwright-browser-provider.js";
+
+test("Playwright provider runs an isolated JSON-only observe/action slice", async () => {
+  const runner = new FakePlaywrightRunner();
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  const opened = await backend.open("research", "https://example.com/");
+  assert.equal(opened.title, "Fixture");
+  const inspected = await backend.inspect("research", opened.tabId);
+  assert.match(inspected.visibleText, /Run/u);
+  const button = inspected.targets.find(({ name }) => name === "Run");
+  assert.ok(button);
+  await assert.rejects(
+    backend.click(
+      "research",
+      opened.tabId,
+      inspected.observationId,
+      "forged-target",
+    ),
+    /forged/u,
+  );
+  await backend.click(
+    "research",
+    opened.tabId,
+    inspected.observationId,
+    button.targetId,
+  );
+  await assert.rejects(
+    backend.click(
+      "research",
+      opened.tabId,
+      inspected.observationId,
+      button.targetId,
+    ),
+    /stale or unknown/u,
+  );
+  assert.ok(runner.calls.every((args) => args[0] === "--json"));
+  assert.ok(runner.calls.some((args) => args.includes("snapshot")));
+  assert.ok(runner.calls.some((args) => args.includes("click")));
+});
+
+test("Playwright provider fails closed on an incompatible snapshot schema", async () => {
+  const runner = new FakePlaywrightRunner();
+  runner.invalidSnapshot = true;
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  const opened = await backend.open("research", "https://example.com/");
+  await assert.rejects(
+    backend.inspect("research", opened.tabId),
+    /snapshot must be an array/u,
+  );
+});
+
+test("Playwright provider revalidates DOM identity and rejects secure fill", async () => {
+  const runner = new FakePlaywrightRunner();
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  const opened = await backend.open("research", "https://example.com/");
+  const inspected = await backend.inspect("research", opened.tabId);
+  const password = inspected.targets.find(({ name }) => name === "Password");
+  assert.equal(password?.secure, true);
+  assert.deepEqual(password?.actions, ["click"]);
+  assert.equal(
+    inspected.targets.some(({ name }) => name === "Hidden"),
+    false,
+  );
+  const button = inspected.targets.find(({ name }) => name === "Run");
+  assert.ok(button);
+  runner.changeIdentity = true;
+  await assert.rejects(
+    backend.click(
+      "research",
+      opened.tabId,
+      inspected.observationId,
+      button.targetId,
+    ),
+    /identity, security, visibility, or actions changed/u,
+  );
+  assert.equal(runner.calls.filter((args) => args.includes("click")).length, 0);
+});
+
+test("Playwright cancellation invalidates the session before immediate reuse", async () => {
+  const runner = new FakePlaywrightRunner();
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  const first = await backend.open("research", "https://example.com/first");
+  runner.abortNextSnapshot = true;
+  runner.delayNextClose();
+  await assert.rejects(backend.inspect("research", first.tabId), /cancelled/u);
+
+  const second = await backend.open("research", "https://example.com/second");
+  const openSessions = runner.calls
+    .filter((args) => args[2] === "open")
+    .map((args) => args[1]);
+  assert.equal(openSessions.length, 2);
+  assert.notEqual(openSessions[0], openSessions[1]);
+  await assert.rejects(
+    backend.inspect("research", first.tabId),
+    /unknown or scoped to another session/u,
+  );
+  assert.notEqual(second.tabId, first.tabId);
+
+  runner.releaseDelayedClose();
+  await runner.delayedCloseFinished;
+  await backend.close();
+});
+
+class FakePlaywrightRunner implements ExternalProviderProcessRunner {
+  readonly calls: string[][] = [];
+  invalidSnapshot = false;
+  changeIdentity = false;
+  abortNextSnapshot = false;
+  delayedCloseFinished: Promise<void> = Promise.resolve();
+  #snapshotCount = 0;
+  #delayClose = false;
+  #releaseClose: (() => void) | undefined;
+  #finishDelayedClose: (() => void) | undefined;
+
+  delayNextClose(): void {
+    this.#delayClose = true;
+    this.delayedCloseFinished = new Promise((resolve) => {
+      this.#finishDelayedClose = resolve;
+    });
+  }
+
+  releaseDelayedClose(): void {
+    this.#releaseClose?.();
+  }
+
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: { timeoutMs: number },
+  ): Promise<ExternalProviderProcessResult> {
+    this.calls.push([...args]);
+    const command = args[2];
+    let response: Record<string, unknown> = {};
+    if (command === "open") {
+      response = { session: args[1]?.slice(3), result: {} };
+    } else if (command === "close" && this.#delayClose) {
+      this.#delayClose = false;
+      await new Promise<void>((resolve) => {
+        this.#releaseClose = resolve;
+      });
+      this.#finishDelayedClose?.();
+    } else if (command === "run-code") {
+      response = args[3]?.includes("aria-ref=")
+        ? {
+            result: JSON.stringify([
+              dom("e1", { tag: "button" }),
+              dom("e2", { tag: "input", type: "text" }),
+              dom("e3", {
+                tag: "input",
+                type: "password",
+                autocomplete: "current-password",
+              }),
+              dom("e4", { tag: "button", visible: false }),
+            ]),
+          }
+        : {
+            result: JSON.stringify([
+              {
+                index: 0,
+                title: "Fixture",
+                url: "https://example.com/",
+                current: true,
+              },
+            ]),
+          };
+    } else if (command === "snapshot") {
+      if (this.abortNextSnapshot) {
+        this.abortNextSnapshot = false;
+        throw new DOMException("provider cancelled", "AbortError");
+      }
+      this.#snapshotCount += 1;
+      response = this.invalidSnapshot
+        ? { snapshot: "bad" }
+        : {
+            snapshot: [
+              { role: "heading", name: "Fixture" },
+              {
+                role: "button",
+                name:
+                  this.changeIdentity && this.#snapshotCount > 1
+                    ? "Changed"
+                    : "Run",
+                ref: "e1",
+              },
+              { role: "textbox", name: "Query", ref: "e2" },
+              { role: "textbox", name: "Password", ref: "e3" },
+              { role: "button", name: "Hidden", ref: "e4" },
+            ],
+          };
+    }
+    return { stdout: JSON.stringify(response), stderr: "" };
+  }
+}
+
+function dom(
+  ref: string,
+  options: {
+    tag: string;
+    type?: string;
+    autocomplete?: string;
+    visible?: boolean;
+  },
+) {
+  return {
+    ref,
+    count: 1,
+    visible: options.visible ?? true,
+    tag: options.tag,
+    type: options.type ?? "",
+    id: "",
+    fieldName: "",
+    autocomplete: options.autocomplete ?? "",
+    href: "",
+  };
+}

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -1,0 +1,155 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  ExternalProviderProcessResult,
+  ExternalProviderProcessRunner,
+} from "../src/main/capabilities/external-provider.js";
+import {
+  probePeekabooCli,
+  probePlaywrightCli,
+} from "../src/main/capabilities/provider-catalog.js";
+
+test("pins and validates the Playwright CLI machine-readable contract", async () => {
+  const runner = new ScriptedRunner([
+    {
+      args: ["--json", "--version"],
+      stdout: JSON.stringify({ version: "0.1.18" }),
+    },
+    {
+      args: ["--json", "list"],
+      stdout: JSON.stringify({
+        browsers: [
+          {
+            name: "default",
+            status: "closed",
+            version: "1.63.0-alpha-2026-08-05",
+          },
+        ],
+      }),
+    },
+  ]);
+  assert.equal(
+    await probePlaywrightCli("/opt/playwright-cli", runner),
+    "0.1.18",
+  );
+  runner.assertComplete();
+});
+
+test("rejects incompatible Playwright versions and JSON schema", async () => {
+  await assert.rejects(
+    probePlaywrightCli(
+      "/opt/playwright-cli",
+      new ScriptedRunner([
+        {
+          args: ["--json", "--version"],
+          stdout: JSON.stringify({ version: "0.0.9" }),
+        },
+      ]),
+    ),
+    /expected >=0\.1\.0/u,
+  );
+  await assert.rejects(
+    probePlaywrightCli(
+      "/opt/playwright-cli",
+      new ScriptedRunner([
+        {
+          args: ["--json", "--version"],
+          stdout: JSON.stringify({ version: "0.2.0" }),
+        },
+      ]),
+    ),
+    /and <0\.2\.0/u,
+  );
+  await assert.rejects(
+    probePlaywrightCli(
+      "/opt/playwright-cli",
+      new ScriptedRunner([
+        {
+          args: ["--json", "--version"],
+          stdout: JSON.stringify({ version: "0.1.18" }),
+        },
+        {
+          args: ["--json", "list"],
+          stdout: JSON.stringify({ browsers: "not-an-array" }),
+        },
+      ]),
+    ),
+    /list\.browsers is invalid/u,
+  );
+});
+
+test("pins Peekaboo 3.x and reports explicit permission diagnostics", async () => {
+  const runner = new ScriptedRunner([
+    {
+      args: ["--version"],
+      stdout: "Peekaboo 3.1.2 (release)\n",
+    },
+    {
+      args: ["tools", "--json"],
+      stdout: JSON.stringify({
+        success: true,
+        data: {
+          tools: ["see", "click", "set_value", "image"].map((name) => ({
+            name,
+            description: `${name} tool`,
+          })),
+        },
+      }),
+    },
+    {
+      args: ["permissions", "status", "--json"],
+      stdout: JSON.stringify({
+        success: true,
+        data: {
+          permissions: [
+            {
+              name: "Screen Recording",
+              isRequired: true,
+              isGranted: true,
+            },
+            {
+              name: "Accessibility",
+              isRequired: true,
+              isGranted: false,
+            },
+          ],
+        },
+      }),
+    },
+  ]);
+  assert.deepEqual(await probePeekabooCli("/opt/peekaboo", runner), {
+    version: "3.1.2",
+    permissionSummary: "Screen Recording=granted, Accessibility=missing",
+  });
+  runner.assertComplete();
+});
+
+class ScriptedRunner implements ExternalProviderProcessRunner {
+  readonly #steps: Array<{
+    args: string[];
+    stdout: string;
+    stderr?: string;
+  }>;
+
+  constructor(
+    steps: Array<{ args: string[]; stdout: string; stderr?: string }>,
+  ) {
+    this.#steps = [...steps];
+  }
+
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: { timeoutMs: number },
+  ): Promise<ExternalProviderProcessResult> {
+    const step = this.#steps.shift();
+    assert.ok(step, `Unexpected provider call: ${args.join(" ")}`);
+    assert.deepEqual(args, step.args);
+    return { stdout: step.stdout, stderr: step.stderr ?? "" };
+  }
+
+  assertComplete(): void {
+    assert.equal(this.#steps.length, 0);
+  }
+}


### PR DESCRIPTION
Closes #42

## What changed

- adds a host-owned provider catalog with bounded, redacted discovery diagnostics in ZenX Settings
- prefers the pinned official `@playwright/cli` 0.1.x for isolated, headless, cross-platform browser work while retaining the bundled Electron/CDP fallback
- adds a strict Playwright JSON adapter for open/list/navigate/inspect/click/fill/close with opaque observations and act-time role/name/DOM/security revalidation
- prefers an optional compatible Peekaboo 3.x provider on macOS for exact-window background semantic actions, while keeping foreground input explicitly labeled and cancellable
- composes the merged WinApp provider on Windows: incompatible or absent WinApp is explicitly unavailable and never falls back to a macOS backend
- handles Windows npm `.cmd` shims by resolving the installed Node entry and spawning it without a shell
- adds a runnable provider smoke and a dedicated CI job that installs official `@playwright/cli@0.1.18`, requires Playwright selection, and executes open → inspect → click → verify → close

## Boundary and safety

- no Zen Core changes: provider processes, permissions, credentials, browser sessions, and diagnostics remain ZenX product/host state
- startup probes pin supported version and machine-readable schema before a provider can be selected
- subprocesses have minimal environments, output bounds, timeout/cancellation, redacted errors, and no shell execution
- Playwright and Peekaboo actions reject forged, stale, hidden, ambiguous, identity-changed, or secure targets before acting
- no silent background-to-foreground downgrade; the provider manifest reports the actual interaction mode

## Validation

- `npm --workspace apps/zenx run check` — 124 tests, typecheck, production build
- `npm run check` — 90 Core/CLI tests and 38 IMZen tests
- `npm --workspace apps/zenx run smoke:providers` — local Electron fallback vertical slice (external CLIs are not installed on this Mac)
- PR CI installs official `@playwright/cli@0.1.18` and Chromium and fails unless the real Playwright adapter completes its vertical slice
- merged base PR #46 already passed the real Windows WinApp adapter/registry smoke on `windows-latest`

Peekaboo is not installed on this Mac, so its live desktop path is not claimed as locally exercised; its 3.x version/tool/permission contract and stale/identity/security behavior are covered by strict tests and explicit diagnostics.
