### PR TITLE
feat(zenx): add automation-control capability for Trigger and Room management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -84,6 +84,9 @@
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。
+- **ZenXAutomationControlCapabilityPackage** — ZenX 产品层通过 capability registry 与进程内 typed
+  Trigger/Room service port 暴露 Trigger 和 Room 管理工具；注册表仍是外层产品配置，命中只发起普通 Turn，
+  工具调用与结果仍进入调用方的 canonical ItemList，且不复制 scheduler、queue 或 transcript。
 - **ZenXThreadTitleProjection** — ZenX 外层产品按 threadId 持久化 provisional、generating、
   generated、manual 与 failed 标题生命周期及单调版本；它不进入 canonical ItemList，
   每次异步生成完成都用版本比较避免覆盖手动改名或重启后的新状态。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -36,6 +36,10 @@ workspace 与 Thread 实际 cwd 派生；Thread 的创建、读取、状态与
 进入各自权威 ItemList，不另建委派记录、消息队列或 transcript；互相监听
 `turn_completed` 后继续发起普通 Turn 是允许的。
 
+Trigger 与 Room 管理也作为显式授权的 bundled capability 提供给 Agent：Agent 可以列举、创建、
+更新、取消或删除 Trigger，并可列举、创建、改名和删除 Room、管理成员及发送消息；这些操作只修改
+ZenX 外层注册表/协作转录，Trigger 命中仍通过 App Server 发起普通 Turn。
+
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。
 

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -28,9 +28,13 @@ simulator for local testing. A hit persists an auditable occurrence with a stabl
 client message ID, then starts a normal App Server Turn. Failures remain visible
 and are never silently retried.
 
-Agent-callable `trigger.create` / `trigger.cancel` tools and a production external
-signal ingress are not part of this slice. They remain follow-up ZenX-host
-features; neither should be added to Zen Core or the Codex-compatible protocol.
+The explicitly granted bundled `zenx-automation-control` capability exposes
+Trigger list/create/update/cancel/delete and Room
+list/create/rename/delete/member/message tools to Agents. Trigger history remains
+auditable after a definition is deleted, and deleting a Room with active mention
+Triggers fails closed. A production external signal ingress remains a follow-up
+ZenX-host feature; none of these operations belong in Zen Core or the
+Codex-compatible protocol.
 
 A Room is shared transcription and routing, not an Agent Thread. Only an explicit
 member mention with a matching trigger delivers Room content to that member's

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -8,7 +8,7 @@
     "dev": "electron-vite dev",
     "build": "electron-vite build",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
-    "test": "tsx --test test/**/*.test.ts",
+    "test": "tsx --test test/*.test.ts",
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -174,7 +174,7 @@ export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPac
         const snapshot = this.#port.snapshot();
         return {
           triggers: snapshot.triggers,
-          history: snapshot.history.slice(-50),
+          history: snapshot.history.slice(0, 50),
         };
       }
       case "zenx_triggers_create":

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -1,0 +1,334 @@
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type {
+  CreateRoomInput,
+  CreateTriggerInput,
+  RoomMember,
+  TriggerSnapshot,
+  UpdateTriggerInput,
+  ZenXRoom,
+  ZenXTrigger,
+} from "../trigger-types.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+export const ZENX_AUTOMATION_CONTROL_CAPABILITY_ID = "zenx-automation-control";
+export const ZENX_AUTOMATION_READ_PERMISSION = "zenx-automation-control.read";
+export const ZENX_AUTOMATION_WRITE_PERMISSION = "zenx-automation-control.write";
+
+export interface ZenXAutomationControlPort {
+  snapshot(): TriggerSnapshot;
+  create(input: CreateTriggerInput): Promise<ZenXTrigger>;
+  update(input: UpdateTriggerInput): Promise<ZenXTrigger>;
+  cancel(triggerId: string): Promise<void>;
+  delete(triggerId: string): Promise<void>;
+  createRoom(input: CreateRoomInput): Promise<ZenXRoom>;
+  renameRoom(roomId: string, name: string): Promise<void>;
+  deleteRoom(roomId: string): Promise<void>;
+  addRoomMember(roomId: string, member: RoomMember): Promise<void>;
+  removeRoomMember(roomId: string, threadId: string): Promise<void>;
+  postAgentRoomMessage(roomId: string, text: string): Promise<void>;
+}
+
+const triggerProperties = {
+  threadId: { type: "string" },
+  kind: { type: "string", enum: ["timer", "thread", "roomMention", "signal"] },
+  label: { type: "string" },
+  prompt: { type: "string" },
+  runAt: { type: "number" },
+  intervalMinutes: { type: "number" },
+  watchedThreadId: { type: "string" },
+  roomId: { type: "string" },
+  mention: { type: "string" },
+  signalName: { type: "string" },
+} as const;
+
+const manifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: ZENX_AUTOMATION_CONTROL_CAPABILITY_ID,
+  displayName: "ZenX automations and Rooms",
+  version: "1.0.0",
+  description:
+    "Inspect and manage ZenX Trigger wakeups and collaborative Rooms without creating another Agent runtime or transcript.",
+  provider: {
+    id: "zenx-automation-service",
+    platforms: ["*"],
+    interactionModes: ["background_safe"],
+    capabilities: ["zenx.triggers.manage", "zenx.rooms.manage"],
+  },
+  permissions: [
+    {
+      id: ZENX_AUTOMATION_READ_PERMISSION,
+      title: "Read automations and Rooms",
+      description:
+        "List Trigger definitions, bounded history, Rooms, and messages.",
+      scope: "workspace",
+    },
+    {
+      id: ZENX_AUTOMATION_WRITE_PERMISSION,
+      title: "Manage automations and Rooms",
+      description:
+        "Create, update, cancel, and delete Triggers and manage Room collaboration.",
+      scope: "local-device",
+    },
+  ],
+  tools: [
+    tool(
+      "zenx_triggers_list",
+      "List Trigger definitions and bounded wakeup history.",
+      {},
+      [],
+      false,
+    ),
+    tool(
+      "zenx_triggers_create",
+      "Create a timer, Thread watcher, Room mention, or signal Trigger.",
+      triggerProperties,
+      ["threadId", "kind", "label", "prompt"],
+    ),
+    tool(
+      "zenx_triggers_update",
+      "Replace an existing Trigger definition while preserving its identity and active state.",
+      { id: { type: "string" }, ...triggerProperties },
+      ["id", "threadId", "kind", "label", "prompt"],
+    ),
+    tool(
+      "zenx_triggers_cancel",
+      "Deactivate a Trigger without deleting its definition or history.",
+      { triggerId: { type: "string" } },
+      ["triggerId"],
+    ),
+    tool(
+      "zenx_triggers_delete",
+      "Delete a Trigger definition; existing audit history remains available.",
+      { triggerId: { type: "string" } },
+      ["triggerId"],
+    ),
+    tool(
+      "zenx_rooms_list",
+      "List Rooms, members, and bounded recent messages.",
+      {},
+      [],
+      false,
+    ),
+    tool(
+      "zenx_rooms_create",
+      "Create a Room with one or more named Thread members.",
+      { name: { type: "string" }, members: membersSchema() },
+      ["name", "members"],
+    ),
+    tool(
+      "zenx_rooms_rename",
+      "Rename an existing Room.",
+      { roomId: { type: "string" }, name: { type: "string" } },
+      ["roomId", "name"],
+    ),
+    tool(
+      "zenx_rooms_delete",
+      "Delete a Room after its active mention Triggers have been removed.",
+      { roomId: { type: "string" } },
+      ["roomId"],
+    ),
+    tool(
+      "zenx_rooms_add_member",
+      "Add a named Thread member to a Room.",
+      {
+        roomId: { type: "string" },
+        name: { type: "string" },
+        threadId: { type: "string" },
+      },
+      ["roomId", "name", "threadId"],
+    ),
+    tool(
+      "zenx_rooms_remove_member",
+      "Remove a Thread member from a Room.",
+      { roomId: { type: "string" }, threadId: { type: "string" } },
+      ["roomId", "threadId"],
+    ),
+    tool(
+      "zenx_rooms_post_message",
+      "Post an Agent-attributed message to a Room; explicit mentions may fire registered mention Triggers.",
+      {
+        roomId: { type: "string" },
+        text: { type: "string" },
+      },
+      ["roomId", "text"],
+    ),
+  ],
+  resources: [],
+};
+
+export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest = manifest;
+  readonly #port: ZenXAutomationControlPort;
+
+  constructor(port: ZenXAutomationControlPort) {
+    this.#port = port;
+  }
+
+  async invoke(name: string, invocation: ToolInvocation): Promise<unknown> {
+    if (name !== invocation.name)
+      throw new Error("Automation tool name mismatch");
+    invocation.signal.throwIfAborted();
+    const args = invocation.arguments;
+    switch (name) {
+      case "zenx_triggers_list": {
+        const snapshot = this.#port.snapshot();
+        return {
+          triggers: snapshot.triggers,
+          history: snapshot.history.slice(-50),
+        };
+      }
+      case "zenx_triggers_create":
+        return await this.#port.create(triggerInput(args));
+      case "zenx_triggers_update":
+        return await this.#port.update({
+          id: string(args, "id"),
+          ...triggerInput(args),
+        });
+      case "zenx_triggers_cancel":
+        await this.#port.cancel(string(args, "triggerId"));
+        return { cancelled: true };
+      case "zenx_triggers_delete":
+        await this.#port.delete(string(args, "triggerId"));
+        return { deleted: true };
+      case "zenx_rooms_list":
+        return {
+          rooms: this.#port.snapshot().rooms.map((room) => ({
+            ...room,
+            messages: room.messages.slice(-50),
+          })),
+        };
+      case "zenx_rooms_create":
+        return await this.#port.createRoom({
+          name: string(args, "name"),
+          members: members(args.members),
+        });
+      case "zenx_rooms_rename":
+        await this.#port.renameRoom(
+          string(args, "roomId"),
+          string(args, "name"),
+        );
+        return { renamed: true };
+      case "zenx_rooms_delete":
+        await this.#port.deleteRoom(string(args, "roomId"));
+        return { deleted: true };
+      case "zenx_rooms_add_member":
+        await this.#port.addRoomMember(string(args, "roomId"), {
+          name: string(args, "name"),
+          threadId: string(args, "threadId"),
+        });
+        return { added: true };
+      case "zenx_rooms_remove_member":
+        await this.#port.removeRoomMember(
+          string(args, "roomId"),
+          string(args, "threadId"),
+        );
+        return { removed: true };
+      case "zenx_rooms_post_message":
+        await this.#port.postAgentRoomMessage(
+          string(args, "roomId"),
+          string(args, "text"),
+        );
+        return { posted: true };
+      default:
+        throw new Error(`Unsupported ZenX automation tool: ${name}`);
+    }
+  }
+}
+
+function tool(
+  name: string,
+  description: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  write = true,
+) {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: "object",
+      properties,
+      required,
+      additionalProperties: false,
+    },
+    permissions: write
+      ? [ZENX_AUTOMATION_WRITE_PERMISSION]
+      : [ZENX_AUTOMATION_READ_PERMISSION],
+    interactionMode: "background_safe" as const,
+    capabilities: [
+      name.startsWith("zenx_rooms")
+        ? "zenx.rooms.manage"
+        : "zenx.triggers.manage",
+    ],
+    maxOutputBytes: 64 * 1024,
+  };
+}
+
+function triggerInput(args: Record<string, unknown>): CreateTriggerInput {
+  const common = {
+    threadId: string(args, "threadId"),
+    label: string(args, "label"),
+    prompt: string(args, "prompt"),
+  };
+  const kind = string(args, "kind");
+  if (kind === "timer")
+    return {
+      ...common,
+      kind,
+      runAt: number(args, "runAt"),
+      ...(args.intervalMinutes === undefined
+        ? {}
+        : { intervalMinutes: number(args, "intervalMinutes") }),
+    };
+  if (kind === "thread")
+    return {
+      ...common,
+      kind,
+      watchedThreadId: string(args, "watchedThreadId"),
+    };
+  if (kind === "roomMention")
+    return {
+      ...common,
+      kind,
+      roomId: string(args, "roomId"),
+      mention: string(args, "mention"),
+    };
+  if (kind === "signal")
+    return { ...common, kind, signalName: string(args, "signalName") };
+  throw new Error("kind must be timer, thread, roomMention, or signal");
+}
+
+function string(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim() === "")
+    throw new Error(`${key} must be a non-empty string`);
+  return value;
+}
+function number(args: Record<string, unknown>, key: string): number {
+  const value = args[key];
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${key} must be a finite number`);
+  return value;
+}
+function members(value: unknown): RoomMember[] {
+  if (!Array.isArray(value)) throw new Error("members must be an array");
+  return value.map((member) => {
+    if (typeof member !== "object" || member === null)
+      throw new Error("member must be an object");
+    return {
+      name: string(member as Record<string, unknown>, "name"),
+      threadId: string(member as Record<string, unknown>, "threadId"),
+    };
+  });
+}
+function membersSchema() {
+  return {
+    type: "array",
+    items: {
+      type: "object",
+      properties: { name: { type: "string" }, threadId: { type: "string" } },
+      required: ["name", "threadId"],
+      additionalProperties: false,
+    },
+  };
+}

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -29,6 +29,7 @@ import type {
   RoomMember,
 } from "./trigger-types.js";
 import { ZenXCapabilityService } from "./capability-service.js";
+import { ZenXAutomationControlCapabilityPackage } from "./capabilities/automation-control-package.js";
 import {
   MutableAppServerRequestPort,
   ZenXSelfControlCapabilityPackage,
@@ -142,6 +143,9 @@ app.whenReady().then(async () => {
       { titles: titleCoordinator },
     );
     await triggerService.start();
+    capabilityService.register(
+      new ZenXAutomationControlCapabilityPackage(triggerService),
+    );
     installTriggerIpc(triggerService);
     if (startupError === undefined) await appServerManager.start();
     else appServerManager.reportStartupError(startupError);

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -377,12 +377,9 @@ export class ZenXTriggerService {
           event.turn.status === "completed" ? "completed" : "failed";
         entry.completedAt = this.#now();
         entry.error = event.turn.error?.message ?? null;
-        const trigger = this.#snapshot.triggers.find(
-          (item) => item.id === entry.triggerId,
-        );
-        if (trigger?.kind === "roomMention" && trigger.room !== undefined) {
+        if (entry.replyRoomId !== null && entry.replyAuthor !== null) {
           const room = this.#snapshot.rooms.find(
-            (item) => item.id === trigger.room?.roomId,
+            (item) => item.id === entry.replyRoomId,
           );
           const projectedAnswer = [...completedItems]
             .reverse()
@@ -395,7 +392,7 @@ export class ZenXTriggerService {
             room.messages.push(
               message(
                 room.id,
-                trigger.room.mention,
+                entry.replyAuthor,
                 answer,
                 "agent",
                 entry.threadId,
@@ -441,48 +438,62 @@ export class ZenXTriggerService {
       scheduledAt?: number;
     },
   ): Promise<void> {
-    const trigger = this.#snapshot.triggers.find(
-      (item) => item.id === triggerId && item.active,
-    );
-    if (trigger === undefined) return;
-    const clientUserMessageId = stableWakeupId(
-      trigger.id,
-      wakeup.occurrenceKey,
-    );
-    if (
-      this.#snapshot.history.some(
-        (entry) => entry.clientUserMessageId === clientUserMessageId,
+    const committed = await this.#mutate(async () => {
+      const trigger = this.#snapshot.triggers.find(
+        (item) => item.id === triggerId && item.active,
+      );
+      if (trigger === undefined) return undefined;
+      const clientUserMessageId = stableWakeupId(
+        trigger.id,
+        wakeup.occurrenceKey,
+      );
+      if (
+        this.#snapshot.history.some(
+          (entry) => entry.clientUserMessageId === clientUserMessageId,
+        )
       )
-    )
-      return;
-    const history: TriggerHistoryEntry = {
-      id: randomUUID(),
-      triggerId: trigger.id,
-      threadId: trigger.threadId,
-      kind: trigger.kind,
-      reason: wakeup.reason,
-      prompt: trigger.prompt,
-      clientUserMessageId,
-      startedAt: this.#now(),
-      completedAt: null,
-      status: "starting",
-      turnId: null,
-      error: null,
-      sourceThreadId: wakeup.sourceThreadId ?? null,
-      sourceTurnId: wakeup.sourceTurnId ?? null,
-      sourceRoomId: wakeup.sourceRoomId ?? null,
-      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-    };
-    await this.#mutate(async () => {
+        return undefined;
+      const committedTrigger = structuredClone(trigger);
+      const history: TriggerHistoryEntry = {
+        id: randomUUID(),
+        triggerId: committedTrigger.id,
+        threadId: committedTrigger.threadId,
+        kind: committedTrigger.kind,
+        reason: wakeup.reason,
+        prompt: committedTrigger.prompt,
+        clientUserMessageId,
+        startedAt: this.#now(),
+        completedAt: null,
+        status: "starting",
+        turnId: null,
+        error: null,
+        sourceThreadId: wakeup.sourceThreadId ?? null,
+        sourceTurnId: wakeup.sourceTurnId ?? null,
+        sourceRoomId: wakeup.sourceRoomId ?? null,
+        sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+        replyRoomId: committedTrigger.room?.roomId ?? null,
+        replyAuthor: committedTrigger.room?.mention ?? null,
+      };
       this.#snapshot.history.unshift(history);
-      if (trigger.timer !== undefined) {
-        if (trigger.timer.intervalMinutes === null) trigger.active = false;
+      const currentTrigger = this.#snapshot.triggers.find(
+        (item) => item.id === committedTrigger.id,
+      );
+      if (currentTrigger?.timer !== undefined) {
+        if (currentTrigger.timer.intervalMinutes === null)
+          currentTrigger.active = false;
         else
-          trigger.timer.nextRunAt =
+          currentTrigger.timer.nextRunAt =
             Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-            trigger.timer.intervalMinutes * 60_000;
+            currentTrigger.timer.intervalMinutes * 60_000;
       }
+      return {
+        trigger: committedTrigger,
+        history,
+        clientUserMessageId,
+      };
     });
+    if (committed === undefined) return;
+    const { trigger, history, clientUserMessageId } = committed;
     this.#rescheduleTimers();
     try {
       await this.#titles

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -12,6 +12,7 @@ import { ZenXTriggerStore } from "./trigger-store.js";
 import type {
   CreateRoomInput,
   CreateTriggerInput,
+  UpdateTriggerInput,
   RoomMember,
   RoomMessage,
   TriggerHistoryEntry,
@@ -177,6 +178,40 @@ export class ZenXTriggerService {
     });
   }
 
+  async update(input: UpdateTriggerInput): Promise<ZenXTrigger> {
+    const replacement = await this.#mutate(async () => {
+      const index = this.#snapshot.triggers.findIndex(
+        (item) => item.id === input.id,
+      );
+      if (index < 0) throw new Error("Trigger was not found");
+      const existing = this.#snapshot.triggers[index]!;
+      const replacement = triggerFromInput(
+        input,
+        existing.id,
+        existing.createdAt,
+        existing.active,
+        this.#now(),
+      );
+      this.#snapshot.triggers[index] = replacement;
+      return replacement;
+    });
+    this.#rescheduleTimers();
+    return replacement;
+  }
+
+  async delete(triggerId: string): Promise<void> {
+    await this.#mutate(async () => {
+      const index = this.#snapshot.triggers.findIndex(
+        (item) => item.id === required(triggerId, "trigger"),
+      );
+      if (index < 0) throw new Error("Trigger was not found");
+      this.#snapshot.triggers.splice(index, 1);
+    });
+    const timer = this.#timers.get(triggerId);
+    if (timer !== undefined) this.#cancelScheduled(timer);
+    this.#timers.delete(triggerId);
+  }
+
   async signal(name: string, detail: string): Promise<void> {
     const signalName = required(name, "signal name");
     const signalDetail = detail.trim();
@@ -206,6 +241,36 @@ export class ZenXTriggerService {
       };
       this.#snapshot.rooms.push(room);
       return room;
+    });
+  }
+
+  async renameRoom(roomId: string, name: string): Promise<void> {
+    await this.#mutate(async () => {
+      const room = this.#snapshot.rooms.find(
+        (entry) => entry.id === required(roomId, "room"),
+      );
+      if (room === undefined) throw new Error("Room was not found");
+      room.name = required(name, "room name");
+    });
+  }
+
+  async deleteRoom(roomId: string): Promise<void> {
+    await this.#mutate(async () => {
+      const normalized = required(roomId, "room");
+      if (
+        this.#snapshot.triggers.some(
+          (trigger) => trigger.active && trigger.room?.roomId === normalized,
+        )
+      ) {
+        throw new Error(
+          "Room has active mention triggers; cancel or delete them first",
+        );
+      }
+      const index = this.#snapshot.rooms.findIndex(
+        (entry) => entry.id === normalized,
+      );
+      if (index < 0) throw new Error("Room was not found");
+      this.#snapshot.rooms.splice(index, 1);
     });
   }
 
@@ -241,19 +306,33 @@ export class ZenXTriggerService {
     author: string,
     text: string,
   ): Promise<void> {
-    const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
-    if (room === undefined) throw new Error("Room was not found");
-    const posted = message(
-      room.id,
-      required(author, "author"),
-      required(text, "message"),
-      "human",
-      null,
-      null,
-      this.#now(),
-    );
-    await this.#mutate(async () => {
+    await this.#postRoomMessage(roomId, author, text, "human");
+  }
+
+  async postAgentRoomMessage(roomId: string, text: string): Promise<void> {
+    await this.#postRoomMessage(roomId, "ZenX Agent", text, "agent");
+  }
+
+  async #postRoomMessage(
+    roomId: string,
+    author: string,
+    text: string,
+    kind: "human" | "agent",
+  ): Promise<void> {
+    const { posted, room } = await this.#mutate(async () => {
+      const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
+      if (room === undefined) throw new Error("Room was not found");
+      const posted = message(
+        room.id,
+        required(author, "author"),
+        required(text, "message"),
+        kind,
+        null,
+        null,
+        this.#now(),
+      );
       room.messages.push(posted);
+      return { posted, room: structuredClone(room) };
     });
     const mentions = room.members.filter((member) =>
       new RegExp(
@@ -541,6 +620,62 @@ function validFuture(value: number, now: number): number {
   if (!Number.isFinite(value) || value <= now)
     throw new Error("Timer must be scheduled in the future");
   return value;
+}
+
+function triggerFromInput(
+  input: CreateTriggerInput,
+  id: string,
+  createdAt: number,
+  active: boolean,
+  now: number,
+): ZenXTrigger {
+  const common = {
+    id,
+    threadId: required(input.threadId, "thread"),
+    kind: input.kind,
+    label: required(input.label, "label"),
+    prompt: required(input.prompt, "prompt"),
+    createdAt,
+    active,
+  };
+  if (input.kind === "timer") {
+    return {
+      ...common,
+      kind: "timer",
+      timer: {
+        nextRunAt: validFuture(input.runAt, now),
+        intervalMinutes:
+          input.intervalMinutes === undefined
+            ? null
+            : positive(input.intervalMinutes),
+      },
+    };
+  }
+  if (input.kind === "thread") {
+    return {
+      ...common,
+      kind: "thread",
+      watch: {
+        threadId: required(input.watchedThreadId, "watched thread"),
+        event: "turn_completed",
+      },
+    };
+  }
+  if (input.kind === "roomMention") {
+    return {
+      ...common,
+      kind: "roomMention",
+      room: {
+        roomId: required(input.roomId, "room"),
+        mention: required(input.mention, "mention"),
+      },
+    };
+  }
+  return {
+    ...common,
+    kind: "signal",
+    signal: { name: required(input.signalName, "signal name") },
+  };
 }
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -46,6 +46,10 @@ export class ZenXTriggerService {
   readonly #timers = new Map<string, unknown>();
   readonly #completedAgentMessages = new Map<string, string>();
   readonly #completedTurnItems = new Map<string, ThreadItem[]>();
+  readonly #pendingCompletedTurns = new Map<
+    string,
+    ServerNotificationParams["turn/completed"]
+  >();
   readonly #now: () => number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
@@ -105,6 +109,7 @@ export class ZenXTriggerService {
   stop(): void {
     for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
     this.#timers.clear();
+    this.#pendingCompletedTurns.clear();
   }
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
@@ -368,44 +373,10 @@ export class ZenXTriggerService {
       event.turn.items,
       this.#completedTurnItems.get(event.turn.id) ?? [],
     );
-    await this.#mutate(async () => {
-      const entry = this.#snapshot.history.find(
-        (item) => item.turnId === event.turn.id && item.status === "running",
-      );
-      if (entry !== undefined) {
-        entry.status =
-          event.turn.status === "completed" ? "completed" : "failed";
-        entry.completedAt = this.#now();
-        entry.error = event.turn.error?.message ?? null;
-        if (entry.replyRoomId !== null && entry.replyAuthor !== null) {
-          const room = this.#snapshot.rooms.find(
-            (item) => item.id === entry.replyRoomId,
-          );
-          const projectedAnswer = [...completedItems]
-            .reverse()
-            .find((item) => item.type === "agentMessage");
-          const answer =
-            projectedAnswer?.type === "agentMessage"
-              ? projectedAnswer.text
-              : (this.#completedAgentMessages.get(event.turn.id) ?? "");
-          if (room !== undefined && answer.length > 0) {
-            room.messages.push(
-              message(
-                room.id,
-                entry.replyAuthor,
-                answer,
-                "agent",
-                entry.threadId,
-                event.turn.id,
-                this.#now(),
-              ),
-            );
-          }
-        }
-      }
-    });
-    this.#completedAgentMessages.delete(event.turn.id);
-    this.#completedTurnItems.delete(event.turn.id);
+    const outcome = await this.#mutate(async () =>
+      this.#applyTurnCompletion(event, completedItems, true),
+    );
+    if (outcome !== "pending") this.#clearCompletedTurn(event.turn.id);
     const watchers = this.#snapshot.triggers.filter(
       (trigger) =>
         trigger.active &&
@@ -423,6 +394,78 @@ export class ZenXTriggerService {
           items: completedItems,
         }),
       });
+  }
+
+  async #reconcileEarlyCompletion(
+    event: ServerNotificationParams["turn/completed"],
+  ): Promise<void> {
+    const completedItems = mergeCompletedItems(
+      event.turn.items,
+      this.#completedTurnItems.get(event.turn.id) ?? [],
+    );
+    const outcome = await this.#mutate(async () =>
+      this.#applyTurnCompletion(event, completedItems, false),
+    );
+    if (outcome !== "pending") this.#clearCompletedTurn(event.turn.id);
+  }
+
+  #applyTurnCompletion(
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+    bufferStarting: boolean,
+  ): "completed" | "pending" | "ignored" {
+    const entry = this.#snapshot.history.find(
+      (item) => item.turnId === event.turn.id && item.status === "running",
+    );
+    if (entry === undefined) {
+      if (
+        bufferStarting &&
+        this.#snapshot.history.some(
+          (item) =>
+            item.threadId === event.threadId &&
+            item.status === "starting" &&
+            item.turnId === null,
+        )
+      ) {
+        this.#pendingCompletedTurns.set(event.turn.id, event);
+        return "pending";
+      }
+      return "ignored";
+    }
+    entry.status = event.turn.status === "completed" ? "completed" : "failed";
+    entry.completedAt = this.#now();
+    entry.error = event.turn.error?.message ?? null;
+    if (entry.replyRoomId !== null && entry.replyAuthor !== null) {
+      const room = this.#snapshot.rooms.find(
+        (item) => item.id === entry.replyRoomId,
+      );
+      const projectedAnswer = [...completedItems]
+        .reverse()
+        .find((item) => item.type === "agentMessage");
+      const answer =
+        projectedAnswer?.type === "agentMessage"
+          ? projectedAnswer.text
+          : (this.#completedAgentMessages.get(event.turn.id) ?? "");
+      if (room !== undefined && answer.length > 0) {
+        room.messages.push(
+          message(
+            room.id,
+            entry.replyAuthor,
+            answer,
+            "agent",
+            entry.threadId,
+            event.turn.id,
+            this.#now(),
+          ),
+        );
+      }
+    }
+    return "completed";
+  }
+
+  #clearCompletedTurn(turnId: string): void {
+    this.#completedAgentMessages.delete(turnId);
+    this.#completedTurnItems.delete(turnId);
   }
 
   async #fire(
@@ -516,15 +559,26 @@ export class ZenXTriggerService {
           },
         ],
       });
-      await this.#mutate(async () => {
+      const earlyCompletion = await this.#mutate(async () => {
         history.status = "running";
         history.turnId = result.turn.id;
+        const completion = this.#pendingCompletedTurns.get(result.turn.id);
+        this.#pendingCompletedTurns.delete(result.turn.id);
+        return completion;
       });
+      if (earlyCompletion !== undefined)
+        await this.#reconcileEarlyCompletion(earlyCompletion);
     } catch (error) {
       await this.#mutate(async () => {
         history.status = "failed";
         history.completedAt = this.#now();
         history.error = error instanceof Error ? error.message : String(error);
+        for (const [turnId, completion] of this.#pendingCompletedTurns) {
+          if (completion.threadId === trigger.threadId) {
+            this.#pendingCompletedTurns.delete(turnId);
+            this.#clearCompletedTurn(turnId);
+          }
+        }
       });
     }
   }

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -45,13 +45,15 @@ export class ZenXTriggerStore {
       if (isLegacyStoredState(value)) {
         return {
           triggers: value.triggers,
-          history: value.history.map((entry) => ({
-            ...entry,
-            sourceThreadId: null,
-            sourceTurnId: null,
-            sourceRoomId: null,
-            sourceRoomMessageId: null,
-          })),
+          history: value.history.map((entry) =>
+            historyWithReplyRoute({
+              ...entry,
+              sourceThreadId: null,
+              sourceTurnId: null,
+              sourceRoomId: null,
+              sourceRoomMessageId: null,
+            }),
+          ),
           rooms: value.rooms,
         };
       }
@@ -89,7 +91,7 @@ function emptySnapshot(): TriggerSnapshot {
 function snapshotFrom(value: StoredState): TriggerSnapshot {
   return {
     triggers: value.triggers,
-    history: value.history,
+    history: value.history.map(historyWithReplyRoute),
     rooms: value.rooms,
   };
 }
@@ -163,8 +165,21 @@ function isHistory(value: unknown): value is TriggerHistoryEntry {
     nullableString(entry["sourceThreadId"]) &&
     nullableString(entry["sourceTurnId"]) &&
     nullableString(entry["sourceRoomId"]) &&
-    nullableString(entry["sourceRoomMessageId"])
+    nullableString(entry["sourceRoomMessageId"]) &&
+    nullableString(entry["replyRoomId"] ?? null) &&
+    nullableString(entry["replyAuthor"] ?? null)
   );
+}
+
+function historyWithReplyRoute(
+  entry: Omit<TriggerHistoryEntry, "replyRoomId" | "replyAuthor"> &
+    Partial<Pick<TriggerHistoryEntry, "replyRoomId" | "replyAuthor">>,
+): TriggerHistoryEntry {
+  return {
+    ...entry,
+    replyRoomId: entry.replyRoomId ?? null,
+    replyAuthor: entry.replyAuthor ?? null,
+  };
 }
 
 function isLegacyHistory(

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -31,6 +31,8 @@ export interface TriggerHistoryEntry {
   sourceTurnId: string | null;
   sourceRoomId: string | null;
   sourceRoomMessageId: string | null;
+  replyRoomId: string | null;
+  replyAuthor: string | null;
 }
 
 export interface RoomMember {

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -93,6 +93,8 @@ export type CreateTriggerInput =
       signalName: string;
     };
 
+export type UpdateTriggerInput = CreateTriggerInput & { id: string };
+
 export interface CreateRoomInput {
   name: string;
   members: RoomMember[];

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ToolInvocation } from "../../../src/tool.js";
+import {
+  ZENX_AUTOMATION_READ_PERMISSION,
+  ZENX_AUTOMATION_WRITE_PERMISSION,
+  ZenXAutomationControlCapabilityPackage,
+  type ZenXAutomationControlPort,
+} from "../src/main/capabilities/automation-control-package.js";
+import type {
+  CreateRoomInput,
+  CreateTriggerInput,
+  RoomMember,
+  TriggerSnapshot,
+  UpdateTriggerInput,
+  ZenXRoom,
+  ZenXTrigger,
+} from "../src/main/trigger-types.js";
+
+test("automation capability exposes separately granted read and mutation tools", () => {
+  const capability = new ZenXAutomationControlCapabilityPackage(new FakePort());
+  const list = capability.manifest.tools.find(
+    (tool) => tool.name === "zenx_triggers_list",
+  );
+  const create = capability.manifest.tools.find(
+    (tool) => tool.name === "zenx_triggers_create",
+  );
+  assert.deepEqual(list?.permissions, [ZENX_AUTOMATION_READ_PERMISSION]);
+  assert.deepEqual(create?.permissions, [ZENX_AUTOMATION_WRITE_PERMISSION]);
+  assert.equal(
+    capability.manifest.provider.interactionModes[0],
+    "background_safe",
+  );
+});
+
+test("automation capability routes Trigger CRUD and Room management", async () => {
+  const port = new FakePort();
+  const capability = new ZenXAutomationControlCapabilityPackage(port);
+  const trigger = await invoke(capability, "zenx_triggers_create", {
+    threadId: "target",
+    kind: "signal",
+    label: "Deploy",
+    prompt: "Check deploy",
+    signalName: "deploy",
+  });
+  assert.equal((trigger as { signalName: string }).signalName, "deploy");
+  await invoke(capability, "zenx_triggers_update", {
+    id: "trigger-1",
+    threadId: "target",
+    kind: "thread",
+    label: "Review",
+    prompt: "Review it",
+    watchedThreadId: "source",
+  });
+  await invoke(capability, "zenx_triggers_cancel", { triggerId: "trigger-1" });
+  await invoke(capability, "zenx_triggers_delete", { triggerId: "trigger-1" });
+  await invoke(capability, "zenx_rooms_create", {
+    name: "release",
+    members: [{ name: "Reviewer", threadId: "target" }],
+  });
+  await invoke(capability, "zenx_rooms_post_message", {
+    roomId: "room-1",
+    text: "Ready",
+  });
+  assert.deepEqual(
+    port.calls.map((call) => call[0]),
+    [
+      "create",
+      "update",
+      "cancel",
+      "delete",
+      "createRoom",
+      "postAgentRoomMessage",
+    ],
+  );
+});
+
+async function invoke(
+  capability: ZenXAutomationControlCapabilityPackage,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const invocation: ToolInvocation = {
+    name,
+    arguments: args,
+    cwd: "/workspace",
+    signal: new AbortController().signal,
+    callId: `call-${name}`,
+  };
+  return await capability.invoke(name, invocation);
+}
+
+class FakePort implements ZenXAutomationControlPort {
+  readonly calls: Array<[string, unknown]> = [];
+  snapshot(): TriggerSnapshot {
+    return { triggers: [], history: [], rooms: [] };
+  }
+  async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
+    this.calls.push(["create", input]);
+    return { id: "trigger-1", createdAt: 1, active: true, ...input };
+  }
+  async update(input: UpdateTriggerInput): Promise<ZenXTrigger> {
+    this.calls.push(["update", input]);
+    return { createdAt: 1, active: true, ...input };
+  }
+  async cancel(id: string): Promise<void> {
+    this.calls.push(["cancel", id]);
+  }
+  async delete(id: string): Promise<void> {
+    this.calls.push(["delete", id]);
+  }
+  async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
+    this.calls.push(["createRoom", input]);
+    return { id: "room-1", createdAt: 1, messages: [], ...input };
+  }
+  async renameRoom(id: string, name: string): Promise<void> {
+    this.calls.push(["renameRoom", { id, name }]);
+  }
+  async deleteRoom(id: string): Promise<void> {
+    this.calls.push(["deleteRoom", id]);
+  }
+  async addRoomMember(id: string, member: RoomMember): Promise<void> {
+    this.calls.push(["addRoomMember", { id, member }]);
+  }
+  async removeRoomMember(id: string, threadId: string): Promise<void> {
+    this.calls.push(["removeRoomMember", { id, threadId }]);
+  }
+  async postAgentRoomMessage(id: string, text: string): Promise<void> {
+    this.calls.push(["postAgentRoomMessage", { id, text }]);
+  }
+}

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -1,13 +1,21 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import type { ToolInvocation } from "../../../src/tool.js";
 import {
   ZENX_AUTOMATION_READ_PERMISSION,
   ZENX_AUTOMATION_WRITE_PERMISSION,
+  ZENX_AUTOMATION_CONTROL_CAPABILITY_ID,
   ZenXAutomationControlCapabilityPackage,
   type ZenXAutomationControlPort,
 } from "../src/main/capabilities/automation-control-package.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
+import { AppServerManager } from "../src/main/app-server-manager.js";
 import type {
   CreateRoomInput,
   CreateTriggerInput,
@@ -76,6 +84,138 @@ test("automation capability routes Trigger CRUD and Room management", async () =
   );
 });
 
+test("automation history listing returns the newest bounded entries", async () => {
+  const history = Array.from({ length: 75 }, (_, index) => ({
+    id: `history-${index}`,
+    triggerId: "trigger-1",
+    threadId: "thread-1",
+    kind: "signal" as const,
+    reason: `reason-${index}`,
+    prompt: "Inspect it",
+    clientUserMessageId: `wakeup-${index}`,
+    startedAt: index,
+    completedAt: index + 1,
+    status: "completed" as const,
+    turnId: `turn-${index}`,
+    error: null,
+    sourceThreadId: null,
+    sourceTurnId: null,
+    sourceRoomId: null,
+    sourceRoomMessageId: null,
+    replyRoomId: null,
+    replyAuthor: null,
+  }));
+  const capability = new ZenXAutomationControlCapabilityPackage(
+    new FakePort({ triggers: [], history, rooms: [] }),
+  );
+
+  const result = (await invoke(capability, "zenx_triggers_list", {})) as {
+    history: Array<{ id: string }>;
+  };
+  assert.equal(result.history.length, 50);
+  assert.equal(result.history[0]?.id, "history-0");
+  assert.equal(result.history.at(-1)?.id, "history-49");
+});
+
+test("granted automation tools are exposed to and executable through the hosted App Server", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-automation-host-"),
+  );
+  const port = new FakePort();
+  const capability = new ZenXAutomationControlCapabilityPackage(port);
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  const manager = new AppServerManager({
+    entryPath: fileURLToPath(
+      new URL("../src/main/app-server-host.ts", import.meta.url),
+    ),
+    tokenFile: path.join(directory, "runtime", "token"),
+    hostConfig: {
+      cwd: directory,
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+    capabilityHost: registry,
+  });
+  try {
+    await registry.initialize();
+    registry.register(capability);
+    assert.deepEqual(registry.hostSnapshot().definitions, []);
+    await registry.grant(ZENX_AUTOMATION_CONTROL_CAPABILITY_ID, [
+      ZENX_AUTOMATION_READ_PERMISSION,
+      ZENX_AUTOMATION_WRITE_PERMISSION,
+    ]);
+    const exposed = registry
+      .hostSnapshot()
+      .definitions.map((definition) => definition.name);
+    assert.deepEqual(exposed, [
+      "zenx_triggers_list",
+      "zenx_triggers_create",
+      "zenx_triggers_update",
+      "zenx_triggers_cancel",
+      "zenx_triggers_delete",
+      "zenx_rooms_list",
+      "zenx_rooms_create",
+      "zenx_rooms_rename",
+      "zenx_rooms_delete",
+      "zenx_rooms_add_member",
+      "zenx_rooms_remove_member",
+      "zenx_rooms_post_message",
+    ]);
+
+    for (const [name, args] of [
+      ["zenx_rooms_list", {}],
+      [
+        "zenx_rooms_create",
+        { name: "release", members: [{ name: "Bot", threadId: "thread-1" }] },
+      ],
+      ["zenx_rooms_rename", { roomId: "room-1", name: "ship" }],
+      ["zenx_rooms_delete", { roomId: "room-1" }],
+      [
+        "zenx_rooms_add_member",
+        { roomId: "room-1", name: "Reviewer", threadId: "thread-2" },
+      ],
+      ["zenx_rooms_remove_member", { roomId: "room-1", threadId: "thread-2" }],
+      ["zenx_rooms_post_message", { roomId: "room-1", text: "Ready" }],
+    ] as const) {
+      const result = await registry.execute({
+        name,
+        arguments: args,
+        cwd: directory,
+        signal: new AbortController().signal,
+        callId: `call-${name}`,
+      });
+      assert.equal(result.exitCode, 0);
+    }
+
+    port.calls.length = 0;
+    const completed = deferred<void>();
+    manager.onNotification((method) => {
+      if (method === "turn/completed") completed.resolve();
+    });
+    await manager.start();
+    const started = await manager.request("thread/start", {});
+    await manager.request("turn/start", {
+      threadId: started.thread.id,
+      input: [{ type: "text", text: "!tool zenx_rooms_list {}" }],
+    });
+    await within(completed.promise);
+    assert(
+      port.calls.some(([name]) => name === "snapshot"),
+      "the hosted App Server must execute the exposed Room list tool",
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 async function invoke(
   capability: ZenXAutomationControlCapabilityPackage,
   name: string,
@@ -93,8 +233,17 @@ async function invoke(
 
 class FakePort implements ZenXAutomationControlPort {
   readonly calls: Array<[string, unknown]> = [];
+  readonly #state: TriggerSnapshot;
+
+  constructor(
+    state: TriggerSnapshot = { triggers: [], history: [], rooms: [] },
+  ) {
+    this.#state = structuredClone(state);
+  }
+
   snapshot(): TriggerSnapshot {
-    return { triggers: [], history: [], rooms: [] };
+    this.calls.push(["snapshot", null]);
+    return structuredClone(this.#state);
   }
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
     this.calls.push(["create", input]);
@@ -128,5 +277,34 @@ class FakePort implements ZenXAutomationControlPort {
   }
   async postAgentRoomMessage(id: string, text: string): Promise<void> {
     this.calls.push(["postAgentRoomMessage", { id, text }]);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  milliseconds = 10_000,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(new Error("Timed out waiting for hosted automation tool")),
+          milliseconds,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -20,6 +20,7 @@ import type {
   CreateRoomInput,
   CreateTriggerInput,
   RoomMember,
+  RoomMessage,
   TriggerSnapshot,
   UpdateTriggerInput,
   ZenXRoom,
@@ -169,47 +170,65 @@ test("granted automation tools are exposed to and executable through the hosted 
       "zenx_rooms_post_message",
     ]);
 
-    for (const [name, args] of [
-      ["zenx_rooms_list", {}],
-      [
-        "zenx_rooms_create",
-        { name: "release", members: [{ name: "Bot", threadId: "thread-1" }] },
-      ],
-      ["zenx_rooms_rename", { roomId: "room-1", name: "ship" }],
-      ["zenx_rooms_delete", { roomId: "room-1" }],
-      [
-        "zenx_rooms_add_member",
-        { roomId: "room-1", name: "Reviewer", threadId: "thread-2" },
-      ],
-      ["zenx_rooms_remove_member", { roomId: "room-1", threadId: "thread-2" }],
-      ["zenx_rooms_post_message", { roomId: "room-1", text: "Ready" }],
-    ] as const) {
-      const result = await registry.execute({
-        name,
-        arguments: args,
-        cwd: directory,
-        signal: new AbortController().signal,
-        callId: `call-${name}`,
-      });
-      assert.equal(result.exitCode, 0);
-    }
-
     port.calls.length = 0;
-    const completed = deferred<void>();
-    manager.onNotification((method) => {
-      if (method === "turn/completed") completed.resolve();
-    });
     await manager.start();
     const started = await manager.request("thread/start", {});
-    await manager.request("turn/start", {
-      threadId: started.thread.id,
-      input: [{ type: "text", text: "!tool zenx_rooms_list {}" }],
+    const hostedTool = async (name: string, args: Record<string, unknown>) => {
+      const completed = deferred<void>();
+      const dispose = manager.onNotification((method, params) => {
+        if (
+          method === "turn/completed" &&
+          (params as { threadId: string }).threadId === started.thread.id
+        ) {
+          dispose();
+          completed.resolve();
+        }
+      });
+      await manager.request("turn/start", {
+        threadId: started.thread.id,
+        input: [
+          { type: "text", text: `!tool ${name} ${JSON.stringify(args)}` },
+        ],
+      });
+      await within(completed.promise);
+    };
+
+    await hostedTool("zenx_rooms_list", {});
+    await hostedTool("zenx_rooms_create", {
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-1" }],
     });
-    await within(completed.promise);
-    assert(
-      port.calls.some(([name]) => name === "snapshot"),
-      "the hosted App Server must execute the exposed Room list tool",
+    await hostedTool("zenx_rooms_rename", {
+      roomId: "room-1",
+      name: "ship",
+    });
+    await hostedTool("zenx_rooms_add_member", {
+      roomId: "room-1",
+      name: "Reviewer",
+      threadId: "thread-2",
+    });
+    await hostedTool("zenx_rooms_remove_member", {
+      roomId: "room-1",
+      threadId: "thread-2",
+    });
+    await hostedTool("zenx_rooms_post_message", {
+      roomId: "room-1",
+      text: "Ready",
+    });
+    await hostedTool("zenx_rooms_delete", { roomId: "room-1" });
+    assert.deepEqual(
+      port.calls.map(([name]) => name),
+      [
+        "snapshot",
+        "createRoom",
+        "renameRoom",
+        "addRoomMember",
+        "removeRoomMember",
+        "postAgentRoomMessage",
+        "deleteRoom",
+      ],
     );
+    assert.deepEqual(port.rooms, []);
   } finally {
     await manager.stop();
     await rm(directory, { recursive: true, force: true });
@@ -233,7 +252,7 @@ async function invoke(
 
 class FakePort implements ZenXAutomationControlPort {
   readonly calls: Array<[string, unknown]> = [];
-  readonly #state: TriggerSnapshot;
+  #state: TriggerSnapshot;
 
   constructor(
     state: TriggerSnapshot = { triggers: [], history: [], rooms: [] },
@@ -244,6 +263,9 @@ class FakePort implements ZenXAutomationControlPort {
   snapshot(): TriggerSnapshot {
     this.calls.push(["snapshot", null]);
     return structuredClone(this.#state);
+  }
+  get rooms(): ZenXRoom[] {
+    return structuredClone(this.#state.rooms);
   }
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
     this.calls.push(["create", input]);
@@ -261,22 +283,52 @@ class FakePort implements ZenXAutomationControlPort {
   }
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
     this.calls.push(["createRoom", input]);
-    return { id: "room-1", createdAt: 1, messages: [], ...input };
+    const room: ZenXRoom = {
+      id: `room-${this.#state.rooms.length + 1}`,
+      createdAt: 1,
+      messages: [],
+      ...structuredClone(input),
+    };
+    this.#state.rooms.push(room);
+    return structuredClone(room);
   }
   async renameRoom(id: string, name: string): Promise<void> {
     this.calls.push(["renameRoom", { id, name }]);
+    this.#room(id).name = name;
   }
   async deleteRoom(id: string): Promise<void> {
     this.calls.push(["deleteRoom", id]);
+    this.#state.rooms = this.#state.rooms.filter((room) => room.id !== id);
   }
   async addRoomMember(id: string, member: RoomMember): Promise<void> {
     this.calls.push(["addRoomMember", { id, member }]);
+    this.#room(id).members.push(structuredClone(member));
   }
   async removeRoomMember(id: string, threadId: string): Promise<void> {
     this.calls.push(["removeRoomMember", { id, threadId }]);
+    this.#room(id).members = this.#room(id).members.filter(
+      (member) => member.threadId !== threadId,
+    );
   }
   async postAgentRoomMessage(id: string, text: string): Promise<void> {
     this.calls.push(["postAgentRoomMessage", { id, text }]);
+    const room = this.#room(id);
+    const posted: RoomMessage = {
+      id: `message-${room.messages.length + 1}`,
+      roomId: id,
+      author: "ZenX Agent",
+      text,
+      createdAt: 1,
+      kind: "agent",
+      originThreadId: null,
+      originTurnId: null,
+    };
+    room.messages.push(posted);
+  }
+  #room(id: string): ZenXRoom {
+    const room = this.#state.rooms.find((candidate) => candidate.id === id);
+    if (room === undefined) throw new Error(`Room ${id} was not found`);
+    return room;
   }
 }
 

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -403,6 +403,52 @@ test("completed Room wakeups keep their original reply route after Trigger updat
   }
 });
 
+test("Room wakeup reconciles a completion delivered before turn/start returns", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-completion-"),
+  );
+  const manager = new ControlledManager();
+  manager.earlyCompletion = {
+    threadId: "thread-target",
+    turn: completedTurn("turn-1", "early answer"),
+  };
+  const store = new ZenXTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer Room",
+      prompt: "Answer the Room.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(terminal.history[0]?.turnId, "turn-1");
+    assert.equal(terminal.rooms[0]?.messages.at(-1)?.author, "Bot");
+    assert.match(
+      terminal.rooms[0]?.messages.at(-1)?.text ?? "",
+      /Conclusion for early answer/u,
+    );
+    const persisted = await store.read();
+    assert.equal(persisted.history[0]?.status, "completed");
+    assert.equal(persisted.rooms[0]?.messages.at(-1)?.author, "Bot");
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("completed Room wakeups keep their original reply route after Trigger deletion", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-room-route-delete-"),
@@ -734,6 +780,7 @@ test("completed Turn projection is bounded and includes commands/results", () =>
 class ControlledManager implements ZenXTriggerAppServerPort {
   readonly requests: ClientRequestParams["turn/start"][] = [];
   requestError: Error | null = null;
+  earlyCompletion: { threadId: string; turn: Turn } | null = null;
   #listener:
     | ((
         method: ServerNotificationMethod,
@@ -747,9 +794,14 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   ): Promise<ClientRequestResults["turn/start"]> {
     this.requests.push(params);
     if (this.requestError !== null) throw this.requestError;
+    const earlyCompletion = this.earlyCompletion;
+    this.earlyCompletion = null;
+    if (earlyCompletion !== null) {
+      this.#listener?.("turn/completed", earlyCompletion);
+    }
     return {
       turn: {
-        id: `wakeup-turn-${this.requests.length}`,
+        id: earlyCompletion?.turn.id ?? `wakeup-turn-${this.requests.length}`,
         items: [],
         itemsView: "full",
         status: "inProgress",

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -356,6 +356,29 @@ test("Room membership enforces unique names and Threads and supports add/remove"
   }
 });
 
+test("concurrent Room deletion makes a queued Agent post fail explicitly", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-room-race-"));
+  const triggers = new ZenXTriggerService(
+    new ControlledManager(),
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Reviewer", threadId: "thread-a" }],
+    });
+    const deletion = triggers.deleteRoom(room.id);
+    const posting = triggers.postAgentRoomMessage(room.id, "Status?");
+    await deletion;
+    await assert.rejects(posting, /Room was not found/u);
+    assert.deepEqual(triggers.snapshot().rooms, []);
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("failed relay is terminal and is not hidden, queued, or retried", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-relay-fail-"));
   const manager = new ControlledManager();

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -19,6 +19,135 @@ import type {
   ThreadItem,
   Turn,
 } from "../src/protocol-client/index.js";
+import type { TriggerSnapshot } from "../src/main/trigger-types.js";
+
+test("fire revalidates an active Trigger after a queued cancellation", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-race-"));
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const trigger = await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect deploy.",
+      signalName: "deploy",
+    });
+    const blocked = store.blockNextWrite();
+    const blocker = triggers.createRoom({
+      name: "queue blocker",
+      members: [{ name: "Target", threadId: "thread-target" }],
+    });
+    await blocked.started;
+
+    const cancellation = triggers.cancel(trigger.id);
+    const fire = triggers.signal("deploy", "completed");
+    blocked.release.resolve();
+    await Promise.all([blocker, cancellation, fire]);
+
+    assert.equal(triggers.snapshot().history.length, 0);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(
+      triggers.snapshot().triggers.find((entry) => entry.id === trigger.id)
+        ?.active,
+      false,
+    );
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("fire revalidates Trigger existence after a queued deletion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-trigger-delete-race-"),
+  );
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const trigger = await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect deploy.",
+      signalName: "deploy",
+    });
+    const blocked = store.blockNextWrite();
+    const blocker = triggers.createRoom({
+      name: "queue blocker",
+      members: [{ name: "Target", threadId: "thread-target" }],
+    });
+    await blocked.started;
+
+    const deletion = triggers.delete(trigger.id);
+    const fire = triggers.signal("deploy", "completed");
+    blocked.release.resolve();
+    await Promise.all([blocker, deletion, fire]);
+
+    assert.equal(triggers.snapshot().history.length, 0);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(
+      triggers.snapshot().triggers.some((entry) => entry.id === trigger.id),
+      false,
+    );
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("fire uses the Trigger snapshot committed by a queued update", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-trigger-update-race-"),
+  );
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const trigger = await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Old deploy",
+      prompt: "Inspect the old deployment.",
+      signalName: "deploy",
+    });
+    const blocked = store.blockNextWrite();
+    const blocker = triggers.createRoom({
+      name: "queue blocker",
+      members: [{ name: "Target", threadId: "thread-target" }],
+    });
+    await blocked.started;
+
+    const update = triggers.update({
+      id: trigger.id,
+      threadId: "thread-new-target",
+      kind: "signal",
+      label: "New deploy",
+      prompt: "Inspect the new deployment.",
+      signalName: "deploy",
+    });
+    const fire = triggers.signal("deploy", "completed");
+    blocked.release.resolve();
+    await Promise.all([blocker, update, fire]);
+
+    const history = triggers.snapshot().history[0];
+    assert.equal(history?.threadId, "thread-new-target");
+    assert.equal(history?.prompt, "Inspect the new deployment.");
+    assert.equal(manager.requests[0]?.threadId, "thread-new-target");
+    assert.match(
+      manager.requests[0]?.input[0]?.text ?? "",
+      /Inspect the new deployment\./u,
+    );
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("timer expiry creates one explicit App Server turn and auditable history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-"));
@@ -203,6 +332,118 @@ test("thread snapshots and two-member Room context route through target Threads"
     triggers.stop();
   } finally {
     await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("completed Room wakeups keep their original reply route after Trigger update", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-route-update-"),
+  );
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const oldRoom = await triggers.createRoom({
+      name: "old",
+      members: [{ name: "OldBot", threadId: "thread-target" }],
+    });
+    const newRoom = await triggers.createRoom({
+      name: "new",
+      members: [{ name: "NewBot", threadId: "thread-target" }],
+    });
+    const trigger = await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer old Room",
+      prompt: "Answer the Room.",
+      roomId: oldRoom.id,
+      mention: "OldBot",
+    });
+    await triggers.postRoomMessage(oldRoom.id, "You", "@OldBot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    const wakeup = running.history[0];
+    await triggers.update({
+      id: trigger.id,
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer new Room",
+      prompt: "Answer the new Room.",
+      roomId: newRoom.id,
+      mention: "NewBot",
+    });
+    manager.complete(
+      "thread-target",
+      completedTurn(wakeup?.turnId ?? "missing", "answer"),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.rooms.find((room) => room.id === oldRoom.id)?.messages.at(-1)
+        ?.author,
+      "OldBot",
+    );
+    assert.equal(
+      snapshot.rooms.find((room) => room.id === newRoom.id)?.messages.length,
+      0,
+    );
+  } finally {
+    triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("completed Room wakeups keep their original reply route after Trigger deletion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-route-delete-"),
+  );
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    const trigger = await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer Room",
+      prompt: "Answer the Room.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    const wakeup = running.history[0];
+    await triggers.delete(trigger.id);
+    manager.complete(
+      "thread-target",
+      completedTurn(wakeup?.turnId ?? "missing", "answer"),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(triggers.snapshot().rooms[0]?.messages.at(-1)?.author, "Bot");
+  } finally {
+    triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -535,6 +776,42 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   complete(threadId: string, turn: Turn): void {
     this.#listener?.("turn/completed", { threadId, turn });
   }
+}
+
+class BlockingTriggerStore extends ZenXTriggerStore {
+  #blocked:
+    | {
+        started: ReturnType<typeof deferred<void>>;
+        release: ReturnType<typeof deferred<void>>;
+      }
+    | undefined;
+
+  blockNextWrite() {
+    const blocked = {
+      started: deferred<void>(),
+      release: deferred<void>(),
+    };
+    this.#blocked = blocked;
+    return blocked;
+  }
+
+  override async write(snapshot: TriggerSnapshot): Promise<void> {
+    const blocked = this.#blocked;
+    this.#blocked = undefined;
+    if (blocked !== undefined) {
+      blocked.started.resolve();
+      await blocked.release.promise;
+    }
+    await super.write(snapshot);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 function completedTurn(

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -66,6 +66,8 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     const migrated = await store.read();
     assert.equal(migrated.history[0]?.sourceThreadId, null);
     assert.equal(migrated.history[0]?.sourceTurnId, null);
+    assert.equal(migrated.history[0]?.replyRoomId, null);
+    assert.equal(migrated.history[0]?.replyAuthor, null);
     await store.write(migrated);
     assert.equal(JSON.parse(await readFile(file, "utf8")).version, 2);
   } finally {
@@ -106,6 +108,8 @@ function validState(): TriggerSnapshot & { version: 2 } {
         sourceTurnId: "turn-b",
         sourceRoomId: null,
         sourceRoomMessageId: null,
+        replyRoomId: null,
+        replyAuthor: null,
       },
     ],
     rooms: [

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "format:check": "prettier --check . && uv run --project apps/imzen --extra dev ruff format --check apps/imzen",
     "lint": "uv run --project apps/imzen --extra dev ruff check apps/imzen",
     "start": "node dist/apps/cli/src/cli.js",
-    "test": "npm run test:node && npm run test:imzen",
+    "test": "npm run test:node && npm run test:imzen && npm run test:zenx",
     "test:imzen": "uv run --project apps/imzen --extra dev pytest -q apps/imzen/tests",
     "test:node": "npm run build && node --test dist/test/*.test.js",
+    "test:zenx": "npm --workspace apps/zenx test",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "engines": {


### PR DESCRIPTION
### Motivation

- Expose a permissioned, agent-callable surface for managing Triggers and Rooms without creating another runtime, transcript, scheduler, or queue.
- Preserve append-only, auditable behavior with stable one-attempt wakeups and trusted Agent-attributed Room posts.

### Description

- Add the bundled `zenx-automation-control` capability with separate read/write permissions and Trigger/Room management tools.
- Revalidate Trigger active state, existence, and deduplication inside the serialized mutation before recording or starting a wakeup, using the committed Trigger snapshot for the attempt.
- Persist immutable Room reply routing metadata with each wakeup history entry so in-flight replies remain tied to their original Room and mention across Trigger update/delete.
- Return the newest bounded history entries and register the capability with the ZenX capability registry at startup.
- Reconcile `turn/completed` notifications that arrive before the `turn/start` response bookkeeping, preserving terminal history and Room replies.

### Validation coverage

- Queued cancellation, deletion, and update race regressions.
- Early completion-before-`turn/start`-response regression with persisted terminal history and Room reply.
- >50 history ordering regression.
- Registry grant and `hostSnapshot` assertions.
- Real child App Server bridge executes all seven Room tools against a stateful automation port: list, create, rename, add member, remove member, post, and delete.

### Testing

- `npx tsx --test test/trigger-service.test.ts test/automation-control-capability.test.ts`: 19/19 passed.
- `npm --workspace apps/zenx run typecheck`: passed.
- `npm --workspace apps/zenx run build`: passed.
- Root `npm run typecheck`: passed.
- Changed-file Prettier and `git diff --check`: passed.
- Full ZenX suite: 132/137 passed locally; five unrelated Windows-host failures remain for POSIX `printf`, POSIX path expectations, and Unix local-process spawning.
- GitHub CI was green on the prior repair; this pushed commit starts the next CI run.
