### PR TITLE
feat(zenx): add Agent-callable Thread lifecycle management

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,8 +19,9 @@
 - **ComposerSubmission** — 接入端一次待确认的用户提交；只在 UI 内保留草稿、
   发送意图和稳定 `clientUserMessageId`，是否已进入会话仍完全由 App Server 的
   canonical Item 投影决定。
-- **ThreadMetadataStore** — ZAS 按 threadId 持久化名称等产品元数据的
-  append-only 外部索引；它由 App Server 投影，但不进入 Agent 上下文或
+- **ThreadMetadataStore** — ZAS 按 threadId 持久化名称与归档状态等产品元数据的
+  append-only 外部索引；归档只影响标准 `thread/list.archived` 产品筛选与生命周期通知，
+  它由 App Server 投影但不进入 Agent 上下文或
   canonical ItemList。损坏或暂时不可读的产品元数据不得阻断 Thread 的创建、
   读取或列表；ZAS 降级为无展示名称并明确记录 warning，而 metadata 写入失败
   仍须返回错误。
@@ -216,6 +217,9 @@ Zen 只在 Codex 0.146.0 没有等价原子语义时增加一项明确命名的�
 - `thread/name/set` 修改 ZAS 的 ThreadMetadataStore 并广播
   `thread/name/updated`；名称不是 Agent Item。`thread/list`、`thread/read` 与
   `thread/resume` 返回当前名称。
+- Codex 标准 `thread/archive` / `thread/unarchive` 修改同一 ThreadMetadataStore
+  并广播对应生命周期通知；`thread/list` 默认只返回未归档 Thread，只有
+  `archived: true` 才返回已归档 Thread，而 `thread/read` / `thread/resume` 始终可读。
 - `thread/list` 必须隔离单个损坏 journal，并使用 Codex 标准
   `status: systemError` 显式返回该 threadId；`thread/read` / `thread/resume`
   仍明确失败，且不得用默认配置伪造可恢复的 Thread snapshot。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -31,7 +31,7 @@ provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协�
 
 ZenX Agent 的自控工具同样属于产品层：bundled capability package 经现有 registry
 显式授权 workspace/local-device 权限后才向 Agent 暴露；Project 列表只按已配置
-workspace 与 Thread 实际 cwd 派生；Thread 的创建、读取、状态与
+workspace 与 Thread 实际 cwd 派生；Thread 的创建、读取、状态、重命名、归档与取消归档，以及
 `start | steer | replace` 发送全部经由 App Server。工具调用和目标 Thread 的结果分别
 进入各自权威 ItemList，不另建委派记录、消息队列或 transcript；互相监听
 `turn_completed` 后继续发起普通 Turn 是允许的。

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -222,7 +222,9 @@ async function threadsCommand(args: ParsedArguments): Promise<void> {
   assertNoPositionals(args);
   const session = await connectClient(args);
   try {
-    const response = await session.client.request("thread/list", {});
+    const response = await session.client.request("thread/list", {
+      archived: flag(args, "archived"),
+    });
     if (!isRecord(response) || !Array.isArray(response.data)) {
       throw new Error("App Server returned an invalid thread list");
     }
@@ -527,11 +529,12 @@ function hostOptions(args: ParsedArguments) {
 function parseArguments(args: string[]): ParsedArguments {
   const options = new Map<string, string | true>();
   const positionals: string[] = [];
-  const booleanOptions = new Set(["approve", "deny"]);
+  const booleanOptions = new Set(["approve", "archived", "deny"]);
   const allowedOptions = new Set([
     "api-key-env",
     "approval",
     "approve",
+    "archived",
     "auth-token-file",
     "base-url",
     "cwd",
@@ -784,6 +787,7 @@ Core options:
   --remote <ws://...>          Connect to an existing Zen App Server
   --auth-token-file <path>     Bearer token file for WebSocket transport
   --thread <id>                Resume an existing Thread
+  --archived                   List archived Threads with zen threads
   --provider fake|openai-subscription|openai-compatible
   --base-url <url>             OpenAI-compatible API base URL
   --api-key-env <name>         Name of the host environment variable containing the key

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -57,15 +57,18 @@ The `zenx-self-control` package is a bundled, cross-platform,
 Capabilities UI grants its workspace-read and local-device-control permissions;
 grant/revoke uses the same host restart behavior as every other package. Its
 provider-valid tools are `zenx_projects_list`, `zenx_threads_list`,
-`zenx_threads_create`, `zenx_threads_read`, `zenx_threads_status`, and
-`zenx_threads_send`.
+`zenx_threads_create`, `zenx_threads_read`, `zenx_threads_status`,
+`zenx_threads_rename`, `zenx_threads_archive`, `zenx_threads_unarchive`, and
+`zenx_threads_send`. Archived Threads remain readable and are returned from
+`zenx_threads_list` only when `archived: true` is requested.
 
 Projects are bounded groupings derived from the configured workspace and
 canonical Thread cwd metadata, not runtime objects. Reads expose bounded recent
 Turn/item projections and omit command output. Create and send operations use a
 narrow in-memory request port attached to the current `AppServerManager`, and
 that port issues only typed `thread/list`, `thread/start`, `thread/read`,
-`turn/start`, `turn/steer`, and `turn/replace` requests. `steer` and `replace`
+`thread/name/set`, `thread/archive`, `thread/unarchive`, `turn/start`,
+`turn/steer`, and `turn/replace` requests. `steer` and `replace`
 require the expected active Turn ID; all sends require a stable client message
 ID. Tool calls, results, interruption, and replacement remain auditable in the
 canonical ItemLists and capability audit projection. Mutual `turn_completed`

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -271,6 +271,8 @@ export class AppServerManager {
     for (const method of [
       "thread/started",
       "thread/name/updated",
+      "thread/archived",
+      "thread/unarchived",
       "thread/settings/updated",
       "turn/started",
       "item/started",

--- a/apps/zenx/src/main/capabilities/self-control-package.ts
+++ b/apps/zenx/src/main/capabilities/self-control-package.ts
@@ -21,6 +21,9 @@ type SelfControlRequestMethod = Extract<
   | "thread/list"
   | "thread/start"
   | "thread/read"
+  | "thread/name/set"
+  | "thread/archive"
+  | "thread/unarchive"
   | "turn/start"
   | "turn/steer"
   | "turn/replace"
@@ -113,7 +116,7 @@ const manifest: ZenXCapabilityManifest = {
       id: ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
       title: "Control local Zen Threads",
       description:
-        "Create local Threads and start, steer, or replace their active Turns through App Server.",
+        "Create, rename, archive, or unarchive local Threads and start, steer, or replace their active Turns through App Server.",
       scope: "local-device",
     },
   ],
@@ -138,6 +141,7 @@ const manifest: ZenXCapabilityManifest = {
           workspace: { type: "string" },
           cwd: { type: "string" },
           query: { type: "string" },
+          archived: { type: "boolean" },
           limit: { type: "integer", minimum: 1, maximum: MAX_LIST_LIMIT },
         },
         additionalProperties: false,
@@ -209,6 +213,53 @@ const manifest: ZenXCapabilityManifest = {
       maxOutputBytes: 64 * 1024,
     },
     {
+      name: "zenx_threads_rename",
+      description:
+        "Set the authoritative user-facing name for a Thread through App Server thread/name/set.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          threadId: { type: "string" },
+          name: { type: "string" },
+        },
+        required: ["threadId", "name"],
+        additionalProperties: false,
+      },
+      permissions: [
+        ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+        ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      ],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.control"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_archive",
+      description:
+        "Archive a Thread through the standard App Server lifecycle without changing its canonical history.",
+      inputSchema: threadIdSchema(),
+      permissions: [
+        ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+        ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      ],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.control"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
+      name: "zenx_threads_unarchive",
+      description:
+        "Restore an archived Thread to normal listings through the standard App Server lifecycle.",
+      inputSchema: threadIdSchema(),
+      permissions: [
+        ZENX_SELF_CONTROL_WORKSPACE_PERMISSION,
+        ZENX_SELF_CONTROL_LOCAL_DEVICE_PERMISSION,
+      ],
+      interactionMode: "background_safe",
+      capabilities: ["zenx.threads.control"],
+      maxOutputBytes: 64 * 1024,
+    },
+    {
       name: "zenx_threads_send",
       description:
         "Send input through explicit App Server start, steer, or replace semantics. steer and replace require the expected active Turn ID; every mode requires a stable clientUserMessageId.",
@@ -271,6 +322,12 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
         return await this.#readThread(args);
       case "zenx_threads_status":
         return await this.#threadStatus(args);
+      case "zenx_threads_rename":
+        return await this.#renameThread(args);
+      case "zenx_threads_archive":
+        return await this.#setArchived(args, true);
+      case "zenx_threads_unarchive":
+        return await this.#setArchived(args, false);
       case "zenx_threads_send":
         return await this.#send(args);
       default:
@@ -327,7 +384,7 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
   }
 
   async #listThreads(args: Record<string, unknown>): Promise<unknown> {
-    assertOnly(args, ["workspace", "cwd", "query", "limit"]);
+    assertOnly(args, ["workspace", "cwd", "query", "archived", "limit"]);
     const workspace = optionalString(args.workspace, "workspace");
     const cwd = optionalString(args.cwd, "cwd");
     if (workspace !== undefined && cwd !== undefined) {
@@ -341,13 +398,16 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     const resolvedFilter =
       cwdFilter === undefined ? undefined : path.resolve(cwdFilter);
     const query = optionalString(args.query, "query")?.toLocaleLowerCase();
+    const archived = optionalBoolean(args.archived, "archived") ?? false;
     const limit = boundedInteger(
       args.limit,
       "limit",
       DEFAULT_LIST_LIMIT,
       MAX_LIST_LIMIT,
     );
-    const threads = (await this.#appServer.request("thread/list", {})).data
+    const threads = (
+      await this.#appServer.request("thread/list", { archived })
+    ).data
       .filter(
         (thread) =>
           resolvedFilter === undefined ||
@@ -358,7 +418,9 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
       .sort((left, right) => right.updatedAt - left.updatedAt);
     return {
       source: SOURCE,
-      threads: threads.slice(0, limit).map(projectThreadSummary),
+      threads: threads
+        .slice(0, limit)
+        .map((thread) => projectThreadSummary(thread, archived)),
       truncated: threads.length > limit,
     };
   }
@@ -470,6 +532,32 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     };
   }
 
+  async #renameThread(args: Record<string, unknown>): Promise<unknown> {
+    assertOnly(args, ["threadId", "name"]);
+    const threadId = requiredString(args.threadId, "threadId");
+    await this.#appServer.request("thread/name/set", {
+      threadId,
+      name: requiredString(args.name, "name"),
+    });
+    const thread = (await this.#appServer.request("thread/read", { threadId }))
+      .thread;
+    return { source: SOURCE, threadId, name: thread.name };
+  }
+
+  async #setArchived(
+    args: Record<string, unknown>,
+    archived: boolean,
+  ): Promise<unknown> {
+    assertOnly(args, ["threadId"]);
+    const threadId = requiredString(args.threadId, "threadId");
+    if (archived) {
+      await this.#appServer.request("thread/archive", { threadId });
+    } else {
+      await this.#appServer.request("thread/unarchive", { threadId });
+    }
+    return { source: SOURCE, threadId, archived };
+  }
+
   async #send(args: Record<string, unknown>): Promise<unknown> {
     assertOnly(args, [
       "threadId",
@@ -558,15 +646,28 @@ function boundedListSchema(): Record<string, unknown> {
   };
 }
 
-function projectThreadSummary(thread: Thread): Record<string, unknown> {
+function projectThreadSummary(
+  thread: Thread,
+  archived = false,
+): Record<string, unknown> {
   return {
     threadId: thread.id,
     cwd: thread.cwd,
     name: thread.name,
     preview: clip(thread.preview),
     status: statusType(thread),
+    archived,
     createdAt: thread.createdAt,
     updatedAt: thread.updatedAt,
+  };
+}
+
+function threadIdSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: { threadId: { type: "string" } },
+    required: ["threadId"],
+    additionalProperties: false,
   };
 }
 
@@ -645,6 +746,14 @@ function limitedString(
 function optionalString(value: unknown, label: string): string | undefined {
   if (value === undefined) return undefined;
   return requiredString(value, label);
+}
+
+function optionalBoolean(value: unknown, label: string): boolean | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new Error(`${label} must be a boolean`);
+  }
+  return value;
 }
 
 function boundedInteger(

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -9,7 +9,10 @@ import {
 import { join, resolve } from "node:path";
 
 import { isAllowedZenXExternalUrl } from "../external-link-policy.js";
-import { isClientRequestMethod } from "../protocol-client/index.js";
+import {
+  isClientRequestMethod,
+  type ServerNotificationParams,
+} from "../protocol-client/index.js";
 import { ipcChannels } from "../preload/ipc.js";
 import { AppServerManager } from "./app-server-manager.js";
 import type { ApprovalDecision } from "./app-server-manager.js";
@@ -235,6 +238,18 @@ function installProtocolIpc(
   });
   manager.onNotification((method, params) => {
     void observeCompletedUserMessageTitle(titles, method, params);
+    if (method === "thread/name/updated") {
+      const event = params as ServerNotificationParams["thread/name/updated"];
+      void titles
+        .synchronizeNativeName(event.threadId, event.threadName)
+        .catch((error: unknown) => {
+          console.warn(
+            `Could not synchronize native Thread name: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        });
+    }
     for (const window of BrowserWindow.getAllWindows()) {
       window.webContents.send(ipcChannels.notification, method, params);
     }

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -15,6 +15,8 @@ export class ZenXThreadTitleCoordinator {
   readonly #titleModel: () => string;
   readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
+  readonly #expectedNativeMirrors = new Map<string, string[]>();
+  readonly #nativeAuthorityVersions = new Map<string, number>();
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
@@ -125,9 +127,16 @@ export class ZenXThreadTitleCoordinator {
   ): Promise<ThreadTitleProjection> {
     this.#assertAvailable();
     const normalized = normalizeManualTitle(title);
+    if (this.#consumeExpectedNativeMirror(threadId, normalized)) {
+      const current = this.#snapshot[threadId];
+      if (current !== undefined) return current;
+    }
+    this.#recordNativeAuthority(threadId);
     return await this.#serial(async () => {
       const current = this.#snapshot[threadId];
-      if (current?.title === normalized) return current;
+      if (current?.status === "manual" && current.title === normalized) {
+        return current;
+      }
       const projection: ThreadTitleProjection = {
         threadId,
         title: normalized,
@@ -136,6 +145,7 @@ export class ZenXThreadTitleCoordinator {
         source: current?.source ?? normalized,
       };
       await this.#commit(projection);
+      await this.#mirror(threadId, normalized);
       return projection;
     });
   }
@@ -183,8 +193,16 @@ export class ZenXThreadTitleCoordinator {
           status: "generated",
           version: current.version + 1,
         };
+        const nativeAuthorityVersion = this.#nativeAuthorityVersion(
+          started.threadId,
+        );
         await this.#commit(projection);
-        await this.#mirror(started.threadId, generated);
+        if (
+          this.#nativeAuthorityVersion(started.threadId) ===
+          nativeAuthorityVersion
+        ) {
+          await this.#mirror(started.threadId, generated);
+        }
       });
     } catch (error) {
       await this.#serial(async () => {
@@ -212,13 +230,41 @@ export class ZenXThreadTitleCoordinator {
   }
 
   async #mirror(threadId: string, title: string): Promise<void> {
+    const expected = this.#expectedNativeMirrors.get(threadId) ?? [];
+    expected.push(title);
+    this.#expectedNativeMirrors.set(threadId, expected);
     try {
       await this.#setNativeName(threadId, title);
     } catch (error) {
+      this.#removeExpectedNativeMirror(threadId, title);
       console.warn(
         `Could not mirror ZenX thread title: ${describeError(error)}`,
       );
     }
+  }
+
+  #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
+    const expected = this.#expectedNativeMirrors.get(threadId);
+    const index = expected?.indexOf(title) ?? -1;
+    if (expected === undefined || index < 0) return false;
+    expected.splice(index, 1);
+    if (expected.length === 0) this.#expectedNativeMirrors.delete(threadId);
+    return true;
+  }
+
+  #removeExpectedNativeMirror(threadId: string, title: string): void {
+    this.#consumeExpectedNativeMirror(threadId, title);
+  }
+
+  #recordNativeAuthority(threadId: string): void {
+    this.#nativeAuthorityVersions.set(
+      threadId,
+      this.#nativeAuthorityVersion(threadId) + 1,
+    );
+  }
+
+  #nativeAuthorityVersion(threadId: string): number {
+    return this.#nativeAuthorityVersions.get(threadId) ?? 0;
   }
 
   #startGeneration(projection: ThreadTitleProjection): void {

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -119,6 +119,27 @@ export class ZenXThreadTitleCoordinator {
     });
   }
 
+  async synchronizeNativeName(
+    threadId: string,
+    title: string,
+  ): Promise<ThreadTitleProjection> {
+    this.#assertAvailable();
+    const normalized = normalizeManualTitle(title);
+    return await this.#serial(async () => {
+      const current = this.#snapshot[threadId];
+      if (current?.title === normalized) return current;
+      const projection: ThreadTitleProjection = {
+        threadId,
+        title: normalized,
+        status: "manual",
+        version: (current?.version ?? 0) + 1,
+        source: current?.source ?? normalized,
+      };
+      await this.#commit(projection);
+      return projection;
+    });
+  }
+
   async retry(threadId: string): Promise<ThreadTitleProjection> {
     this.#assertAvailable();
     const generating = await this.#serial(async () => {

--- a/apps/zenx/src/protocol-client/methods.ts
+++ b/apps/zenx/src/protocol-client/methods.ts
@@ -9,6 +9,8 @@ export const clientRequestMethods = [
   "thread/read",
   "thread/list",
   "thread/name/set",
+  "thread/archive",
+  "thread/unarchive",
   "thread/settings/update",
   "thread/unsubscribe",
   "turn/start",

--- a/apps/zenx/src/protocol-client/types.ts
+++ b/apps/zenx/src/protocol-client/types.ts
@@ -101,8 +101,14 @@ export interface ClientRequestParams {
   "thread/start": ThreadConfigurationParams;
   "thread/resume": { threadId: string } & ThreadConfigurationParams;
   "thread/read": { threadId: string; includeTurns?: boolean };
-  "thread/list": { limit?: number; cursor?: string | null };
+  "thread/list": {
+    limit?: number;
+    cursor?: string | null;
+    archived?: boolean | null;
+  };
   "thread/name/set": { threadId: string; name: string };
+  "thread/archive": { threadId: string };
+  "thread/unarchive": { threadId: string };
   "thread/settings/update": { threadId: string; model: string };
   "thread/unsubscribe": { threadId: string };
   "turn/start": {
@@ -141,6 +147,8 @@ export interface ClientRequestResults {
     backwardsCursor: null;
   };
   "thread/name/set": Record<string, never>;
+  "thread/archive": Record<string, never>;
+  "thread/unarchive": { thread: Thread };
   "thread/settings/update": Record<string, never>;
   "thread/unsubscribe": {
     status: "unsubscribed" | "notSubscribed";
@@ -156,6 +164,8 @@ export type ClientRequestMethod = keyof ClientRequestParams;
 export interface ServerNotificationParams {
   "thread/started": { thread: Thread };
   "thread/name/updated": { threadId: string; threadName: string };
+  "thread/archived": { threadId: string };
+  "thread/unarchived": { threadId: string };
   "thread/settings/updated": {
     threadId: string;
     threadSettings: UpdatedThreadSettings;

--- a/apps/zenx/src/protocol-client/types.ts
+++ b/apps/zenx/src/protocol-client/types.ts
@@ -143,7 +143,7 @@ export interface ClientRequestResults {
   "thread/read": { thread: Thread };
   "thread/list": {
     data: Thread[];
-    nextCursor: null;
+    nextCursor: string | null;
     backwardsCursor: null;
   };
   "thread/name/set": Record<string, never>;

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -168,6 +168,9 @@ export function App() {
     const disposeNotifications = window.zenx.protocol.onNotification(
       (method, params) => {
         if (active) {
+          if (method === "thread/archived" || method === "thread/unarchived") {
+            void loadThreads();
+          }
           setThreads((current) =>
             applyThreadNotification(current, method, params),
           );

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -132,6 +132,10 @@ export function applyThreadNotification(
         : thread,
     );
   }
+  if (method === "thread/archived") {
+    const event = params as ServerNotificationParams["thread/archived"];
+    return threads.filter((thread) => thread.id !== event.threadId);
+  }
   if (method === "thread/settings/updated") {
     const update =
       params as ServerNotificationParams["thread/settings/updated"];

--- a/apps/zenx/test/protocol-client.test.ts
+++ b/apps/zenx/test/protocol-client.test.ts
@@ -10,9 +10,19 @@ import { serveCodexWebSocket } from "../../../src/protocol/codex/websocket.js";
 import {
   readBearerTokenFile,
   ZenXProtocolClient,
+  type ClientRequestResults,
   type ConnectionStatus,
   type ServerNotificationMethod,
 } from "../src/protocol-client/index.js";
+
+test("types paginated thread/list cursors from the wire response", () => {
+  const nextCursor: ClientRequestResults["thread/list"]["nextCursor"] =
+    "opaque-next-cursor";
+  const backwardsCursor: ClientRequestResults["thread/list"]["backwardsCursor"] =
+    null;
+  assert.equal(nextCursor, "opaque-next-cursor");
+  assert.equal(backwardsCursor, null);
+});
 
 function testHost(models: readonly string[] = ["fake"]) {
   return createHostedAppServer({
@@ -53,6 +63,34 @@ test("reads bearer credentials only from a private regular file", async () => {
     }
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("continues a paginated thread/list through the typed client", async () => {
+  const server = await serveCodexWebSocket({
+    appServer: testHost(),
+    zenHome: path.join(os.tmpdir(), "zenx-pagination-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const client = await ZenXProtocolClient.connect(
+    clientOptions(server.url, "zenx-pagination"),
+  );
+  try {
+    await client.request("thread/start", {});
+    await client.request("thread/start", {});
+
+    const first = await client.request("thread/list", { limit: 1 });
+    assert.equal(first.data.length, 1);
+    assert.equal(typeof first.nextCursor, "string");
+    const second = await client.request("thread/list", {
+      cursor: first.nextCursor,
+    });
+    assert.equal(second.data.length, 1);
+    assert.equal(second.nextCursor, null);
+    assert.equal(second.backwardsCursor, null);
+  } finally {
+    client.close();
+    await server.close();
   }
 });
 

--- a/apps/zenx/test/self-control-capability.test.ts
+++ b/apps/zenx/test/self-control-capability.test.ts
@@ -48,6 +48,9 @@ const SELF_CONTROL_TOOL_NAMES = [
   "zenx_threads_create",
   "zenx_threads_read",
   "zenx_threads_status",
+  "zenx_threads_rename",
+  "zenx_threads_archive",
+  "zenx_threads_unarchive",
   "zenx_threads_send",
 ];
 
@@ -153,6 +156,39 @@ test("real ZenX host control tools make active semantics explicit", async () => 
       (listed.threads as Array<{ threadId: string }>)[0]?.threadId,
       threadId,
     );
+
+    const renamed = await invoke(tools, "zenx_threads_rename", {
+      threadId,
+      name: "Agent-managed Thread",
+    });
+    assert.equal(renamed.name, "Agent-managed Thread");
+    const archived = await invoke(tools, "zenx_threads_archive", { threadId });
+    assert.equal(archived.archived, true);
+    const activeAfterArchive = await invoke(tools, "zenx_threads_list", {
+      limit: 10,
+    });
+    assert.equal(
+      (activeAfterArchive.threads as Array<{ threadId: string }>).some(
+        (thread) => thread.threadId === threadId,
+      ),
+      false,
+    );
+    const archivedList = await invoke(tools, "zenx_threads_list", {
+      archived: true,
+      limit: 10,
+    });
+    assert.equal(
+      (
+        archivedList.threads as Array<{ threadId: string; archived: boolean }>
+      )[0]?.archived,
+      true,
+    );
+    const archivedRead = await invoke(tools, "zenx_threads_read", { threadId });
+    assert.equal(archivedRead.threadId, threadId);
+    const unarchived = await invoke(tools, "zenx_threads_unarchive", {
+      threadId,
+    });
+    assert.equal(unarchived.archived, false);
 
     const bridgeThread = await manager.request("thread/start", {
       cwd: directory,

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -162,6 +162,17 @@ test("applies name and turn lifecycle notifications without altering errors", ()
   assert.equal(settled[1]?.status.type, "systemError");
 });
 
+test("removes archived Threads from the active renderer projection", () => {
+  const first = makeThread("first", 20, { type: "idle" });
+  const archived = makeThread("archived", 10, { type: "idle" });
+  assert.deepEqual(
+    applyThreadNotification([first, archived], "thread/archived", {
+      threadId: archived.id,
+    }).map((thread) => thread.id),
+    ["first"],
+  );
+});
+
 function makeThread(
   id: string,
   updatedAt: number,

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -81,6 +81,14 @@ test("an App Server rename becomes authoritative over pending generation", async
   });
 });
 
+test("an App Server rename between generated commit and mirror restores native authority", async () => {
+  await assertRenameWinsGenerationRace("after-generated-commit");
+});
+
+test("an App Server rename while generated mirror is in flight restores native authority", async () => {
+  await assertRenameWinsGenerationRace("during-generated-mirror");
+});
+
 test("observer bounds canonical text and logs failures without rejecting", async () => {
   const observed: string[] = [];
   const warnings: string[] = [];
@@ -135,6 +143,76 @@ async function withCoordinator(
     });
     await titles.initialize();
     await run({ titles, inference });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function assertRenameWinsGenerationRace(
+  phase: "after-generated-commit" | "during-generated-mirror",
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-authority-race-"),
+  );
+  try {
+    const inference = new ControlledInference();
+    let nativeName = "";
+    let synchronization: Promise<unknown> | undefined;
+    let injected = false;
+    let titles!: ZenXThreadTitleCoordinator;
+    titles = new ZenXThreadTitleCoordinator({
+      store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+      inference,
+      titleModel: () => "gpt-5.6-luna",
+      setNativeName: async (_threadId, title) => {
+        if (
+          phase === "during-generated-mirror" &&
+          title === "Late generated" &&
+          !injected
+        ) {
+          injected = true;
+          nativeName = "Agent authority";
+          synchronization = titles.synchronizeNativeName(
+            "thread-race",
+            "Agent authority",
+          );
+          await tick();
+        }
+        nativeName = title;
+        void titles.synchronizeNativeName("thread-race", title);
+      },
+    });
+    if (phase === "after-generated-commit") {
+      titles.onChange((snapshot) => {
+        if (snapshot["thread-race"]?.status !== "generated" || injected) return;
+        injected = true;
+        nativeName = "Agent authority";
+        synchronization = titles.synchronizeNativeName(
+          "thread-race",
+          "Agent authority",
+        );
+      });
+    }
+    await titles.initialize();
+    await titles.observe("thread-race", "Original title source");
+    inference.resolve("Late generated");
+    for (
+      let attempt = 0;
+      attempt < 5_000 && synchronization === undefined;
+      attempt += 1
+    ) {
+      await tick();
+    }
+    assert.notEqual(synchronization, undefined);
+    await synchronization;
+    assert.deepEqual(titles.snapshot()["thread-race"], {
+      threadId: "thread-race",
+      title: "Agent authority",
+      status: "manual",
+      version: 4,
+      source: "Original title source",
+    });
+    assert.equal(nativeName, "Agent authority");
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -62,6 +62,25 @@ test("a canonical duplicate cannot restart generation or overwrite a pre-observe
   });
 });
 
+test("an App Server rename becomes authoritative over pending generation", async () => {
+  await withCoordinator(async ({ titles, inference }) => {
+    await titles.observe("thread-agent-renamed", "Original title source");
+    await titles.synchronizeNativeName(
+      "thread-agent-renamed",
+      "Agent-managed name",
+    );
+    inference.resolve("Late generated name");
+    await tick();
+    assert.deepEqual(titles.snapshot()["thread-agent-renamed"], {
+      threadId: "thread-agent-renamed",
+      title: "Agent-managed name",
+      status: "manual",
+      version: 3,
+      source: "Original title source",
+    });
+  });
+});
+
 test("observer bounds canonical text and logs failures without rejecting", async () => {
   const observed: string[] = [];
   const warnings: string[] = [];

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -53,6 +53,7 @@ export interface ThreadSnapshot {
   sandbox: SandboxMode;
   approvalPolicy: ApprovalPolicy;
   name?: string;
+  archived: boolean;
 }
 
 export interface UnavailableThreadSnapshot {
@@ -60,6 +61,7 @@ export interface UnavailableThreadSnapshot {
   status: "systemError";
   error: string;
   name?: string;
+  archived: boolean;
 }
 
 export type ThreadListEntry = ThreadSnapshot | UnavailableThreadSnapshot;
@@ -95,8 +97,17 @@ export interface ThreadNameUpdatedEvent {
   name: string;
 }
 
+export interface ThreadArchivedUpdatedEvent {
+  type: "thread_archived_updated";
+  threadId: string;
+  archived: boolean;
+}
+
 export type AppServerEvent =
-  RuntimeEvent | ThreadSettingsUpdatedEvent | ThreadNameUpdatedEvent;
+  | RuntimeEvent
+  | ThreadSettingsUpdatedEvent
+  | ThreadNameUpdatedEvent
+  | ThreadArchivedUpdatedEvent;
 
 export interface UpdateThreadSettingsInput {
   model: string;
@@ -185,7 +196,9 @@ export class ZenAppServer {
     return await this.#snapshot(thread);
   }
 
-  async listThreads(): Promise<ThreadListEntry[]> {
+  async listThreads(
+    options: { archived?: boolean } = {},
+  ): Promise<ThreadListEntry[]> {
     const threadIds = await this.#journal.listThreadIds();
     const snapshots: ThreadListEntry[] = [];
     for (const threadId of threadIds) {
@@ -204,7 +217,8 @@ export class ZenAppServer {
         snapshots.push(await this.#unavailableSnapshot(threadId, error));
       }
     }
-    return snapshots;
+    const archived = options.archived ?? false;
+    return snapshots.filter((snapshot) => snapshot.archived === archived);
   }
 
   async readThread(threadId: string): Promise<ThreadSnapshot> {
@@ -261,6 +275,32 @@ export class ZenAppServer {
       thread,
       this.#activeTurns.get(threadId)?.turnId,
     );
+  }
+
+  async setThreadArchived(
+    threadId: string,
+    archived: boolean,
+  ): Promise<ThreadSnapshot> {
+    return await this.#withThreadMutation(threadId, async () => {
+      const thread = await this.#requireThread(threadId);
+      const current = await this.#threadMetadata.read(threadId);
+      if ((current.archived ?? false) === archived) {
+        return await this.#snapshot(
+          thread,
+          this.#activeTurns.get(threadId)?.turnId,
+        );
+      }
+      await this.#threadMetadata.setArchived(threadId, archived);
+      this.#emit({
+        type: "thread_archived_updated",
+        threadId,
+        archived,
+      });
+      return await this.#snapshot(
+        thread,
+        this.#activeTurns.get(threadId)?.turnId,
+      );
+    });
   }
 
   async startTurn(
@@ -843,6 +883,7 @@ export class ZenAppServer {
       provider: configuration.provider,
       sandbox: configuration.sandbox,
       approvalPolicy: configuration.approvalPolicy,
+      archived: productMetadata.archived ?? false,
       ...(productMetadata.name === undefined
         ? {}
         : { name: productMetadata.name }),
@@ -866,6 +907,7 @@ export class ZenAppServer {
       id: threadId,
       status: "systemError",
       error: error instanceof Error ? error.message : String(error),
+      archived: productMetadata.archived ?? false,
       ...(productMetadata.name === undefined
         ? {}
         : { name: productMetadata.name }),

--- a/src/protocol/codex/README.md
+++ b/src/protocol/codex/README.md
@@ -17,6 +17,8 @@ Client requests：
 - `thread/read`
 - `thread/list`
 - `thread/name/set`
+- `thread/archive`
+- `thread/unarchive`
 - `thread/settings/update`
 - `thread/unsubscribe`
 - `turn/start`
@@ -33,6 +35,8 @@ Server notifications：
 
 - `thread/started`
 - `thread/name/updated`
+- `thread/archived`
+- `thread/unarchived`
 - `thread/settings/updated`
 - `turn/started`
 - `item/started`

--- a/src/protocol/codex/README.md
+++ b/src/protocol/codex/README.md
@@ -58,6 +58,13 @@ plan collaboration mode 等未实现配置返回 `-32602`。T3 总会发送的
 Thread，也不覆盖 Zen 的 Agent 行为。实时 token usage 暂不投影，避免发送
 不完整的 0.146.0 类型。
 
+`thread/list` 当前只接受 `archived`、`limit` 与 `cursor`。非终页返回的 opaque
+cursor 绑定 archived filter、按 threadId 排序的筛选快照与当前位置，但不绑定 page
+limit；续页可以省略或改变 limit。跨筛选器、无效或已过期 cursor 返回 `-32602`，
+不得静默重放第一页。终页的 `nextCursor` 为 null。固定子集不支持 `sortKey` /
+`sortDirection`，因此不伪造依赖反向排序 watermark 语义的 `backwardsCursor`，该字段
+始终为 null，排序参数仍返回 `-32602`。
+
 ## Transport
 
 `stdio.ts` 实现每行一个 JSON-RPC message 的 stdio transport；

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -316,21 +316,47 @@ export class CodexConnection {
         return;
       }
       case "thread/list": {
+        rejectUnsupportedValues(params, ["archived", "cursor", "limit"]);
         const archived = optionalBoolean(params.archived, "archived") ?? false;
+        const requestedCursor = optionalNonEmptyString(params.cursor, "cursor");
+        const decodedCursor =
+          requestedCursor === undefined
+            ? undefined
+            : decodeThreadListCursor(requestedCursor);
         const snapshots = await this.#appServer.listThreads({ archived });
-        const limit =
-          typeof params.limit === "number" && params.limit >= 0
-            ? params.limit
-            : snapshots.length;
+        const limit = optionalListLimit(params.limit, snapshots.length);
+        const snapshotIds = snapshots.map((snapshot) => snapshot.id);
+        const cursor =
+          decodedCursor === undefined
+            ? {
+                version: 1 as const,
+                archived,
+                offset: 0,
+                threadIds: snapshotIds,
+              }
+            : decodedCursor;
+        if (cursor.archived !== archived) {
+          throw new InvalidParamsError(
+            "thread/list cursor does not match the requested archived filter",
+          );
+        }
+        if (!sameStrings(cursor.threadIds, snapshotIds)) {
+          throw new InvalidParamsError(
+            "thread/list cursor expired because the filtered Thread snapshot changed",
+          );
+        }
+        const page = snapshots.slice(cursor.offset, cursor.offset + limit);
+        const nextOffset = cursor.offset + page.length;
         this.#send({
           id: request.id,
           result: {
-            data: snapshots
-              .slice(0, limit)
-              .map((snapshot) =>
-                projectThread(snapshot, { includeTurns: false }),
-              ),
-            nextCursor: null,
+            data: page.map((snapshot) =>
+              projectThread(snapshot, { includeTurns: false }),
+            ),
+            nextCursor:
+              limit > 0 && nextOffset < snapshots.length
+                ? encodeThreadListCursor({ ...cursor, offset: nextOffset })
+                : null,
             backwardsCursor: null,
           },
         });
@@ -924,6 +950,71 @@ function optionalBoolean(value: unknown, key: string): boolean | undefined {
     throw new InvalidParamsError(`${key} must be a boolean`);
   }
   return value;
+}
+
+interface ThreadListCursor {
+  version: 1;
+  archived: boolean;
+  offset: number;
+  threadIds: string[];
+}
+
+function optionalListLimit(value: unknown, fallback: number): number {
+  if (value === undefined || value === null) return fallback;
+  if (
+    !Number.isInteger(value) ||
+    (value as number) < 0 ||
+    (value as number) > 0xffff_ffff
+  ) {
+    throw new InvalidParamsError("limit must be an unsigned 32-bit integer");
+  }
+  return value as number;
+}
+
+function encodeThreadListCursor(cursor: ThreadListCursor): string {
+  return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+}
+
+function decodeThreadListCursor(value: string): ThreadListCursor {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new InvalidParamsError("Invalid thread/list cursor");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch {
+    throw new InvalidParamsError("Invalid thread/list cursor");
+  }
+  if (
+    !isRecord(parsed) ||
+    parsed.version !== 1 ||
+    typeof parsed.archived !== "boolean" ||
+    !Number.isInteger(parsed.offset) ||
+    (parsed.offset as number) < 0 ||
+    !Array.isArray(parsed.threadIds) ||
+    parsed.threadIds.some(
+      (threadId) => typeof threadId !== "string" || threadId.length === 0,
+    ) ||
+    (parsed.offset as number) > parsed.threadIds.length
+  ) {
+    throw new InvalidParamsError("Invalid thread/list cursor");
+  }
+  return {
+    version: 1,
+    archived: parsed.archived,
+    offset: parsed.offset as number,
+    threadIds: parsed.threadIds as string[],
+  };
+}
+
+function sameStrings(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
 }
 
 function requiredStringArray(

--- a/src/protocol/codex/connection.ts
+++ b/src/protocol/codex/connection.ts
@@ -270,6 +270,29 @@ export class CodexConnection {
         this.#send({ id: request.id, result: {} });
         return;
       }
+      case "thread/archive": {
+        rejectUnsupportedValues(params, ["threadId"]);
+        await this.#appServer.setThreadArchived(
+          requiredString(params, "threadId"),
+          true,
+        );
+        this.#send({ id: request.id, result: {} });
+        return;
+      }
+      case "thread/unarchive": {
+        rejectUnsupportedValues(params, ["threadId"]);
+        const snapshot = await this.#appServer.setThreadArchived(
+          requiredString(params, "threadId"),
+          false,
+        );
+        this.#send({
+          id: request.id,
+          result: {
+            thread: projectThread(snapshot, { includeTurns: false }),
+          },
+        });
+        return;
+      }
       case "thread/settings/update": {
         rejectUnsupportedValues(params, ["threadId", "model"]);
         const threadId = requiredString(params, "threadId");
@@ -293,7 +316,8 @@ export class CodexConnection {
         return;
       }
       case "thread/list": {
-        const snapshots = await this.#appServer.listThreads();
+        const archived = optionalBoolean(params.archived, "archived") ?? false;
+        const snapshots = await this.#appServer.listThreads({ archived });
         const limit =
           typeof params.limit === "number" && params.limit >= 0
             ? params.limit
@@ -449,6 +473,13 @@ export class CodexConnection {
   }
 
   async #projectEvent(event: AppServerEvent): Promise<void> {
+    if (event.type === "thread_archived_updated") {
+      this.#send({
+        method: event.archived ? "thread/archived" : "thread/unarchived",
+        params: { threadId: event.threadId },
+      });
+      return;
+    }
     if (event.type === "thread_name_updated") {
       if (this.#subscribedThreads.has(event.threadId)) {
         this.#send({
@@ -766,7 +797,8 @@ export class CodexConnection {
   #sendErrorNotification(error: unknown, event: AppServerEvent): void {
     if (
       event.type === "thread_name_updated" ||
-      event.type === "thread_settings_updated"
+      event.type === "thread_settings_updated" ||
+      event.type === "thread_archived_updated"
     ) {
       console.warn(`Could not project ${event.type} notification`, error);
       return;
@@ -880,6 +912,16 @@ function optionalNonEmptyString(
   }
   if (typeof value !== "string" || value.length === 0) {
     throw new InvalidParamsError(`${key} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalBoolean(value: unknown, key: string): boolean | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value !== "boolean") {
+    throw new InvalidParamsError(`${key} must be a boolean`);
   }
   return value;
 }

--- a/src/thread-metadata.ts
+++ b/src/thread-metadata.ts
@@ -3,11 +3,16 @@ import path from "node:path";
 
 export interface ThreadProductMetadata {
   name?: string;
+  archived?: boolean;
 }
 
 export interface ThreadMetadataStore {
   read(threadId: string): Promise<ThreadProductMetadata>;
   setName(threadId: string, name: string): Promise<ThreadProductMetadata>;
+  setArchived(
+    threadId: string,
+    archived: boolean,
+  ): Promise<ThreadProductMetadata>;
 }
 
 interface ThreadNameSetEvent {
@@ -16,6 +21,15 @@ interface ThreadNameSetEvent {
   name: string;
   updatedAt: string;
 }
+
+interface ThreadArchivedSetEvent {
+  type: "thread_archived_set";
+  threadId: string;
+  archived: boolean;
+  updatedAt: string;
+}
+
+type ThreadMetadataEvent = ThreadNameSetEvent | ThreadArchivedSetEvent;
 
 export class InMemoryThreadMetadataStore implements ThreadMetadataStore {
   readonly #metadata = new Map<string, ThreadProductMetadata>();
@@ -28,7 +42,16 @@ export class InMemoryThreadMetadataStore implements ThreadMetadataStore {
     threadId: string,
     name: string,
   ): Promise<ThreadProductMetadata> {
-    const metadata = { name };
+    const metadata = { ...this.#metadata.get(threadId), name };
+    this.#metadata.set(threadId, metadata);
+    return structuredClone(metadata);
+  }
+
+  async setArchived(
+    threadId: string,
+    archived: boolean,
+  ): Promise<ThreadProductMetadata> {
+    const metadata = { ...this.#metadata.get(threadId), archived };
     this.#metadata.set(threadId, metadata);
     return structuredClone(metadata);
   }
@@ -54,12 +77,28 @@ export class JsonlThreadMetadataStore implements ThreadMetadataStore {
     name: string,
   ): Promise<ThreadProductMetadata> {
     await this.#load();
-    const event: ThreadNameSetEvent = {
+    return await this.#append({
       type: "thread_name_set",
       threadId,
       name,
       updatedAt: new Date().toISOString(),
-    };
+    });
+  }
+
+  async setArchived(
+    threadId: string,
+    archived: boolean,
+  ): Promise<ThreadProductMetadata> {
+    await this.#load();
+    return await this.#append({
+      type: "thread_archived_set",
+      threadId,
+      archived,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async #append(event: ThreadMetadataEvent): Promise<ThreadProductMetadata> {
     const write = this.#writeChain.then(async () => {
       await mkdir(path.dirname(this.#filename), { recursive: true });
       const file = await open(this.#filename, "a", 0o600);
@@ -69,11 +108,17 @@ export class JsonlThreadMetadataStore implements ThreadMetadataStore {
       } finally {
         await file.close();
       }
-      this.#metadata.set(threadId, { name });
+      const current = this.#metadata.get(event.threadId) ?? {};
+      this.#metadata.set(
+        event.threadId,
+        event.type === "thread_name_set"
+          ? { ...current, name: event.name }
+          : { ...current, archived: event.archived },
+      );
     });
     this.#writeChain = write.catch(() => undefined);
     await write;
-    return { name };
+    return structuredClone(this.#metadata.get(event.threadId) ?? {});
   }
 
   async #load(): Promise<void> {
@@ -112,13 +157,19 @@ export class JsonlThreadMetadataStore implements ThreadMetadataStore {
         );
         continue;
       }
-      if (!isThreadNameSetEvent(event)) {
+      if (!isThreadMetadataEvent(event)) {
         console.warn(
           `Ignoring invalid thread metadata in ${this.#filename} at line ${String(index + 1)}`,
         );
         continue;
       }
-      this.#metadata.set(event.threadId, { name: event.name });
+      const current = this.#metadata.get(event.threadId) ?? {};
+      this.#metadata.set(
+        event.threadId,
+        event.type === "thread_name_set"
+          ? { ...current, name: event.name }
+          : { ...current, archived: event.archived },
+      );
     }
   }
 }
@@ -149,6 +200,28 @@ function isThreadNameSetEvent(value: unknown): value is ThreadNameSetEvent {
     "updatedAt" in value &&
     typeof value.updatedAt === "string"
   );
+}
+
+function isThreadArchivedSetEvent(
+  value: unknown,
+): value is ThreadArchivedSetEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "type" in value &&
+    value.type === "thread_archived_set" &&
+    "threadId" in value &&
+    typeof value.threadId === "string" &&
+    value.threadId.length > 0 &&
+    "archived" in value &&
+    typeof value.archived === "boolean" &&
+    "updatedAt" in value &&
+    typeof value.updatedAt === "string"
+  );
+}
+
+function isThreadMetadataEvent(value: unknown): value is ThreadMetadataEvent {
+  return isThreadNameSetEvent(value) || isThreadArchivedSetEvent(value);
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -724,6 +724,115 @@ test("archives Threads through the fixed Codex lifecycle and filters lists", asy
   }
 });
 
+test("paginates active and archived Thread lists with filter-bound cursors", async () => {
+  const server = await serveCodexWebSocket({
+    appServer: testHost(),
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const client = await CodexClient.connect(server.url);
+  try {
+    await client.initialize({
+      name: "pagination",
+      title: "Pagination",
+      version: "1",
+    });
+    const threadIds: string[] = [];
+    for (let index = 0; index < 4; index += 1) {
+      const result = await client.request("thread/start", {});
+      const thread = responseResult<Record<string, unknown>>(result, "thread");
+      assert.equal(typeof thread.id, "string");
+      threadIds.push(thread.id as string);
+    }
+    const archivedIds = [threadIds[1]!, threadIds[3]!].sort();
+    const activeIds = [threadIds[0]!, threadIds[2]!].sort();
+    for (const threadId of archivedIds) {
+      await client.request("thread/archive", { threadId });
+    }
+
+    const firstActive = await threadListPage(client, { limit: 1 });
+    assert.deepEqual(firstActive.ids, activeIds.slice(0, 1));
+    assert.equal(typeof firstActive.nextCursor, "string");
+    assert.equal(firstActive.backwardsCursor, null);
+    const secondActive = await threadListPage(client, {
+      cursor: firstActive.nextCursor,
+    });
+    assert.deepEqual(secondActive.ids, activeIds.slice(1));
+    assert.equal(secondActive.nextCursor, null);
+    assert.equal(secondActive.backwardsCursor, null);
+
+    const firstArchived = await threadListPage(client, {
+      archived: true,
+      limit: 1,
+    });
+    assert.deepEqual(firstArchived.ids, archivedIds.slice(0, 1));
+    assert.equal(typeof firstArchived.nextCursor, "string");
+    const secondArchived = await threadListPage(client, {
+      archived: true,
+      limit: 10,
+      cursor: firstArchived.nextCursor,
+    });
+    assert.deepEqual(secondArchived.ids, archivedIds.slice(1));
+    assert.equal(secondArchived.nextCursor, null);
+
+    await assert.rejects(
+      client.request("thread/list", {
+        archived: false,
+        limit: 1,
+        cursor: firstArchived.nextCursor,
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+    await assert.rejects(
+      client.request("thread/list", {
+        archived: true,
+        limit: 1,
+        cursor: "not-a-valid-cursor",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+    await assert.rejects(
+      client.request("thread/list", {
+        limit: 1,
+        sortDirection: "desc",
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+
+    const archivedRead = await client.request("thread/read", {
+      threadId: archivedIds[0],
+    });
+    assert.equal(
+      responseResult<Record<string, unknown>>(archivedRead, "thread").id,
+      archivedIds[0],
+    );
+    const archivedResume = await client.request("thread/resume", {
+      threadId: archivedIds[0],
+    });
+    assert.equal(
+      responseResult<Record<string, unknown>>(archivedResume, "thread").id,
+      archivedIds[0],
+    );
+
+    const beforeSnapshotChange = await threadListPage(client, { limit: 1 });
+    assert.equal(typeof beforeSnapshotChange.nextCursor, "string");
+    await client.request("thread/start", {});
+    await assert.rejects(
+      client.request("thread/list", {
+        cursor: beforeSnapshotChange.nextCursor,
+      }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+  } finally {
+    client.close();
+    await server.close();
+  }
+});
+
 test("streams the minimal Codex Thread/Turn/Item lifecycle over WebSocket", async () => {
   const server = await serveCodexWebSocket({
     appServer: testHost(),
@@ -1646,6 +1755,31 @@ async function executeCli(
       },
     );
   });
+}
+
+async function threadListPage(
+  client: CodexClient,
+  params: { archived?: boolean; limit?: number; cursor?: string | null },
+): Promise<{
+  ids: string[];
+  nextCursor: string | null;
+  backwardsCursor: string | null;
+}> {
+  const result = await client.request("thread/list", params);
+  assert(isRecord(result) && Array.isArray(result.data));
+  assert(result.nextCursor === null || typeof result.nextCursor === "string");
+  assert(
+    result.backwardsCursor === null ||
+      typeof result.backwardsCursor === "string",
+  );
+  return {
+    ids: result.data.map((entry) => {
+      assert(isRecord(entry) && typeof entry.id === "string");
+      return entry.id;
+    }),
+    nextCursor: result.nextCursor,
+    backwardsCursor: result.backwardsCursor,
+  };
 }
 
 function deferred<T>(): {

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -634,6 +634,96 @@ test("synchronizes ZAS-owned thread names without adding Agent items", async () 
   }
 });
 
+test("archives Threads through the fixed Codex lifecycle and filters lists", async () => {
+  const appServer = testHost();
+  const server = await serveCodexWebSocket({
+    appServer,
+    zenHome: path.join(os.tmpdir(), "zen-home"),
+    listen: "ws://127.0.0.1:0",
+  });
+  const initiating = await CodexClient.connect(server.url);
+  const observing = await CodexClient.connect(server.url);
+  try {
+    await initiating.initialize({
+      name: "initiating",
+      title: "Initiating",
+      version: "1",
+    });
+    await observing.initialize({
+      name: "observing",
+      title: "Observing",
+      version: "1",
+    });
+    const started = await initiating.request("thread/start", {});
+    const thread = responseResult<Record<string, unknown>>(started, "thread");
+    assert.equal(typeof thread.id, "string");
+    const threadId = thread.id as string;
+
+    const archived = deferred<Record<string, unknown>>();
+    const unarchived = deferred<Record<string, unknown>>();
+    observing.onNotification("thread/archived", (params) => {
+      if (isRecord(params)) archived.resolve(params);
+    });
+    observing.onNotification("thread/unarchived", (params) => {
+      if (isRecord(params)) unarchived.resolve(params);
+    });
+
+    assert.deepEqual(
+      await initiating.request("thread/archive", { threadId }),
+      {},
+    );
+    assert.deepEqual(await within(archived.promise), { threadId });
+    const activeList = await initiating.request("thread/list", {});
+    assert(isRecord(activeList) && Array.isArray(activeList.data));
+    assert.equal(activeList.data.length, 0);
+    const archivedList = await initiating.request("thread/list", {
+      archived: true,
+    });
+    assert(isRecord(archivedList) && Array.isArray(archivedList.data));
+    assert.equal(archivedList.data.length, 1);
+    await assert.rejects(
+      initiating.request("thread/list", { archived: "yes" }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32602,
+    );
+    assert.equal(
+      responseResult<Record<string, unknown>>(
+        await initiating.request("thread/read", { threadId }),
+        "thread",
+      ).id,
+      threadId,
+    );
+
+    const restored = await initiating.request("thread/unarchive", {
+      threadId,
+    });
+    assert.equal(
+      responseResult<Record<string, unknown>>(restored, "thread").id,
+      threadId,
+    );
+    assert.deepEqual(await within(unarchived.promise), { threadId });
+    const restoredList = await initiating.request("thread/list", {});
+    assert(isRecord(restoredList) && Array.isArray(restoredList.data));
+    assert.equal(restoredList.data.length, 1);
+    assert.equal(
+      (await appServer.readThread(threadId)).items.some(
+        (item) => "archived" in item,
+      ),
+      false,
+    );
+
+    await assert.rejects(
+      initiating.request("thread/archive", { threadId: "missing" }),
+      (error: unknown) =>
+        error instanceof CodexClientError && error.code === -32000,
+    );
+  } finally {
+    initiating.close();
+    observing.close();
+    await server.close();
+  }
+});
+
 test("streams the minimal Codex Thread/Turn/Item lifecycle over WebSocket", async () => {
   const server = await serveCodexWebSocket({
     appServer: testHost(),

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -239,6 +239,53 @@ test("persists user-facing names outside the canonical ItemList", async () => {
   }
 });
 
+test("persists archive state as product metadata and filters listings", async () => {
+  const temporaryDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zen-thread-archive-test-"),
+  );
+  try {
+    const journal = new InMemoryThreadJournal();
+    const filename = path.join(temporaryDirectory, "thread-metadata.jsonl");
+    const server = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    const thread = await server.startThread();
+    const originalItems = thread.items;
+
+    const archived = await server.setThreadArchived(thread.id, true);
+    assert.equal(archived.archived, true);
+    assert.deepEqual(archived.items, originalItems);
+    assert.deepEqual(await server.listThreads(), []);
+    assert.equal(
+      (await server.listThreads({ archived: true }))[0]?.id,
+      thread.id,
+    );
+    await server.setThreadName(thread.id, "Archived work");
+    assert.equal(
+      (await server.listThreads({ archived: true }))[0]?.name,
+      "Archived work",
+    );
+    assert.equal((await server.readThread(thread.id)).id, thread.id);
+
+    const replayed = createServer({
+      journal,
+      threadMetadata: new JsonlThreadMetadataStore(filename),
+    });
+    assert.equal((await replayed.readThread(thread.id)).archived, true);
+    assert.equal((await replayed.readThread(thread.id)).name, "Archived work");
+    await replayed.setThreadArchived(thread.id, false);
+    assert.equal((await replayed.listThreads())[0]?.id, thread.id);
+    assert.deepEqual(await replayed.listThreads({ archived: true }), []);
+    assert.deepEqual(
+      (await journal.read(thread.id)).map((item) => item.type),
+      ["thread_metadata"],
+    );
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+});
+
 test("product metadata corruption never blocks canonical threads", async (t) => {
   t.mock.method(console, "warn", () => undefined);
   const temporaryDirectory = await mkdtemp(


### PR DESCRIPTION
## Summary

- expose Agent-callable `zenx_threads_rename`, `zenx_threads_archive`, and `zenx_threads_unarchive` tools
- persist archive state in the existing append-only `ThreadMetadataStore`, outside the canonical ItemList
- implement the pinned Codex 0.146.0 `thread/archive`, `thread/unarchive`, lifecycle notifications, and `thread/list.archived` filtering
- keep CLI and ZenX renderer projections consistent, including `zen threads --archived`
- synchronize App Server renames into the ZenX title coordinator so Agent renames remain authoritative over late title generation

## Protocol and architecture

The pinned `@openai/codex@0.146.0` schema was generated before implementation. It already defines `thread/archive`, `thread/unarchive`, `thread/archived`, `thread/unarchived`, and the `thread/list.archived` filter, so this PR adds no Zen protocol extension.

Archive state is product metadata only. It never enters canonical Items, never changes Agent context, and never creates another Thread/runtime/transcript. Archived Threads remain readable through `thread/read` and `thread/resume`; default lists show non-archived Threads and `archived: true` explicitly selects archived Threads. Project grouping remains derived solely from configured workspace and Thread cwd.

## Validation

Passed:

- `npm run lint`
- `npm run typecheck`
- `npm run build --workspace @zen/zenx`
- Prettier check for every changed file
- focused Core/protocol lifecycle tests: 2/2
- focused ZenX hosted self-control, renderer, title-authority, and typed protocol tests: 21/21
- real hosted Agent self-control lifecycle test, including rename/archive/read/unarchive

Full Windows-suite observations (unchanged gates, no weakening):

- `npm run check` reaches repository-wide Prettier and reports CRLF differences in 120 pre-existing untouched files in this Windows checkout
- `npm run test:node`: 85 passed, 6 pre-existing Windows failures, 1 skipped; failures are POSIX `printf` and mode-bit assumptions
- ZenX full tests: 123 passed, 5 pre-existing Windows failures; failures are POSIX command/path/executable assumptions
- IMZen: 37 passed, 1 pre-existing Windows chmod/mode-bit failure

Closes #50
