### PR TITLE
fix(zenx): fence Trigger lifecycle completions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,8 @@
   新 Turn 输入投影；它不是第二份权威 transcript，canonical `user_message` 仍是唯一输入事实。
 - **ZenXTriggerAppServerPort** — ZenX Trigger 服务观察 completed Item/Turn 并发起普通
   `turn/start` 所需的最小 host-local App Server 边界；它不引入另一套 Runtime、队列或重试器。
+- **ZenXTriggerLifecycleGeneration** — ZenX Trigger 服务每段 start→stop 生命周期的单调内存 fence；
+  notification、timer、`turn/start` 与 completion callback 只有仍属于当前 generation 才能修改外层审计历史、Room 或瞬态关联状态。
 - **ZenXExternalLinkPolicy** — ZenX renderer 与 Electron 主进程共同执行的外链 allowlist；
   只有 `http:`、`https:`、`mailto:` 可交给操作系统，页内锚点留在 renderer 处理。
 - **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -190,9 +190,8 @@ app.on("before-quit", (event) => {
   if (quitting || appServerManager === undefined) return;
   event.preventDefault();
   quitting = true;
-  triggerService?.stop();
-  void appServerManager
-    .stop()
+  void Promise.resolve(triggerService?.stop())
+    .then(async () => await appServerManager!.stop())
     .then(async () => {
       selfControlPort.detach();
       await capabilityService?.close();

--- a/apps/zenx/src/main/real-smoke.ts
+++ b/apps/zenx/src/main/real-smoke.ts
@@ -486,7 +486,7 @@ void app.whenReady().then(async () => {
       durationMs: 0,
     });
   } finally {
-    triggers?.stop();
+    await triggers?.stop();
     await closeServer(webServer).catch(() => {
       cleanup = "failed";
     });

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -528,8 +528,7 @@ export class ZenXTriggerService {
           !pending.rejected &&
           pending.generation === generation &&
           pending.event.threadId === trigger.threadId &&
-          (pending.clientUserMessageId === null ||
-            pending.clientUserMessageId === clientUserMessageId)
+          pending.clientUserMessageId === clientUserMessageId
         ) {
           this.#applyCompletion(
             snapshot,
@@ -772,12 +771,16 @@ export class ZenXTriggerService {
       soleWakeup.threadId === event.threadId
         ? soleClientId
         : null;
-    const rejected =
-      clientIds.length > 1 ||
-      (clientIds.length === 1 && clientUserMessageId === null);
     const existing = this.#pendingCompletedTurns.get(event.turn.id);
     if (existing?.rejected === true) return;
-    if (rejected) {
+    if (
+      clientIds.length === 0 &&
+      existing !== undefined &&
+      existing.clientUserMessageId !== null
+    ) {
+      return;
+    }
+    if (clientIds.length !== 1 || clientUserMessageId === null) {
       this.#completedTurnItems.delete(event.turn.id);
       this.#setBounded(
         this.#pendingCompletedTurns,
@@ -793,37 +796,22 @@ export class ZenXTriggerService {
       return;
     }
     if (existing !== undefined) {
-      if (
-        existing.clientUserMessageId !== null &&
-        (clientUserMessageId === null ||
-          existing.clientUserMessageId === clientUserMessageId)
-      ) {
+      if (existing.clientUserMessageId === clientUserMessageId) {
         return;
       }
-      if (
-        existing.clientUserMessageId === null &&
-        clientUserMessageId === null
-      ) {
-        return;
-      }
-      if (
-        existing.clientUserMessageId !== null &&
-        existing.clientUserMessageId !== clientUserMessageId
-      ) {
-        this.#completedTurnItems.delete(event.turn.id);
-        this.#setBounded(
-          this.#pendingCompletedTurns,
-          event.turn.id,
-          {
-            generation,
-            event,
-            clientUserMessageId: null,
-            rejected: true,
-          },
-          (turnId) => this.#completedTurnItems.delete(turnId),
-        );
-        return;
-      }
+      this.#completedTurnItems.delete(event.turn.id);
+      this.#setBounded(
+        this.#pendingCompletedTurns,
+        event.turn.id,
+        {
+          generation,
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+        },
+        (turnId) => this.#completedTurnItems.delete(turnId),
+      );
+      return;
     }
     this.#setBounded(
       this.#pendingCompletedTurns,

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -51,6 +51,7 @@ interface PendingCompletion {
   generation: number;
   event: ServerNotificationParams["turn/completed"];
   clientUserMessageId: string | null;
+  rejected: boolean;
 }
 
 interface CompletedItemBuffer {
@@ -524,6 +525,7 @@ export class ZenXTriggerService {
         history.turnId = result.turn.id;
         if (
           pending !== undefined &&
+          !pending.rejected &&
           pending.generation === generation &&
           pending.event.threadId === trigger.threadId &&
           (pending.clientUserMessageId === null ||
@@ -748,49 +750,85 @@ export class ZenXTriggerService {
     event: ServerNotificationParams["turn/completed"],
     completedItems: readonly ThreadItem[],
   ): void {
-    const clientIds = new Set(
-      completedItems
-        .filter((item) => item.type === "userMessage")
-        .map((item) => item.clientId)
-        .filter((clientId): clientId is string => clientId !== null),
+    const sameThreadWakeups = [...this.#inFlightWakeups.values()].filter(
+      (entry) =>
+        entry.generation === generation && entry.threadId === event.threadId,
     );
-    const matchingWakeups = new Map<string, InFlightWakeup>();
-    for (const clientId of clientIds) {
-      const wakeup = this.#inFlightWakeups.get(clientId);
-      if (
-        wakeup?.generation === generation &&
-        wakeup.threadId === event.threadId
-      ) {
-        matchingWakeups.set(clientId, wakeup);
-      }
-    }
-    let clientUserMessageId: string | null = null;
-    if (matchingWakeups.size === 1) {
-      clientUserMessageId = matchingWakeups.keys().next().value ?? null;
-    } else if (matchingWakeups.size > 1 || clientIds.size > 0) {
-      this.#clearTransientTurn(event.turn.id);
-      return;
-    } else if (
-      ![...this.#inFlightWakeups.values()].some(
-        (entry) =>
-          entry.generation === generation && entry.threadId === event.threadId,
-      )
-    ) {
+    if (sameThreadWakeups.length === 0) {
       this.#clearTransientTurn(event.turn.id);
       return;
     }
+    const clientIds = completedItems
+      .filter((item) => item.type === "userMessage")
+      .map((item) => item.clientId)
+      .filter((clientId): clientId is string => clientId !== null);
+    const soleClientId = clientIds.length === 1 ? clientIds[0]! : null;
+    const soleWakeup =
+      soleClientId === null
+        ? undefined
+        : this.#inFlightWakeups.get(soleClientId);
+    const clientUserMessageId =
+      soleWakeup?.generation === generation &&
+      soleWakeup.threadId === event.threadId
+        ? soleClientId
+        : null;
+    const rejected =
+      clientIds.length > 1 ||
+      (clientIds.length === 1 && clientUserMessageId === null);
     const existing = this.#pendingCompletedTurns.get(event.turn.id);
-    if (
-      existing !== undefined &&
-      existing.clientUserMessageId !== clientUserMessageId
-    ) {
-      this.#clearTransientTurn(event.turn.id);
+    if (existing?.rejected === true) return;
+    if (rejected) {
+      this.#completedTurnItems.delete(event.turn.id);
+      this.#setBounded(
+        this.#pendingCompletedTurns,
+        event.turn.id,
+        {
+          generation,
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+        },
+        (turnId) => this.#completedTurnItems.delete(turnId),
+      );
       return;
+    }
+    if (existing !== undefined) {
+      if (
+        existing.clientUserMessageId !== null &&
+        (clientUserMessageId === null ||
+          existing.clientUserMessageId === clientUserMessageId)
+      ) {
+        return;
+      }
+      if (
+        existing.clientUserMessageId === null &&
+        clientUserMessageId === null
+      ) {
+        return;
+      }
+      if (
+        existing.clientUserMessageId !== null &&
+        existing.clientUserMessageId !== clientUserMessageId
+      ) {
+        this.#completedTurnItems.delete(event.turn.id);
+        this.#setBounded(
+          this.#pendingCompletedTurns,
+          event.turn.id,
+          {
+            generation,
+            event,
+            clientUserMessageId: null,
+            rejected: true,
+          },
+          (turnId) => this.#completedTurnItems.delete(turnId),
+        );
+        return;
+      }
     }
     this.#setBounded(
       this.#pendingCompletedTurns,
       event.turn.id,
-      { generation, event, clientUserMessageId },
+      { generation, event, clientUserMessageId, rejected: false },
       (turnId) => this.#completedTurnItems.delete(turnId),
     );
   }

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -37,19 +37,51 @@ export interface ZenXTriggerTitlePort {
   observe(threadId: string, input: string): Promise<unknown>;
 }
 
+const MAX_TRANSIENT_TURNS = 64;
+const MAX_COMPLETED_ITEMS_PER_TURN = 64;
+
+interface InFlightWakeup {
+  generation: number;
+  historyId: string;
+  threadId: string;
+  clientUserMessageId: string;
+}
+
+interface PendingCompletion {
+  generation: number;
+  event: ServerNotificationParams["turn/completed"];
+  clientUserMessageId: string | null;
+}
+
+interface CompletedItemBuffer {
+  generation: number;
+  threadId: string;
+  items: ThreadItem[];
+}
+
+class StaleTriggerGenerationError extends Error {
+  constructor() {
+    super("ZenX Trigger service lifecycle changed");
+  }
+}
+
 export class ZenXTriggerService {
   readonly #manager: ZenXTriggerAppServerPort;
   readonly #store: ZenXTriggerStore;
   readonly #titles: ZenXTriggerTitlePort | undefined;
   readonly #listeners = new Set<(snapshot: TriggerSnapshot) => void>();
   readonly #timers = new Map<string, unknown>();
-  readonly #completedAgentMessages = new Map<string, string>();
-  readonly #completedTurnItems = new Map<string, ThreadItem[]>();
+  readonly #completedTurnItems = new Map<string, CompletedItemBuffer>();
+  readonly #pendingCompletedTurns = new Map<string, PendingCompletion>();
+  readonly #inFlightWakeups = new Map<string, InFlightWakeup>();
   readonly #now: () => number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
   #snapshot: TriggerSnapshot = { triggers: [], history: [], rooms: [] };
   #mutation: Promise<void> = Promise.resolve();
+  #generation = 0;
+  #activeGeneration: number | null = null;
+  #disposeNotifications: (() => void) | undefined;
 
   constructor(
     manager: ZenXTriggerAppServerPort,
@@ -72,38 +104,76 @@ export class ZenXTriggerService {
   }
 
   async start(): Promise<void> {
-    this.#snapshot = await this.#store.read();
-    for (const entry of this.#snapshot.history) {
-      if (entry.status === "starting" || entry.status === "running") {
-        entry.status = "failed";
-        entry.completedAt = this.#now();
-        entry.error =
-          "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
-      }
-    }
-    await this.#persist();
-    this.#rescheduleTimers();
-    this.#manager.onNotification((method, params) => {
-      if (method === "item/completed") {
-        const event = params as ServerNotificationParams["item/completed"];
-        const items = this.#completedTurnItems.get(event.turnId) ?? [];
-        const next = items.filter((item) => item.id !== event.item.id);
-        next.push(event.item);
-        this.#completedTurnItems.set(event.turnId, next);
-        if (event.item.type === "agentMessage") {
-          this.#completedAgentMessages.set(event.turnId, event.item.text);
-        }
-      } else if (method === "turn/completed") {
-        void this.#handleTurnCompleted(
-          params as ServerNotificationParams["turn/completed"],
-        );
-      }
+    const generation = this.#beginGeneration();
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
     });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = await this.#store.read();
+      this.#assertGeneration(generation);
+      for (const entry of snapshot.history) {
+        if (entry.status === "starting" || entry.status === "running") {
+          entry.status = "failed";
+          entry.completedAt = this.#now();
+          entry.error =
+            "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
+        }
+      }
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      this.#rescheduleTimers(generation);
+      const listener = (
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ): void => {
+        if (!this.#isActive(generation)) return;
+        if (method === "item/completed") {
+          this.#handleItemCompleted(
+            generation,
+            params as ServerNotificationParams["item/completed"],
+          );
+        } else if (method === "turn/completed") {
+          void this.#handleTurnCompleted(
+            generation,
+            params as ServerNotificationParams["turn/completed"],
+          ).catch((error: unknown) => {
+            if (this.#isActive(generation)) {
+              console.warn(
+                `Could not process Trigger completion: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+          });
+        }
+      };
+      this.#disposeNotifications = this.#manager.onNotification(listener);
+    } catch (error) {
+      if (!(error instanceof StaleTriggerGenerationError)) throw error;
+    } finally {
+      release();
+    }
   }
 
-  stop(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async stop(): Promise<void> {
+    const drain = this.#mutation;
+    this.#activeGeneration = null;
+    this.#disposeNotifications?.();
+    this.#disposeNotifications = undefined;
+    this.#cancelTimers();
+    this.#clearTransientState();
+    await drain;
+    this.#clearTransientState();
+  }
+
+  async close(): Promise<void> {
+    await this.stop();
+    this.#listeners.clear();
   }
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
@@ -114,7 +184,8 @@ export class ZenXTriggerService {
   }
 
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const trigger = await this.#mutate(generation, async (snapshot) => {
       const common = {
         id: randomUUID(),
         threadId: required(input.threadId, "thread"),
@@ -156,19 +227,17 @@ export class ZenXTriggerService {
                   ...common,
                   signal: { name: required(input.signalName, "signal name") },
                 };
-      this.#snapshot.triggers.push(trigger);
-      return trigger;
-    }).then((trigger) => {
-      this.#rescheduleTimers();
+      snapshot.triggers.push(trigger);
       return trigger;
     });
+    this.#rescheduleTimers(generation);
+    return structuredClone(trigger);
   }
 
   async cancel(triggerId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const trigger = this.#snapshot.triggers.find(
-        (item) => item.id === triggerId,
-      );
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const trigger = snapshot.triggers.find((item) => item.id === triggerId);
       if (trigger === undefined) throw new Error("Trigger was not found");
       trigger.active = false;
       const timer = this.#timers.get(trigger.id);
@@ -178,6 +247,7 @@ export class ZenXTriggerService {
   }
 
   async signal(name: string, detail: string): Promise<void> {
+    const generation = this.#runningGeneration();
     const signalName = required(name, "signal name");
     const signalDetail = detail.trim();
     const matches = this.#snapshot.triggers.filter(
@@ -187,7 +257,7 @@ export class ZenXTriggerService {
         trigger.signal?.name === signalName,
     );
     for (const trigger of matches)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `External signal ${signalName}: ${signalDetail}`,
         occurrenceKey: `signal:${randomUUID()}`,
         projection: `Signal name: ${signalName}\nSignal detail: ${bounded(signalDetail, 4_000)}`,
@@ -195,7 +265,8 @@ export class ZenXTriggerService {
   }
 
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const room = await this.#mutate(generation, async (snapshot) => {
       const members = validateMembers(input.members);
       const room: ZenXRoom = {
         id: randomUUID(),
@@ -204,14 +275,16 @@ export class ZenXTriggerService {
         messages: [],
         createdAt: this.#now(),
       };
-      this.#snapshot.rooms.push(room);
+      snapshot.rooms.push(room);
       return room;
     });
+    return structuredClone(room);
   }
 
   async addRoomMember(roomId: string, member: RoomMember): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -220,8 +293,9 @@ export class ZenXTriggerService {
   }
 
   async removeRoomMember(roomId: string, threadId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -241,20 +315,25 @@ export class ZenXTriggerService {
     author: string,
     text: string,
   ): Promise<void> {
-    const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
-    if (room === undefined) throw new Error("Room was not found");
-    const posted = message(
-      room.id,
-      required(author, "author"),
-      required(text, "message"),
-      "human",
-      null,
-      null,
-      this.#now(),
+    const generation = this.#runningGeneration();
+    const { posted, room } = await this.#mutate(
+      generation,
+      async (snapshot) => {
+        const room = snapshot.rooms.find((entry) => entry.id === roomId);
+        if (room === undefined) throw new Error("Room was not found");
+        const posted = message(
+          room.id,
+          required(author, "author"),
+          required(text, "message"),
+          "human",
+          null,
+          null,
+          this.#now(),
+        );
+        room.messages.push(posted);
+        return { posted, room: structuredClone(room) };
+      },
     );
-    await this.#mutate(async () => {
-      room.messages.push(posted);
-    });
     const mentions = room.members.filter((member) =>
       new RegExp(
         `(^|\\s)@${escapeRegExp(member.name)}(?=\\s|$|[,.!?])`,
@@ -272,7 +351,7 @@ export class ZenXTriggerService {
             member.name.toLocaleLowerCase(),
       );
       for (const trigger of matches)
-        await this.#fire(trigger.id, {
+        await this.#fire(generation, trigger.id, {
           reason: `Room #${room.name} mention from ${posted.author}: ${posted.text}`,
           occurrenceKey: `room:${room.id}:${posted.id}`,
           sourceRoomId: room.id,
@@ -283,53 +362,34 @@ export class ZenXTriggerService {
   }
 
   async #handleTurnCompleted(
+    generation: number,
     event: ServerNotificationParams["turn/completed"],
   ): Promise<void> {
+    if (!this.#isActive(generation)) return;
     const completedItems = mergeCompletedItems(
       event.turn.items,
-      this.#completedTurnItems.get(event.turn.id) ?? [],
+      this.#completedTurnItems.get(event.turn.id)?.items ?? [],
     );
-    await this.#mutate(async () => {
-      const entry = this.#snapshot.history.find(
-        (item) => item.turnId === event.turn.id && item.status === "running",
-      );
-      if (entry !== undefined) {
-        entry.status =
-          event.turn.status === "completed" ? "completed" : "failed";
-        entry.completedAt = this.#now();
-        entry.error = event.turn.error?.message ?? null;
-        const trigger = this.#snapshot.triggers.find(
-          (item) => item.id === entry.triggerId,
+    const running = this.#snapshot.history.find(
+      (item) => item.turnId === event.turn.id && item.status === "running",
+    );
+    if (running !== undefined) {
+      await this.#mutateMaybe(generation, async (snapshot) => {
+        const current = snapshot.history.find(
+          (entry) =>
+            entry.id === running.id &&
+            entry.turnId === event.turn.id &&
+            entry.status === "running",
         );
-        if (trigger?.kind === "roomMention" && trigger.room !== undefined) {
-          const room = this.#snapshot.rooms.find(
-            (item) => item.id === trigger.room?.roomId,
-          );
-          const projectedAnswer = [...completedItems]
-            .reverse()
-            .find((item) => item.type === "agentMessage");
-          const answer =
-            projectedAnswer?.type === "agentMessage"
-              ? projectedAnswer.text
-              : (this.#completedAgentMessages.get(event.turn.id) ?? "");
-          if (room !== undefined && answer.length > 0) {
-            room.messages.push(
-              message(
-                room.id,
-                trigger.room.mention,
-                answer,
-                "agent",
-                entry.threadId,
-                event.turn.id,
-                this.#now(),
-              ),
-            );
-          }
-        }
-      }
-    });
-    this.#completedAgentMessages.delete(event.turn.id);
-    this.#completedTurnItems.delete(event.turn.id);
+        if (current === undefined) return undefined;
+        this.#applyCompletion(snapshot, running.id, event, completedItems);
+        return true;
+      });
+      this.#clearTransientTurn(event.turn.id);
+    } else {
+      this.#bufferEarlyCompletion(generation, event, completedItems);
+    }
+    if (!this.#isActive(generation)) return;
     const watchers = this.#snapshot.triggers.filter(
       (trigger) =>
         trigger.active &&
@@ -337,7 +397,7 @@ export class ZenXTriggerService {
         trigger.watch?.threadId === event.threadId,
     );
     for (const trigger of watchers)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `Thread ${event.threadId} emitted turn_completed for ${event.turn.id}`,
         occurrenceKey: `thread:${event.threadId}:${event.turn.id}`,
         sourceThreadId: event.threadId,
@@ -350,6 +410,7 @@ export class ZenXTriggerService {
   }
 
   async #fire(
+    generation: number,
     triggerId: string,
     wakeup: {
       reason: string;
@@ -362,50 +423,63 @@ export class ZenXTriggerService {
       scheduledAt?: number;
     },
   ): Promise<void> {
-    const trigger = this.#snapshot.triggers.find(
-      (item) => item.id === triggerId && item.active,
-    );
-    if (trigger === undefined) return;
-    const clientUserMessageId = stableWakeupId(
-      trigger.id,
-      wakeup.occurrenceKey,
-    );
-    if (
-      this.#snapshot.history.some(
-        (entry) => entry.clientUserMessageId === clientUserMessageId,
-      )
-    )
-      return;
-    const history: TriggerHistoryEntry = {
-      id: randomUUID(),
-      triggerId: trigger.id,
-      threadId: trigger.threadId,
-      kind: trigger.kind,
-      reason: wakeup.reason,
-      prompt: trigger.prompt,
-      clientUserMessageId,
-      startedAt: this.#now(),
-      completedAt: null,
-      status: "starting",
-      turnId: null,
-      error: null,
-      sourceThreadId: wakeup.sourceThreadId ?? null,
-      sourceTurnId: wakeup.sourceTurnId ?? null,
-      sourceRoomId: wakeup.sourceRoomId ?? null,
-      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-    };
-    await this.#mutate(async () => {
-      this.#snapshot.history.unshift(history);
-      if (trigger.timer !== undefined) {
-        if (trigger.timer.intervalMinutes === null) trigger.active = false;
-        else
-          trigger.timer.nextRunAt =
-            Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-            trigger.timer.intervalMinutes * 60_000;
-      }
-    });
-    this.#rescheduleTimers();
+    let activeWakeup: InFlightWakeup | undefined;
     try {
+      const committed = await this.#mutateMaybe(
+        generation,
+        async (snapshot) => {
+          const trigger = snapshot.triggers.find(
+            (item) => item.id === triggerId && item.active,
+          );
+          if (trigger === undefined) return undefined;
+          const clientUserMessageId = stableWakeupId(
+            trigger.id,
+            wakeup.occurrenceKey,
+          );
+          if (
+            snapshot.history.some(
+              (entry) => entry.clientUserMessageId === clientUserMessageId,
+            )
+          )
+            return undefined;
+          const history: TriggerHistoryEntry = {
+            id: randomUUID(),
+            triggerId: trigger.id,
+            threadId: trigger.threadId,
+            kind: trigger.kind,
+            reason: wakeup.reason,
+            prompt: trigger.prompt,
+            clientUserMessageId,
+            startedAt: this.#now(),
+            completedAt: null,
+            status: "starting",
+            turnId: null,
+            error: null,
+            sourceThreadId: wakeup.sourceThreadId ?? null,
+            sourceTurnId: wakeup.sourceTurnId ?? null,
+            sourceRoomId: wakeup.sourceRoomId ?? null,
+            sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+            replyRoomId: trigger.room?.roomId ?? null,
+            replyAuthor: trigger.room?.mention ?? null,
+          };
+          snapshot.history.unshift(history);
+          if (trigger.timer !== undefined) {
+            if (trigger.timer.intervalMinutes === null) trigger.active = false;
+            else
+              trigger.timer.nextRunAt =
+                Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
+                trigger.timer.intervalMinutes * 60_000;
+          }
+          return {
+            trigger: structuredClone(trigger),
+            historyId: history.id,
+            clientUserMessageId,
+          };
+        },
+      );
+      if (committed === undefined) return;
+      const { trigger, historyId, clientUserMessageId } = committed;
+      this.#rescheduleTimers(generation);
       await this.#titles
         ?.observe(
           trigger.threadId,
@@ -416,50 +490,108 @@ export class ZenXTriggerService {
             `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
           ),
         );
+      if (!this.#isActive(generation)) return;
+      activeWakeup = {
+        generation,
+        historyId,
+        threadId: trigger.threadId,
+        clientUserMessageId,
+      };
+      this.#inFlightWakeups.set(clientUserMessageId, activeWakeup);
       const result = await this.#manager.request("turn/start", {
         threadId: trigger.threadId,
         clientUserMessageId,
         input: [
           {
             type: "text",
-            text: wakeupInput(trigger, history, wakeup.projection),
+            text: wakeupInput(
+              trigger,
+              this.#history(historyId),
+              wakeup.projection,
+            ),
           },
         ],
       });
-      await this.#mutate(async () => {
+      if (!this.#isActive(generation)) return;
+      const pending = this.#pendingCompletedTurns.get(result.turn.id);
+      const bufferedItems = this.#completedTurnItems.get(result.turn.id)?.items;
+      await this.#mutate(generation, async (snapshot) => {
+        const history = snapshot.history.find(
+          (entry) => entry.id === historyId,
+        );
+        if (history === undefined || history.status !== "starting") return;
         history.status = "running";
         history.turnId = result.turn.id;
+        if (
+          pending !== undefined &&
+          pending.generation === generation &&
+          pending.event.threadId === trigger.threadId &&
+          (pending.clientUserMessageId === null ||
+            pending.clientUserMessageId === clientUserMessageId)
+        ) {
+          this.#applyCompletion(
+            snapshot,
+            historyId,
+            pending.event,
+            mergeCompletedItems(pending.event.turn.items, bufferedItems ?? []),
+          );
+        }
       });
+      if (pending !== undefined) this.#clearTransientTurn(result.turn.id);
     } catch (error) {
-      await this.#mutate(async () => {
-        history.status = "failed";
-        history.completedAt = this.#now();
-        history.error = error instanceof Error ? error.message : String(error);
-      });
+      if (error instanceof StaleTriggerGenerationError) return;
+      if (activeWakeup === undefined) throw error;
+      if (this.#isActive(generation)) {
+        const failedWakeup = activeWakeup;
+        await this.#mutate(generation, async (snapshot) => {
+          const history = snapshot.history.find(
+            (entry) => entry.id === failedWakeup.historyId,
+          );
+          if (history === undefined || history.status !== "starting") return;
+          history.status = "failed";
+          history.completedAt = this.#now();
+          history.error =
+            error instanceof Error ? error.message : String(error);
+        });
+      }
+    } finally {
+      if (
+        activeWakeup !== undefined &&
+        this.#inFlightWakeups.get(activeWakeup.clientUserMessageId) ===
+          activeWakeup
+      ) {
+        this.#inFlightWakeups.delete(activeWakeup.clientUserMessageId);
+      }
+      this.#evictUnmatchablePending(generation);
     }
   }
 
-  #rescheduleTimers(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  #rescheduleTimers(generation: number): void {
+    if (!this.#isActive(generation)) return;
+    this.#cancelTimers();
     for (const trigger of this.#snapshot.triggers) {
       if (!trigger.active || trigger.timer === undefined) continue;
-      this.#scheduleTimer(trigger.id, trigger.timer.nextRunAt);
+      this.#scheduleTimer(generation, trigger.id, trigger.timer.nextRunAt);
     }
   }
 
-  #scheduleTimer(triggerId: string, scheduledAt: number): void {
+  #scheduleTimer(
+    generation: number,
+    triggerId: string,
+    scheduledAt: number,
+  ): void {
     const delay = Math.max(
       0,
       Math.min(2_147_000_000, scheduledAt - this.#now()),
     );
     const timer = this.#schedule(() => {
+      if (!this.#isActive(generation)) return;
       this.#timers.delete(triggerId);
       if (this.#now() < scheduledAt) {
-        this.#scheduleTimer(triggerId, scheduledAt);
+        this.#scheduleTimer(generation, triggerId, scheduledAt);
         return;
       }
-      void this.#fire(triggerId, {
+      void this.#fire(generation, triggerId, {
         reason: `Timer reached ${new Date(scheduledAt).toISOString()}`,
         occurrenceKey: `timer:${scheduledAt}`,
         scheduledAt,
@@ -468,29 +600,285 @@ export class ZenXTriggerService {
     this.#timers.set(triggerId, timer);
   }
 
-  async #mutate<T>(operation: () => Promise<T>): Promise<T> {
+  async #mutate<T>(
+    generation: number,
+    operation: (snapshot: TriggerSnapshot) => Promise<T>,
+  ): Promise<T> {
+    this.#assertGeneration(generation);
     const previous = this.#mutation;
     let release!: () => void;
     this.#mutation = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
-    const previousSnapshot = structuredClone(this.#snapshot);
     try {
-      const result = await operation();
-      await this.#persist();
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
       return result;
-    } catch (error) {
-      this.#snapshot = previousSnapshot;
-      throw error;
     } finally {
       release();
     }
   }
 
-  async #persist(): Promise<void> {
-    await this.#store.write(this.#snapshot);
+  async #mutateMaybe<T>(
+    generation: number,
+    operation: (snapshot: TriggerSnapshot) => Promise<T | undefined>,
+  ): Promise<T | undefined> {
+    this.#assertGeneration(generation);
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      if (result === undefined) return undefined;
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      return result;
+    } finally {
+      release();
+    }
+  }
+
+  #notifyListeners(): void {
     for (const listener of this.#listeners) listener(this.snapshot());
+  }
+
+  #beginGeneration(): number {
+    const generation = ++this.#generation;
+    this.#activeGeneration = generation;
+    this.#disposeNotifications?.();
+    this.#disposeNotifications = undefined;
+    this.#cancelTimers();
+    this.#clearTransientState();
+    return generation;
+  }
+
+  #runningGeneration(): number {
+    if (this.#activeGeneration === null)
+      throw new Error("ZenX Trigger service is not running");
+    return this.#activeGeneration;
+  }
+
+  #isActive(generation: number): boolean {
+    return this.#activeGeneration === generation;
+  }
+
+  #assertGeneration(generation: number): void {
+    if (!this.#isActive(generation)) throw new StaleTriggerGenerationError();
+  }
+
+  #cancelTimers(): void {
+    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
+    this.#timers.clear();
+  }
+
+  #clearTransientState(): void {
+    this.#completedTurnItems.clear();
+    this.#pendingCompletedTurns.clear();
+    this.#inFlightWakeups.clear();
+  }
+
+  #clearTransientTurn(turnId: string): void {
+    this.#completedTurnItems.delete(turnId);
+    this.#pendingCompletedTurns.delete(turnId);
+  }
+
+  #handleItemCompleted(
+    generation: number,
+    event: ServerNotificationParams["item/completed"],
+  ): void {
+    if (!this.#isPotentialWakeupTurn(generation, event.threadId, event.turnId))
+      return;
+    const current = this.#completedTurnItems.get(event.turnId);
+    const items = (current?.items ?? []).filter(
+      (item) => item.id !== event.item.id,
+    );
+    items.push(event.item);
+    this.#setBounded(
+      this.#completedTurnItems,
+      event.turnId,
+      {
+        generation,
+        threadId: event.threadId,
+        items: items.slice(-MAX_COMPLETED_ITEMS_PER_TURN),
+      },
+      (turnId) => this.#pendingCompletedTurns.delete(turnId),
+    );
+  }
+
+  #isPotentialWakeupTurn(
+    generation: number,
+    threadId: string,
+    turnId: string,
+  ): boolean {
+    return (
+      this.#snapshot.history.some(
+        (entry) => entry.turnId === turnId && entry.status === "running",
+      ) ||
+      this.#pendingCompletedTurns.has(turnId) ||
+      this.#snapshot.triggers.some(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "thread" &&
+          trigger.watch?.threadId === threadId,
+      ) ||
+      [...this.#inFlightWakeups.values()].some(
+        (entry) =>
+          entry.generation === generation && entry.threadId === threadId,
+      )
+    );
+  }
+
+  #bufferEarlyCompletion(
+    generation: number,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const clientIds = new Set(
+      completedItems
+        .filter((item) => item.type === "userMessage")
+        .map((item) => item.clientId)
+        .filter((clientId): clientId is string => clientId !== null),
+    );
+    const matchingWakeups = new Map<string, InFlightWakeup>();
+    for (const clientId of clientIds) {
+      const wakeup = this.#inFlightWakeups.get(clientId);
+      if (
+        wakeup?.generation === generation &&
+        wakeup.threadId === event.threadId
+      ) {
+        matchingWakeups.set(clientId, wakeup);
+      }
+    }
+    let clientUserMessageId: string | null = null;
+    if (matchingWakeups.size === 1) {
+      clientUserMessageId = matchingWakeups.keys().next().value ?? null;
+    } else if (matchingWakeups.size > 1 || clientIds.size > 0) {
+      this.#clearTransientTurn(event.turn.id);
+      return;
+    } else if (
+      ![...this.#inFlightWakeups.values()].some(
+        (entry) =>
+          entry.generation === generation && entry.threadId === event.threadId,
+      )
+    ) {
+      this.#clearTransientTurn(event.turn.id);
+      return;
+    }
+    const existing = this.#pendingCompletedTurns.get(event.turn.id);
+    if (
+      existing !== undefined &&
+      existing.clientUserMessageId !== clientUserMessageId
+    ) {
+      this.#clearTransientTurn(event.turn.id);
+      return;
+    }
+    this.#setBounded(
+      this.#pendingCompletedTurns,
+      event.turn.id,
+      { generation, event, clientUserMessageId },
+      (turnId) => this.#completedTurnItems.delete(turnId),
+    );
+  }
+
+  #applyCompletion(
+    snapshot: TriggerSnapshot,
+    historyId: string,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const entry = snapshot.history.find((item) => item.id === historyId);
+    if (
+      entry === undefined ||
+      (entry.status !== "running" && entry.status !== "starting")
+    )
+      return;
+    entry.status = event.turn.status === "completed" ? "completed" : "failed";
+    entry.completedAt = this.#now();
+    entry.error = event.turn.error?.message ?? null;
+    if (entry.replyRoomId === null || entry.replyAuthor === null) return;
+    const room = snapshot.rooms.find((item) => item.id === entry.replyRoomId);
+    const answer = [...completedItems]
+      .reverse()
+      .find((item) => item.type === "agentMessage");
+    if (
+      room !== undefined &&
+      answer?.type === "agentMessage" &&
+      answer.text.length > 0
+    ) {
+      room.messages.push(
+        message(
+          room.id,
+          entry.replyAuthor,
+          answer.text,
+          "agent",
+          entry.threadId,
+          event.turn.id,
+          this.#now(),
+        ),
+      );
+    }
+  }
+
+  #history(historyId: string): TriggerHistoryEntry {
+    const history = this.#snapshot.history.find(
+      (entry) => entry.id === historyId,
+    );
+    if (history === undefined) throw new StaleTriggerGenerationError();
+    return history;
+  }
+
+  #evictUnmatchablePending(generation: number): void {
+    const activeClientIds = new Set(
+      [...this.#inFlightWakeups.values()]
+        .filter((entry) => entry.generation === generation)
+        .map((entry) => entry.clientUserMessageId),
+    );
+    const activeThreads = new Set(
+      [...this.#inFlightWakeups.values()]
+        .filter((entry) => entry.generation === generation)
+        .map((entry) => entry.threadId),
+    );
+    for (const [turnId, pending] of this.#pendingCompletedTurns) {
+      if (
+        pending.generation !== generation ||
+        (pending.clientUserMessageId === null
+          ? !activeThreads.has(pending.event.threadId)
+          : !activeClientIds.has(pending.clientUserMessageId))
+      ) {
+        this.#clearTransientTurn(turnId);
+      }
+    }
+  }
+
+  #setBounded<K, V>(
+    map: Map<K, V>,
+    key: K,
+    value: V,
+    onEvict: (key: K) => void,
+  ): void {
+    map.delete(key);
+    map.set(key, value);
+    while (map.size > MAX_TRANSIENT_TURNS) {
+      const oldest = map.keys().next().value as K | undefined;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+      onEvict(oldest);
+    }
   }
 }
 

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -11,7 +11,12 @@ import type {
 } from "./trigger-types.js";
 
 interface StoredState extends TriggerSnapshot {
+  version: 3;
+}
+
+interface Version2StoredState extends Omit<TriggerSnapshot, "history"> {
   version: 2;
+  history: Array<Omit<TriggerHistoryEntry, "replyRoomId" | "replyAuthor">>;
 }
 
 interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
@@ -19,7 +24,12 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
   history: Array<
     Omit<
       TriggerHistoryEntry,
-      "sourceThreadId" | "sourceTurnId" | "sourceRoomId" | "sourceRoomMessageId"
+      | "sourceThreadId"
+      | "sourceTurnId"
+      | "sourceRoomId"
+      | "sourceRoomMessageId"
+      | "replyRoomId"
+      | "replyAuthor"
     >
   >;
 }
@@ -42,6 +52,17 @@ export class ZenXTriggerStore {
     try {
       const value = JSON.parse(await handle.readFile("utf8")) as unknown;
       if (isStoredState(value)) return snapshotFrom(value);
+      if (isVersion2StoredState(value)) {
+        return {
+          triggers: value.triggers,
+          history: value.history.map((entry) => ({
+            ...entry,
+            replyRoomId: null,
+            replyAuthor: null,
+          })),
+          rooms: value.rooms,
+        };
+      }
       if (isLegacyStoredState(value)) {
         return {
           triggers: value.triggers,
@@ -51,6 +72,8 @@ export class ZenXTriggerStore {
             sourceTurnId: null,
             sourceRoomId: null,
             sourceRoomMessageId: null,
+            replyRoomId: null,
+            replyAuthor: null,
           })),
           rooms: value.rooms,
         };
@@ -71,7 +94,7 @@ export class ZenXTriggerStore {
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    const value: StoredState = { version: 2, ...snapshot };
+    const value: StoredState = { version: 3, ...snapshot };
     if (!isStoredState(value))
       throw new Error("ZenX refused to persist an invalid trigger registry");
     await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
@@ -98,9 +121,20 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
-    state["version"] === 2 &&
+    state["version"] === 3 &&
     arrayOf(state["triggers"], isTrigger) &&
     arrayOf(state["history"], isHistory) &&
+    arrayOf(state["rooms"], isRoom)
+  );
+}
+
+function isVersion2StoredState(value: unknown): value is Version2StoredState {
+  const state = record(value);
+  return (
+    state !== null &&
+    state["version"] === 2 &&
+    arrayOf(state["triggers"], isTrigger) &&
+    arrayOf(state["history"], isVersion2History) &&
     arrayOf(state["rooms"], isRoom)
   );
 }
@@ -156,6 +190,18 @@ function isTrigger(value: unknown): value is ZenXTrigger {
 }
 
 function isHistory(value: unknown): value is TriggerHistoryEntry {
+  const entry = record(value);
+  return (
+    isVersion2History(value) &&
+    entry !== null &&
+    nullableString(entry["replyRoomId"]) &&
+    nullableString(entry["replyAuthor"])
+  );
+}
+
+function isVersion2History(
+  value: unknown,
+): value is Version2StoredState["history"][number] {
   const entry = record(value);
   return (
     isLegacyHistory(value) &&

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -31,6 +31,8 @@ export interface TriggerHistoryEntry {
   sourceTurnId: string | null;
   sourceRoomId: string | null;
   sourceRoomMessageId: string | null;
+  replyRoomId: string | null;
+  replyAuthor: string | null;
 }
 
 export interface RoomMember {

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -292,6 +292,137 @@ test("early completion rejects duplicate canonical occurrences of one client ID"
   }
 });
 
+test("early completion rejects zero non-null canonical identity for one wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn("turn-no-identity", "missing identity"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "turn-no-identity",
+        "late exact evidence",
+        [],
+        starting.history[0]!.clientUserMessageId,
+      ),
+    );
+    response.resolve(startResult("turn-no-identity"));
+    await firing;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(snapshot.history[0]?.turnId, "turn-no-identity");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects zero identity with concurrent same-thread wakeups", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-concurrent-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "shared-thread" }],
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-no-identity", "ambiguous identity"),
+    );
+    const [firstEntry, secondEntry] = starting.history;
+    responses
+      .get(firstEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-no-identity"));
+    responses
+      .get(secondEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-other"));
+    await Promise.all([first, second]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.filter((entry) => entry.status === "running").length,
+      2,
+    );
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("late unidentifiable duplicate preserves an exact concurrent same-thread candidate", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-late-unidentified-"),

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -20,6 +20,247 @@ import type {
   Turn,
 } from "../src/protocol-client/index.js";
 
+test("stop unsubscribes and fences stale callbacks and in-flight start responses", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-stop-fence-"));
+  const manager = new ControlledManager();
+  const startResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await startResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    const writesBeforeStop = store.writes;
+
+    await triggers.stop();
+    assert.equal(manager.activeListeners, 0);
+    assert.equal(manager.disposeCount, 1);
+    manager.completeStale(
+      "thread-target",
+      completedTurn("turn-after-stop", "late", [], wakeup.clientUserMessageId),
+    );
+    startResponse.resolve(startResult("turn-after-stop"));
+    await firing;
+    await settle();
+
+    assert.equal(store.writes, writesBeforeStop);
+    assert.equal(triggers.snapshot().history[0]?.status, "starting");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a stale generation cannot overwrite state loaded by a restarted service", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-restart-fence-"),
+  );
+  const manager = new ControlledManager();
+  const firstResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await firstResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await triggers.stop();
+    await triggers.start();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    const writesAfterRestart = store.writes;
+
+    firstResponse.resolve(startResult("stale-turn"));
+    await firing;
+    manager.completeStale("thread-target", completedTurn("stale-turn", "late"));
+    await settle();
+
+    assert.equal(store.writes, writesAfterRestart);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(triggers.snapshot().history[0]?.turnId, null);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion uses canonical client identity and replies to the captured Room once", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-early-exact-"));
+  const manager = new ControlledManager();
+  manager.requestHandler = async (params) => {
+    manager.complete(
+      params.threadId,
+      completedTurn(
+        "early-turn",
+        "room wakeup",
+        [],
+        params.clientUserMessageId ?? null,
+      ),
+    );
+    return startResult("early-turn");
+  };
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+
+    assert.equal(terminal.history[0]?.turnId, "early-turn");
+    assert.equal(
+      terminal.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    const writesBeforeDuplicate = store.writes;
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "early-turn",
+        "duplicate",
+        [],
+        terminal.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await settle();
+    assert.equal(store.writes, writesBeforeDuplicate);
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("concurrent same-thread starts correlate only by exact completion evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-concurrent-correlation-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "beta", [], betaEntry.clientUserMessageId),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const correlated = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.find((entry) => entry.id === betaEntry.id)?.status ===
+        "completed",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === betaEntry.id)?.turnId,
+      "turn-beta",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-alpha", "alpha", [], alphaEntry.clientUserMessageId),
+    );
+    await snapshotWhen(triggers, (snapshot) =>
+      snapshot.history.every((entry) => entry.status === "completed"),
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("timer expiry creates one explicit App Server turn and auditable history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-"));
   const manager = managerFor(directory);
@@ -388,6 +629,128 @@ test("failed relay is terminal and is not hidden, queued, or retried", async () 
   }
 });
 
+test("failed start evicts early candidates and ignores late unrelated completion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-failed-start-cleanup-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "candidate-turn",
+        "candidate",
+        [],
+        starting.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    response.reject(new Error("App Server connection closed"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(
+      triggers.snapshot().history[0]?.error,
+      "App Server connection closed",
+    );
+
+    manager.complete(
+      "unrelated-thread",
+      completedTurn("candidate-turn", "late duplicate"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("unknown-turn", "unrelated"),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    await triggers.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ambiguous early completions are bounded and require the returned turn id", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-early-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    for (let index = 0; index < 65; index += 1) {
+      manager.completeItem("thread-target", `ambiguous-${String(index)}`, {
+        type: "agentMessage",
+        id: `agent-${String(index)}`,
+        text: `candidate ${String(index)}`,
+        phase: "final_answer",
+        memoryCitation: null,
+      });
+      manager.complete(
+        "thread-target",
+        completedTurn(`ambiguous-${String(index)}`, "no client identity"),
+      );
+    }
+    await settle();
+    response.resolve(startResult("ambiguous-0"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "ambiguous-0",
+        "exact late completion",
+        [],
+        triggers.snapshot().history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+  } finally {
+    await triggers.close();
+    assert.equal(manager.activeListeners, 0);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("long timers reschedule at the clamp boundary instead of firing early", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-long-timer-"));
   const manager = new ControlledManager();
@@ -470,12 +833,28 @@ test("completed Turn projection is bounded and includes commands/results", () =>
 class ControlledManager implements ZenXTriggerAppServerPort {
   readonly requests: ClientRequestParams["turn/start"][] = [];
   requestError: Error | null = null;
-  #listener:
+  requestHandler:
+    | ((
+        params: ClientRequestParams["turn/start"],
+      ) => Promise<ClientRequestResults["turn/start"]>)
+    | undefined;
+  disposeCount = 0;
+  readonly #listeners = new Set<
+    (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void
+  >();
+  #lastListener:
     | ((
         method: ServerNotificationMethod,
         params: ServerNotificationParams[ServerNotificationMethod],
       ) => void)
     | undefined;
+
+  get activeListeners(): number {
+    return this.#listeners.size;
+  }
 
   async request(
     _method: "turn/start",
@@ -483,18 +862,9 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   ): Promise<ClientRequestResults["turn/start"]> {
     this.requests.push(params);
     if (this.requestError !== null) throw this.requestError;
-    return {
-      turn: {
-        id: `wakeup-turn-${this.requests.length}`,
-        items: [],
-        itemsView: "full",
-        status: "inProgress",
-        error: null,
-        startedAt: Date.now(),
-        completedAt: null,
-        durationMs: null,
-      },
-    };
+    return this.requestHandler === undefined
+      ? startResult(`wakeup-turn-${this.requests.length}`)
+      : await this.requestHandler(params);
   }
 
   onNotification(
@@ -503,21 +873,63 @@ class ControlledManager implements ZenXTriggerAppServerPort {
       params: ServerNotificationParams[ServerNotificationMethod],
     ) => void,
   ): () => void {
-    this.#listener = listener;
+    this.#listeners.add(listener);
+    this.#lastListener = listener;
     return () => {
-      if (this.#listener === listener) this.#listener = undefined;
+      if (this.#listeners.delete(listener)) this.disposeCount += 1;
     };
   }
 
   complete(threadId: string, turn: Turn): void {
-    this.#listener?.("turn/completed", { threadId, turn });
+    for (const listener of this.#listeners) {
+      listener("turn/completed", { threadId, turn });
+    }
   }
+
+  completeItem(threadId: string, turnId: string, item: ThreadItem): void {
+    for (const listener of this.#listeners) {
+      listener("item/completed", {
+        threadId,
+        turnId,
+        item,
+        completedAtMs: Date.now(),
+      });
+    }
+  }
+
+  completeStale(threadId: string, turn: Turn): void {
+    this.#lastListener?.("turn/completed", { threadId, turn });
+  }
+}
+
+class CountingTriggerStore extends ZenXTriggerStore {
+  writes = 0;
+  override async write(snapshot: Parameters<ZenXTriggerStore["write"]>[0]) {
+    this.writes += 1;
+    await super.write(snapshot);
+  }
+}
+
+function startResult(id: string): ClientRequestResults["turn/start"] {
+  return {
+    turn: {
+      id,
+      items: [],
+      itemsView: "full",
+      status: "inProgress",
+      error: null,
+      startedAt: Date.now(),
+      completedAt: null,
+      durationMs: null,
+    },
+  };
 }
 
 function completedTurn(
   id: string,
   userText: string,
   extra: ThreadItem[] = [],
+  clientId: string | null = null,
 ): Turn {
   return {
     id,
@@ -525,7 +937,7 @@ function completedTurn(
       {
         type: "userMessage",
         id: `${id}-user`,
-        clientId: null,
+        clientId,
         content: [{ type: "text", text: userText, text_elements: [] }],
       },
       ...extra,
@@ -546,6 +958,16 @@ function completedTurn(
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function userInputForClientId(
   turns: readonly Turn[],
   clientId: string | null | undefined,
@@ -564,6 +986,15 @@ function userInputForClientId(
 
 async function settle(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 20));
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await settle();
+  }
 }
 
 function managerFor(directory: string): AppServerManager {
@@ -593,7 +1024,11 @@ async function snapshotWhen(
     (resolve, reject) => {
       const timeout = setTimeout(() => {
         dispose();
-        reject(new Error("Timed out waiting for trigger"));
+        reject(
+          new Error(
+            `Timed out waiting for trigger: ${JSON.stringify(service.snapshot())}`,
+          ),
+        );
       }, 10_000);
       const dispose = service.onChange((snapshot) => {
         if (predicate(snapshot)) {

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -173,6 +173,205 @@ test("early completion uses canonical client identity and replies to the capture
   }
 });
 
+test("early completion rejects matching plus unrelated canonical client IDs", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-contradictory-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "contradictory-turn",
+        "matching",
+        [canonicalUserMessage("unrelated-user", "unrelated-client")],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("contradictory-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("contradictory-turn", "exact late", [], clientId),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects duplicate canonical occurrences of one client ID", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-duplicate-evidence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "duplicate-evidence-turn",
+        "matching",
+        [canonicalUserMessage("duplicate-user", clientId)],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("duplicate-evidence-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("late unidentifiable duplicate preserves an exact concurrent same-thread candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-late-unidentified-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "exact", [], betaEntry.clientUserMessageId),
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "late without identity"),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === betaEntry.id)?.status,
+      "completed",
+    );
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("concurrent same-thread starts correlate only by exact completion evidence", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-concurrent-correlation-"),
@@ -955,6 +1154,15 @@ function completedTurn(
     startedAt: 1,
     completedAt: 2,
     durationMs: 1,
+  };
+}
+
+function canonicalUserMessage(id: string, clientId: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id,
+    clientId,
+    content: [{ type: "text", text: id, text_elements: [] }],
   };
 }
 

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -53,6 +53,8 @@ test("migrates fully validated version 1 history to nullable source metadata", a
       sourceTurnId: _sourceTurnId,
       sourceRoomId: _sourceRoomId,
       sourceRoomMessageId: _sourceRoomMessageId,
+      replyRoomId: _replyRoomId,
+      replyAuthor: _replyAuthor,
       ...entry
     }) => entry,
   );
@@ -66,16 +68,39 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     const migrated = await store.read();
     assert.equal(migrated.history[0]?.sourceThreadId, null);
     assert.equal(migrated.history[0]?.sourceTurnId, null);
+    assert.equal(migrated.history[0]?.replyRoomId, null);
     await store.write(migrated);
-    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 2);
+    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 3);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
 
-function validState(): TriggerSnapshot & { version: 2 } {
+test("migrates version 2 history to nullable immutable reply routing", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-store-v2-"));
+  const file = path.join(directory, "triggers.json");
+  const state = validState();
+  const history = state.history.map(
+    ({ replyRoomId: _replyRoomId, replyAuthor: _replyAuthor, ...entry }) =>
+      entry,
+  );
+  try {
+    await writeFile(
+      file,
+      JSON.stringify({ ...state, version: 2, history }),
+      "utf8",
+    );
+    const migrated = await new ZenXTriggerStore(file).read();
+    assert.equal(migrated.history[0]?.replyRoomId, null);
+    assert.equal(migrated.history[0]?.replyAuthor, null);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function validState(): TriggerSnapshot & { version: 3 } {
   return {
-    version: 2,
+    version: 3,
     triggers: [
       {
         id: "trigger-a",
@@ -106,6 +131,8 @@ function validState(): TriggerSnapshot & { version: 2 } {
         sourceTurnId: "turn-b",
         sourceRoomId: null,
         sourceRoomMessageId: null,
+        replyRoomId: null,
+        replyAuthor: null,
       },
     ],
     rooms: [


### PR DESCRIPTION
## Motivation

PR #49 exhausted its review loop with unresolved Trigger lifecycle-generation and completion-correlation blockers. This is the scoped architectural successor for #58; PR #49 remains draft/unmerged and its Agent Trigger/Room CRUD slice is not included.

## What changed

- Add the documented in-memory `ZenXTriggerLifecycleGeneration` fence for each `start → stop` interval.
- Retain and invoke App Server notification disposers; make `stop()` await the current mutation boundary and clear timers plus all transient correlation buffers.
- Fence notification handlers, timers, `turn/start` responses, completion callbacks, persisted Trigger history, Room replies, and transient state by the active generation.
- Correlate early completions only after the exact returned turn id matches; validate canonical `userMessage.clientId` against the in-flight wakeup when present and reject contradictory or multi-wakeup evidence.
- Bound early-completion turns and completed-item turns to 64 entries, bound items per turn to 64, and evict on terminal result, failed start, stop, close, or generation change.
- Persist immutable Room reply routing with each wakeup history record, with a validated v3 store migration from v1/v2.
- Preserve one ordinary App Server `turn/start` attempt with the existing stable `clientUserMessageId`; no scheduler, queue, retry engine, transcript, Runtime, protocol method, or Zen Core Item was added.

From PR #49, this ports only the #58-relevant architectural ideas: immutable reply routing and an early-completion regression shape. It replaces #49's same-thread guessing/unbounded pending map with generation-scoped exact evidence and does not port the automation-control capability or Trigger/Room CRUD.

## Tests

Added deterministic coverage for:

- unsubscribe and no post-stop writes, including a retained stale callback;
- stale generations versus restarted state;
- canonical early completion before `turn/start` returns;
- concurrent same-thread starts without cross-correlation;
- failed start/disconnect, late/duplicate/unrelated completion, at-most-one Room reply;
- ambiguity rejection, 64-turn bounded eviction, item/pending cleanup, close and restart;
- v1/v2 store migration to immutable reply routing;
- existing successful/failed wakeups and ordinary watcher/Room behavior.

## Validation

Passed locally on Windows:

- `npx tsx --test test/trigger-service.test.ts test/trigger-store.test.ts` — 17/17
- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- root `npm run typecheck`
- root `npm run build`
- changed-file Prettier and `git diff --check`

Honest local environment limitations:

- full ZenX tests: 134/139; the same five Windows-host failures are POSIX `printf`, POSIX path expectations, and Unix local-process spawning.
- root Node tests: 86/93 passed, 6 Windows permission/POSIX-shell failures, 1 platform skip.
- IMZen: 37/38; the remaining failure relies on POSIX chmod semantics.
- root `npm run check` stops at repository-wide Prettier because this Windows checkout materializes CRLF for the whole tree; all changed files pass Prettier. GitHub Linux CI is authoritative.

Closes #58
