### PR TITLE
ZenX Browser: attach authenticated user browser sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:windows-computer
 
+  zenx-windows-user-browser-smoke:
+    name: ZenX Windows attached user-browser smoke
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace apps/zenx run smoke:windows-user-browser
+
   zenx-playwright-provider-smoke:
     name: ZenX real Playwright provider smoke
     runs-on: macos-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,6 +81,7 @@
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。
 - **ZenXCapabilityProviderCatalog** — ZenX 产品层探测并诊断可选的成熟外部执行后端，按显式优先级选择
   Playwright、Peekaboo、WinApp 或适用平台的 bundled fallback；版本、权限与可用性只属于 host 配置和瞬时诊断，不进入 Zen Core。
+- **ZenXUserBrowserCdpProvider** — ZenX 产品层仅在用户显式选择 user-session 模式并提供 loopback CDP endpoint 时附着到已运行的 Chrome/Edge/Chromium，把目标页投影为既有的 opaque observation 工具且关闭时只断开连接，不导出认证材料、关闭标签或清理用户 profile。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -19,8 +19,10 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
 Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
-首批 browser provider 优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
-回落到 bundled Electron/CDP 临时 profile；两者都只暴露有界 DOM 操作。computer
+首批 browser provider 默认优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
+回落到 bundled Electron/CDP 临时 profile；用户也可显式选择 loopback CDP user-session
+provider 附着到自己预先开启的 Chrome/Edge/Chromium，原位使用认证状态而不导出 cookie、
+storage 或 auth header，连接失败时绝不回落到隔离登录态；三者都只暴露有界 DOM 操作。computer
 公共 contract 暴露语义动作、平台能力与 background-safe/foreground-required 影响协商；
 当前 macOS provider 优先复用 Peekaboo 3.x 的 background-first 操作，缺失或不兼容时以 bundled
 AX/窗口定向截图和明确提示、可取消的前台输入形成基线；

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -88,10 +88,32 @@ per-session/global tab caps plus explicit tab/session close tools.
 cleanup, and advances the partition generation; reopening the same `sessionId`
 therefore starts without the prior cookies or session storage. Generation state
 exists only for active/pending sessions, so logical session bookkeeping is bounded.
-Attaching the user's existing Chrome profile or tabs is not implemented; it
-would be a separate explicit opt-in mode with different privacy and interaction
-impact. This implementation does not claim parity with any proprietary browser
-automation product.
+User-browser attachment is a separate explicit opt-in mode. Start a supported
+Chrome, Edge, or Chromium 100+ yourself with a loopback remote-debugging port,
+open or sign into the pages you want ZenX to use, then start ZenX with:
+
+```powershell
+$env:ZENX_BROWSER_MODE = "user-session"
+$env:ZENX_USER_BROWSER_CDP_ENDPOINT = "http://127.0.0.1:9222"
+npm --workspace apps/zenx run dev
+```
+
+Modern Chromium releases may require the user to choose an explicit non-default
+`--user-data-dir` when enabling `--remote-debugging-port=9222`; ZenX never starts
+the browser, copies cookie databases, or attempts to unlock a profile directory.
+The endpoint must be unauthenticated loopback HTTP and must identify Chrome,
+Edge, or Chromium. Unavailable or incompatible endpoints remain terminal
+`user-browser-cdp` diagnostics and never fall back to Playwright/Electron.
+Inspection and action reuse authenticated page state in place, but only bounded
+visible text and opaque target IDs reach the Agent; cookies, storage state, auth
+headers, and credentials are never requested or returned. Closing a tab/session
+in this mode only detaches ZenX state, and closing ZenX only disconnects CDP; the
+user's tabs, browser process, storage, and profile remain intact. Settings labels
+browser provider diagnostics as `user-session` or `isolated-session`.
+
+The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
+the bundled ephemeral Electron/CDP provider. This implementation does not claim
+parity with any proprietary browser automation product.
 
 The computer contract is platform-neutral: tools describe semantic observation,
 press/value/capture operations and their interaction impact, while a platform
@@ -230,6 +252,7 @@ npm run check
 npm --workspace apps/zenx run smoke:capabilities
 # Windows only, after installing Microsoft WinApp CLI:
 npm --workspace apps/zenx run smoke:windows-computer
+npm --workspace apps/zenx run smoke:windows-user-browser
 npm --workspace apps/zenx run smoke:providers
 ```
 
@@ -270,6 +293,11 @@ provider/version/permission diagnostics. CI installs the pinned official
 `@playwright/cli` and requires that provider to be selected; a local run may
 exercise the Electron fallback when the CLI is absent. The smoke only probes
 Peekaboo availability and permissions; it never sends desktop input.
+The Windows user-browser smoke launches a real installed Chrome/Edge process
+with an explicit temporary profile and CDP port, establishes authenticated state
+inside that browser, attaches ZenX, lists/inspects/acts in the existing tab, and
+then verifies ZenX detach leaves the browser process and tabs alive without
+projecting cookie material.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -80,9 +80,9 @@ moving the OS pointer or activating a browser window. Inspection returns bounded
 visible text plus opaque IDs bound to the latest tab/document observation, never
 raw CSS selectors, cookies, storage, headers, or unrelated tabs. Actions
 revalidate visibility, supported action, and semantic identity, then invalidate
-the observation; navigation and close do likewise. Password values are omitted
-and secure controls reject typing. `browser_type` is deliberately non-secret-only
-because its text argument is part of the canonical tool call. Sessions have hard
+the observation; navigation and close do likewise. Existing input values are
+omitted, while text arguments dispatch normally regardless of password or
+autocomplete metadata and remain ordinary canonical tool-call arguments. Sessions have hard
 per-session/global tab caps plus explicit tab/session close tools.
 `browser_close_session` destroys all session windows, awaits storage/cache/auth
 cleanup, and advances the partition generation; reopening the same `sessionId`
@@ -187,8 +187,8 @@ mature external implementations while retaining a runnable bundled baseline:
   role/name/type/security/visibility/action fingerprint. Missing or incompatible
   CLI installations remain explicit in provider diagnostics and use the existing
   bundled Chromium CDP ephemeral-partition provider. Install `@playwright/cli`
-  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; attaching a user
-  profile is still unsupported. See <https://playwright.dev/agent-cli/introduction>
+  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; user-session attachment
+  remains a separate explicit CDP provider. See <https://playwright.dev/agent-cli/introduction>
   and <https://playwright.dev/docs/api/class-browsercontext>.
 - A future `isolated` interaction mode/provider can place arbitrary control in a
   VM, cloud desktop, or remote host. OSWorld's provider separation across
@@ -265,8 +265,8 @@ the child-host capability bridge, derived projects, Thread create/list/read/stat
 active `start | steer | replace`, follow-up delivery, bounded redaction, canonical
 command audit, and the real OpenAI subscription tool serialization boundary.
 The packaged capability smoke covers a real hidden dedicated browser
-open/inspect/navigate/click/type/close, including forged/stale/changed/hidden and
-password target rejection. It also seeds a cookie and session storage, closes
+open/inspect/navigate/click/type/close, including forged/stale/changed/hidden
+rejection and ordinary password-field input dispatch. It also seeds a cookie and session storage, closes
 the session, reopens the same ID, and verifies both are absent. It asserts those
 background-safe browser operations
 leave the real pointer position and foreground application unchanged. The macOS

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -12,6 +12,7 @@
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
+    "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",
     "smoke:providers": "npm run build && electron ./out/main/provider-smoke.js",
     "check": "npm run typecheck && npm test && npm run build"
   },

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -153,7 +153,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_inspect",
       description:
-        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Password/secure values are never returned and secure controls cannot be typed.",
+        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Existing input values are not returned.",
       inputSchema: browserTargetSchema(),
       permissions: ["browser.tabs.read"],
       interactionMode: "background_safe",
@@ -175,7 +175,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_type",
       description:
-        "Replace a non-secret value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Password/secure controls and secret text are unsupported because tool arguments are journaled.",
+        "Replace the value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Text is dispatched as an ordinary tool argument regardless of field metadata.",
       inputSchema: browserTargetSchema(
         {
           observationId: stringSchema(),
@@ -216,7 +216,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Instructions for targeted, inspect-before-act browser automation.",
       content:
-        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Typing is for non-secret text only because tool arguments are journaled, and password/secure controls are rejected. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
+        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Text is dispatched as an ordinary tool argument regardless of field metadata. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
     },
     {
       id: "browser-research",
@@ -511,11 +511,6 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
       targetId,
       "type",
     );
-    if (target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
@@ -681,11 +676,6 @@ export function resolveBrowserObservedTarget(
     throw new Error("Browser target ID is forged, stale, or unknown");
   }
   if (!target.actions.includes(action)) {
-    if (action === "type" && target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     throw new Error(`Browser target does not support ${action}`);
   }
   return target;
@@ -703,7 +693,7 @@ export const browserInspectScript = `(() => {
     ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
   );
   const typeable = (element) => {
-    if (secure(element) || element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
+    if (element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
     if (element instanceof HTMLTextAreaElement) return true;
     if (!(element instanceof HTMLInputElement)) return false;
     return !["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase());
@@ -747,7 +737,6 @@ export const browserInspectScript = `(() => {
         href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
         secure: isSecure,
         actions,
-        ...(!isSecure && (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) ? { value: element.value.slice(0, 160) } : {}),
       };
     }),
   };
@@ -804,7 +793,6 @@ export function browserActionScript(
       element.click();
       return { ok: true };
     }
-    if (secure) return { ok: false, reason: "secure-control" };
     if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) || element.disabled || element.readOnly) return { ok: false, reason: "not-typeable" };
     if (element instanceof HTMLInputElement && ["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase())) return { ok: false, reason: "not-typeable" };
     const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -440,7 +440,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     const inspected = await evaluateInTab<{
       visibleText: string;
       targets: BrowserTargetFingerprint[];
-    }>(tab, INSPECT_SCRIPT);
+    }>(tab, browserInspectScript);
     const observationId = randomUUID();
     const targets = new Map<string, BrowserTargetFingerprint>();
     const projectedTargets = inspected.targets.slice(0, 80).map((target) => {
@@ -485,7 +485,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "click"),
+      browserActionScript(target, "click"),
     );
     if (!result.ok) {
       throw new Error(
@@ -519,7 +519,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "type", text, submit),
+      browserActionScript(target, "type", text, submit),
     );
     if (!result.ok) {
       throw new Error(
@@ -691,7 +691,7 @@ export function resolveBrowserObservedTarget(
   return target;
 }
 
-const INSPECT_SCRIPT = `(() => {
+export const browserInspectScript = `(() => {
   const visible = (element) => {
     const style = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
@@ -753,7 +753,7 @@ const INSPECT_SCRIPT = `(() => {
   };
 })()`;
 
-function actionScript(
+export function browserActionScript(
   target: BrowserTargetFingerprint,
   action: "click" | "type",
   text = "",
@@ -850,7 +850,7 @@ function summarizeTab(tab: BrowserTab): BrowserTabSummary {
     sessionId: tab.sessionId,
     tabId: tab.tabId,
     title: tab.window.getTitle().slice(0, 256),
-    url: redactUrl(tab.window.webContents.getURL()),
+    url: redactBrowserUrl(tab.window.webContents.getURL()),
     loading: tab.window.webContents.isLoading(),
   };
 }
@@ -875,7 +875,7 @@ function safeBrowserUrl(raw: string): string {
   return url.toString();
 }
 
-function redactUrl(raw: string): string {
+export function redactBrowserUrl(raw: string): string {
   if (raw.length === 0) return "";
   const url = new URL(raw);
   url.username = "";

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -653,14 +653,13 @@ function playwrightTargetFingerprint(
     autocomplete: dom.autocomplete,
     href: dom.href || node.url || "",
     secure,
-    actions: playwrightNodeActions(node, dom, secure),
+    actions: playwrightNodeActions(node, dom),
   };
 }
 
 function playwrightNodeActions(
   node: PlaywrightAriaNode,
   dom: PlaywrightDomMetadata,
-  secure: boolean,
 ): Array<"click" | "type"> {
   if (node.disabled === true) return [];
   const clickRoles = new Set([
@@ -691,8 +690,7 @@ function playwrightNodeActions(
     ...(clickRoles.has(node.role) || node.cursor === "pointer"
       ? (["click"] as const)
       : []),
-    ...(!secure &&
-    typeRoles.has(node.role) &&
+    ...(typeRoles.has(node.role) &&
     !(dom.tag === "input" && nonTypeableInput.has(dom.type.toLowerCase()))
       ? (["type"] as const)
       : []),
@@ -759,11 +757,6 @@ function requireObservedTarget(
   }
   if (target.disabled || !target.actions.includes(action)) {
     throw new Error(`Browser target does not support ${action}`);
-  }
-  if (action === "type" && target.secure) {
-    throw new Error(
-      "browser_type rejects password or secure controls because supplied text is journaled",
-    );
   }
   return target;
 }

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -19,6 +19,7 @@ import {
 } from "./external-provider.js";
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
+import { connectUserBrowserCdp } from "./user-browser-provider.js";
 import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
@@ -57,10 +58,80 @@ const MAX_PEEKABOO_EXCLUSIVE = [4, 0, 0] as const;
 
 export async function selectBrowserProvider(
   options: ZenXCapabilityProviderCatalogOptions,
-): Promise<ZenXCapabilityProviderSelection<ZenXBrowserBackend>> {
+): Promise<ZenXOptionalCapabilityProviderSelection<ZenXBrowserBackend>> {
   const runner = options.runner ?? new SystemExternalProviderProcessRunner();
   const environment = options.environment ?? process.env;
   const platform = options.platform ?? process.platform;
+  const browserMode = environment.ZENX_BROWSER_MODE ?? "isolated";
+  if (browserMode === "user-session") {
+    const endpoint = environment.ZENX_USER_BROWSER_CDP_ENDPOINT;
+    if (endpoint === undefined || endpoint.trim().length === 0) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          unavailableDiagnostic(
+            "browser",
+            "user-browser-cdp",
+            ["background_safe"],
+            ["user_session", "authenticated_state_in_place", "cdp"],
+            "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
+          ),
+        ],
+      };
+    }
+    try {
+      const connection = await connectUserBrowserCdp(endpoint);
+      return {
+        backend: connection.backend,
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          {
+            capabilityId: "browser",
+            providerId: "user-browser-cdp",
+            status: "selected",
+            interactionModes: ["background_safe"],
+            capabilities: [
+              "user_session",
+              "authenticated_state_in_place",
+              "cdp",
+              "dom.inspect",
+              "dom.interact",
+            ],
+            version: connection.product,
+            permissionSummary:
+              "Explicit loopback CDP attachment; uses authenticated page state in place and never exports cookies, storage, headers, or credentials",
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          unavailableDiagnostic(
+            "browser",
+            "user-browser-cdp",
+            ["background_safe"],
+            ["user_session", "authenticated_state_in_place", "cdp"],
+            describeError(error),
+          ),
+        ],
+      };
+    }
+  }
+  if (browserMode !== "isolated") {
+    return {
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "browser",
+          "browser-mode",
+          ["isolated", "background_safe"],
+          ["explicit_mode_selection"],
+          `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
+        ),
+      ],
+    };
+  }
   const configured = environment.ZENX_PLAYWRIGHT_CLI;
   const executable = await discoverExecutable(configured ?? "playwright-cli", {
     environment,
@@ -139,6 +210,56 @@ export async function selectBrowserProvider(
       ],
     };
   }
+}
+
+function userBrowserManifest(): ZenXCapabilityManifest {
+  const manifest = structuredClone(browserCapabilityManifest);
+  return {
+    ...manifest,
+    description:
+      "An explicit attachment to a user-opened Chrome, Edge, or Chromium CDP session that uses authenticated page state in place without exporting session material.",
+    provider: {
+      id: "user-browser-cdp",
+      platforms: ["darwin", "win32", "linux"],
+      interactionModes: ["background_safe"],
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        "cdp",
+        "dom.inspect",
+        "dom.navigate",
+        "dom.interact",
+      ],
+    },
+    tools: manifest.tools.map((tool) => ({
+      ...tool,
+      description:
+        tool.name === "browser_close_session"
+          ? "Detach ZenX capability state from one user-browser session without closing tabs, clearing storage, or changing the user profile."
+          : tool.name === "browser_close"
+            ? "Detach one explicit user-browser tab from this ZenX session without closing the user's tab."
+            : tool.description
+                .replaceAll("dedicated ZenX", "attached user")
+                .replaceAll("hidden tab", "user browser tab")
+                .replaceAll("ephemeral ZenX", "attached user"),
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        ...tool.capabilities.filter(
+          (capability) => capability !== "dedicated_profile",
+        ),
+      ],
+    })),
+    resources: manifest.resources.map((resource) =>
+      resource.id === "safe-browser-use"
+        ? {
+            ...resource,
+            content:
+              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Never ask for or return cookies, storage state, auth headers, or credentials. Typing is non-secret-only. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
+          }
+        : resource,
+    ),
+  };
 }
 
 export async function selectComputerProvider(

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -20,6 +20,7 @@ import {
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
 import { connectUserBrowserCdp } from "./user-browser-provider.js";
+import type { UserBrowserConnection } from "./user-browser-provider.js";
 import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
@@ -46,6 +47,10 @@ export interface ZenXCapabilityProviderCatalogOptions {
   environment?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   runner?: ExternalProviderProcessRunner;
+  userBrowserConnector?: (
+    endpoint: string,
+    signal?: AbortSignal,
+  ) => Promise<UserBrowserConnection>;
 }
 
 // @playwright/cli has its own 0.1.x package version. It embeds Playwright
@@ -69,18 +74,23 @@ export async function selectBrowserProvider(
       return {
         manifest: userBrowserManifest(),
         diagnostics: [
-          unavailableDiagnostic(
-            "browser",
-            "user-browser-cdp",
-            ["background_safe"],
-            ["user_session", "authenticated_state_in_place", "cdp"],
-            "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
-          ),
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
+            ),
+            sessionMode: "user-session",
+          },
         ],
       };
     }
     try {
-      const connection = await connectUserBrowserCdp(endpoint);
+      const connection = await (
+        options.userBrowserConnector ?? connectUserBrowserCdp
+      )(endpoint);
       return {
         backend: connection.backend,
         manifest: userBrowserManifest(),
@@ -100,6 +110,7 @@ export async function selectBrowserProvider(
             version: connection.product,
             permissionSummary:
               "Explicit loopback CDP attachment; uses authenticated page state in place and never exports cookies, storage, headers, or credentials",
+            sessionMode: "user-session",
           },
         ],
       };
@@ -107,13 +118,16 @@ export async function selectBrowserProvider(
       return {
         manifest: userBrowserManifest(),
         diagnostics: [
-          unavailableDiagnostic(
-            "browser",
-            "user-browser-cdp",
-            ["background_safe"],
-            ["user_session", "authenticated_state_in_place", "cdp"],
-            describeError(error),
-          ),
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              describeError(error),
+            ),
+            sessionMode: "user-session",
+          },
         ],
       };
     }
@@ -122,13 +136,16 @@ export async function selectBrowserProvider(
     return {
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "browser-mode",
-          ["isolated", "background_safe"],
-          ["explicit_mode_selection"],
-          `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "browser-mode",
+            ["isolated", "background_safe"],
+            ["explicit_mode_selection"],
+            `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
+          ),
+          sessionMode: "invalid",
+        },
       ],
     };
   }
@@ -145,15 +162,18 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          configured === undefined
-            ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
-            : `Configured Playwright CLI is not executable: ${configured}`,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            configured === undefined
+              ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
+              : `Configured Playwright CLI is not executable: ${configured}`,
+          ),
+          sessionMode: "isolated-session",
+        },
         fallbackDiagnostic,
       ],
     };
@@ -189,6 +209,7 @@ export async function selectBrowserProvider(
           version,
           permissionSummary:
             "Isolated in-memory Playwright session; no foreground desktop input",
+          sessionMode: "isolated-session",
         },
         fallbackDiagnostic,
       ],
@@ -198,14 +219,17 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          describeError(error),
-          executable,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            describeError(error),
+            executable,
+          ),
+          sessionMode: "isolated-session",
+        },
         electronBrowserDiagnostic("fallback"),
       ],
     };
@@ -255,7 +279,7 @@ function userBrowserManifest(): ZenXCapabilityManifest {
         ? {
             ...resource,
             content:
-              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Never ask for or return cookies, storage state, auth headers, or credentials. Typing is non-secret-only. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
+              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Text is dispatched as an ordinary tool argument regardless of field metadata. Never request or return browser session internals such as cookies, storage state, or auth headers. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
           }
         : resource,
     ),
@@ -568,6 +592,7 @@ function electronBrowserDiagnostic(
     interactionModes: ["background_safe"],
     capabilities: ["dedicated_profile", "cdp", "dom.inspect", "dom.interact"],
     permissionSummary: "Bundled hidden ephemeral Electron partition",
+    sessionMode: "isolated-session",
   };
 }
 

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -89,6 +89,7 @@ export interface ZenXCapabilityProviderDiagnostic {
   version?: string;
   permissionSummary?: string;
   reason?: string;
+  sessionMode?: "isolated-session" | "user-session" | "invalid";
 }
 
 export interface ZenXCapabilitySummary {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 
 import WebSocket from "ws";
 
@@ -40,8 +41,24 @@ interface UserBrowserSession {
 
 interface UserBrowserTabState {
   documentVersion: number;
+  url: string;
+  documentIdentity?: string;
   observation?: BrowserObservation;
+  actionInFlight: boolean;
 }
+
+export const userBrowserDocumentIdentityScript = `(() => {
+    const key = "__zenxCapabilityDocumentIdentity";
+    let state = document[key];
+    if (typeof state !== "object" || state === null || typeof state.id !== "string" || typeof state.activation !== "number") {
+      state = { id: String(Date.now()) + ":" + String(Math.random()), activation: 0 };
+      Object.defineProperty(document, key, { value: state, configurable: false, enumerable: false });
+      addEventListener("pageshow", (event) => { if (event.persisted) state.activation += 1; });
+      addEventListener("popstate", () => { state.activation += 1; });
+      addEventListener("hashchange", () => { state.activation += 1; });
+    }
+    return JSON.stringify({ href: location.href, origin: location.origin, id: state.id, activation: state.activation });
+  })()`;
 
 export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #client: UserBrowserCdpClient;
@@ -72,8 +89,18 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     }
     for (const target of targets) {
       session.targetIds.add(target.targetId);
-      if (!this.#tabs.has(target.targetId)) {
-        this.#tabs.set(target.targetId, { documentVersion: 1 });
+      const tab = this.#tabs.get(target.targetId);
+      if (tab === undefined) {
+        this.#tabs.set(target.targetId, {
+          documentVersion: 1,
+          url: target.url,
+          actionInFlight: false,
+        });
+      } else if (tab.url !== target.url) {
+        tab.url = target.url;
+        tab.documentVersion += 1;
+        tab.documentIdentity = undefined;
+        tab.observation = undefined;
       }
     }
     return targets
@@ -89,7 +116,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const session = this.#session(sessionId);
     const targetId = await this.#client.createTarget(url, signal);
     session.targetIds.add(targetId);
-    this.#tabs.set(targetId, { documentVersion: 1 });
+    this.#tabs.set(targetId, {
+      documentVersion: 1,
+      url,
+      actionInFlight: false,
+    });
     return await this.#summary(sessionId, targetId, signal);
   }
 
@@ -100,8 +131,13 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const tab = this.#tab(sessionId, tabId);
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
     await this.#client.navigate(tabId, url, signal);
     tab.documentVersion += 1;
+    tab.url = url;
+    tab.documentIdentity = undefined;
     tab.observation = undefined;
     return await this.#summary(sessionId, tabId, signal);
   }
@@ -112,10 +148,19 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
     const tab = this.#tab(sessionId, tabId);
-    const raw = asRecord(
-      await this.#client.evaluate(tabId, browserInspectScript, signal),
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
+    const envelope = asRecord(
+      await this.#client.evaluate(
+        tabId,
+        `(() => ({ documentIdentity: ${userBrowserDocumentIdentityScript}, inspection: ${browserInspectScript} }))()`,
+        signal,
+      ),
     );
+    const raw = asRecord(envelope?.inspection);
     if (
+      typeof envelope?.documentIdentity !== "string" ||
       raw === undefined ||
       typeof raw.visibleText !== "string" ||
       !Array.isArray(raw.targets)
@@ -141,6 +186,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       };
     });
     const observationId = randomUUID();
+    tab.documentIdentity = envelope.documentIdentity;
     tab.observation = {
       id: observationId,
       documentVersion: tab.documentVersion,
@@ -230,6 +276,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const tab = this.#tab(sessionId, tabId);
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
     const target = resolveBrowserObservedTarget(
       tab.observation,
       tab.documentVersion,
@@ -237,21 +286,45 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       targetId,
       action,
     );
-    const response = asRecord(
-      await this.#client.evaluate(
-        tabId,
-        browserActionScript(target, action, text, submit),
-        signal,
-      ),
-    );
+    const expectedDocumentIdentity = tab.documentIdentity;
     tab.observation = undefined;
+    tab.documentIdentity = undefined;
+    tab.actionInFlight = true;
+    let response: Record<string, unknown> | undefined;
+    try {
+      response = asRecord(
+        await this.#client.evaluate(
+          tabId,
+          userBrowserActionScript(
+            expectedDocumentIdentity,
+            target,
+            action,
+            text,
+            submit,
+          ),
+          signal,
+        ),
+      );
+    } catch (error) {
+      throw new Error(
+        `User browser action outcome is unknown after cancellation or connection failure; inspect the current tab before another action (${describeError(error)})`,
+      );
+    } finally {
+      tab.actionInFlight = false;
+    }
     if (response?.ok !== true) {
       throw new Error(
         `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
       );
     }
     tab.documentVersion += 1;
-    return await this.#summary(sessionId, tabId, signal);
+    try {
+      return await this.#summary(sessionId, tabId, signal);
+    } catch (error) {
+      throw new Error(
+        `User browser action outcome is unknown because post-action confirmation failed; inspect the current tab before another action (${describeError(error)})`,
+      );
+    }
   }
 
   #session(sessionId: string): UserBrowserSession {
@@ -296,7 +369,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
 }
 
 export interface UserBrowserConnection {
-  backend: UserBrowserCdpBackend;
+  backend: ZenXBrowserBackend;
   product: string;
 }
 
@@ -311,7 +384,12 @@ export async function connectUserBrowserCdp(
   const response = await fetch(new URL("/json/version", base), {
     signal: probeSignal,
     headers: { accept: "application/json" },
+    redirect: "error",
   });
+  const finalUrl = validateCdpEndpoint(response.url);
+  if (finalUrl.pathname !== "/json/version") {
+    throw new Error("User browser CDP version response URL is invalid");
+  }
   if (!response.ok) {
     throw new Error(
       `User browser CDP version probe failed with HTTP ${String(response.status)}`,
@@ -333,7 +411,9 @@ export async function connectUserBrowserCdp(
     socketUrl.protocol !== "ws:" ||
     !isLoopbackHostname(socketUrl.hostname) ||
     socketUrl.username.length > 0 ||
-    socketUrl.password.length > 0
+    socketUrl.password.length > 0 ||
+    socketUrl.search.length > 0 ||
+    socketUrl.hash.length > 0
   ) {
     throw new Error(
       "User browser CDP WebSocket must be an unauthenticated loopback ws:// endpoint",
@@ -599,6 +679,46 @@ function validateCdpEndpoint(raw: string): URL {
     );
   }
   return url;
+}
+
+export function windowsBrowserExecutableCandidates(
+  environment: NodeJS.ProcessEnv,
+): string[] {
+  const roots = [
+    environment.ProgramFiles,
+    environment["ProgramFiles(x86)"],
+    environment.LOCALAPPDATA,
+  ].filter((entry): entry is string => entry !== undefined && entry.length > 0);
+  return [
+    ...roots.map((root) =>
+      path.win32.join(root, "Google", "Chrome", "Application", "chrome.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Microsoft", "Edge", "Application", "msedge.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Chromium", "Application", "chrome.exe"),
+    ),
+  ];
+}
+
+function userBrowserActionScript(
+  expectedDocumentIdentity: string | undefined,
+  target: BrowserTargetFingerprint,
+  action: "click" | "type",
+  text: string,
+  submit: boolean,
+): string {
+  return `(() => {
+    const expectedDocumentIdentity = ${JSON.stringify(expectedDocumentIdentity)};
+    const actualDocumentIdentity = ${userBrowserDocumentIdentityScript};
+    if (actualDocumentIdentity !== expectedDocumentIdentity) return { ok: false, reason: "document-changed" };
+    return ${browserActionScript(target, action, text, submit)};
+  })()`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isLoopbackHostname(hostname: string): boolean {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1,0 +1,675 @@
+import { randomUUID } from "node:crypto";
+
+import WebSocket from "ws";
+
+import {
+  browserActionScript,
+  browserInspectScript,
+  redactBrowserUrl,
+  resolveBrowserObservedTarget,
+  type BrowserInspection,
+  type BrowserObservation,
+  type BrowserTabSummary,
+  type BrowserTargetFingerprint,
+  type ZenXBrowserBackend,
+} from "./browser-provider.js";
+
+export interface UserBrowserCdpTarget {
+  targetId: string;
+  type: string;
+  title: string;
+  url: string;
+}
+
+export interface UserBrowserCdpClient {
+  listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
+  createTarget(url: string, signal?: AbortSignal): Promise<string>;
+  navigate(targetId: string, url: string, signal?: AbortSignal): Promise<void>;
+  evaluate(
+    targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
+  close(): Promise<void> | void;
+}
+
+interface UserBrowserSession {
+  targetIds: Set<string>;
+  ignoredTargetIds: Set<string>;
+}
+
+interface UserBrowserTabState {
+  documentVersion: number;
+  observation?: BrowserObservation;
+}
+
+export class UserBrowserCdpBackend implements ZenXBrowserBackend {
+  readonly #client: UserBrowserCdpClient;
+  readonly #sessions = new Map<string, UserBrowserSession>();
+  readonly #tabs = new Map<string, UserBrowserTabState>();
+
+  constructor(client: UserBrowserCdpClient) {
+    this.#client = client;
+  }
+
+  async listTabs(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary[]> {
+    const session = this.#session(sessionId);
+    const targets = (await this.#client.listTargets(signal)).filter(
+      (target) =>
+        target.type === "page" &&
+        isInspectableUrl(target.url) &&
+        !session.ignoredTargetIds.has(target.targetId),
+    );
+    const live = new Set(targets.map((target) => target.targetId));
+    for (const targetId of session.targetIds) {
+      if (!live.has(targetId)) {
+        session.targetIds.delete(targetId);
+        this.#tabs.delete(targetId);
+      }
+    }
+    for (const target of targets) {
+      session.targetIds.add(target.targetId);
+      if (!this.#tabs.has(target.targetId)) {
+        this.#tabs.set(target.targetId, { documentVersion: 1 });
+      }
+    }
+    return targets
+      .slice(0, 24)
+      .map((target) => summarizeTarget(sessionId, target));
+  }
+
+  async open(
+    sessionId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const session = this.#session(sessionId);
+    const targetId = await this.#client.createTarget(url, signal);
+    session.targetIds.add(targetId);
+    this.#tabs.set(targetId, { documentVersion: 1 });
+    return await this.#summary(sessionId, targetId, signal);
+  }
+
+  async navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#tab(sessionId, tabId);
+    await this.#client.navigate(tabId, url, signal);
+    tab.documentVersion += 1;
+    tab.observation = undefined;
+    return await this.#summary(sessionId, tabId, signal);
+  }
+
+  async inspect(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserInspection> {
+    const tab = this.#tab(sessionId, tabId);
+    const raw = asRecord(
+      await this.#client.evaluate(tabId, browserInspectScript, signal),
+    );
+    if (
+      raw === undefined ||
+      typeof raw.visibleText !== "string" ||
+      !Array.isArray(raw.targets)
+    ) {
+      throw new Error(
+        "User browser CDP inspection returned an unsupported shape",
+      );
+    }
+    const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
+    const targets = new Map<string, BrowserTargetFingerprint>();
+    const projected = fingerprints.map((fingerprint) => {
+      const targetId = randomUUID();
+      targets.set(targetId, fingerprint);
+      return {
+        targetId,
+        role: fingerprint.role,
+        name: fingerprint.name,
+        actions: [...fingerprint.actions],
+        ...(fingerprint.secure ? { secure: true as const } : {}),
+        ...(fingerprint.value === undefined
+          ? {}
+          : { value: fingerprint.value }),
+      };
+    });
+    const observationId = randomUUID();
+    tab.observation = {
+      id: observationId,
+      documentVersion: tab.documentVersion,
+      targets,
+    };
+    const summary = await this.#summary(sessionId, tabId, signal);
+    return {
+      ...summary,
+      observationId,
+      documentVersion: tab.documentVersion,
+      visibleText: raw.visibleText.slice(0, 8_000),
+      targets: projected,
+    };
+  }
+
+  async click(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "click",
+      "",
+      false,
+      signal,
+    );
+  }
+
+  async type(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "type",
+      text,
+      submit,
+      signal,
+    );
+  }
+
+  closeTab(sessionId: string, tabId: string): void {
+    const session = this.#requireSession(sessionId);
+    if (!session.targetIds.delete(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    session.ignoredTargetIds.add(tabId);
+    this.#tabs.delete(tabId);
+  }
+
+  closeSession(sessionId: string): number {
+    const session = this.#requireSession(sessionId);
+    const count = session.targetIds.size;
+    for (const targetId of session.targetIds) this.#tabs.delete(targetId);
+    this.#sessions.delete(sessionId);
+    return count;
+  }
+
+  async close(): Promise<void> {
+    this.#sessions.clear();
+    this.#tabs.clear();
+    await this.#client.close();
+  }
+
+  async #act(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    action: "click" | "type",
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#tab(sessionId, tabId);
+    const target = resolveBrowserObservedTarget(
+      tab.observation,
+      tab.documentVersion,
+      observationId,
+      targetId,
+      action,
+    );
+    const response = asRecord(
+      await this.#client.evaluate(
+        tabId,
+        browserActionScript(target, action, text, submit),
+        signal,
+      ),
+    );
+    tab.observation = undefined;
+    if (response?.ok !== true) {
+      throw new Error(
+        `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
+      );
+    }
+    tab.documentVersion += 1;
+    return await this.#summary(sessionId, tabId, signal);
+  }
+
+  #session(sessionId: string): UserBrowserSession {
+    let session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      session = { targetIds: new Set(), ignoredTargetIds: new Set() };
+      this.#sessions.set(sessionId, session);
+    }
+    return session;
+  }
+
+  #requireSession(sessionId: string): UserBrowserSession {
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      throw new Error(`Unknown user browser session: ${sessionId}`);
+    }
+    return session;
+  }
+
+  #tab(sessionId: string, tabId: string): UserBrowserTabState {
+    const session = this.#requireSession(sessionId);
+    if (!session.targetIds.has(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    return tab;
+  }
+
+  async #summary(
+    sessionId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const target = (await this.#client.listTargets(signal)).find(
+      (candidate) =>
+        candidate.targetId === targetId && candidate.type === "page",
+    );
+    if (target === undefined) throw new Error("User browser tab was closed");
+    return summarizeTarget(sessionId, target);
+  }
+}
+
+export interface UserBrowserConnection {
+  backend: UserBrowserCdpBackend;
+  product: string;
+}
+
+export async function connectUserBrowserCdp(
+  endpoint: string,
+  signal?: AbortSignal,
+): Promise<UserBrowserConnection> {
+  const base = validateCdpEndpoint(endpoint);
+  const timeout = AbortSignal.timeout(5_000);
+  const probeSignal =
+    signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+  const response = await fetch(new URL("/json/version", base), {
+    signal: probeSignal,
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `User browser CDP version probe failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const version = asRecord(await response.json());
+  if (version === undefined) {
+    throw new Error("User browser CDP version response is invalid");
+  }
+  const product = validateUserBrowserVersion(version);
+  const webSocketDebuggerUrl = version.webSocketDebuggerUrl;
+  if (typeof webSocketDebuggerUrl !== "string") {
+    throw new Error(
+      "User browser CDP version response is missing webSocketDebuggerUrl",
+    );
+  }
+  const socketUrl = new URL(webSocketDebuggerUrl);
+  if (
+    socketUrl.protocol !== "ws:" ||
+    !isLoopbackHostname(socketUrl.hostname) ||
+    socketUrl.username.length > 0 ||
+    socketUrl.password.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP WebSocket must be an unauthenticated loopback ws:// endpoint",
+    );
+  }
+  const client = await JsonRpcUserBrowserCdpClient.connect(
+    socketUrl.toString(),
+    probeSignal,
+  );
+  return { backend: new UserBrowserCdpBackend(client), product };
+}
+
+export function validateUserBrowserVersion(
+  value: Record<string, unknown>,
+): string {
+  const product = value.Browser;
+  const match =
+    typeof product === "string"
+      ? /^(?:Chrome|Chromium|Edg)\/(\d+)(?:\.\d+){1,3}(?:[-+].*)?$/u.exec(
+          product,
+        )
+      : null;
+  if (
+    typeof product !== "string" ||
+    match === null ||
+    Number.parseInt(match[1] ?? "0", 10) < 100
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must report a supported Chrome, Edge, or Chromium product",
+    );
+  }
+  return product;
+}
+
+class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
+  readonly #socket: WebSocket;
+  readonly #pending = new Map<
+    number,
+    { resolve(value: unknown): void; reject(error: Error): void }
+  >();
+  readonly #targetSessions = new Map<string, string>();
+  #nextId = 1;
+  #closed = false;
+
+  private constructor(socket: WebSocket) {
+    this.#socket = socket;
+    socket.on("message", (data) => this.#receive(data.toString()));
+    socket.on("close", () =>
+      this.#failAll(new Error("User browser CDP connection closed")),
+    );
+    socket.on("error", (error) => this.#failAll(error));
+  }
+
+  static async connect(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<JsonRpcUserBrowserCdpClient> {
+    const socket = new WebSocket(url, { handshakeTimeout: 5_000 });
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        socket.close();
+        reject(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error("User browser CDP connection aborted"),
+        );
+      };
+      socket.once("open", () => {
+        signal?.removeEventListener("abort", abort);
+        resolve();
+      });
+      socket.once("error", (error) => {
+        signal?.removeEventListener("abort", abort);
+        reject(error);
+      });
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) abort();
+    });
+    return new JsonRpcUserBrowserCdpClient(socket);
+  }
+
+  async listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]> {
+    const response = asRecord(
+      await this.#send("Target.getTargets", {}, undefined, signal),
+    );
+    const infos = response?.targetInfos;
+    if (!Array.isArray(infos))
+      throw new Error("User browser CDP Target.getTargets response is invalid");
+    return infos.map((value) => {
+      const target = asRecord(value);
+      if (
+        target === undefined ||
+        typeof target.targetId !== "string" ||
+        typeof target.type !== "string" ||
+        typeof target.title !== "string" ||
+        typeof target.url !== "string"
+      ) {
+        throw new Error("User browser CDP target metadata is invalid");
+      }
+      return {
+        targetId: target.targetId,
+        type: target.type,
+        title: target.title,
+        url: target.url,
+      };
+    });
+  }
+
+  async createTarget(url: string, signal?: AbortSignal): Promise<string> {
+    const response = asRecord(
+      await this.#send("Target.createTarget", { url }, undefined, signal),
+    );
+    if (typeof response?.targetId !== "string")
+      throw new Error("User browser CDP createTarget response is invalid");
+    return response.targetId;
+  }
+
+  async navigate(
+    targetId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const sessionId = await this.#attach(targetId, signal);
+    await this.#send("Page.navigate", { url }, sessionId, signal);
+  }
+
+  async evaluate(
+    targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const sessionId = await this.#attach(targetId, signal);
+    const response = asRecord(
+      await this.#send(
+        "Runtime.evaluate",
+        { expression, awaitPromise: true, returnByValue: true },
+        sessionId,
+        signal,
+      ),
+    );
+    if (response?.exceptionDetails !== undefined) {
+      throw new Error("User browser CDP evaluation failed");
+    }
+    return asRecord(response?.result)?.value;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#socket.close();
+    this.#failAll(new Error("User browser CDP connection closed"));
+  }
+
+  async #attach(targetId: string, signal?: AbortSignal): Promise<string> {
+    const existing = this.#targetSessions.get(targetId);
+    if (existing !== undefined) return existing;
+    const response = asRecord(
+      await this.#send(
+        "Target.attachToTarget",
+        { targetId, flatten: true },
+        undefined,
+        signal,
+      ),
+    );
+    if (typeof response?.sessionId !== "string")
+      throw new Error("User browser CDP attach response is invalid");
+    this.#targetSessions.set(targetId, response.sessionId);
+    return response.sessionId;
+  }
+
+  async #send(
+    method: string,
+    params: Record<string, unknown>,
+    sessionId?: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
+      throw new Error("User browser CDP connection is unavailable");
+    }
+    const id = this.#nextId++;
+    return await new Promise((resolve, reject) => {
+      const abort = () => {
+        this.#pending.delete(id);
+        reject(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error("User browser CDP command aborted"),
+        );
+      };
+      this.#pending.set(id, {
+        resolve: (value) => {
+          signal?.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error) => {
+          signal?.removeEventListener("abort", abort);
+          reject(error);
+        },
+      });
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) {
+        abort();
+        return;
+      }
+      this.#socket.send(
+        JSON.stringify({
+          id,
+          method,
+          params,
+          ...(sessionId === undefined ? {} : { sessionId }),
+        }),
+      );
+    });
+  }
+
+  #receive(raw: string): void {
+    let message: Record<string, unknown> | undefined;
+    try {
+      message = asRecord(JSON.parse(raw));
+    } catch {
+      this.#failAll(new Error("User browser CDP returned invalid JSON"));
+      return;
+    }
+    if (message === undefined || typeof message.id !== "number") return;
+    const pending = this.#pending.get(message.id);
+    if (pending === undefined) return;
+    this.#pending.delete(message.id);
+    const error = asRecord(message.error);
+    if (error !== undefined) {
+      pending.reject(
+        new Error(
+          `User browser CDP command failed: ${String(error.message ?? "unknown error")}`,
+        ),
+      );
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  #failAll(error: Error): void {
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+  }
+}
+
+function validateCdpEndpoint(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("User browser CDP endpoint is not a valid URL");
+  }
+  if (
+    url.protocol !== "http:" ||
+    !isLoopbackHostname(url.hostname) ||
+    url.username.length > 0 ||
+    url.password.length > 0 ||
+    url.search.length > 0 ||
+    url.hash.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must be an unauthenticated loopback http:// URL",
+    );
+  }
+  return url;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]"
+  );
+}
+
+function isInspectableUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function summarizeTarget(
+  sessionId: string,
+  target: UserBrowserCdpTarget,
+): BrowserTabSummary {
+  return {
+    sessionId,
+    tabId: target.targetId,
+    title: target.title.slice(0, 256),
+    url: redactBrowserUrl(target.url),
+    loading: false,
+  };
+}
+
+function requireFingerprint(value: unknown): BrowserTargetFingerprint {
+  const target = asRecord(value);
+  const actions = target?.actions;
+  if (
+    target === undefined ||
+    ![
+      "selector",
+      "tag",
+      "role",
+      "name",
+      "type",
+      "id",
+      "fieldName",
+      "autocomplete",
+      "href",
+    ].every((key) => typeof target[key] === "string") ||
+    typeof target.secure !== "boolean" ||
+    !Array.isArray(actions) ||
+    !actions.every((action) => action === "click" || action === "type") ||
+    (target.value !== undefined && typeof target.value !== "string")
+  ) {
+    throw new Error("User browser CDP inspection target is invalid");
+  }
+  return {
+    selector: target.selector as string,
+    tag: target.tag as string,
+    role: target.role as string,
+    name: target.name as string,
+    type: target.type as string,
+    id: target.id as string,
+    fieldName: target.fieldName as string,
+    autocomplete: target.autocomplete as string,
+    href: target.href as string,
+    secure: target.secure,
+    actions: [...actions],
+    ...(target.value === undefined ? {} : { value: target.value }),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -31,12 +31,14 @@ export interface UserBrowserCdpClient {
     expression: string,
     signal?: AbortSignal,
   ): Promise<unknown>;
+  documentIdentity(targetId: string, signal?: AbortSignal): Promise<string>;
   close(): Promise<void> | void;
 }
 
 interface UserBrowserSession {
   targetIds: Set<string>;
   ignoredTargetIds: Set<string>;
+  detaching: boolean;
 }
 
 interface UserBrowserTabState {
@@ -44,26 +46,15 @@ interface UserBrowserTabState {
   url: string;
   documentIdentity?: string;
   observation?: BrowserObservation;
-  actionInFlight: boolean;
+  operation?: Promise<void>;
+  detaching: boolean;
 }
-
-export const userBrowserDocumentIdentityScript = `(() => {
-    const key = "__zenxCapabilityDocumentIdentity";
-    let state = document[key];
-    if (typeof state !== "object" || state === null || typeof state.id !== "string" || typeof state.activation !== "number") {
-      state = { id: String(Date.now()) + ":" + String(Math.random()), activation: 0 };
-      Object.defineProperty(document, key, { value: state, configurable: false, enumerable: false });
-      addEventListener("pageshow", (event) => { if (event.persisted) state.activation += 1; });
-      addEventListener("popstate", () => { state.activation += 1; });
-      addEventListener("hashchange", () => { state.activation += 1; });
-    }
-    return JSON.stringify({ href: location.href, origin: location.origin, id: state.id, activation: state.activation });
-  })()`;
 
 export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #client: UserBrowserCdpClient;
   readonly #sessions = new Map<string, UserBrowserSession>();
   readonly #tabs = new Map<string, UserBrowserTabState>();
+  #closing = false;
 
   constructor(client: UserBrowserCdpClient) {
     this.#client = client;
@@ -74,6 +65,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary[]> {
     const session = this.#session(sessionId);
+    this.#assertSessionIdle(session);
     const targets = (await this.#client.listTargets(signal)).filter(
       (target) =>
         target.type === "page" &&
@@ -94,7 +86,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         this.#tabs.set(target.targetId, {
           documentVersion: 1,
           url: target.url,
-          actionInFlight: false,
+          detaching: false,
         });
       } else if (tab.url !== target.url) {
         tab.url = target.url;
@@ -119,7 +111,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     this.#tabs.set(targetId, {
       documentVersion: 1,
       url,
-      actionInFlight: false,
+      detaching: false,
     });
     return await this.#summary(sessionId, targetId, signal);
   }
@@ -130,16 +122,23 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     url: string,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
+    const operation = this.#startOperation(tab, async () => {
+      await this.#client.navigate(tabId, url);
+      tab.documentVersion += 1;
+      tab.url = url;
+      tab.documentIdentity = undefined;
+      tab.observation = undefined;
+      return await this.#summary(sessionId, tabId);
+    });
+    try {
+      return await raceAbort(operation, signal);
+    } catch (error) {
+      throw new Error(
+        `User browser navigation outcome is unknown after cancellation or connection failure (${describeError(error)})`,
+      );
     }
-    await this.#client.navigate(tabId, url, signal);
-    tab.documentVersion += 1;
-    tab.url = url;
-    tab.documentIdentity = undefined;
-    tab.observation = undefined;
-    return await this.#summary(sessionId, tabId, signal);
   }
 
   async inspect(
@@ -147,59 +146,59 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     tabId: string,
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
-    }
-    const envelope = asRecord(
-      await this.#client.evaluate(
-        tabId,
-        `(() => ({ documentIdentity: ${userBrowserDocumentIdentityScript}, inspection: ${browserInspectScript} }))()`,
-        signal,
-      ),
-    );
-    const raw = asRecord(envelope?.inspection);
-    if (
-      typeof envelope?.documentIdentity !== "string" ||
-      raw === undefined ||
-      typeof raw.visibleText !== "string" ||
-      !Array.isArray(raw.targets)
-    ) {
-      throw new Error(
-        "User browser CDP inspection returned an unsupported shape",
+    const operation = this.#startOperation(tab, async () => {
+      const before = await this.#client.documentIdentity(tabId);
+      const raw = asRecord(
+        await this.#client.evaluate(tabId, browserInspectScript),
       );
-    }
-    const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
-    const targets = new Map<string, BrowserTargetFingerprint>();
-    const projected = fingerprints.map((fingerprint) => {
-      const targetId = randomUUID();
-      targets.set(targetId, fingerprint);
+      const after = await this.#client.documentIdentity(tabId);
+      if (before !== after) {
+        throw new Error("User browser document changed during inspection");
+      }
+      if (
+        raw === undefined ||
+        typeof raw.visibleText !== "string" ||
+        !Array.isArray(raw.targets)
+      ) {
+        throw new Error(
+          "User browser CDP inspection returned an unsupported shape",
+        );
+      }
+      const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
+      const targets = new Map<string, BrowserTargetFingerprint>();
+      const projected = fingerprints.map((fingerprint) => {
+        const targetId = randomUUID();
+        targets.set(targetId, fingerprint);
+        return {
+          targetId,
+          role: fingerprint.role,
+          name: fingerprint.name,
+          actions: [...fingerprint.actions],
+          ...(fingerprint.secure ? { secure: true as const } : {}),
+          ...(fingerprint.value === undefined
+            ? {}
+            : { value: fingerprint.value }),
+        };
+      });
+      const observationId = randomUUID();
+      tab.documentIdentity = after;
+      tab.observation = {
+        id: observationId,
+        documentVersion: tab.documentVersion,
+        targets,
+      };
+      const summary = await this.#summary(sessionId, tabId);
       return {
-        targetId,
-        role: fingerprint.role,
-        name: fingerprint.name,
-        actions: [...fingerprint.actions],
-        ...(fingerprint.secure ? { secure: true as const } : {}),
-        ...(fingerprint.value === undefined
-          ? {}
-          : { value: fingerprint.value }),
+        ...summary,
+        observationId,
+        documentVersion: tab.documentVersion,
+        visibleText: raw.visibleText.slice(0, 8_000),
+        targets: projected,
       };
     });
-    const observationId = randomUUID();
-    tab.documentIdentity = envelope.documentIdentity;
-    tab.observation = {
-      id: observationId,
-      documentVersion: tab.documentVersion,
-      targets,
-    };
-    const summary = await this.#summary(sessionId, tabId, signal);
-    return {
-      ...summary,
-      observationId,
-      documentVersion: tab.documentVersion,
-      visibleText: raw.visibleText.slice(0, 8_000),
-      targets: projected,
-    };
+    return await raceAbort(operation, signal);
   }
 
   async click(
@@ -242,27 +241,44 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     );
   }
 
-  closeTab(sessionId: string, tabId: string): void {
+  async closeTab(sessionId: string, tabId: string): Promise<void> {
     const session = this.#requireSession(sessionId);
-    if (!session.targetIds.delete(tabId)) {
+    if (!session.targetIds.has(tabId)) {
       throw new Error(`Unknown user browser tab: ${tabId}`);
     }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    tab.detaching = true;
+    await tab.operation;
+    session.targetIds.delete(tabId);
     session.ignoredTargetIds.add(tabId);
     this.#tabs.delete(tabId);
   }
 
-  closeSession(sessionId: string): number {
+  async closeSession(sessionId: string): Promise<number> {
     const session = this.#requireSession(sessionId);
+    session.detaching = true;
     const count = session.targetIds.size;
-    for (const targetId of session.targetIds) this.#tabs.delete(targetId);
+    const tabs = [...session.targetIds].map((targetId) => {
+      const tab = this.#tabs.get(targetId);
+      if (tab !== undefined) tab.detaching = true;
+      return { targetId, tab };
+    });
+    await Promise.all(tabs.map(({ tab }) => tab?.operation));
+    for (const { targetId } of tabs) this.#tabs.delete(targetId);
     this.#sessions.delete(sessionId);
     return count;
   }
 
   async close(): Promise<void> {
+    this.#closing = true;
+    for (const session of this.#sessions.values()) session.detaching = true;
+    for (const tab of this.#tabs.values()) tab.detaching = true;
+    const operations = [...this.#tabs.values()].map((tab) => tab.operation);
+    await this.#client.close();
+    await Promise.all(operations);
     this.#sessions.clear();
     this.#tabs.clear();
-    await this.#client.close();
   }
 
   async #act(
@@ -275,10 +291,8 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     submit: boolean,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
-    }
     const target = resolveBrowserObservedTarget(
       tab.observation,
       tab.documentVersion,
@@ -289,58 +303,95 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const expectedDocumentIdentity = tab.documentIdentity;
     tab.observation = undefined;
     tab.documentIdentity = undefined;
-    tab.actionInFlight = true;
-    let response: Record<string, unknown> | undefined;
-    try {
-      response = asRecord(
+    let dispatched = false;
+    const operation = this.#startOperation(tab, async () => {
+      const actualDocumentIdentity = await this.#client.documentIdentity(tabId);
+      if (actualDocumentIdentity !== expectedDocumentIdentity) {
+        throw new DocumentChangedError();
+      }
+      dispatched = true;
+      const response = asRecord(
         await this.#client.evaluate(
           tabId,
-          userBrowserActionScript(
-            expectedDocumentIdentity,
-            target,
-            action,
-            text,
-            submit,
-          ),
-          signal,
+          browserActionScript(target, action, text, submit),
         ),
       );
-    } catch (error) {
-      throw new Error(
-        `User browser action outcome is unknown after cancellation or connection failure; inspect the current tab before another action (${describeError(error)})`,
-      );
-    } finally {
-      tab.actionInFlight = false;
-    }
-    if (response?.ok !== true) {
-      throw new Error(
-        `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
-      );
-    }
-    tab.documentVersion += 1;
+      if (response?.ok !== true) {
+        throw new ActionRejectedError(String(response?.reason ?? "unknown"));
+      }
+      tab.documentVersion += 1;
+      return await this.#summary(sessionId, tabId);
+    });
     try {
-      return await this.#summary(sessionId, tabId, signal);
+      return await raceAbort(operation, signal);
     } catch (error) {
+      if (error instanceof DocumentChangedError) {
+        throw new Error("User browser document changed; inspect again");
+      }
+      if (error instanceof ActionRejectedError) {
+        throw new Error(
+          `User browser target changed or action was rejected (${error.message}); inspect again`,
+        );
+      }
       throw new Error(
-        `User browser action outcome is unknown because post-action confirmation failed; inspect the current tab before another action (${describeError(error)})`,
+        `User browser action outcome is unknown after cancellation or connection failure${dispatched ? "" : " before dispatch confirmation"}; inspect the current tab before another action (${describeError(error)})`,
       );
+    }
+  }
+
+  #startOperation<T>(
+    tab: UserBrowserTabState,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    if (tab.detaching) throw new Error("User browser tab is detaching");
+    if (tab.operation !== undefined) {
+      throw new Error("User browser tab operation is already in flight");
+    }
+    const result = run();
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    tab.operation = settled;
+    void settled.then(() => {
+      if (tab.operation === settled) tab.operation = undefined;
+    });
+    return result;
+  }
+
+  #assertSessionIdle(session: UserBrowserSession): void {
+    for (const targetId of session.targetIds) {
+      const tab = this.#tabs.get(targetId);
+      if (tab?.detaching === true)
+        throw new Error("User browser tab is detaching");
+      if (tab?.operation !== undefined) {
+        throw new Error("User browser tab operation is already in flight");
+      }
     }
   }
 
   #session(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
     let session = this.#sessions.get(sessionId);
     if (session === undefined) {
-      session = { targetIds: new Set(), ignoredTargetIds: new Set() };
+      session = {
+        targetIds: new Set(),
+        ignoredTargetIds: new Set(),
+        detaching: false,
+      };
       this.#sessions.set(sessionId, session);
     }
+    if (session.detaching) throw new Error("User browser session is detaching");
     return session;
   }
 
   #requireSession(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
     const session = this.#sessions.get(sessionId);
     if (session === undefined) {
       throw new Error(`Unknown user browser session: ${sessionId}`);
     }
+    if (session.detaching) throw new Error("User browser session is detaching");
     return session;
   }
 
@@ -455,6 +506,17 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     { resolve(value: unknown): void; reject(error: Error): void }
   >();
   readonly #targetSessions = new Map<string, string>();
+  readonly #sessionTargets = new Map<string, string>();
+  readonly #targetDocuments = new Map<
+    string,
+    {
+      revision: number;
+      frameId: string;
+      loaderId: string;
+      url: string;
+      alive: boolean;
+    }
+  >();
   #nextId = 1;
   #closed = false;
 
@@ -560,6 +622,43 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     return asRecord(response?.result)?.value;
   }
 
+  async documentIdentity(
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const sessionId = await this.#attach(targetId, signal);
+    const response = asRecord(
+      await this.#send("Page.getFrameTree", {}, sessionId, signal),
+    );
+    const frame = asRecord(asRecord(response?.frameTree)?.frame);
+    if (
+      frame === undefined ||
+      typeof frame.id !== "string" ||
+      typeof frame.loaderId !== "string" ||
+      typeof frame.url !== "string"
+    ) {
+      throw new Error("User browser CDP document identity is invalid");
+    }
+    const state = this.#targetDocuments.get(targetId);
+    if (state?.alive === false)
+      throw new Error("User browser target disappeared");
+    const revision = state?.revision ?? 0;
+    this.#targetDocuments.set(targetId, {
+      revision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+      alive: true,
+    });
+    return JSON.stringify({
+      targetId,
+      revision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+    });
+  }
+
   close(): void {
     if (this.#closed) return;
     this.#closed = true;
@@ -581,6 +680,15 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     if (typeof response?.sessionId !== "string")
       throw new Error("User browser CDP attach response is invalid");
     this.#targetSessions.set(targetId, response.sessionId);
+    this.#sessionTargets.set(response.sessionId, targetId);
+    this.#targetDocuments.set(targetId, {
+      revision: 0,
+      frameId: "",
+      loaderId: "",
+      url: "",
+      alive: true,
+    });
+    await this.#send("Page.enable", {}, response.sessionId, signal);
     return response.sessionId;
   }
 
@@ -637,7 +745,11 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       this.#failAll(new Error("User browser CDP returned invalid JSON"));
       return;
     }
-    if (message === undefined || typeof message.id !== "number") return;
+    if (message === undefined) return;
+    if (typeof message.id !== "number") {
+      this.#receiveEvent(message);
+      return;
+    }
     const pending = this.#pending.get(message.id);
     if (pending === undefined) return;
     this.#pending.delete(message.id);
@@ -653,10 +765,86 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     }
   }
 
+  #receiveEvent(message: Record<string, unknown>): void {
+    const method = message.method;
+    const params = asRecord(message.params);
+    if (typeof method !== "string" || params === undefined) return;
+    if (
+      method === "Target.targetDestroyed" &&
+      typeof params.targetId === "string"
+    ) {
+      this.#invalidateTarget(params.targetId, true);
+      return;
+    }
+    if (
+      method === "Target.detachedFromTarget" &&
+      typeof params.sessionId === "string"
+    ) {
+      const targetId = this.#sessionTargets.get(params.sessionId);
+      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      return;
+    }
+    if (
+      method === "Inspector.detached" &&
+      typeof message.sessionId === "string"
+    ) {
+      const targetId = this.#sessionTargets.get(message.sessionId);
+      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      return;
+    }
+    if (typeof message.sessionId !== "string") return;
+    const targetId = this.#sessionTargets.get(message.sessionId);
+    if (targetId === undefined) return;
+    if (
+      userBrowserDocumentEventInvalidates(
+        method,
+        params,
+        this.#targetDocuments.get(targetId)?.frameId,
+      )
+    ) {
+      this.#invalidateTarget(targetId, false);
+    }
+  }
+
+  #invalidateTarget(targetId: string, disappeared: boolean): void {
+    const state = this.#targetDocuments.get(targetId) ?? {
+      revision: 0,
+      frameId: "",
+      loaderId: "",
+      url: "",
+      alive: true,
+    };
+    state.revision += 1;
+    state.alive = !disappeared;
+    this.#targetDocuments.set(targetId, state);
+  }
+
   #failAll(error: Error): void {
+    for (const targetId of this.#targetSessions.keys()) {
+      this.#invalidateTarget(targetId, true);
+    }
     for (const pending of this.#pending.values()) pending.reject(error);
     this.#pending.clear();
   }
+}
+
+export function userBrowserDocumentEventInvalidates(
+  method: string,
+  params: Record<string, unknown>,
+  mainFrameId?: string,
+): boolean {
+  if (method === "Page.frameNavigated") {
+    const frame = asRecord(params.frame);
+    return frame !== undefined && frame.parentId === undefined;
+  }
+  if (
+    method !== "Page.navigatedWithinDocument" &&
+    method !== "Page.frameStartedLoading" &&
+    method !== "Page.backForwardCacheNotUsed"
+  ) {
+    return false;
+  }
+  return typeof params.frameId === "string" && params.frameId === mainFrameId;
 }
 
 function validateCdpEndpoint(raw: string): URL {
@@ -702,23 +890,43 @@ export function windowsBrowserExecutableCandidates(
   ];
 }
 
-function userBrowserActionScript(
-  expectedDocumentIdentity: string | undefined,
-  target: BrowserTargetFingerprint,
-  action: "click" | "type",
-  text: string,
-  submit: boolean,
-): string {
-  return `(() => {
-    const expectedDocumentIdentity = ${JSON.stringify(expectedDocumentIdentity)};
-    const actualDocumentIdentity = ${userBrowserDocumentIdentityScript};
-    if (actualDocumentIdentity !== expectedDocumentIdentity) return { ok: false, reason: "document-changed" };
-    return ${browserActionScript(target, action, text, submit)};
-  })()`;
-}
-
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+class DocumentChangedError extends Error {}
+class ActionRejectedError extends Error {}
+
+async function raceAbort<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal === undefined) return await operation;
+  if (signal.aborted) throw abortReason(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("cancelled", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted === true) throw abortReason(signal);
 }
 
 function isLoopbackHostname(hostname: string): boolean {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -70,12 +70,19 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
             manifest: undefined,
             diagnostics: [],
           };
-    this.#registry.register(
-      new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
-      "bundled",
-    );
+    if (browser.backend !== undefined) {
+      this.#registry.register(
+        new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
+        "bundled",
+      );
+    }
     for (const diagnostic of browser.diagnostics) {
       this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+    if (browser.backend === undefined) {
+      this.#registry.recordDiscoveryError(
+        `Browser provider: ${browser.diagnostics[0]?.reason ?? "unavailable"}`,
+      );
     }
     const computer =
       this.#computerBackend === undefined

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -92,19 +92,20 @@ void app.whenReady().then(async () => {
     const password = inspected.targets.find(({ name }) => name === "Password");
     assert.equal(password?.secure, true);
     assert.equal(password?.value, undefined);
-    assert.equal(password?.actions.includes("type"), false);
+    assert.equal(password?.actions.includes("type"), true);
     if (password !== undefined) {
-      await assert.rejects(
-        invoke(registry, "browser_type", {
-          sessionId: "desktop-smoke",
-          tabId,
-          observationId: inspected.observationId,
-          targetId: password.targetId,
-          text: "not-a-secret",
-        }),
-        /password or secure controls/u,
-      );
+      await invoke(registry, "browser_type", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: password.targetId,
+        text: "ordinary-argument",
+      });
     }
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
     const input = requiredBrowserTarget(inspected, "Name", "type");
     await invoke(registry, "browser_type", {
       sessionId: "desktop-smoke",
@@ -236,7 +237,7 @@ void app.whenReady().then(async () => {
     assert.equal(foregroundAfter.bundleId, foregroundBefore.bundleId);
 
     console.log(
-      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, changed, and password targets; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
+      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, and changed targets while password input dispatches normally; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
     );
   } catch (error) {
     console.error("ZenX capability desktop smoke failed", error);

--- a/apps/zenx/src/main/provider-smoke.ts
+++ b/apps/zenx/src/main/provider-smoke.ts
@@ -30,6 +30,10 @@ void app.whenReady().then(async () => {
     const selectedBrowser = browser.diagnostics.find(
       (diagnostic) => diagnostic.status === "selected",
     );
+    assert.ok(
+      browser.backend,
+      `Browser provider is unavailable: ${JSON.stringify(browser.diagnostics)}`,
+    );
     if (process.env.ZENX_REQUIRE_PLAYWRIGHT === "1") {
       assert.equal(
         selectedBrowser?.providerId,

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:http";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
+
+if (process.platform !== "win32") {
+  throw new Error("The real user-browser CDP smoke is Windows-only");
+}
+
+const server = createServer((request, response) => {
+  if (request.url === "/seed") {
+    response.statusCode = 302;
+    response.setHeader(
+      "set-cookie",
+      "zenx_smoke_auth=present; HttpOnly; SameSite=Lax",
+    );
+    response.setHeader("location", "/account");
+    response.end();
+    return;
+  }
+  const authenticated =
+    request.headers.cookie?.includes("zenx_smoke_auth=present") === true;
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.end(
+    `<!doctype html><title>User session smoke</title><main><p>${authenticated ? "Signed in through existing browser state" : "Signed out"}</p><button id="continue" onclick="this.textContent='Attached action complete'">Continue</button></main>`,
+  );
+});
+
+let browser: ChildProcess | undefined;
+let directory: string | undefined;
+
+try {
+  const executable = await findBrowserExecutable();
+  directory = await mkdtemp(path.join(os.tmpdir(), "zenx-user-browser-smoke-"));
+  const port = await listen();
+  browser = spawn(
+    executable,
+    [
+      `--user-data-dir=${directory}`,
+      "--remote-debugging-port=0",
+      "--no-first-run",
+      "--no-default-browser-check",
+      `http://127.0.0.1:${String(port)}/seed`,
+    ],
+    { stdio: "ignore", windowsHide: true },
+  );
+  const debuggingPort = await readDevToolsPort(directory);
+  const endpoint = `http://127.0.0.1:${debuggingPort}`;
+  const selection = await selectBrowserProvider({
+    userDataDirectory: directory,
+    platform: "win32",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: endpoint,
+    },
+  });
+  const backend = selection.backend;
+  assert.ok(
+    backend,
+    `Expected user-browser provider: ${JSON.stringify(selection.diagnostics)}`,
+  );
+  const selected = selection.diagnostics.find(
+    (diagnostic) => diagnostic.status === "selected",
+  );
+  assert.equal(selected?.providerId, "user-browser-cdp");
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  const tabs = await retry(async () => {
+    const current = await backend.listTabs("windows-smoke");
+    return current.some((tab) => tab.url.includes("/account"))
+      ? current
+      : undefined;
+  });
+  const account = tabs.find((tab) => tab.url.includes("/account"));
+  assert.ok(account, "Expected the already-running authenticated account tab");
+  const inspection = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(
+    inspection.visibleText,
+    /Signed in through existing browser state/u,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(inspection),
+    /zenx_smoke_auth|cookie|storageState|authorization/iu,
+  );
+  const target = inspection.targets.find(
+    (candidate) => candidate.name === "Continue",
+  );
+  assert.ok(target, "Expected the existing user tab action target");
+  await backend.click(
+    "windows-smoke",
+    account.tabId,
+    inspection.observationId,
+    target.targetId,
+  );
+  const verified = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(verified.visibleText, /Attached action complete/u);
+  const detached = await backend.closeSession("windows-smoke");
+  await backend.close();
+  assert.equal(detached, tabs.length);
+  assert.equal(
+    browser.exitCode,
+    null,
+    "Closing ZenX must leave the user browser running",
+  );
+  const browserTargets = (await (
+    await fetch(`${endpoint}/json/list`)
+  ).json()) as unknown[];
+  assert.ok(
+    browserTargets.length > 0,
+    "Closing ZenX must leave user tabs intact",
+  );
+  console.log(
+    JSON.stringify({
+      passed: true,
+      provider: "user-browser-cdp",
+      product: selected?.version,
+      inheritedAuthenticatedState: true,
+      agentReceivedSessionMaterial: false,
+      browserAndTabsSurvivedDetach: true,
+    }),
+  );
+} finally {
+  await closeServer();
+  if (browser?.pid !== undefined) {
+    await stopProcessTree(browser.pid);
+  }
+  if (directory !== undefined) {
+    await rm(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 250,
+    });
+  }
+}
+
+async function findBrowserExecutable(): Promise<string> {
+  const candidates = [
+    process.env.ZENX_USER_BROWSER_EXECUTABLE,
+    path.join(
+      process.env.ProgramFiles ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env["ProgramFiles(x86)"] ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env.LOCALAPPDATA ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env.ProgramFiles ?? "",
+      "Microsoft",
+      "Edge",
+      "Application",
+      "msedge.exe",
+    ),
+    path.join(
+      process.env["ProgramFiles(x86)"] ?? "",
+      "Microsoft",
+      "Edge",
+      "Application",
+      "msedge.exe",
+    ),
+  ].filter(
+    (candidate): candidate is string =>
+      candidate !== undefined && candidate.length > 0,
+  );
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Keep probing the explicit finite list.
+    }
+  }
+  throw new Error(
+    "No supported Chrome or Edge executable found for the Windows user-browser smoke",
+  );
+}
+
+async function readDevToolsPort(userDataDirectory: string): Promise<string> {
+  return await retry(async () => {
+    try {
+      const [port] = (
+        await readFile(
+          path.join(userDataDirectory, "DevToolsActivePort"),
+          "utf8",
+        )
+      ).split(/\r?\n/u);
+      return /^\d+$/u.test(port ?? "") ? port : undefined;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
+async function retry<T>(operation: () => Promise<T | undefined>): Promise<T> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await operation();
+    if (result !== undefined) return result;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    "Timed out waiting for the real user browser CDP smoke fixture",
+  );
+}
+
+async function listen(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("Smoke server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}
+
+async function stopProcessTree(pid: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const cleanup = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    cleanup.once("exit", () => resolve());
+    cleanup.once("error", () => resolve());
+  });
+}

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
+import { windowsBrowserExecutableCandidates } from "./capabilities/user-browser-provider.js";
 
 if (process.platform !== "win32") {
   throw new Error("The real user-browser CDP smoke is Windows-only");
@@ -140,41 +141,7 @@ try {
 async function findBrowserExecutable(): Promise<string> {
   const candidates = [
     process.env.ZENX_USER_BROWSER_EXECUTABLE,
-    path.join(
-      process.env.ProgramFiles ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env["ProgramFiles(x86)"] ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env.LOCALAPPDATA ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env.ProgramFiles ?? "",
-      "Microsoft",
-      "Edge",
-      "Application",
-      "msedge.exe",
-    ),
-    path.join(
-      process.env["ProgramFiles(x86)"] ?? "",
-      "Microsoft",
-      "Edge",
-      "Application",
-      "msedge.exe",
-    ),
+    ...windowsBrowserExecutableCandidates(process.env),
   ].filter(
     (candidate): candidate is string =>
       candidate !== undefined && candidate.length > 0,

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -177,6 +177,13 @@ export function CapabilitySettings() {
               <code>{provider.providerId}</code>
               <span>{provider.status}</span>
               <span>{provider.interactionModes.join(", ")}</span>
+              {provider.capabilityId === "browser" ? (
+                <span>
+                  {provider.capabilities.includes("user_session")
+                    ? "user-session"
+                    : "isolated-session"}
+                </span>
+              ) : null}
               <span>{provider.version ?? "bundled"}</span>
             </div>
           ))}

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -178,11 +178,7 @@ export function CapabilitySettings() {
               <span>{provider.status}</span>
               <span>{provider.interactionModes.join(", ")}</span>
               {provider.capabilityId === "browser" ? (
-                <span>
-                  {provider.capabilities.includes("user_session")
-                    ? "user-session"
-                    : "isolated-session"}
-                </span>
+                <span>{provider.sessionMode ?? "mode-unreported"}</span>
               ) : null}
               <span>{provider.version ?? "bundled"}</span>
             </div>

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -86,12 +86,12 @@ test("browser vertical slice targets one session/tab through structured operatio
   ]);
 });
 
-test("browser rejects stale, forged, and secure opaque targets", () => {
+test("browser rejects stale and forged targets without classifying text sensitivity", () => {
   const editable = fingerprint({ actions: ["click", "type"] });
   const password = fingerprint({
     type: "password",
     secure: true,
-    actions: ["click"],
+    actions: ["click", "type"],
   });
   const observation: BrowserObservation = {
     id: "observation-1",
@@ -133,16 +133,15 @@ test("browser rejects stale, forged, and secure opaque targets", () => {
       ),
     /forged/u,
   );
-  assert.throws(
-    () =>
-      resolveBrowserObservedTarget(
-        observation,
-        7,
-        "observation-1",
-        "password",
-        "type",
-      ),
-    /password or secure controls/u,
+  assert.equal(
+    resolveBrowserObservedTarget(
+      observation,
+      7,
+      "observation-1",
+      "password",
+      "type",
+    ),
+    password,
   );
 });
 

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -64,7 +64,7 @@ test("Playwright provider fails closed on an incompatible snapshot schema", asyn
   );
 });
 
-test("Playwright provider revalidates DOM identity and rejects secure fill", async () => {
+test("Playwright provider revalidates DOM identity and dispatches password fill normally", async () => {
   const runner = new FakePlaywrightRunner();
   const backend = new PlaywrightCliBrowserBackend({
     executable: "/opt/playwright-cli",
@@ -75,19 +75,30 @@ test("Playwright provider revalidates DOM identity and rejects secure fill", asy
   const inspected = await backend.inspect("research", opened.tabId);
   const password = inspected.targets.find(({ name }) => name === "Password");
   assert.equal(password?.secure, true);
-  assert.deepEqual(password?.actions, ["click"]);
+  assert.deepEqual(password?.actions, ["click", "type"]);
+  assert.ok(password);
+  await backend.type(
+    "research",
+    opened.tabId,
+    inspected.observationId,
+    password.targetId,
+    "ordinary argument",
+    false,
+  );
+  assert.equal(runner.calls.filter((args) => args.includes("fill")).length, 1);
+  const refreshed = await backend.inspect("research", opened.tabId);
   assert.equal(
     inspected.targets.some(({ name }) => name === "Hidden"),
     false,
   );
-  const button = inspected.targets.find(({ name }) => name === "Run");
+  const button = refreshed.targets.find(({ name }) => name === "Run");
   assert.ok(button);
   runner.changeIdentity = true;
   await assert.rejects(
     backend.click(
       "research",
       opened.tabId,
-      inspected.observationId,
+      refreshed.observationId,
       button.targetId,
     ),
     /identity, security, visibility, or actions changed/u,

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -10,6 +10,12 @@ import {
   probePlaywrightCli,
   selectBrowserProvider,
 } from "../src/main/capabilities/provider-catalog.js";
+import {
+  BrowserZenXCapabilityPackage,
+  type ZenXBrowserBackend,
+} from "../src/main/capabilities/browser-provider.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
 
 test("requested user-session mode never falls back to an isolated provider", async () => {
   const selection = await selectBrowserProvider({
@@ -20,11 +26,59 @@ test("requested user-session mode never falls back to an isolated provider", asy
   assert.equal(selection.backend, undefined);
   assert.equal(selection.diagnostics[0]?.providerId, "user-browser-cdp");
   assert.equal(selection.diagnostics[0]?.status, "unavailable");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
   assert.match(selection.diagnostics[0]?.reason ?? "", /CDP_ENDPOINT/u);
   assert.equal(
     selection.diagnostics.some((entry) => entry.status === "fallback"),
     false,
   );
+});
+
+test("selected user-session provider is registered but hidden until explicitly granted", async () => {
+  const backend = stubBrowserBackend();
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: "http://127.0.0.1:9222",
+    },
+    platform: "win32",
+    userBrowserConnector: async () => ({
+      backend,
+      product: "Chrome/140.0.1.2",
+    }),
+  });
+  assert.equal(selection.backend, backend);
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
+
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+    { platform: "win32" },
+  );
+  await registry.initialize();
+  assert.ok(selection.backend);
+  registry.register(
+    new BrowserZenXCapabilityPackage(selection.backend, selection.manifest),
+  );
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  await registry.grant("browser");
+  assert.ok(
+    registry
+      .hostSnapshot()
+      .definitions.some(({ name }) => name === "browser_list_tabs"),
+  );
+  await registry.close();
+});
+
+test("invalid browser modes are explicit instead of masquerading as isolated", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "surprise" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.sessionMode, "invalid");
 });
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {
@@ -169,4 +223,32 @@ class ScriptedRunner implements ExternalProviderProcessRunner {
   assertComplete(): void {
     assert.equal(this.#steps.length, 0);
   }
+}
+
+function stubBrowserBackend(): ZenXBrowserBackend {
+  return {
+    async listTabs() {
+      return [];
+    },
+    async open() {
+      throw new Error("not used");
+    },
+    async navigate() {
+      throw new Error("not used");
+    },
+    async inspect() {
+      throw new Error("not used");
+    },
+    async click() {
+      throw new Error("not used");
+    },
+    async type() {
+      throw new Error("not used");
+    },
+    closeTab() {},
+    closeSession() {
+      return 0;
+    },
+    close() {},
+  };
 }

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -8,7 +8,24 @@ import type {
 import {
   probePeekabooCli,
   probePlaywrightCli,
+  selectBrowserProvider,
 } from "../src/main/capabilities/provider-catalog.js";
+
+test("requested user-session mode never falls back to an isolated provider", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "user-session" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.providerId, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.status, "unavailable");
+  assert.match(selection.diagnostics[0]?.reason ?? "", /CDP_ENDPOINT/u);
+  assert.equal(
+    selection.diagnostics.some((entry) => entry.status === "fallback"),
+    false,
+  );
+});
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {
   const runner = new ScriptedRunner([

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import test from "node:test";
 
 import {
@@ -6,6 +7,7 @@ import {
   UserBrowserCdpBackend,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
+  windowsBrowserExecutableCandidates,
 } from "../src/main/capabilities/user-browser-provider.js";
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
@@ -69,6 +71,157 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   assert.deepEqual(client.closedTargets, []);
 });
 
+test("external navigation makes an attached-tab observation fail closed", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+
+  client.currentUrl = "https://example.test/other";
+  client.documentIdentity = "document-b";
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /document-changed/u,
+  );
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+});
+
+test("listing after external navigation invalidates the old observation before dispatch", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.currentUrl = "https://example.test/other";
+  await backend.listTabs("work");
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+  assert.equal(client.actionCount, 0);
+});
+
+test("cancelled action is outcome-unknown and its observation cannot be retried", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.actionStarted;
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  await assert.rejects(action, /outcome is unknown/u);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+  client.releaseAction();
+});
+
+test("disconnect makes action outcome unknown and concurrent observation reuse dispatches once", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const first = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|already in flight/u,
+  );
+  client.rejectAction(new Error("CDP disconnected"));
+  await assert.rejects(first, /outcome is unknown/u);
+  assert.equal(client.actionCount, 1);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+});
+
+test("password and autocomplete metadata do not block ordinary text dispatch", async () => {
+  for (const metadata of [
+    { type: "password", autocomplete: "" },
+    { type: "text", autocomplete: "current-password" },
+    { type: "text", autocomplete: "new-password" },
+    { type: "text", autocomplete: "one-time-code" },
+  ]) {
+    const client = new FakeUserBrowserClient();
+    client.inspectionTarget = {
+      ...client.inspectionTarget,
+      ...metadata,
+      secure: true,
+      actions: ["type"],
+    };
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    await backend.type(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+      "ordinary argument",
+      false,
+    );
+    assert.equal(client.actionCount, 1);
+  }
+});
+
 test("user browser contract accepts only supported Chrome Edge or Chromium products", () => {
   assert.equal(
     validateUserBrowserVersion({ Browser: "Chrome/140.0.7339.1" }),
@@ -103,11 +256,98 @@ test("user browser attachment rejects remote or credential-bearing CDP endpoints
   );
 });
 
+test("user browser attachment rejects redirects and query-authenticated WebSockets", async () => {
+  const redirect = createServer((_request, response) => {
+    response.statusCode = 302;
+    response.setHeader("location", "http://127.0.0.1:1/json/version");
+    response.end();
+  });
+  const redirectPort = await listen(redirect);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(redirectPort)}`),
+    /fetch|redirect|failed/u,
+  );
+  await close(redirect);
+
+  const querySocket = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        Browser: "Chrome/140.0.1.2",
+        webSocketDebuggerUrl:
+          "ws://127.0.0.1:9222/devtools/browser/id?token=secret",
+      }),
+    );
+  });
+  const queryPort = await listen(querySocket);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(queryPort)}`),
+    /unauthenticated loopback ws/u,
+  );
+  await close(querySocket);
+});
+
+test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
+  const candidates = windowsBrowserExecutableCandidates({
+    ProgramFiles: "C:\\Program Files",
+    "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local",
+  });
+  assert.ok(
+    candidates.includes(
+      "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Microsoft\\Edge\\Application\\msedge.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes("C:\\Program Files\\Chromium\\Application\\chrome.exe"),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Chromium\\Application\\chrome.exe",
+    ),
+  );
+});
+
 class FakeUserBrowserClient implements UserBrowserCdpClient {
   actionCount = 0;
   closeCount = 0;
   readonly closedTargets: string[] = [];
   readonly calls: string[] = [];
+  currentUrl = "https://example.test/account";
+  documentIdentity = "document-a";
+  holdActions = false;
+  inspectionTarget = {
+    selector: "#continue",
+    tag: "button",
+    role: "button",
+    name: "Continue",
+    type: "",
+    id: "continue",
+    fieldName: "",
+    autocomplete: "",
+    href: "",
+    secure: false,
+    actions: ["click"] as Array<"click" | "type">,
+  };
+  readonly #actionStarted = deferred<void>();
+  #heldAction = deferred<void>();
+
+  get actionStarted(): Promise<void> {
+    return this.#actionStarted.promise;
+  }
+
+  releaseAction(): void {
+    this.#heldAction.resolve();
+  }
+
+  rejectAction(error: Error): void {
+    this.#heldAction.reject(error);
+  }
 
   async listTargets() {
     this.calls.push("Target.getTargets");
@@ -116,7 +356,7 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
         targetId: "target-1",
         type: "page",
         title: "Account",
-        url: "https://example.test/account",
+        url: this.currentUrl,
       },
     ];
   }
@@ -130,33 +370,78 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     this.calls.push("Page.navigate");
   }
 
-  async evaluate(_targetId: string, expression: string): Promise<unknown> {
+  async evaluate(
+    _targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     this.calls.push("Runtime.evaluate");
     if (!expression.includes("const expected")) {
       return {
-        visibleText: "Signed in as Alice",
-        targets: [
-          {
-            selector: "#continue",
-            tag: "button",
-            role: "button",
-            name: "Continue",
-            type: "",
-            id: "continue",
-            fieldName: "",
-            autocomplete: "",
-            href: "",
-            secure: false,
-            actions: ["click"],
-          },
-        ],
+        documentIdentity: this.documentIdentity,
+        inspection: {
+          visibleText: "Signed in as Alice",
+          targets: [this.inspectionTarget],
+        },
       };
     }
     this.actionCount += 1;
+    if (!expression.includes(JSON.stringify(this.documentIdentity))) {
+      return { ok: false, reason: "document-changed" };
+    }
+    if (this.holdActions) {
+      this.#actionStarted.resolve();
+      await Promise.race([this.#heldAction.promise, abortPromise(signal)]);
+    }
     return { ok: true };
   }
 
   async close() {
     this.closeCount += 1;
   }
+}
+
+function abortPromise(signal?: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal === undefined) return;
+    const abort = () =>
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new DOMException("cancelled", "AbortError"),
+      );
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function listen(
+  server: ReturnType<typeof createServer>,
+): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("test server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
 }

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  connectUserBrowserCdp,
+  UserBrowserCdpBackend,
+  type UserBrowserCdpClient,
+  validateUserBrowserVersion,
+} from "../src/main/capabilities/user-browser-provider.js";
+
+test("user browser mode inherits visible authenticated state without exposing session material", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+
+  const tabs = await backend.listTabs("work");
+  assert.deepEqual(tabs, [
+    {
+      sessionId: "work",
+      tabId: "target-1",
+      title: "Account",
+      url: "https://example.test/account",
+      loading: false,
+    },
+  ]);
+
+  const inspection = await backend.inspect("work", "target-1");
+  assert.match(inspection.visibleText, /Signed in as Alice/u);
+  assert.equal(inspection.targets[0]?.name, "Continue");
+  assert.doesNotMatch(
+    JSON.stringify({ tabs, inspection }),
+    /cookie|storageState|authorization|secret-cookie-value/iu,
+  );
+
+  const target = inspection.targets[0];
+  assert.ok(target);
+  await backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  assert.equal(client.actionCount, 1);
+  assert.equal(
+    client.calls.some((call) =>
+      /cookie|storage|authorization|network\./iu.test(call),
+    ),
+    false,
+  );
+});
+
+test("closing user browser capability only detaches and never closes user targets", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+
+  assert.equal(await backend.closeSession("work"), 1);
+  await backend.close();
+
+  assert.equal(client.closeCount, 1);
+  assert.equal(client.closedTargets.length, 0);
+});
+
+test("detaching a user tab keeps it open and out of the logical ZenX session", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  backend.closeTab("work", "target-1");
+  assert.deepEqual(await backend.listTabs("work"), []);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("user browser contract accepts only supported Chrome Edge or Chromium products", () => {
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chrome/140.0.7339.1" }),
+    "Chrome/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Edg/140.0.7339.1" }),
+    "Edg/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chromium/140.0.7339.1" }),
+    "Chromium/140.0.7339.1",
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Firefox/141.0" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Chrome/99.0.1.2" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+});
+
+test("user browser attachment rejects remote or credential-bearing CDP endpoints", async () => {
+  await assert.rejects(
+    connectUserBrowserCdp("https://example.test:9222"),
+    /unauthenticated loopback http/u,
+  );
+  await assert.rejects(
+    connectUserBrowserCdp("http://user:secret@127.0.0.1:9222"),
+    /unauthenticated loopback http/u,
+  );
+});
+
+class FakeUserBrowserClient implements UserBrowserCdpClient {
+  actionCount = 0;
+  closeCount = 0;
+  readonly closedTargets: string[] = [];
+  readonly calls: string[] = [];
+
+  async listTargets() {
+    this.calls.push("Target.getTargets");
+    return [
+      {
+        targetId: "target-1",
+        type: "page",
+        title: "Account",
+        url: "https://example.test/account",
+      },
+    ];
+  }
+
+  async createTarget(_url: string) {
+    this.calls.push("Target.createTarget");
+    return "target-2";
+  }
+
+  async navigate(_targetId: string, _url: string) {
+    this.calls.push("Page.navigate");
+  }
+
+  async evaluate(_targetId: string, expression: string): Promise<unknown> {
+    this.calls.push("Runtime.evaluate");
+    if (!expression.includes("const expected")) {
+      return {
+        visibleText: "Signed in as Alice",
+        targets: [
+          {
+            selector: "#continue",
+            tag: "button",
+            role: "button",
+            name: "Continue",
+            type: "",
+            id: "continue",
+            fieldName: "",
+            autocomplete: "",
+            href: "",
+            secure: false,
+            actions: ["click"],
+          },
+        ],
+      };
+    }
+    this.actionCount += 1;
+    return { ok: true };
+  }
+
+  async close() {
+    this.closeCount += 1;
+  }
+}

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -4,11 +4,43 @@ import test from "node:test";
 
 import {
   connectUserBrowserCdp,
+  userBrowserDocumentEventInvalidates,
   UserBrowserCdpBackend,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
   windowsBrowserExecutableCandidates,
 } from "../src/main/capabilities/user-browser-provider.js";
+
+test("CDP lifecycle contract invalidates history, reload, activation, and top-frame navigation", () => {
+  for (const method of [
+    "Page.navigatedWithinDocument",
+    "Page.frameStartedLoading",
+    "Page.backForwardCacheNotUsed",
+  ]) {
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "main" }, "main"),
+      true,
+      method,
+    );
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "child" }, "main"),
+      false,
+      `${method} subframe`,
+    );
+  }
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "main", loaderId: "loader", url: "https://example.test" },
+    }),
+    true,
+  );
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "child", parentId: "main" },
+    }),
+    false,
+  );
+});
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
   const client = new FakeUserBrowserClient();
@@ -66,7 +98,7 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   const client = new FakeUserBrowserClient();
   const backend = new UserBrowserCdpBackend(client);
   await backend.listTabs("work");
-  backend.closeTab("work", "target-1");
+  await backend.closeTab("work", "target-1");
   assert.deepEqual(await backend.listTabs("work"), []);
   assert.deepEqual(client.closedTargets, []);
 });
@@ -80,7 +112,7 @@ test("external navigation makes an attached-tab observation fail closed", async 
   assert.ok(target);
 
   client.currentUrl = "https://example.test/other";
-  client.documentIdentity = "document-b";
+  client.documentToken = "document-b";
   await assert.rejects(
     backend.click(
       "work",
@@ -88,7 +120,7 @@ test("external navigation makes an attached-tab observation fail closed", async 
       inspection.observationId,
       target.targetId,
     ),
-    /document-changed/u,
+    /document changed/u,
   );
   await assert.rejects(
     backend.click(
@@ -142,6 +174,16 @@ test("cancelled action is outcome-unknown and its observation cannot be retried"
   controller.abort(new DOMException("cancelled", "AbortError"));
   await assert.rejects(action, /outcome is unknown/u);
   await assert.rejects(
+    backend.inspect("work", "target-1"),
+    /operation is already in flight/u,
+  );
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /operation is already in flight/u,
+  );
+  assert.equal(client.actionCount, 1);
+  assert.equal(client.navigateCount, 0);
+  await assert.rejects(
     backend.click(
       "work",
       "target-1",
@@ -151,6 +193,179 @@ test("cancelled action is outcome-unknown and its observation cannot be retried"
     /stale or unknown/u,
   );
   client.releaseAction();
+  await client.actionSettled;
+  await nextTurn();
+  await backend.inspect("work", "target-1");
+});
+
+test("provider-owned lifecycle invalidates same-document history reload and activation observations", async () => {
+  for (const lifecycle of [
+    "pushState",
+    "replaceState-same-url",
+    "reload",
+    "bfcache-activation",
+  ]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.advanceDocument(lifecycle);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /document changed/u,
+    );
+    assert.equal(client.actionCount, 0, lifecycle);
+  }
+});
+
+test("target disappearance and disconnect fail before action dispatch", async () => {
+  for (const failure of ["target disappeared", "CDP disconnected"]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.identityFailure = new Error(failure);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /outcome is unknown/u,
+    );
+    assert.equal(client.actionCount, 0, failure);
+  }
+});
+
+test("post-confirmation cancellation retains the tab fence until confirmation settles", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdPostConfirmation = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.postConfirmationStarted;
+  controller.abort();
+  await assert.rejects(action, /outcome is unknown/u);
+  await assert.rejects(backend.inspect("work", "target-1"), /in flight/u);
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /in flight/u,
+  );
+  assert.equal(client.navigateCount, 0);
+  client.releasePostConfirmation();
+  await client.postConfirmationSettled;
+  await nextTurn();
+  await backend.inspect("work", "target-1");
+  assert.equal(client.actionCount, 1);
+});
+
+test("navigate is exclusive and detach waits for an already dispatched action", async () => {
+  const navigationClient = new FakeUserBrowserClient();
+  const navigationBackend = new UserBrowserCdpBackend(navigationClient);
+  await navigationBackend.listTabs("work");
+  navigationClient.holdNavigations = true;
+  const firstNavigate = navigationBackend.navigate(
+    "work",
+    "target-1",
+    "https://example.test/next",
+  );
+  await navigationClient.navigationStarted;
+  await assert.rejects(
+    navigationBackend.navigate(
+      "work",
+      "target-1",
+      "https://example.test/other",
+    ),
+    /operation is already in flight/u,
+  );
+  assert.equal(navigationClient.navigateCount, 1);
+  navigationClient.releaseNavigation();
+  await firstNavigate;
+
+  const actionClient = new FakeUserBrowserClient();
+  const actionBackend = new UserBrowserCdpBackend(actionClient);
+  await actionBackend.listTabs("work");
+  const inspection = await actionBackend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  actionClient.holdActions = true;
+  const action = actionBackend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await actionClient.actionStarted;
+  let detached = false;
+  const detach = actionBackend.closeSession("work").then((count) => {
+    detached = true;
+    return count;
+  });
+  await assert.rejects(actionBackend.inspect("work", "target-1"), /detaching/u);
+  await assert.rejects(
+    actionBackend.open("work", "https://example.test/late"),
+    /session is detaching/u,
+  );
+  assert.equal(detached, false);
+  assert.equal(actionClient.actionCount, 1);
+  assert.equal(actionClient.calls.includes("Target.createTarget"), false);
+  actionClient.releaseAction();
+  await action;
+  assert.equal(await detach, 1);
+  assert.equal(actionClient.actionCount, 1);
+  assert.deepEqual(actionClient.closedTargets, []);
+});
+
+test("closeTab fences the tab immediately and waits for its held mutation", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  let detached = false;
+  const closeTab = backend.closeTab("work", "target-1").then(() => {
+    detached = true;
+  });
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/late"),
+    /detaching/u,
+  );
+  assert.equal(detached, false);
+  assert.equal(client.navigateCount, 0);
+  client.releaseAction();
+  await action;
+  await closeTab;
+  assert.equal(client.actionCount, 1);
+  assert.deepEqual(client.closedTargets, []);
 });
 
 test("disconnect makes action outcome unknown and concurrent observation reuse dispatches once", async () => {
@@ -315,12 +530,16 @@ test("Windows browser discovery covers machine and per-user Chrome Edge and Chro
 
 class FakeUserBrowserClient implements UserBrowserCdpClient {
   actionCount = 0;
+  navigateCount = 0;
   closeCount = 0;
   readonly closedTargets: string[] = [];
   readonly calls: string[] = [];
   currentUrl = "https://example.test/account";
-  documentIdentity = "document-a";
+  documentToken = "document-a";
+  identityFailure?: Error;
   holdActions = false;
+  holdNavigations = false;
+  holdPostConfirmation = false;
   inspectionTarget = {
     selector: "#continue",
     tag: "button",
@@ -336,13 +555,47 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   };
   readonly #actionStarted = deferred<void>();
   #heldAction = deferred<void>();
+  readonly #actionSettled = deferred<void>();
+  readonly #navigationStarted = deferred<void>();
+  readonly #heldNavigation = deferred<void>();
+  readonly #postConfirmationStarted = deferred<void>();
+  readonly #heldPostConfirmation = deferred<void>();
+  readonly #postConfirmationSettled = deferred<void>();
 
   get actionStarted(): Promise<void> {
     return this.#actionStarted.promise;
   }
 
+  get actionSettled(): Promise<void> {
+    return this.#actionSettled.promise;
+  }
+
+  get navigationStarted(): Promise<void> {
+    return this.#navigationStarted.promise;
+  }
+
+  get postConfirmationStarted(): Promise<void> {
+    return this.#postConfirmationStarted.promise;
+  }
+
+  get postConfirmationSettled(): Promise<void> {
+    return this.#postConfirmationSettled.promise;
+  }
+
+  advanceDocument(reason: string): void {
+    this.documentToken = `${this.documentToken}:${reason}`;
+  }
+
   releaseAction(): void {
     this.#heldAction.resolve();
+  }
+
+  releaseNavigation(): void {
+    this.#heldNavigation.resolve();
+  }
+
+  releasePostConfirmation(): void {
+    this.#heldPostConfirmation.resolve();
   }
 
   rejectAction(error: Error): void {
@@ -351,6 +604,12 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   async listTargets() {
     this.calls.push("Target.getTargets");
+    if (this.holdPostConfirmation && this.actionCount > 0) {
+      this.#postConfirmationStarted.resolve();
+      await this.#heldPostConfirmation.promise;
+      this.#postConfirmationSettled.resolve();
+      this.holdPostConfirmation = false;
+    }
     return [
       {
         targetId: "target-1",
@@ -368,30 +627,39 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   async navigate(_targetId: string, _url: string) {
     this.calls.push("Page.navigate");
+    this.navigateCount += 1;
+    if (this.holdNavigations) {
+      this.#navigationStarted.resolve();
+      await this.#heldNavigation.promise;
+    }
+  }
+
+  async documentIdentity(): Promise<string> {
+    this.calls.push("Page.getFrameTree");
+    if (this.identityFailure !== undefined) throw this.identityFailure;
+    return this.documentToken;
   }
 
   async evaluate(
     _targetId: string,
     expression: string,
-    signal?: AbortSignal,
+    _signal?: AbortSignal,
   ): Promise<unknown> {
     this.calls.push("Runtime.evaluate");
-    if (!expression.includes("const expected")) {
+    if (!expression.includes("const expected =")) {
       return {
-        documentIdentity: this.documentIdentity,
-        inspection: {
-          visibleText: "Signed in as Alice",
-          targets: [this.inspectionTarget],
-        },
+        visibleText: "Signed in as Alice",
+        targets: [this.inspectionTarget],
       };
     }
     this.actionCount += 1;
-    if (!expression.includes(JSON.stringify(this.documentIdentity))) {
-      return { ok: false, reason: "document-changed" };
-    }
     if (this.holdActions) {
       this.#actionStarted.resolve();
-      await Promise.race([this.#heldAction.promise, abortPromise(signal)]);
+      try {
+        await this.#heldAction.promise;
+      } finally {
+        this.#actionSettled.resolve();
+      }
     }
     return { ok: true };
   }
@@ -399,20 +667,6 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   async close() {
     this.closeCount += 1;
   }
-}
-
-function abortPromise(signal?: AbortSignal): Promise<never> {
-  return new Promise((_, reject) => {
-    if (signal === undefined) return;
-    const abort = () =>
-      reject(
-        signal.reason instanceof Error
-          ? signal.reason
-          : new DOMException("cancelled", "AbortError"),
-      );
-    signal.addEventListener("abort", abort, { once: true });
-    if (signal.aborted) abort();
-  });
 }
 
 function deferred<T>() {
@@ -423,6 +677,10 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 async function listen(


### PR DESCRIPTION
## Summary

- add an explicit `user-session` browser provider selected with `ZENX_BROWSER_MODE=user-session` and an unauthenticated loopback CDP endpoint
- attach to an already-running Chrome, Edge, or Chromium 100+ session, exposing bounded visible DOM observations and opaque action targets without requesting or returning cookies, storage state, auth headers, or credentials
- keep Playwright/Electron isolated mode separate and make requested user-session failures terminal instead of falling back to a logged-out isolated browser
- detach ZenX tab/session state and close only the CDP connection, leaving the user's browser, tabs, storage, and profile intact
- label user-session versus isolated-session diagnostics in Settings and document the opt-in launch contract
- add deterministic contract coverage plus a real Windows Chrome/Edge smoke and CI job

## Validation

Passed:
- `npx tsx --test apps/zenx/test/user-browser-provider.test.ts apps/zenx/test/provider-catalog.test.ts` (9/9)
- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- `npm --workspace apps/zenx run smoke:windows-user-browser` against real Chrome 151 (authenticated state inherited in place; inspect/click succeeded; no session material projected; browser and tabs survived detach)
- `npm --workspace apps/zenx run smoke:providers` (isolated provider regression)
- Prettier check for every changed file
- `git diff --check`

Environment-blocked baseline checks:
- `npm --workspace apps/zenx run check` reaches the full suite, where 5 pre-existing POSIX-only assumptions fail on native Windows (`printf`, `/tmp` path expectations, and spawning an extensionless fixture). All new tests pass.
- `npm run check` stops in repository-wide formatting because the Windows checkout reports CRLF differences across 130 untouched files. Every changed file passes Prettier.
- `smoke:capabilities` is a macOS CI smoke and reaches the existing macOS-only computer provider failure when run on Windows; the relevant provider smoke passes.

Closes #53