### PR TITLE
ZenX: fence user-browser CDP lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:windows-computer
 
+  zenx-windows-user-browser-smoke:
+    name: ZenX Windows attached user-browser smoke
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace apps/zenx run smoke:windows-user-browser
+
   zenx-playwright-provider-smoke:
     name: ZenX real Playwright provider smoke
     runs-on: macos-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,6 +82,7 @@
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。
 - **ZenXCapabilityProviderCatalog** — ZenX 产品层探测并诊断可选的成熟外部执行后端，按显式优先级选择
   Playwright、Peekaboo、WinApp 或适用平台的 bundled fallback；版本、权限与可用性只属于 host 配置和瞬时诊断，不进入 Zen Core。
+- **ZenXUserBrowserCdpProvider** — ZenX 产品层仅在用户显式选择 user-session 模式并提供 loopback CDP endpoint 时附着到已运行的 Chrome/Edge/Chromium，把目标页投影为既有的 opaque observation 工具且关闭时只断开连接，不导出认证材料、关闭标签或清理用户 profile。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
   与 provider-owned execution/document identity 重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
 - **ZenXUserBrowserSessionFence** — ZenX user-browser provider 用可丢弃的 session incarnation 与 operation lease
-  串行化 open/list/inspect/mutation/detach/close，以 transient marker 对已发送但丢失响应的 create 进行重对账，并在 logical close、target detach/destroy 或连接失败时回收 CDP attachment；它不关闭用户 tab/profile，也不进入 durable 状态。
+  串行化 open/list/inspect/mutation/detach/close，以 operation-owned transient marker、pre-create target snapshot 与有界 CDP command outcome 对已发送但丢失响应的 create 进行同 endpoint 重对账，并在 logical close、target detach/destroy 或连接失败时回收 CDP attachment；它不关闭用户 tab/profile，也不进入 durable 状态。
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,7 +76,9 @@
   、必须接管前台的 `foreground_required` 或在独立桌面执行的 `isolated`，让产品提示、调度和 host policy
   协商实际影响且禁止静默降级。
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
-  重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
+  与 provider-owned execution/document identity 重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
+- **ZenXUserBrowserSessionFence** — ZenX user-browser provider 用可丢弃的 session incarnation 与 operation lease
+  串行化 open/list/inspect/mutation/detach/close，并在 logical close、target detach/destroy 或连接失败时回收 CDP attachment；它不关闭用户 tab/profile，也不进入 durable 状态。
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
   与 provider-owned execution/document identity 重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
 - **ZenXUserBrowserSessionFence** — ZenX user-browser provider 用可丢弃的 session incarnation 与 operation lease
-  串行化 open/list/inspect/mutation/detach/close，并在 logical close、target detach/destroy 或连接失败时回收 CDP attachment；它不关闭用户 tab/profile，也不进入 durable 状态。
+  串行化 open/list/inspect/mutation/detach/close，以 transient marker 对已发送但丢失响应的 create 进行重对账，并在 logical close、target detach/destroy 或连接失败时回收 CDP attachment；它不关闭用户 tab/profile，也不进入 durable 状态。
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -19,8 +19,10 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
 Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
-首批 browser provider 优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
-回落到 bundled Electron/CDP 临时 profile；两者都只暴露有界 DOM 操作。computer
+首批 browser provider 默认优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
+回落到 bundled Electron/CDP 临时 profile；用户也可显式选择 loopback CDP user-session
+provider 附着到自己预先开启的 Chrome/Edge/Chromium，原位使用认证状态而不导出 cookie、
+storage 或 auth header，连接失败时绝不回落到隔离登录态；三者都只暴露有界 DOM 操作。computer
 公共 contract 暴露语义动作、平台能力与 background-safe/foreground-required 影响协商；
 当前 macOS provider 优先复用 Peekaboo 3.x 的 background-first 操作，缺失或不兼容时以 bundled
 AX/窗口定向截图和明确提示、可取消的前台输入形成基线；

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -119,8 +119,10 @@ mutations retain their tab lease through post-confirmation. Logical close sends
 `Target.closeTarget` for user tabs.
 Provider-created tabs start with a unique transient marker in background,
 non-focused mode and are then navigated to the requested URL; the marker lets a
-lost `Target.createTarget` reply be reconciled without mistaking a user tab for
-ZenX-owned work.
+lost `Target.createTarget` reply be reconciled against the operation's
+pre-create target snapshot without mistaking a user tab for ZenX-owned work.
+CDP commands have bounded outcomes, and HTTP reconciliation plus the browser
+WebSocket are restricted to the same numeric loopback authority.
 
 The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
 the bundled ephemeral Electron/CDP provider. This implementation does not claim
@@ -307,8 +309,9 @@ Peekaboo availability and permissions; it never sends desktop input.
 The Windows user-browser smoke launches a real installed Chrome/Edge process
 with an explicit temporary profile and CDP port, establishes authenticated state
 inside that browser, attaches ZenX, lists/inspects/acts in the existing tab, and
-then verifies ZenX detach leaves the browser process and tabs alive without
-projecting cookie material.
+opens a provider-created background tab while checking the foreground HWND and
+both tabs' document visibility. It then verifies ZenX detach leaves the browser
+process and tabs alive without projecting cookie material.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -113,6 +113,10 @@ headers, and credentials are never requested or returned. Closing a tab/session
 in this mode only detaches ZenX state, and closing ZenX only disconnects CDP; the
 user's tabs, browser process, storage, and profile remain intact. Settings labels
 browser provider diagnostics as `user-session` or `isolated-session`.
+Inspect/action dispatch is bound to a provider-owned CDP execution document and
+mutations retain their tab lease through post-confirmation. Logical close sends
+`Target.detachFromTarget` only for ZenX-owned attachments and never sends
+`Target.closeTarget` for user tabs.
 
 The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
 the bundled ephemeral Electron/CDP provider. This implementation does not claim

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -83,9 +83,9 @@ moving the OS pointer or activating a browser window. Inspection returns bounded
 visible text plus opaque IDs bound to the latest tab/document observation, never
 raw CSS selectors, cookies, storage, headers, or unrelated tabs. Actions
 revalidate visibility, supported action, and semantic identity, then invalidate
-the observation; navigation and close do likewise. Password values are omitted
-and secure controls reject typing. `browser_type` is deliberately non-secret-only
-because its text argument is part of the canonical tool call. Sessions have hard
+the observation; navigation and close do likewise. Existing input values are
+omitted, while text arguments dispatch normally regardless of password or
+autocomplete metadata and remain ordinary canonical tool-call arguments. Sessions have hard
 per-session/global tab caps plus explicit tab/session close tools.
 `browser_close_session` destroys all session windows, awaits storage/cache/auth
 cleanup, and advances the partition generation; reopening the same `sessionId`
@@ -190,8 +190,8 @@ mature external implementations while retaining a runnable bundled baseline:
   role/name/type/security/visibility/action fingerprint. Missing or incompatible
   CLI installations remain explicit in provider diagnostics and use the existing
   bundled Chromium CDP ephemeral-partition provider. Install `@playwright/cli`
-  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; attaching a user
-  profile is still unsupported. See <https://playwright.dev/agent-cli/introduction>
+  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; user-session attachment
+  remains a separate explicit CDP provider. See <https://playwright.dev/agent-cli/introduction>
   and <https://playwright.dev/docs/api/class-browsercontext>.
 - A future `isolated` interaction mode/provider can place arbitrary control in a
   VM, cloud desktop, or remote host. OSWorld's provider separation across
@@ -268,8 +268,8 @@ the child-host capability bridge, derived projects, Thread create/list/read/stat
 active `start | steer | replace`, follow-up delivery, bounded redaction, canonical
 command audit, and the real OpenAI subscription tool serialization boundary.
 The packaged capability smoke covers a real hidden dedicated browser
-open/inspect/navigate/click/type/close, including forged/stale/changed/hidden and
-password target rejection. It also seeds a cookie and session storage, closes
+open/inspect/navigate/click/type/close, including forged/stale/changed/hidden
+rejection and ordinary password-field input dispatch. It also seeds a cookie and session storage, closes
 the session, reopens the same ID, and verifies both are absent. It asserts those
 background-safe browser operations
 leave the real pointer position and foreground application unchanged. The macOS

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -117,6 +117,10 @@ Inspect/action dispatch is bound to a provider-owned CDP execution document and
 mutations retain their tab lease through post-confirmation. Logical close sends
 `Target.detachFromTarget` only for ZenX-owned attachments and never sends
 `Target.closeTarget` for user tabs.
+Provider-created tabs start with a unique transient marker in background,
+non-focused mode and are then navigated to the requested URL; the marker lets a
+lost `Target.createTarget` reply be reconciled without mistaking a user tab for
+ZenX-owned work.
 
 The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
 the bundled ephemeral Electron/CDP provider. This implementation does not claim

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -91,10 +91,32 @@ per-session/global tab caps plus explicit tab/session close tools.
 cleanup, and advances the partition generation; reopening the same `sessionId`
 therefore starts without the prior cookies or session storage. Generation state
 exists only for active/pending sessions, so logical session bookkeeping is bounded.
-Attaching the user's existing Chrome profile or tabs is not implemented; it
-would be a separate explicit opt-in mode with different privacy and interaction
-impact. This implementation does not claim parity with any proprietary browser
-automation product.
+User-browser attachment is a separate explicit opt-in mode. Start a supported
+Chrome, Edge, or Chromium 100+ yourself with a loopback remote-debugging port,
+open or sign into the pages you want ZenX to use, then start ZenX with:
+
+```powershell
+$env:ZENX_BROWSER_MODE = "user-session"
+$env:ZENX_USER_BROWSER_CDP_ENDPOINT = "http://127.0.0.1:9222"
+npm --workspace apps/zenx run dev
+```
+
+Modern Chromium releases may require the user to choose an explicit non-default
+`--user-data-dir` when enabling `--remote-debugging-port=9222`; ZenX never starts
+the browser, copies cookie databases, or attempts to unlock a profile directory.
+The endpoint must be unauthenticated loopback HTTP and must identify Chrome,
+Edge, or Chromium. Unavailable or incompatible endpoints remain terminal
+`user-browser-cdp` diagnostics and never fall back to Playwright/Electron.
+Inspection and action reuse authenticated page state in place, but only bounded
+visible text and opaque target IDs reach the Agent; cookies, storage state, auth
+headers, and credentials are never requested or returned. Closing a tab/session
+in this mode only detaches ZenX state, and closing ZenX only disconnects CDP; the
+user's tabs, browser process, storage, and profile remain intact. Settings labels
+browser provider diagnostics as `user-session` or `isolated-session`.
+
+The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
+the bundled ephemeral Electron/CDP provider. This implementation does not claim
+parity with any proprietary browser automation product.
 
 The computer contract is platform-neutral: tools describe semantic observation,
 press/value/capture operations and their interaction impact, while a platform
@@ -233,6 +255,7 @@ npm run check
 npm --workspace apps/zenx run smoke:capabilities
 # Windows only, after installing Microsoft WinApp CLI:
 npm --workspace apps/zenx run smoke:windows-computer
+npm --workspace apps/zenx run smoke:windows-user-browser
 npm --workspace apps/zenx run smoke:providers
 ```
 
@@ -273,6 +296,11 @@ provider/version/permission diagnostics. CI installs the pinned official
 `@playwright/cli` and requires that provider to be selected; a local run may
 exercise the Electron fallback when the CLI is absent. The smoke only probes
 Peekaboo availability and permissions; it never sends desktop input.
+The Windows user-browser smoke launches a real installed Chrome/Edge process
+with an explicit temporary profile and CDP port, establishes authenticated state
+inside that browser, attaches ZenX, lists/inspects/acts in the existing tab, and
+then verifies ZenX detach leaves the browser process and tabs alive without
+projecting cookie material.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -12,6 +12,7 @@
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
+    "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",
     "smoke:providers": "npm run build && electron ./out/main/provider-smoke.js",
     "check": "npm run typecheck && npm test && npm run build"
   },

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -153,7 +153,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_inspect",
       description:
-        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Password/secure values are never returned and secure controls cannot be typed.",
+        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Existing input values are not returned.",
       inputSchema: browserTargetSchema(),
       permissions: ["browser.tabs.read"],
       interactionMode: "background_safe",
@@ -175,7 +175,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_type",
       description:
-        "Replace a non-secret value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Password/secure controls and secret text are unsupported because tool arguments are journaled.",
+        "Replace the value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Text is dispatched as an ordinary tool argument regardless of field metadata.",
       inputSchema: browserTargetSchema(
         {
           observationId: stringSchema(),
@@ -216,7 +216,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Instructions for targeted, inspect-before-act browser automation.",
       content:
-        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Typing is for non-secret text only because tool arguments are journaled, and password/secure controls are rejected. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
+        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Text is dispatched as an ordinary tool argument regardless of field metadata. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
     },
     {
       id: "browser-research",
@@ -511,11 +511,6 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
       targetId,
       "type",
     );
-    if (target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
@@ -681,11 +676,6 @@ export function resolveBrowserObservedTarget(
     throw new Error("Browser target ID is forged, stale, or unknown");
   }
   if (!target.actions.includes(action)) {
-    if (action === "type" && target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     throw new Error(`Browser target does not support ${action}`);
   }
   return target;
@@ -703,7 +693,7 @@ export const browserInspectScript = `(() => {
     ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
   );
   const typeable = (element) => {
-    if (secure(element) || element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
+    if (element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
     if (element instanceof HTMLTextAreaElement) return true;
     if (!(element instanceof HTMLInputElement)) return false;
     return !["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase());
@@ -747,7 +737,6 @@ export const browserInspectScript = `(() => {
         href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
         secure: isSecure,
         actions,
-        ...(!isSecure && (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) ? { value: element.value.slice(0, 160) } : {}),
       };
     }),
   };
@@ -804,7 +793,6 @@ export function browserActionScript(
       element.click();
       return { ok: true };
     }
-    if (secure) return { ok: false, reason: "secure-control" };
     if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) || element.disabled || element.readOnly) return { ok: false, reason: "not-typeable" };
     if (element instanceof HTMLInputElement && ["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase())) return { ok: false, reason: "not-typeable" };
     const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -440,7 +440,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     const inspected = await evaluateInTab<{
       visibleText: string;
       targets: BrowserTargetFingerprint[];
-    }>(tab, INSPECT_SCRIPT);
+    }>(tab, browserInspectScript);
     const observationId = randomUUID();
     const targets = new Map<string, BrowserTargetFingerprint>();
     const projectedTargets = inspected.targets.slice(0, 80).map((target) => {
@@ -485,7 +485,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "click"),
+      browserActionScript(target, "click"),
     );
     if (!result.ok) {
       throw new Error(
@@ -519,7 +519,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "type", text, submit),
+      browserActionScript(target, "type", text, submit),
     );
     if (!result.ok) {
       throw new Error(
@@ -691,7 +691,7 @@ export function resolveBrowserObservedTarget(
   return target;
 }
 
-const INSPECT_SCRIPT = `(() => {
+export const browserInspectScript = `(() => {
   const visible = (element) => {
     const style = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
@@ -753,7 +753,7 @@ const INSPECT_SCRIPT = `(() => {
   };
 })()`;
 
-function actionScript(
+export function browserActionScript(
   target: BrowserTargetFingerprint,
   action: "click" | "type",
   text = "",
@@ -850,7 +850,7 @@ function summarizeTab(tab: BrowserTab): BrowserTabSummary {
     sessionId: tab.sessionId,
     tabId: tab.tabId,
     title: tab.window.getTitle().slice(0, 256),
-    url: redactUrl(tab.window.webContents.getURL()),
+    url: redactBrowserUrl(tab.window.webContents.getURL()),
     loading: tab.window.webContents.isLoading(),
   };
 }
@@ -875,7 +875,7 @@ function safeBrowserUrl(raw: string): string {
   return url.toString();
 }
 
-function redactUrl(raw: string): string {
+export function redactBrowserUrl(raw: string): string {
   if (raw.length === 0) return "";
   const url = new URL(raw);
   url.username = "";

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -653,14 +653,13 @@ function playwrightTargetFingerprint(
     autocomplete: dom.autocomplete,
     href: dom.href || node.url || "",
     secure,
-    actions: playwrightNodeActions(node, dom, secure),
+    actions: playwrightNodeActions(node, dom),
   };
 }
 
 function playwrightNodeActions(
   node: PlaywrightAriaNode,
   dom: PlaywrightDomMetadata,
-  secure: boolean,
 ): Array<"click" | "type"> {
   if (node.disabled === true) return [];
   const clickRoles = new Set([
@@ -691,8 +690,7 @@ function playwrightNodeActions(
     ...(clickRoles.has(node.role) || node.cursor === "pointer"
       ? (["click"] as const)
       : []),
-    ...(!secure &&
-    typeRoles.has(node.role) &&
+    ...(typeRoles.has(node.role) &&
     !(dom.tag === "input" && nonTypeableInput.has(dom.type.toLowerCase()))
       ? (["type"] as const)
       : []),
@@ -759,11 +757,6 @@ function requireObservedTarget(
   }
   if (target.disabled || !target.actions.includes(action)) {
     throw new Error(`Browser target does not support ${action}`);
-  }
-  if (action === "type" && target.secure) {
-    throw new Error(
-      "browser_type rejects password or secure controls because supplied text is journaled",
-    );
   }
   return target;
 }

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -19,6 +19,7 @@ import {
 } from "./external-provider.js";
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
+import { connectUserBrowserCdp } from "./user-browser-provider.js";
 import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
@@ -57,10 +58,80 @@ const MAX_PEEKABOO_EXCLUSIVE = [4, 0, 0] as const;
 
 export async function selectBrowserProvider(
   options: ZenXCapabilityProviderCatalogOptions,
-): Promise<ZenXCapabilityProviderSelection<ZenXBrowserBackend>> {
+): Promise<ZenXOptionalCapabilityProviderSelection<ZenXBrowserBackend>> {
   const runner = options.runner ?? new SystemExternalProviderProcessRunner();
   const environment = options.environment ?? process.env;
   const platform = options.platform ?? process.platform;
+  const browserMode = environment.ZENX_BROWSER_MODE ?? "isolated";
+  if (browserMode === "user-session") {
+    const endpoint = environment.ZENX_USER_BROWSER_CDP_ENDPOINT;
+    if (endpoint === undefined || endpoint.trim().length === 0) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          unavailableDiagnostic(
+            "browser",
+            "user-browser-cdp",
+            ["background_safe"],
+            ["user_session", "authenticated_state_in_place", "cdp"],
+            "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
+          ),
+        ],
+      };
+    }
+    try {
+      const connection = await connectUserBrowserCdp(endpoint);
+      return {
+        backend: connection.backend,
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          {
+            capabilityId: "browser",
+            providerId: "user-browser-cdp",
+            status: "selected",
+            interactionModes: ["background_safe"],
+            capabilities: [
+              "user_session",
+              "authenticated_state_in_place",
+              "cdp",
+              "dom.inspect",
+              "dom.interact",
+            ],
+            version: connection.product,
+            permissionSummary:
+              "Explicit loopback CDP attachment; uses authenticated page state in place and never exports cookies, storage, headers, or credentials",
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          unavailableDiagnostic(
+            "browser",
+            "user-browser-cdp",
+            ["background_safe"],
+            ["user_session", "authenticated_state_in_place", "cdp"],
+            describeError(error),
+          ),
+        ],
+      };
+    }
+  }
+  if (browserMode !== "isolated") {
+    return {
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "browser",
+          "browser-mode",
+          ["isolated", "background_safe"],
+          ["explicit_mode_selection"],
+          `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
+        ),
+      ],
+    };
+  }
   const configured = environment.ZENX_PLAYWRIGHT_CLI;
   const executable = await discoverExecutable(configured ?? "playwright-cli", {
     environment,
@@ -139,6 +210,56 @@ export async function selectBrowserProvider(
       ],
     };
   }
+}
+
+function userBrowserManifest(): ZenXCapabilityManifest {
+  const manifest = structuredClone(browserCapabilityManifest);
+  return {
+    ...manifest,
+    description:
+      "An explicit attachment to a user-opened Chrome, Edge, or Chromium CDP session that uses authenticated page state in place without exporting session material.",
+    provider: {
+      id: "user-browser-cdp",
+      platforms: ["darwin", "win32", "linux"],
+      interactionModes: ["background_safe"],
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        "cdp",
+        "dom.inspect",
+        "dom.navigate",
+        "dom.interact",
+      ],
+    },
+    tools: manifest.tools.map((tool) => ({
+      ...tool,
+      description:
+        tool.name === "browser_close_session"
+          ? "Detach ZenX capability state from one user-browser session without closing tabs, clearing storage, or changing the user profile."
+          : tool.name === "browser_close"
+            ? "Detach one explicit user-browser tab from this ZenX session without closing the user's tab."
+            : tool.description
+                .replaceAll("dedicated ZenX", "attached user")
+                .replaceAll("hidden tab", "user browser tab")
+                .replaceAll("ephemeral ZenX", "attached user"),
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        ...tool.capabilities.filter(
+          (capability) => capability !== "dedicated_profile",
+        ),
+      ],
+    })),
+    resources: manifest.resources.map((resource) =>
+      resource.id === "safe-browser-use"
+        ? {
+            ...resource,
+            content:
+              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Never ask for or return cookies, storage state, auth headers, or credentials. Typing is non-secret-only. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
+          }
+        : resource,
+    ),
+  };
 }
 
 export async function selectComputerProvider(

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -20,6 +20,7 @@ import {
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
 import { connectUserBrowserCdp } from "./user-browser-provider.js";
+import type { UserBrowserConnection } from "./user-browser-provider.js";
 import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
@@ -46,6 +47,10 @@ export interface ZenXCapabilityProviderCatalogOptions {
   environment?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   runner?: ExternalProviderProcessRunner;
+  userBrowserConnector?: (
+    endpoint: string,
+    signal?: AbortSignal,
+  ) => Promise<UserBrowserConnection>;
 }
 
 // @playwright/cli has its own 0.1.x package version. It embeds Playwright
@@ -69,18 +74,23 @@ export async function selectBrowserProvider(
       return {
         manifest: userBrowserManifest(),
         diagnostics: [
-          unavailableDiagnostic(
-            "browser",
-            "user-browser-cdp",
-            ["background_safe"],
-            ["user_session", "authenticated_state_in_place", "cdp"],
-            "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
-          ),
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
+            ),
+            sessionMode: "user-session",
+          },
         ],
       };
     }
     try {
-      const connection = await connectUserBrowserCdp(endpoint);
+      const connection = await (
+        options.userBrowserConnector ?? connectUserBrowserCdp
+      )(endpoint);
       return {
         backend: connection.backend,
         manifest: userBrowserManifest(),
@@ -100,6 +110,7 @@ export async function selectBrowserProvider(
             version: connection.product,
             permissionSummary:
               "Explicit loopback CDP attachment; uses authenticated page state in place and never exports cookies, storage, headers, or credentials",
+            sessionMode: "user-session",
           },
         ],
       };
@@ -107,13 +118,16 @@ export async function selectBrowserProvider(
       return {
         manifest: userBrowserManifest(),
         diagnostics: [
-          unavailableDiagnostic(
-            "browser",
-            "user-browser-cdp",
-            ["background_safe"],
-            ["user_session", "authenticated_state_in_place", "cdp"],
-            describeError(error),
-          ),
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              describeError(error),
+            ),
+            sessionMode: "user-session",
+          },
         ],
       };
     }
@@ -122,13 +136,16 @@ export async function selectBrowserProvider(
     return {
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "browser-mode",
-          ["isolated", "background_safe"],
-          ["explicit_mode_selection"],
-          `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "browser-mode",
+            ["isolated", "background_safe"],
+            ["explicit_mode_selection"],
+            `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
+          ),
+          sessionMode: "invalid",
+        },
       ],
     };
   }
@@ -145,15 +162,18 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          configured === undefined
-            ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
-            : `Configured Playwright CLI is not executable: ${configured}`,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            configured === undefined
+              ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
+              : `Configured Playwright CLI is not executable: ${configured}`,
+          ),
+          sessionMode: "isolated-session",
+        },
         fallbackDiagnostic,
       ],
     };
@@ -189,6 +209,7 @@ export async function selectBrowserProvider(
           version,
           permissionSummary:
             "Isolated in-memory Playwright session; no foreground desktop input",
+          sessionMode: "isolated-session",
         },
         fallbackDiagnostic,
       ],
@@ -198,14 +219,17 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          describeError(error),
-          executable,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            describeError(error),
+            executable,
+          ),
+          sessionMode: "isolated-session",
+        },
         electronBrowserDiagnostic("fallback"),
       ],
     };
@@ -255,7 +279,7 @@ function userBrowserManifest(): ZenXCapabilityManifest {
         ? {
             ...resource,
             content:
-              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Never ask for or return cookies, storage state, auth headers, or credentials. Typing is non-secret-only. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
+              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Text is dispatched as an ordinary tool argument regardless of field metadata. Never request or return browser session internals such as cookies, storage state, or auth headers. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
           }
         : resource,
     ),
@@ -568,6 +592,7 @@ function electronBrowserDiagnostic(
     interactionModes: ["background_safe"],
     capabilities: ["dedicated_profile", "cdp", "dom.inspect", "dom.interact"],
     permissionSummary: "Bundled hidden ephemeral Electron partition",
+    sessionMode: "isolated-session",
   };
 }
 

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -89,6 +89,7 @@ export interface ZenXCapabilityProviderDiagnostic {
   version?: string;
   permissionSummary?: string;
   reason?: string;
+  sessionMode?: "isolated-session" | "user-session" | "invalid";
 }
 
 export interface ZenXCapabilitySummary {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import path from "node:path";
 
 import WebSocket from "ws";
 
@@ -40,8 +41,24 @@ interface UserBrowserSession {
 
 interface UserBrowserTabState {
   documentVersion: number;
+  url: string;
+  documentIdentity?: string;
   observation?: BrowserObservation;
+  actionInFlight: boolean;
 }
+
+export const userBrowserDocumentIdentityScript = `(() => {
+    const key = "__zenxCapabilityDocumentIdentity";
+    let state = document[key];
+    if (typeof state !== "object" || state === null || typeof state.id !== "string" || typeof state.activation !== "number") {
+      state = { id: String(Date.now()) + ":" + String(Math.random()), activation: 0 };
+      Object.defineProperty(document, key, { value: state, configurable: false, enumerable: false });
+      addEventListener("pageshow", (event) => { if (event.persisted) state.activation += 1; });
+      addEventListener("popstate", () => { state.activation += 1; });
+      addEventListener("hashchange", () => { state.activation += 1; });
+    }
+    return JSON.stringify({ href: location.href, origin: location.origin, id: state.id, activation: state.activation });
+  })()`;
 
 export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #client: UserBrowserCdpClient;
@@ -72,8 +89,18 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     }
     for (const target of targets) {
       session.targetIds.add(target.targetId);
-      if (!this.#tabs.has(target.targetId)) {
-        this.#tabs.set(target.targetId, { documentVersion: 1 });
+      const tab = this.#tabs.get(target.targetId);
+      if (tab === undefined) {
+        this.#tabs.set(target.targetId, {
+          documentVersion: 1,
+          url: target.url,
+          actionInFlight: false,
+        });
+      } else if (tab.url !== target.url) {
+        tab.url = target.url;
+        tab.documentVersion += 1;
+        tab.documentIdentity = undefined;
+        tab.observation = undefined;
       }
     }
     return targets
@@ -89,7 +116,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const session = this.#session(sessionId);
     const targetId = await this.#client.createTarget(url, signal);
     session.targetIds.add(targetId);
-    this.#tabs.set(targetId, { documentVersion: 1 });
+    this.#tabs.set(targetId, {
+      documentVersion: 1,
+      url,
+      actionInFlight: false,
+    });
     return await this.#summary(sessionId, targetId, signal);
   }
 
@@ -100,8 +131,13 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const tab = this.#tab(sessionId, tabId);
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
     await this.#client.navigate(tabId, url, signal);
     tab.documentVersion += 1;
+    tab.url = url;
+    tab.documentIdentity = undefined;
     tab.observation = undefined;
     return await this.#summary(sessionId, tabId, signal);
   }
@@ -112,10 +148,19 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
     const tab = this.#tab(sessionId, tabId);
-    const raw = asRecord(
-      await this.#client.evaluate(tabId, browserInspectScript, signal),
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
+    const envelope = asRecord(
+      await this.#client.evaluate(
+        tabId,
+        `(() => ({ documentIdentity: ${userBrowserDocumentIdentityScript}, inspection: ${browserInspectScript} }))()`,
+        signal,
+      ),
     );
+    const raw = asRecord(envelope?.inspection);
     if (
+      typeof envelope?.documentIdentity !== "string" ||
       raw === undefined ||
       typeof raw.visibleText !== "string" ||
       !Array.isArray(raw.targets)
@@ -141,6 +186,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       };
     });
     const observationId = randomUUID();
+    tab.documentIdentity = envelope.documentIdentity;
     tab.observation = {
       id: observationId,
       documentVersion: tab.documentVersion,
@@ -230,6 +276,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const tab = this.#tab(sessionId, tabId);
+    if (tab.actionInFlight) {
+      throw new Error("User browser action is already in flight for this tab");
+    }
     const target = resolveBrowserObservedTarget(
       tab.observation,
       tab.documentVersion,
@@ -237,21 +286,45 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       targetId,
       action,
     );
-    const response = asRecord(
-      await this.#client.evaluate(
-        tabId,
-        browserActionScript(target, action, text, submit),
-        signal,
-      ),
-    );
+    const expectedDocumentIdentity = tab.documentIdentity;
     tab.observation = undefined;
+    tab.documentIdentity = undefined;
+    tab.actionInFlight = true;
+    let response: Record<string, unknown> | undefined;
+    try {
+      response = asRecord(
+        await this.#client.evaluate(
+          tabId,
+          userBrowserActionScript(
+            expectedDocumentIdentity,
+            target,
+            action,
+            text,
+            submit,
+          ),
+          signal,
+        ),
+      );
+    } catch (error) {
+      throw new Error(
+        `User browser action outcome is unknown after cancellation or connection failure; inspect the current tab before another action (${describeError(error)})`,
+      );
+    } finally {
+      tab.actionInFlight = false;
+    }
     if (response?.ok !== true) {
       throw new Error(
         `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
       );
     }
     tab.documentVersion += 1;
-    return await this.#summary(sessionId, tabId, signal);
+    try {
+      return await this.#summary(sessionId, tabId, signal);
+    } catch (error) {
+      throw new Error(
+        `User browser action outcome is unknown because post-action confirmation failed; inspect the current tab before another action (${describeError(error)})`,
+      );
+    }
   }
 
   #session(sessionId: string): UserBrowserSession {
@@ -296,7 +369,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
 }
 
 export interface UserBrowserConnection {
-  backend: UserBrowserCdpBackend;
+  backend: ZenXBrowserBackend;
   product: string;
 }
 
@@ -311,7 +384,12 @@ export async function connectUserBrowserCdp(
   const response = await fetch(new URL("/json/version", base), {
     signal: probeSignal,
     headers: { accept: "application/json" },
+    redirect: "error",
   });
+  const finalUrl = validateCdpEndpoint(response.url);
+  if (finalUrl.pathname !== "/json/version") {
+    throw new Error("User browser CDP version response URL is invalid");
+  }
   if (!response.ok) {
     throw new Error(
       `User browser CDP version probe failed with HTTP ${String(response.status)}`,
@@ -333,7 +411,9 @@ export async function connectUserBrowserCdp(
     socketUrl.protocol !== "ws:" ||
     !isLoopbackHostname(socketUrl.hostname) ||
     socketUrl.username.length > 0 ||
-    socketUrl.password.length > 0
+    socketUrl.password.length > 0 ||
+    socketUrl.search.length > 0 ||
+    socketUrl.hash.length > 0
   ) {
     throw new Error(
       "User browser CDP WebSocket must be an unauthenticated loopback ws:// endpoint",
@@ -599,6 +679,46 @@ function validateCdpEndpoint(raw: string): URL {
     );
   }
   return url;
+}
+
+export function windowsBrowserExecutableCandidates(
+  environment: NodeJS.ProcessEnv,
+): string[] {
+  const roots = [
+    environment.ProgramFiles,
+    environment["ProgramFiles(x86)"],
+    environment.LOCALAPPDATA,
+  ].filter((entry): entry is string => entry !== undefined && entry.length > 0);
+  return [
+    ...roots.map((root) =>
+      path.win32.join(root, "Google", "Chrome", "Application", "chrome.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Microsoft", "Edge", "Application", "msedge.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Chromium", "Application", "chrome.exe"),
+    ),
+  ];
+}
+
+function userBrowserActionScript(
+  expectedDocumentIdentity: string | undefined,
+  target: BrowserTargetFingerprint,
+  action: "click" | "type",
+  text: string,
+  submit: boolean,
+): string {
+  return `(() => {
+    const expectedDocumentIdentity = ${JSON.stringify(expectedDocumentIdentity)};
+    const actualDocumentIdentity = ${userBrowserDocumentIdentityScript};
+    if (actualDocumentIdentity !== expectedDocumentIdentity) return { ok: false, reason: "document-changed" };
+    return ${browserActionScript(target, action, text, submit)};
+  })()`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isLoopbackHostname(hostname: string): boolean {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -25,6 +25,10 @@ export interface UserBrowserCdpTarget {
 export interface UserBrowserCdpClient {
   listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
   createTarget(url: string, signal?: AbortSignal): Promise<string>;
+  findTargetByUrl(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<UserBrowserCdpTarget | undefined>;
   navigate(targetId: string, url: string, signal?: AbortSignal): Promise<void>;
   evaluateDocument(
     targetId: string,
@@ -41,6 +45,8 @@ interface UserBrowserSession {
   targetIds: Set<string>;
   ignoredTargetIds: Set<string>;
   operations: Set<Promise<void>>;
+  unresolvedCreates: Set<string>;
+  detachFailures: unknown[];
   detaching: boolean;
 }
 
@@ -59,6 +65,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #client: UserBrowserCdpClient;
   readonly #sessions = new Map<string, UserBrowserSession>();
   readonly #tabs = new Map<string, UserBrowserTabState>();
+  readonly #detachOperations = new Map<string, Promise<void>>();
+  readonly #sessionCloseOperations = new Map<string, Promise<number>>();
+  #closeOperation?: Promise<void>;
   #closing = false;
 
   constructor(client: UserBrowserCdpClient) {
@@ -73,7 +82,21 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const session = this.#session(sessionId);
     this.#assertSessionIdle(session);
     const operation = this.#startSessionOperation(session, async () => {
-      const targets = (await this.#client.listTargets()).filter(
+      const listed = await this.#client.listTargets();
+      for (const target of listed) {
+        if (!isPendingCreateUrl(target.url)) continue;
+        session.targetIds.add(target.targetId);
+        if (!this.#tabs.has(target.targetId)) {
+          this.#tabs.set(target.targetId, {
+            ownerSessionId: session.id,
+            documentVersion: 1,
+            url: target.url,
+            detaching: false,
+            tainted: "provider-created target requires cleanup",
+          });
+        }
+      }
+      const targets = listed.filter(
         (target) =>
           target.type === "page" &&
           isInspectableUrl(target.url) &&
@@ -92,7 +115,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         }
       }
       const detached = await Promise.allSettled(
-        disappeared.map((targetId) => this.#client.detachTarget(targetId)),
+        disappeared.map((targetId) => this.#detachTarget(targetId)),
       );
       const detachFailure = detached.find(
         (result): result is PromiseRejectedResult =>
@@ -133,20 +156,41 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     throwIfAborted(signal);
     const session = this.#session(sessionId);
     const operation = this.#startSessionOperation(session, async () => {
-      const targetId = await this.#client.createTarget(url);
+      const pendingUrl = `about:blank#zenx-pending-${randomUUID()}`;
+      let targetId: string;
+      try {
+        targetId = await this.#client.createTarget(pendingUrl);
+      } catch (error) {
+        const recovered = await this.#client
+          .findTargetByUrl(pendingUrl)
+          .catch(() => undefined);
+        if (recovered === undefined) {
+          session.unresolvedCreates.add(pendingUrl);
+          throw new Error(
+            `User browser create outcome is unknown (${describeError(error)})`,
+          );
+        }
+        this.#accountTarget(session, recovered.targetId, recovered.url, true);
+        throw new Error(
+          `User browser create outcome is unknown; recovered provider target ${recovered.targetId} for cleanup (${describeError(error)})`,
+        );
+      }
       // Account for the target before observing the session fence. A concurrent
       // close can then deterministically detach it instead of orphaning it.
-      session.targetIds.add(targetId);
-      this.#tabs.set(targetId, {
-        ownerSessionId: session.id,
-        documentVersion: 1,
-        url,
-        detaching: session.detaching,
-      });
+      this.#accountTarget(session, targetId, pendingUrl, false);
       this.#assertSessionCurrent(session);
-      const summary = await this.#summary(sessionId, targetId);
-      this.#assertSessionCurrent(session);
-      return summary;
+      const tab = this.#tabs.get(targetId);
+      try {
+        await this.#client.navigate(targetId, url);
+        if (tab !== undefined) tab.url = url;
+        this.#assertSessionCurrent(session);
+        const summary = await this.#summary(sessionId, targetId);
+        this.#assertSessionCurrent(session);
+        return summary;
+      } catch (error) {
+        if (tab !== undefined) tab.tainted = describeError(error);
+        throw error;
+      }
     });
     return await raceAbort(operation, signal);
   }
@@ -295,64 +339,112 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const tab = this.#tabs.get(tabId);
     if (tab === undefined) throw new Error("User browser tab was closed");
     tab.detaching = true;
-    await tab.operation;
-    try {
-      await this.#client.detachTarget(tabId);
-    } finally {
-      session.targetIds.delete(tabId);
-      session.ignoredTargetIds.add(tabId);
-      this.#tabs.delete(tabId);
-    }
+    const operation = (async () => {
+      await tab.operation;
+      try {
+        await this.#detachTarget(tabId);
+      } catch (error) {
+        session.detachFailures.push(error);
+        throw error;
+      } finally {
+        session.targetIds.delete(tabId);
+        session.ignoredTargetIds.add(tabId);
+        this.#tabs.delete(tabId);
+      }
+    })();
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    session.operations.add(settled);
+    void settled.then(() => session.operations.delete(settled));
+    await operation;
   }
 
   async closeSession(sessionId: string): Promise<number> {
+    const existing = this.#sessionCloseOperations.get(sessionId);
+    if (existing !== undefined) return await existing;
     const session = this.#requireSession(sessionId);
     session.detaching = true;
     for (const targetId of session.targetIds) {
       const tab = this.#tabs.get(targetId);
       if (tab !== undefined) tab.detaching = true;
     }
-    await Promise.all([...session.operations]);
-    const targetIds = [...session.targetIds];
-    const count = targetIds.length;
-    const detached = await Promise.allSettled(
-      targetIds.map((targetId) => this.#client.detachTarget(targetId)),
-    );
-    for (const targetId of targetIds) this.#tabs.delete(targetId);
-    this.#sessions.delete(sessionId);
-    const failure = detached.find(
-      (result): result is PromiseRejectedResult => result.status === "rejected",
-    );
-    if (failure !== undefined) throw failure.reason;
-    return count;
+    const closing = (async () => {
+      await Promise.all([...session.operations]);
+      const targetIds = [...session.targetIds];
+      const count = targetIds.length;
+      const detached = await Promise.allSettled(
+        targetIds.map((targetId) => this.#detachTarget(targetId)),
+      );
+      for (const targetId of targetIds) this.#tabs.delete(targetId);
+      this.#sessions.delete(sessionId);
+      const failure = detached.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (failure !== undefined) throw failure.reason;
+      if (session.detachFailures[0] !== undefined)
+        throw session.detachFailures[0];
+      if (session.unresolvedCreates.size > 0) {
+        throw new Error(
+          "User browser create outcome is unknown; provider session is tainted",
+        );
+      }
+      return count;
+    })();
+    this.#sessionCloseOperations.set(sessionId, closing);
+    void closing
+      .finally(() => {
+        if (this.#sessionCloseOperations.get(sessionId) === closing)
+          this.#sessionCloseOperations.delete(sessionId);
+      })
+      .catch(() => undefined);
+    return await closing;
   }
 
   async close(): Promise<void> {
+    if (this.#closeOperation !== undefined) return await this.#closeOperation;
     this.#closing = true;
     for (const session of this.#sessions.values()) session.detaching = true;
     for (const tab of this.#tabs.values()) tab.detaching = true;
-    const operations = [...this.#sessions.values()].flatMap((session) => [
-      ...session.operations,
-    ]);
-    await Promise.all(operations);
-    const detached = await Promise.allSettled(
-      [...this.#tabs.keys()].map((targetId) =>
-        this.#client.detachTarget(targetId),
-      ),
-    );
-    let closeFailure: unknown;
-    try {
-      await this.#client.close();
-    } catch (error) {
-      closeFailure = error;
-    }
-    this.#sessions.clear();
-    this.#tabs.clear();
-    const detachFailure = detached.find(
-      (result): result is PromiseRejectedResult => result.status === "rejected",
-    );
-    if (detachFailure !== undefined) throw detachFailure.reason;
-    if (closeFailure !== undefined) throw closeFailure;
+    const closing = (async () => {
+      const operations = [
+        ...this.#sessionCloseOperations.values(),
+        ...[...this.#sessions.values()].flatMap((session) => [
+          ...session.operations,
+        ]),
+      ];
+      const settledOperations = await Promise.allSettled(operations);
+      const detached = await Promise.allSettled(
+        [...this.#tabs.keys()].map((targetId) => this.#detachTarget(targetId)),
+      );
+      let closeFailure: unknown;
+      try {
+        await this.#client.close();
+      } catch (error) {
+        closeFailure = error;
+      }
+      const priorDetachFailure = [...this.#sessions.values()]
+        .flatMap((session) => session.detachFailures)
+        .at(0);
+      this.#sessions.clear();
+      this.#tabs.clear();
+      const detachFailure = detached.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      const operationFailure = settledOperations.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (operationFailure !== undefined) throw operationFailure.reason;
+      if (priorDetachFailure !== undefined) throw priorDetachFailure;
+      if (detachFailure !== undefined) throw detachFailure.reason;
+      if (closeFailure !== undefined) throw closeFailure;
+    })();
+    this.#closeOperation = closing;
+    return await closing;
   }
 
   async #act(
@@ -493,6 +585,8 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         targetIds: new Set(),
         ignoredTargetIds: new Set(),
         operations: new Set(),
+        unresolvedCreates: new Set(),
+        detachFailures: [],
         detaching: false,
       };
       this.#sessions.set(sessionId, session);
@@ -538,6 +632,38 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     );
     if (target === undefined) throw new Error("User browser tab was closed");
     return summarizeTarget(sessionId, target);
+  }
+
+  #accountTarget(
+    session: UserBrowserSession,
+    targetId: string,
+    url: string,
+    tainted: boolean,
+  ): void {
+    session.targetIds.add(targetId);
+    this.#tabs.set(targetId, {
+      ownerSessionId: session.id,
+      documentVersion: 1,
+      url,
+      detaching: session.detaching,
+      ...(tainted ? { tainted: "create outcome requires cleanup" } : {}),
+    });
+  }
+
+  #detachTarget(targetId: string): Promise<void> {
+    const existing = this.#detachOperations.get(targetId);
+    if (existing !== undefined) return existing;
+    const operation = Promise.resolve().then(() =>
+      this.#client.detachTarget(targetId),
+    );
+    this.#detachOperations.set(targetId, operation);
+    void operation
+      .finally(() => {
+        if (this.#detachOperations.get(targetId) === operation)
+          this.#detachOperations.delete(targetId);
+      })
+      .catch(() => undefined);
+    return operation;
   }
 }
 
@@ -594,6 +720,7 @@ export async function connectUserBrowserCdp(
   }
   const client = await JsonRpcUserBrowserCdpClient.connect(
     socketUrl.toString(),
+    base,
     probeSignal,
   );
   return { backend: new UserBrowserCdpBackend(client), product };
@@ -623,6 +750,7 @@ export function validateUserBrowserVersion(
 
 class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
   readonly #socket: WebSocket;
+  readonly #httpBase: URL;
   readonly #pending = new Map<
     number,
     { resolve(value: unknown): void; reject(error: Error): void }
@@ -646,8 +774,9 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
   #nextId = 1;
   #closed = false;
 
-  private constructor(socket: WebSocket) {
+  private constructor(socket: WebSocket, httpBase: URL) {
     this.#socket = socket;
+    this.#httpBase = httpBase;
     socket.on("message", (data) => this.#receive(data.toString()));
     socket.on("close", () =>
       this.#failAll(new Error("User browser CDP connection closed")),
@@ -657,6 +786,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
 
   static async connect(
     url: string,
+    httpBase: URL,
     signal?: AbortSignal,
   ): Promise<JsonRpcUserBrowserCdpClient> {
     const socket = new WebSocket(url, { handshakeTimeout: 5_000 });
@@ -680,7 +810,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       signal?.addEventListener("abort", abort, { once: true });
       if (signal?.aborted === true) abort();
     });
-    return new JsonRpcUserBrowserCdpClient(socket);
+    return new JsonRpcUserBrowserCdpClient(socket, httpBase);
   }
 
   async listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]> {
@@ -712,11 +842,58 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
 
   async createTarget(url: string, signal?: AbortSignal): Promise<string> {
     const response = asRecord(
-      await this.#send("Target.createTarget", { url }, undefined, signal),
+      await this.#send(
+        "Target.createTarget",
+        { url, background: true, focus: false },
+        undefined,
+        signal,
+      ),
     );
     if (typeof response?.targetId !== "string")
       throw new Error("User browser CDP createTarget response is invalid");
     return response.targetId;
+  }
+
+  async findTargetByUrl(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<UserBrowserCdpTarget | undefined> {
+    const timeout = AbortSignal.timeout(5_000);
+    const requestSignal =
+      signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+    const response = await fetch(new URL("/json/list", this.#httpBase), {
+      signal: requestSignal,
+      headers: { accept: "application/json" },
+      redirect: "error",
+    });
+    const finalUrl = validateCdpEndpoint(response.url);
+    if (finalUrl.pathname !== "/json/list" || !response.ok) {
+      throw new Error("User browser CDP target reconciliation failed");
+    }
+    const value: unknown = await response.json();
+    if (!Array.isArray(value)) {
+      throw new Error(
+        "User browser CDP target reconciliation response is invalid",
+      );
+    }
+    for (const item of value) {
+      const target = asRecord(item);
+      const targetId = target?.id ?? target?.targetId;
+      if (
+        typeof targetId === "string" &&
+        typeof target?.type === "string" &&
+        typeof target?.url === "string" &&
+        target.url === url
+      ) {
+        return {
+          targetId,
+          type: target.type,
+          title: typeof target.title === "string" ? target.title : "",
+          url: target.url,
+        };
+      }
+    }
+    return undefined;
   }
 
   async navigate(
@@ -1096,22 +1273,19 @@ export function userBrowserDocumentEventInvalidates(
     const frame = asRecord(params.frame);
     return frame !== undefined && frame.parentId === undefined;
   }
-  if (method === "Page.lifecycleEvent") {
-    return (
-      typeof params.frameId === "string" &&
-      params.frameId === mainFrameId &&
-      (params.name === "backForwardCacheRestore" ||
-        params.name === "bfCacheRestore")
-    );
-  }
   if (
     method !== "Page.navigatedWithinDocument" &&
+    method !== "Page.frameStartedNavigating" &&
     method !== "Page.frameStartedLoading" &&
     method !== "Page.backForwardCacheNotUsed"
   ) {
     return false;
   }
   return typeof params.frameId === "string" && params.frameId === mainFrameId;
+}
+
+function isPendingCreateUrl(url: string): boolean {
+  return url.startsWith("about:blank#zenx-pending-");
 }
 
 function validateCdpEndpoint(raw: string): URL {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1,0 +1,675 @@
+import { randomUUID } from "node:crypto";
+
+import WebSocket from "ws";
+
+import {
+  browserActionScript,
+  browserInspectScript,
+  redactBrowserUrl,
+  resolveBrowserObservedTarget,
+  type BrowserInspection,
+  type BrowserObservation,
+  type BrowserTabSummary,
+  type BrowserTargetFingerprint,
+  type ZenXBrowserBackend,
+} from "./browser-provider.js";
+
+export interface UserBrowserCdpTarget {
+  targetId: string;
+  type: string;
+  title: string;
+  url: string;
+}
+
+export interface UserBrowserCdpClient {
+  listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
+  createTarget(url: string, signal?: AbortSignal): Promise<string>;
+  navigate(targetId: string, url: string, signal?: AbortSignal): Promise<void>;
+  evaluate(
+    targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown>;
+  close(): Promise<void> | void;
+}
+
+interface UserBrowserSession {
+  targetIds: Set<string>;
+  ignoredTargetIds: Set<string>;
+}
+
+interface UserBrowserTabState {
+  documentVersion: number;
+  observation?: BrowserObservation;
+}
+
+export class UserBrowserCdpBackend implements ZenXBrowserBackend {
+  readonly #client: UserBrowserCdpClient;
+  readonly #sessions = new Map<string, UserBrowserSession>();
+  readonly #tabs = new Map<string, UserBrowserTabState>();
+
+  constructor(client: UserBrowserCdpClient) {
+    this.#client = client;
+  }
+
+  async listTabs(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary[]> {
+    const session = this.#session(sessionId);
+    const targets = (await this.#client.listTargets(signal)).filter(
+      (target) =>
+        target.type === "page" &&
+        isInspectableUrl(target.url) &&
+        !session.ignoredTargetIds.has(target.targetId),
+    );
+    const live = new Set(targets.map((target) => target.targetId));
+    for (const targetId of session.targetIds) {
+      if (!live.has(targetId)) {
+        session.targetIds.delete(targetId);
+        this.#tabs.delete(targetId);
+      }
+    }
+    for (const target of targets) {
+      session.targetIds.add(target.targetId);
+      if (!this.#tabs.has(target.targetId)) {
+        this.#tabs.set(target.targetId, { documentVersion: 1 });
+      }
+    }
+    return targets
+      .slice(0, 24)
+      .map((target) => summarizeTarget(sessionId, target));
+  }
+
+  async open(
+    sessionId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const session = this.#session(sessionId);
+    const targetId = await this.#client.createTarget(url, signal);
+    session.targetIds.add(targetId);
+    this.#tabs.set(targetId, { documentVersion: 1 });
+    return await this.#summary(sessionId, targetId, signal);
+  }
+
+  async navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#tab(sessionId, tabId);
+    await this.#client.navigate(tabId, url, signal);
+    tab.documentVersion += 1;
+    tab.observation = undefined;
+    return await this.#summary(sessionId, tabId, signal);
+  }
+
+  async inspect(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserInspection> {
+    const tab = this.#tab(sessionId, tabId);
+    const raw = asRecord(
+      await this.#client.evaluate(tabId, browserInspectScript, signal),
+    );
+    if (
+      raw === undefined ||
+      typeof raw.visibleText !== "string" ||
+      !Array.isArray(raw.targets)
+    ) {
+      throw new Error(
+        "User browser CDP inspection returned an unsupported shape",
+      );
+    }
+    const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
+    const targets = new Map<string, BrowserTargetFingerprint>();
+    const projected = fingerprints.map((fingerprint) => {
+      const targetId = randomUUID();
+      targets.set(targetId, fingerprint);
+      return {
+        targetId,
+        role: fingerprint.role,
+        name: fingerprint.name,
+        actions: [...fingerprint.actions],
+        ...(fingerprint.secure ? { secure: true as const } : {}),
+        ...(fingerprint.value === undefined
+          ? {}
+          : { value: fingerprint.value }),
+      };
+    });
+    const observationId = randomUUID();
+    tab.observation = {
+      id: observationId,
+      documentVersion: tab.documentVersion,
+      targets,
+    };
+    const summary = await this.#summary(sessionId, tabId, signal);
+    return {
+      ...summary,
+      observationId,
+      documentVersion: tab.documentVersion,
+      visibleText: raw.visibleText.slice(0, 8_000),
+      targets: projected,
+    };
+  }
+
+  async click(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "click",
+      "",
+      false,
+      signal,
+    );
+  }
+
+  async type(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "type",
+      text,
+      submit,
+      signal,
+    );
+  }
+
+  closeTab(sessionId: string, tabId: string): void {
+    const session = this.#requireSession(sessionId);
+    if (!session.targetIds.delete(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    session.ignoredTargetIds.add(tabId);
+    this.#tabs.delete(tabId);
+  }
+
+  closeSession(sessionId: string): number {
+    const session = this.#requireSession(sessionId);
+    const count = session.targetIds.size;
+    for (const targetId of session.targetIds) this.#tabs.delete(targetId);
+    this.#sessions.delete(sessionId);
+    return count;
+  }
+
+  async close(): Promise<void> {
+    this.#sessions.clear();
+    this.#tabs.clear();
+    await this.#client.close();
+  }
+
+  async #act(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    action: "click" | "type",
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const tab = this.#tab(sessionId, tabId);
+    const target = resolveBrowserObservedTarget(
+      tab.observation,
+      tab.documentVersion,
+      observationId,
+      targetId,
+      action,
+    );
+    const response = asRecord(
+      await this.#client.evaluate(
+        tabId,
+        browserActionScript(target, action, text, submit),
+        signal,
+      ),
+    );
+    tab.observation = undefined;
+    if (response?.ok !== true) {
+      throw new Error(
+        `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
+      );
+    }
+    tab.documentVersion += 1;
+    return await this.#summary(sessionId, tabId, signal);
+  }
+
+  #session(sessionId: string): UserBrowserSession {
+    let session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      session = { targetIds: new Set(), ignoredTargetIds: new Set() };
+      this.#sessions.set(sessionId, session);
+    }
+    return session;
+  }
+
+  #requireSession(sessionId: string): UserBrowserSession {
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      throw new Error(`Unknown user browser session: ${sessionId}`);
+    }
+    return session;
+  }
+
+  #tab(sessionId: string, tabId: string): UserBrowserTabState {
+    const session = this.#requireSession(sessionId);
+    if (!session.targetIds.has(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    return tab;
+  }
+
+  async #summary(
+    sessionId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const target = (await this.#client.listTargets(signal)).find(
+      (candidate) =>
+        candidate.targetId === targetId && candidate.type === "page",
+    );
+    if (target === undefined) throw new Error("User browser tab was closed");
+    return summarizeTarget(sessionId, target);
+  }
+}
+
+export interface UserBrowserConnection {
+  backend: UserBrowserCdpBackend;
+  product: string;
+}
+
+export async function connectUserBrowserCdp(
+  endpoint: string,
+  signal?: AbortSignal,
+): Promise<UserBrowserConnection> {
+  const base = validateCdpEndpoint(endpoint);
+  const timeout = AbortSignal.timeout(5_000);
+  const probeSignal =
+    signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+  const response = await fetch(new URL("/json/version", base), {
+    signal: probeSignal,
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `User browser CDP version probe failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const version = asRecord(await response.json());
+  if (version === undefined) {
+    throw new Error("User browser CDP version response is invalid");
+  }
+  const product = validateUserBrowserVersion(version);
+  const webSocketDebuggerUrl = version.webSocketDebuggerUrl;
+  if (typeof webSocketDebuggerUrl !== "string") {
+    throw new Error(
+      "User browser CDP version response is missing webSocketDebuggerUrl",
+    );
+  }
+  const socketUrl = new URL(webSocketDebuggerUrl);
+  if (
+    socketUrl.protocol !== "ws:" ||
+    !isLoopbackHostname(socketUrl.hostname) ||
+    socketUrl.username.length > 0 ||
+    socketUrl.password.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP WebSocket must be an unauthenticated loopback ws:// endpoint",
+    );
+  }
+  const client = await JsonRpcUserBrowserCdpClient.connect(
+    socketUrl.toString(),
+    probeSignal,
+  );
+  return { backend: new UserBrowserCdpBackend(client), product };
+}
+
+export function validateUserBrowserVersion(
+  value: Record<string, unknown>,
+): string {
+  const product = value.Browser;
+  const match =
+    typeof product === "string"
+      ? /^(?:Chrome|Chromium|Edg)\/(\d+)(?:\.\d+){1,3}(?:[-+].*)?$/u.exec(
+          product,
+        )
+      : null;
+  if (
+    typeof product !== "string" ||
+    match === null ||
+    Number.parseInt(match[1] ?? "0", 10) < 100
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must report a supported Chrome, Edge, or Chromium product",
+    );
+  }
+  return product;
+}
+
+class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
+  readonly #socket: WebSocket;
+  readonly #pending = new Map<
+    number,
+    { resolve(value: unknown): void; reject(error: Error): void }
+  >();
+  readonly #targetSessions = new Map<string, string>();
+  #nextId = 1;
+  #closed = false;
+
+  private constructor(socket: WebSocket) {
+    this.#socket = socket;
+    socket.on("message", (data) => this.#receive(data.toString()));
+    socket.on("close", () =>
+      this.#failAll(new Error("User browser CDP connection closed")),
+    );
+    socket.on("error", (error) => this.#failAll(error));
+  }
+
+  static async connect(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<JsonRpcUserBrowserCdpClient> {
+    const socket = new WebSocket(url, { handshakeTimeout: 5_000 });
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        socket.close();
+        reject(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error("User browser CDP connection aborted"),
+        );
+      };
+      socket.once("open", () => {
+        signal?.removeEventListener("abort", abort);
+        resolve();
+      });
+      socket.once("error", (error) => {
+        signal?.removeEventListener("abort", abort);
+        reject(error);
+      });
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) abort();
+    });
+    return new JsonRpcUserBrowserCdpClient(socket);
+  }
+
+  async listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]> {
+    const response = asRecord(
+      await this.#send("Target.getTargets", {}, undefined, signal),
+    );
+    const infos = response?.targetInfos;
+    if (!Array.isArray(infos))
+      throw new Error("User browser CDP Target.getTargets response is invalid");
+    return infos.map((value) => {
+      const target = asRecord(value);
+      if (
+        target === undefined ||
+        typeof target.targetId !== "string" ||
+        typeof target.type !== "string" ||
+        typeof target.title !== "string" ||
+        typeof target.url !== "string"
+      ) {
+        throw new Error("User browser CDP target metadata is invalid");
+      }
+      return {
+        targetId: target.targetId,
+        type: target.type,
+        title: target.title,
+        url: target.url,
+      };
+    });
+  }
+
+  async createTarget(url: string, signal?: AbortSignal): Promise<string> {
+    const response = asRecord(
+      await this.#send("Target.createTarget", { url }, undefined, signal),
+    );
+    if (typeof response?.targetId !== "string")
+      throw new Error("User browser CDP createTarget response is invalid");
+    return response.targetId;
+  }
+
+  async navigate(
+    targetId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const sessionId = await this.#attach(targetId, signal);
+    await this.#send("Page.navigate", { url }, sessionId, signal);
+  }
+
+  async evaluate(
+    targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const sessionId = await this.#attach(targetId, signal);
+    const response = asRecord(
+      await this.#send(
+        "Runtime.evaluate",
+        { expression, awaitPromise: true, returnByValue: true },
+        sessionId,
+        signal,
+      ),
+    );
+    if (response?.exceptionDetails !== undefined) {
+      throw new Error("User browser CDP evaluation failed");
+    }
+    return asRecord(response?.result)?.value;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#socket.close();
+    this.#failAll(new Error("User browser CDP connection closed"));
+  }
+
+  async #attach(targetId: string, signal?: AbortSignal): Promise<string> {
+    const existing = this.#targetSessions.get(targetId);
+    if (existing !== undefined) return existing;
+    const response = asRecord(
+      await this.#send(
+        "Target.attachToTarget",
+        { targetId, flatten: true },
+        undefined,
+        signal,
+      ),
+    );
+    if (typeof response?.sessionId !== "string")
+      throw new Error("User browser CDP attach response is invalid");
+    this.#targetSessions.set(targetId, response.sessionId);
+    return response.sessionId;
+  }
+
+  async #send(
+    method: string,
+    params: Record<string, unknown>,
+    sessionId?: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
+      throw new Error("User browser CDP connection is unavailable");
+    }
+    const id = this.#nextId++;
+    return await new Promise((resolve, reject) => {
+      const abort = () => {
+        this.#pending.delete(id);
+        reject(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error("User browser CDP command aborted"),
+        );
+      };
+      this.#pending.set(id, {
+        resolve: (value) => {
+          signal?.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error) => {
+          signal?.removeEventListener("abort", abort);
+          reject(error);
+        },
+      });
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) {
+        abort();
+        return;
+      }
+      this.#socket.send(
+        JSON.stringify({
+          id,
+          method,
+          params,
+          ...(sessionId === undefined ? {} : { sessionId }),
+        }),
+      );
+    });
+  }
+
+  #receive(raw: string): void {
+    let message: Record<string, unknown> | undefined;
+    try {
+      message = asRecord(JSON.parse(raw));
+    } catch {
+      this.#failAll(new Error("User browser CDP returned invalid JSON"));
+      return;
+    }
+    if (message === undefined || typeof message.id !== "number") return;
+    const pending = this.#pending.get(message.id);
+    if (pending === undefined) return;
+    this.#pending.delete(message.id);
+    const error = asRecord(message.error);
+    if (error !== undefined) {
+      pending.reject(
+        new Error(
+          `User browser CDP command failed: ${String(error.message ?? "unknown error")}`,
+        ),
+      );
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  #failAll(error: Error): void {
+    for (const pending of this.#pending.values()) pending.reject(error);
+    this.#pending.clear();
+  }
+}
+
+function validateCdpEndpoint(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("User browser CDP endpoint is not a valid URL");
+  }
+  if (
+    url.protocol !== "http:" ||
+    !isLoopbackHostname(url.hostname) ||
+    url.username.length > 0 ||
+    url.password.length > 0 ||
+    url.search.length > 0 ||
+    url.hash.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must be an unauthenticated loopback http:// URL",
+    );
+  }
+  return url;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]"
+  );
+}
+
+function isInspectableUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function summarizeTarget(
+  sessionId: string,
+  target: UserBrowserCdpTarget,
+): BrowserTabSummary {
+  return {
+    sessionId,
+    tabId: target.targetId,
+    title: target.title.slice(0, 256),
+    url: redactBrowserUrl(target.url),
+    loading: false,
+  };
+}
+
+function requireFingerprint(value: unknown): BrowserTargetFingerprint {
+  const target = asRecord(value);
+  const actions = target?.actions;
+  if (
+    target === undefined ||
+    ![
+      "selector",
+      "tag",
+      "role",
+      "name",
+      "type",
+      "id",
+      "fieldName",
+      "autocomplete",
+      "href",
+    ].every((key) => typeof target[key] === "string") ||
+    typeof target.secure !== "boolean" ||
+    !Array.isArray(actions) ||
+    !actions.every((action) => action === "click" || action === "type") ||
+    (target.value !== undefined && typeof target.value !== "string")
+  ) {
+    throw new Error("User browser CDP inspection target is invalid");
+  }
+  return {
+    selector: target.selector as string,
+    tag: target.tag as string,
+    role: target.role as string,
+    name: target.name as string,
+    type: target.type as string,
+    id: target.id as string,
+    fieldName: target.fieldName as string,
+    autocomplete: target.autocomplete as string,
+    href: target.href as string,
+    secure: target.secure,
+    actions: [...actions],
+    ...(target.value === undefined ? {} : { value: target.value }),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -15,6 +15,8 @@ import {
   type ZenXBrowserBackend,
 } from "./browser-provider.js";
 
+const USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS = 2_000;
+
 export interface UserBrowserCdpTarget {
   targetId: string;
   type: string;
@@ -25,10 +27,10 @@ export interface UserBrowserCdpTarget {
 export interface UserBrowserCdpClient {
   listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
   createTarget(url: string, signal?: AbortSignal): Promise<string>;
-  findTargetByUrl(
+  findTargetsByUrl(
     url: string,
     signal?: AbortSignal,
-  ): Promise<UserBrowserCdpTarget | undefined>;
+  ): Promise<UserBrowserCdpTarget[]>;
   navigate(targetId: string, url: string, signal?: AbortSignal): Promise<void>;
   evaluateDocument(
     targetId: string,
@@ -45,7 +47,8 @@ interface UserBrowserSession {
   targetIds: Set<string>;
   ignoredTargetIds: Set<string>;
   operations: Set<Promise<void>>;
-  unresolvedCreates: Set<string>;
+  operationTail: Promise<void>;
+  unresolvedCreates: Map<string, Set<string>>;
   detachFailures: unknown[];
   detaching: boolean;
 }
@@ -83,19 +86,6 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     this.#assertSessionIdle(session);
     const operation = this.#startSessionOperation(session, async () => {
       const listed = await this.#client.listTargets();
-      for (const target of listed) {
-        if (!isPendingCreateUrl(target.url)) continue;
-        session.targetIds.add(target.targetId);
-        if (!this.#tabs.has(target.targetId)) {
-          this.#tabs.set(target.targetId, {
-            ownerSessionId: session.id,
-            documentVersion: 1,
-            url: target.url,
-            detaching: false,
-            tainted: "provider-created target requires cleanup",
-          });
-        }
-      }
       const targets = listed.filter(
         (target) =>
           target.type === "page" &&
@@ -157,27 +147,59 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const session = this.#session(sessionId);
     const operation = this.#startSessionOperation(session, async () => {
       const pendingUrl = `about:blank#zenx-pending-${randomUUID()}`;
+      const beforeTargets = await this.#client.listTargets();
+      const beforeTargetIds = new Set(
+        beforeTargets.map((target) => target.targetId),
+      );
+      if (beforeTargets.some((target) => target.url === pendingUrl)) {
+        throw new Error("User browser create marker already exists");
+      }
       let targetId: string;
       try {
         targetId = await this.#client.createTarget(pendingUrl);
       } catch (error) {
-        const recovered = await this.#client
-          .findTargetByUrl(pendingUrl)
-          .catch(() => undefined);
+        session.unresolvedCreates.set(pendingUrl, beforeTargetIds);
+        const recovered = await this.#reconcileCreate(
+          session,
+          pendingUrl,
+          beforeTargetIds,
+        );
         if (recovered === undefined) {
-          session.unresolvedCreates.add(pendingUrl);
           throw new Error(
             `User browser create outcome is unknown (${describeError(error)})`,
           );
         }
-        this.#accountTarget(session, recovered.targetId, recovered.url, true);
         throw new Error(
           `User browser create outcome is unknown; recovered provider target ${recovered.targetId} for cleanup (${describeError(error)})`,
         );
       }
+      if (beforeTargetIds.has(targetId)) {
+        session.unresolvedCreates.set(pendingUrl, beforeTargetIds);
+        throw new Error("User browser create returned a pre-existing target");
+      }
       // Account for the target before observing the session fence. A concurrent
       // close can then deterministically detach it instead of orphaning it.
       this.#accountTarget(session, targetId, pendingUrl, false);
+      const matches = await this.#client
+        .findTargetsByUrl(pendingUrl)
+        .catch(() => []);
+      const createdMatches = matches.filter(
+        (target) =>
+          target.type === "page" && !beforeTargetIds.has(target.targetId),
+      );
+      if (
+        createdMatches.length !== 1 ||
+        createdMatches[0]?.targetId !== targetId
+      ) {
+        const tab = this.#tabs.get(targetId);
+        if (tab !== undefined) tab.tainted = "create marker was ambiguous";
+        if (createdMatches.some((target) => target.targetId !== targetId)) {
+          session.unresolvedCreates.set(pendingUrl, beforeTargetIds);
+        }
+        throw new Error(
+          "User browser create marker reconciliation is ambiguous",
+        );
+      }
       this.#assertSessionCurrent(session);
       const tab = this.#tabs.get(targetId);
       try {
@@ -340,6 +362,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     if (tab === undefined) throw new Error("User browser tab was closed");
     tab.detaching = true;
     const operation = (async () => {
+      await session.operationTail;
       await tab.operation;
       try {
         await this.#detachTarget(tabId);
@@ -372,6 +395,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     }
     const closing = (async () => {
       await Promise.all([...session.operations]);
+      await this.#reconcileUnresolvedCreates(session);
       const targetIds = [...session.targetIds];
       const count = targetIds.length;
       const detached = await Promise.allSettled(
@@ -416,6 +440,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         ]),
       ];
       const settledOperations = await Promise.allSettled(operations);
+      await Promise.allSettled(
+        [...this.#sessions.values()].map((session) =>
+          this.#reconcileUnresolvedCreates(session),
+        ),
+      );
       const detached = await Promise.allSettled(
         [...this.#tabs.keys()].map((targetId) => this.#detachTarget(targetId)),
       );
@@ -428,6 +457,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       const priorDetachFailure = [...this.#sessions.values()]
         .flatMap((session) => session.detachFailures)
         .at(0);
+      const unresolvedCreate = [...this.#sessions.values()].some(
+        (session) => session.unresolvedCreates.size > 0,
+      );
       this.#sessions.clear();
       this.#tabs.clear();
       const detachFailure = detached.find(
@@ -440,6 +472,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       );
       if (operationFailure !== undefined) throw operationFailure.reason;
       if (priorDetachFailure !== undefined) throw priorDetachFailure;
+      if (unresolvedCreate) {
+        throw new Error(
+          "User browser create outcome is unknown; provider backend is tainted",
+        );
+      }
       if (detachFailure !== undefined) throw detachFailure.reason;
       if (closeFailure !== undefined) throw closeFailure;
     })();
@@ -543,12 +580,18 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     run: () => Promise<T>,
   ): Promise<T> {
     this.#assertSessionCurrent(session);
-    const result = run();
+    const previous = session.operationTail;
+    const result = (async () => {
+      await previous;
+      this.#assertSessionCurrent(session);
+      return await run();
+    })();
     const settled = result.then(
       () => undefined,
       () => undefined,
     );
     session.operations.add(settled);
+    session.operationTail = settled;
     void settled.then(() => session.operations.delete(settled));
     return result;
   }
@@ -585,7 +628,8 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         targetIds: new Set(),
         ignoredTargetIds: new Set(),
         operations: new Set(),
-        unresolvedCreates: new Set(),
+        operationTail: Promise.resolve(),
+        unresolvedCreates: new Map(),
         detachFailures: [],
         detaching: false,
       };
@@ -665,6 +709,36 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       .catch(() => undefined);
     return operation;
   }
+
+  async #reconcileCreate(
+    session: UserBrowserSession,
+    markerUrl: string,
+    beforeTargetIds: Set<string>,
+  ): Promise<UserBrowserCdpTarget | undefined> {
+    const matches = await this.#client
+      .findTargetsByUrl(markerUrl)
+      .catch(() => []);
+    const candidates = matches.filter(
+      (target) =>
+        target.type === "page" && !beforeTargetIds.has(target.targetId),
+    );
+    if (candidates.length !== 1) return undefined;
+    const recovered = candidates[0];
+    if (recovered === undefined) return undefined;
+    session.unresolvedCreates.delete(markerUrl);
+    if (!session.targetIds.has(recovered.targetId)) {
+      this.#accountTarget(session, recovered.targetId, recovered.url, true);
+    }
+    return recovered;
+  }
+
+  async #reconcileUnresolvedCreates(
+    session: UserBrowserSession,
+  ): Promise<void> {
+    for (const [markerUrl, beforeTargetIds] of session.unresolvedCreates) {
+      await this.#reconcileCreate(session, markerUrl, beforeTargetIds);
+    }
+  }
 }
 
 export interface UserBrowserConnection {
@@ -709,13 +783,16 @@ export async function connectUserBrowserCdp(
   if (
     socketUrl.protocol !== "ws:" ||
     !isLoopbackHostname(socketUrl.hostname) ||
+    socketUrl.hostname !== base.hostname ||
+    effectivePort(socketUrl) !== effectivePort(base) ||
+    !/^\/devtools\/browser\/[^/]+$/u.test(socketUrl.pathname) ||
     socketUrl.username.length > 0 ||
     socketUrl.password.length > 0 ||
     socketUrl.search.length > 0 ||
     socketUrl.hash.length > 0
   ) {
     throw new Error(
-      "User browser CDP WebSocket must be an unauthenticated loopback ws:// endpoint",
+      "User browser CDP WebSocket must use the same loopback authority as the HTTP endpoint",
     );
   }
   const client = await JsonRpcUserBrowserCdpClient.connect(
@@ -847,6 +924,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         { url, background: true, focus: false },
         undefined,
         signal,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
       ),
     );
     if (typeof response?.targetId !== "string")
@@ -854,10 +932,10 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     return response.targetId;
   }
 
-  async findTargetByUrl(
+  async findTargetsByUrl(
     url: string,
     signal?: AbortSignal,
-  ): Promise<UserBrowserCdpTarget | undefined> {
+  ): Promise<UserBrowserCdpTarget[]> {
     const timeout = AbortSignal.timeout(5_000);
     const requestSignal =
       signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
@@ -876,6 +954,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         "User browser CDP target reconciliation response is invalid",
       );
     }
+    const matches: UserBrowserCdpTarget[] = [];
     for (const item of value) {
       const target = asRecord(item);
       const targetId = target?.id ?? target?.targetId;
@@ -885,15 +964,15 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         typeof target?.url === "string" &&
         target.url === url
       ) {
-        return {
+        matches.push({
           targetId,
           type: target.type,
           title: typeof target.title === "string" ? target.title : "",
           url: target.url,
-        };
+        });
       }
     }
-    return undefined;
+    return matches;
   }
 
   async navigate(
@@ -1047,7 +1126,13 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       return;
     }
     try {
-      await this.#send("Target.detachFromTarget", { sessionId });
+      await this.#send(
+        "Target.detachFromTarget",
+        { sessionId },
+        undefined,
+        undefined,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+      );
     } finally {
       this.#reapTarget(targetId);
     }
@@ -1120,14 +1205,21 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     params: Record<string, unknown>,
     sessionId?: string,
     signal?: AbortSignal,
+    outcomeTimeoutMs = USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
   ): Promise<unknown> {
     if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
       throw new Error("User browser CDP connection is unavailable");
     }
     const id = this.#nextId++;
     return await new Promise((resolve, reject) => {
+      let timeout: NodeJS.Timeout | undefined;
+      const finish = () => {
+        signal?.removeEventListener("abort", abort);
+        if (timeout !== undefined) clearTimeout(timeout);
+      };
       const abort = () => {
         this.#pending.delete(id);
+        finish();
         reject(
           signal?.reason instanceof Error
             ? signal.reason
@@ -1136,14 +1228,23 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       };
       this.#pending.set(id, {
         resolve: (value) => {
-          signal?.removeEventListener("abort", abort);
+          finish();
           resolve(value);
         },
         reject: (error) => {
-          signal?.removeEventListener("abort", abort);
+          finish();
           reject(error);
         },
       });
+      timeout = setTimeout(() => {
+        if (!this.#pending.delete(id)) return;
+        finish();
+        reject(
+          new Error(
+            `User browser CDP ${method} outcome timed out after dispatch`,
+          ),
+        );
+      }, outcomeTimeoutMs);
       signal?.addEventListener("abort", abort, { once: true });
       if (signal?.aborted === true) {
         abort();
@@ -1284,10 +1385,6 @@ export function userBrowserDocumentEventInvalidates(
   return typeof params.frameId === "string" && params.frameId === mainFrameId;
 }
 
-function isPendingCreateUrl(url: string): boolean {
-  return url.startsWith("about:blank#zenx-pending-");
-}
-
 function validateCdpEndpoint(raw: string): URL {
   let url: URL;
   try {
@@ -1381,9 +1478,19 @@ function throwIfAborted(signal?: AbortSignal): void {
 }
 
 function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "[::1]") return true;
+  const octets = hostname.split(".");
   return (
-    hostname === "127.0.0.1" || hostname === "localhost" || hostname === "[::1]"
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((octet) => /^\d{1,3}$/u.test(octet)) &&
+    octets.every((octet) => Number(octet) <= 255)
   );
+}
+
+function effectivePort(url: URL): string {
+  if (url.port.length > 0) return url.port;
+  return url.protocol === "http:" || url.protocol === "ws:" ? "80" : "";
 }
 
 function isInspectableUrl(raw: string): boolean {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -26,28 +26,33 @@ export interface UserBrowserCdpClient {
   listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
   createTarget(url: string, signal?: AbortSignal): Promise<string>;
   navigate(targetId: string, url: string, signal?: AbortSignal): Promise<void>;
-  evaluate(
+  evaluateDocument(
     targetId: string,
     expression: string,
+    expectedDocumentIdentity?: string,
     signal?: AbortSignal,
-  ): Promise<unknown>;
-  documentIdentity(targetId: string, signal?: AbortSignal): Promise<string>;
+  ): Promise<{ value: unknown; documentIdentity: string }>;
+  detachTarget(targetId: string): Promise<void>;
   close(): Promise<void> | void;
 }
 
 interface UserBrowserSession {
+  id: string;
   targetIds: Set<string>;
   ignoredTargetIds: Set<string>;
+  operations: Set<Promise<void>>;
   detaching: boolean;
 }
 
 interface UserBrowserTabState {
+  ownerSessionId: string;
   documentVersion: number;
   url: string;
   documentIdentity?: string;
   observation?: BrowserObservation;
   operation?: Promise<void>;
   detaching: boolean;
+  tainted?: string;
 }
 
 export class UserBrowserCdpBackend implements ZenXBrowserBackend {
@@ -64,40 +69,60 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     sessionId: string,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary[]> {
+    throwIfAborted(signal);
     const session = this.#session(sessionId);
     this.#assertSessionIdle(session);
-    const targets = (await this.#client.listTargets(signal)).filter(
-      (target) =>
-        target.type === "page" &&
-        isInspectableUrl(target.url) &&
-        !session.ignoredTargetIds.has(target.targetId),
-    );
-    const live = new Set(targets.map((target) => target.targetId));
-    for (const targetId of session.targetIds) {
-      if (!live.has(targetId)) {
-        session.targetIds.delete(targetId);
-        this.#tabs.delete(targetId);
+    const operation = this.#startSessionOperation(session, async () => {
+      const targets = (await this.#client.listTargets()).filter(
+        (target) =>
+          target.type === "page" &&
+          isInspectableUrl(target.url) &&
+          !session.ignoredTargetIds.has(target.targetId) &&
+          (this.#tabs.get(target.targetId) === undefined ||
+            this.#tabs.get(target.targetId)?.ownerSessionId === session.id),
+      );
+      this.#assertSessionCurrent(session);
+      const live = new Set(targets.map((target) => target.targetId));
+      const disappeared: string[] = [];
+      for (const targetId of session.targetIds) {
+        if (!live.has(targetId)) {
+          session.targetIds.delete(targetId);
+          this.#tabs.delete(targetId);
+          disappeared.push(targetId);
+        }
       }
-    }
-    for (const target of targets) {
-      session.targetIds.add(target.targetId);
-      const tab = this.#tabs.get(target.targetId);
-      if (tab === undefined) {
-        this.#tabs.set(target.targetId, {
-          documentVersion: 1,
-          url: target.url,
-          detaching: false,
-        });
-      } else if (tab.url !== target.url) {
-        tab.url = target.url;
-        tab.documentVersion += 1;
-        tab.documentIdentity = undefined;
-        tab.observation = undefined;
+      const detached = await Promise.allSettled(
+        disappeared.map((targetId) => this.#client.detachTarget(targetId)),
+      );
+      const detachFailure = detached.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (detachFailure !== undefined) throw detachFailure.reason;
+      this.#assertSessionCurrent(session);
+      for (const target of targets) {
+        session.targetIds.add(target.targetId);
+        const tab = this.#tabs.get(target.targetId);
+        if (tab === undefined) {
+          this.#tabs.set(target.targetId, {
+            ownerSessionId: session.id,
+            documentVersion: 1,
+            url: target.url,
+            detaching: false,
+          });
+        } else if (tab.url !== target.url) {
+          tab.url = target.url;
+          tab.documentVersion += 1;
+          tab.documentIdentity = undefined;
+          tab.observation = undefined;
+        }
       }
-    }
-    return targets
-      .slice(0, 24)
-      .map((target) => summarizeTarget(sessionId, target));
+      this.#assertSessionCurrent(session);
+      return targets
+        .slice(0, 24)
+        .map((target) => summarizeTarget(sessionId, target));
+    });
+    return await raceAbort(operation, signal);
   }
 
   async open(
@@ -105,15 +130,25 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     url: string,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
     const session = this.#session(sessionId);
-    const targetId = await this.#client.createTarget(url, signal);
-    session.targetIds.add(targetId);
-    this.#tabs.set(targetId, {
-      documentVersion: 1,
-      url,
-      detaching: false,
+    const operation = this.#startSessionOperation(session, async () => {
+      const targetId = await this.#client.createTarget(url);
+      // Account for the target before observing the session fence. A concurrent
+      // close can then deterministically detach it instead of orphaning it.
+      session.targetIds.add(targetId);
+      this.#tabs.set(targetId, {
+        ownerSessionId: session.id,
+        documentVersion: 1,
+        url,
+        detaching: session.detaching,
+      });
+      this.#assertSessionCurrent(session);
+      const summary = await this.#summary(sessionId, targetId);
+      this.#assertSessionCurrent(session);
+      return summary;
     });
-    return await this.#summary(sessionId, targetId, signal);
+    return await raceAbort(operation, signal);
   }
 
   async navigate(
@@ -123,14 +158,19 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     throwIfAborted(signal);
-    const tab = this.#tab(sessionId, tabId);
-    const operation = this.#startOperation(tab, async () => {
-      await this.#client.navigate(tabId, url);
-      tab.documentVersion += 1;
-      tab.url = url;
-      tab.documentIdentity = undefined;
-      tab.observation = undefined;
-      return await this.#summary(sessionId, tabId);
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
+    const operation = this.#startOperation(session, tab, async () => {
+      try {
+        await this.#client.navigate(tabId, url);
+        tab.documentVersion += 1;
+        tab.url = url;
+        tab.documentIdentity = undefined;
+        tab.observation = undefined;
+        return await this.#summary(sessionId, tabId);
+      } catch (error) {
+        tab.tainted = describeError(error);
+        throw error;
+      }
     });
     try {
       return await raceAbort(operation, signal);
@@ -147,16 +187,21 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
     throwIfAborted(signal);
-    const tab = this.#tab(sessionId, tabId);
-    const operation = this.#startOperation(tab, async () => {
-      const before = await this.#client.documentIdentity(tabId);
-      const raw = asRecord(
-        await this.#client.evaluate(tabId, browserInspectScript),
-      );
-      const after = await this.#client.documentIdentity(tabId);
-      if (before !== after) {
-        throw new Error("User browser document changed during inspection");
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
+    const operation = this.#startOperation(session, tab, async () => {
+      let evaluation: { value: unknown; documentIdentity: string };
+      try {
+        evaluation = await this.#client.evaluateDocument(
+          tabId,
+          browserInspectScript,
+        );
+      } catch (error) {
+        if (error instanceof UserBrowserDocumentChangedAfterDispatchError) {
+          throw new Error("User browser document changed during inspection");
+        }
+        throw error;
       }
+      const raw = asRecord(evaluation.value);
       if (
         raw === undefined ||
         typeof raw.visibleText !== "string" ||
@@ -183,13 +228,14 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         };
       });
       const observationId = randomUUID();
-      tab.documentIdentity = after;
+      const summary = await this.#summary(sessionId, tabId);
+      this.#assertSessionCurrent(session);
+      tab.documentIdentity = evaluation.documentIdentity;
       tab.observation = {
         id: observationId,
         documentVersion: tab.documentVersion,
         targets,
       };
-      const summary = await this.#summary(sessionId, tabId);
       return {
         ...summary,
         observationId,
@@ -250,23 +296,34 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     if (tab === undefined) throw new Error("User browser tab was closed");
     tab.detaching = true;
     await tab.operation;
-    session.targetIds.delete(tabId);
-    session.ignoredTargetIds.add(tabId);
-    this.#tabs.delete(tabId);
+    try {
+      await this.#client.detachTarget(tabId);
+    } finally {
+      session.targetIds.delete(tabId);
+      session.ignoredTargetIds.add(tabId);
+      this.#tabs.delete(tabId);
+    }
   }
 
   async closeSession(sessionId: string): Promise<number> {
     const session = this.#requireSession(sessionId);
     session.detaching = true;
-    const count = session.targetIds.size;
-    const tabs = [...session.targetIds].map((targetId) => {
+    for (const targetId of session.targetIds) {
       const tab = this.#tabs.get(targetId);
       if (tab !== undefined) tab.detaching = true;
-      return { targetId, tab };
-    });
-    await Promise.all(tabs.map(({ tab }) => tab?.operation));
-    for (const { targetId } of tabs) this.#tabs.delete(targetId);
+    }
+    await Promise.all([...session.operations]);
+    const targetIds = [...session.targetIds];
+    const count = targetIds.length;
+    const detached = await Promise.allSettled(
+      targetIds.map((targetId) => this.#client.detachTarget(targetId)),
+    );
+    for (const targetId of targetIds) this.#tabs.delete(targetId);
     this.#sessions.delete(sessionId);
+    const failure = detached.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure !== undefined) throw failure.reason;
     return count;
   }
 
@@ -274,11 +331,28 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     this.#closing = true;
     for (const session of this.#sessions.values()) session.detaching = true;
     for (const tab of this.#tabs.values()) tab.detaching = true;
-    const operations = [...this.#tabs.values()].map((tab) => tab.operation);
-    await this.#client.close();
+    const operations = [...this.#sessions.values()].flatMap((session) => [
+      ...session.operations,
+    ]);
     await Promise.all(operations);
+    const detached = await Promise.allSettled(
+      [...this.#tabs.keys()].map((targetId) =>
+        this.#client.detachTarget(targetId),
+      ),
+    );
+    let closeFailure: unknown;
+    try {
+      await this.#client.close();
+    } catch (error) {
+      closeFailure = error;
+    }
     this.#sessions.clear();
     this.#tabs.clear();
+    const detachFailure = detached.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (detachFailure !== undefined) throw detachFailure.reason;
+    if (closeFailure !== undefined) throw closeFailure;
   }
 
   async #act(
@@ -292,7 +366,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     throwIfAborted(signal);
-    const tab = this.#tab(sessionId, tabId);
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
     const target = resolveBrowserObservedTarget(
       tab.observation,
       tab.documentVersion,
@@ -304,28 +378,37 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     tab.documentIdentity = undefined;
     let dispatched = false;
-    const operation = this.#startOperation(tab, async () => {
-      const actualDocumentIdentity = await this.#client.documentIdentity(tabId);
-      if (actualDocumentIdentity !== expectedDocumentIdentity) {
-        throw new DocumentChangedError();
-      }
-      dispatched = true;
-      const response = asRecord(
-        await this.#client.evaluate(
+    const operation = this.#startOperation(session, tab, async () => {
+      let evaluation: { value: unknown; documentIdentity: string };
+      try {
+        dispatched = true;
+        evaluation = await this.#client.evaluateDocument(
           tabId,
           browserActionScript(target, action, text, submit),
-        ),
-      );
+          expectedDocumentIdentity,
+        );
+      } catch (error) {
+        if (error instanceof UserBrowserDocumentChangedBeforeDispatchError)
+          throw error;
+        tab.tainted = describeError(error);
+        throw error;
+      }
+      const response = asRecord(evaluation.value);
       if (response?.ok !== true) {
         throw new ActionRejectedError(String(response?.reason ?? "unknown"));
       }
       tab.documentVersion += 1;
-      return await this.#summary(sessionId, tabId);
+      try {
+        return await this.#summary(sessionId, tabId);
+      } catch (error) {
+        tab.tainted = describeError(error);
+        throw error;
+      }
     });
     try {
       return await raceAbort(operation, signal);
     } catch (error) {
-      if (error instanceof DocumentChangedError) {
+      if (error instanceof UserBrowserDocumentChangedBeforeDispatchError) {
         throw new Error("User browser document changed; inspect again");
       }
       if (error instanceof ActionRejectedError) {
@@ -340,6 +423,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   }
 
   #startOperation<T>(
+    session: UserBrowserSession,
     tab: UserBrowserTabState,
     run: () => Promise<T>,
   ): Promise<T> {
@@ -347,7 +431,10 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     if (tab.operation !== undefined) {
       throw new Error("User browser tab operation is already in flight");
     }
-    const result = run();
+    if (tab.tainted !== undefined) {
+      throw new Error(`User browser tab is tainted (${tab.tainted})`);
+    }
+    const result = this.#startSessionOperation(session, run);
     const settled = result.then(
       () => undefined,
       () => undefined,
@@ -359,11 +446,38 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     return result;
   }
 
+  #startSessionOperation<T>(
+    session: UserBrowserSession,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    this.#assertSessionCurrent(session);
+    const result = run();
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    session.operations.add(settled);
+    void settled.then(() => session.operations.delete(settled));
+    return result;
+  }
+
+  #assertSessionCurrent(session: UserBrowserSession): void {
+    if (
+      this.#closing ||
+      session.detaching ||
+      this.#sessions.get(session.id) !== session
+    ) {
+      throw new Error("User browser session is detaching");
+    }
+  }
+
   #assertSessionIdle(session: UserBrowserSession): void {
     for (const targetId of session.targetIds) {
       const tab = this.#tabs.get(targetId);
       if (tab?.detaching === true)
         throw new Error("User browser tab is detaching");
+      if (tab?.tainted !== undefined)
+        throw new Error(`User browser tab is tainted (${tab.tainted})`);
       if (tab?.operation !== undefined) {
         throw new Error("User browser tab operation is already in flight");
       }
@@ -375,8 +489,10 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     let session = this.#sessions.get(sessionId);
     if (session === undefined) {
       session = {
+        id: sessionId,
         targetIds: new Set(),
         ignoredTargetIds: new Set(),
+        operations: new Set(),
         detaching: false,
       };
       this.#sessions.set(sessionId, session);
@@ -395,14 +511,20 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     return session;
   }
 
-  #tab(sessionId: string, tabId: string): UserBrowserTabState {
+  #sessionTab(
+    sessionId: string,
+    tabId: string,
+  ): { session: UserBrowserSession; tab: UserBrowserTabState } {
     const session = this.#requireSession(sessionId);
     if (!session.targetIds.has(tabId)) {
       throw new Error(`Unknown user browser tab: ${tabId}`);
     }
     const tab = this.#tabs.get(tabId);
     if (tab === undefined) throw new Error("User browser tab was closed");
-    return tab;
+    if (tab.tainted !== undefined) {
+      throw new Error(`User browser tab is tainted (${tab.tainted})`);
+    }
+    return { session, tab };
   }
 
   async #summary(
@@ -507,6 +629,10 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
   >();
   readonly #targetSessions = new Map<string, string>();
   readonly #sessionTargets = new Map<string, string>();
+  readonly #targetAttachments = new Map<
+    string,
+    { promise: Promise<string>; invalidated: boolean }
+  >();
   readonly #targetDocuments = new Map<
     string,
     {
@@ -602,30 +728,77 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     await this.#send("Page.navigate", { url }, sessionId, signal);
   }
 
-  async evaluate(
+  async evaluateDocument(
     targetId: string,
     expression: string,
+    expectedDocumentIdentity?: string,
     signal?: AbortSignal,
-  ): Promise<unknown> {
-    const sessionId = await this.#attach(targetId, signal);
-    const response = asRecord(
-      await this.#send(
-        "Runtime.evaluate",
-        { expression, awaitPromise: true, returnByValue: true },
-        sessionId,
-        signal,
-      ),
-    );
-    if (response?.exceptionDetails !== undefined) {
-      throw new Error("User browser CDP evaluation failed");
+  ): Promise<{ value: unknown; documentIdentity: string }> {
+    throwIfAborted(signal);
+    const before = await this.#executionDocument(targetId);
+    if (
+      expectedDocumentIdentity !== undefined &&
+      before.identity !== expectedDocumentIdentity
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
     }
-    return asRecord(response?.result)?.value;
+    let response: Record<string, unknown> | undefined;
+    try {
+      response = asRecord(
+        await this.#send(
+          "Runtime.evaluate",
+          {
+            expression,
+            awaitPromise: true,
+            returnByValue: true,
+            contextId: before.executionContextId,
+          },
+          before.sessionId,
+        ),
+      );
+      if (response?.exceptionDetails !== undefined) {
+        throw new Error("User browser CDP evaluation failed");
+      }
+      const confirmation = asRecord(
+        await this.#send(
+          "Runtime.evaluate",
+          {
+            expression: "void 0",
+            awaitPromise: true,
+            returnByValue: true,
+            contextId: before.executionContextId,
+          },
+          before.sessionId,
+        ),
+      );
+      if (confirmation?.exceptionDetails !== undefined) {
+        throw new Error("User browser CDP post-confirmation failed");
+      }
+      const after = await this.#executionDocument(targetId);
+      if (after.identity !== before.identity) {
+        throw new UserBrowserDocumentChangedAfterDispatchError();
+      }
+      return {
+        value: asRecord(response?.result)?.value,
+        documentIdentity: after.identity,
+      };
+    } catch (error) {
+      if (error instanceof UserBrowserDocumentChangedAfterDispatchError)
+        throw error;
+      throw new UserBrowserDocumentChangedAfterDispatchError(
+        describeError(error),
+      );
+    }
   }
 
-  async documentIdentity(
+  async #executionDocument(
     targetId: string,
     signal?: AbortSignal,
-  ): Promise<string> {
+  ): Promise<{
+    identity: string;
+    executionContextId: number;
+    sessionId: string;
+  }> {
     const sessionId = await this.#attach(targetId, signal);
     const response = asRecord(
       await this.#send("Page.getFrameTree", {}, sessionId, signal),
@@ -650,13 +823,57 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       url: frame.url,
       alive: true,
     });
-    return JSON.stringify({
+    const world = asRecord(
+      await this.#send(
+        "Page.createIsolatedWorld",
+        {
+          frameId: frame.id,
+          worldName: "__zenx_user_browser_document__",
+          grantUniveralAccess: false,
+        },
+        sessionId,
+        signal,
+      ),
+    );
+    if (typeof world?.executionContextId !== "number") {
+      throw new Error("User browser CDP execution context is invalid");
+    }
+    const identity = JSON.stringify({
       targetId,
+      sessionId,
       revision,
       frameId: frame.id,
       loaderId: frame.loaderId,
       url: frame.url,
+      executionContextId: world.executionContextId,
     });
+    return {
+      identity,
+      executionContextId: world.executionContextId,
+      sessionId,
+    };
+  }
+
+  async detachTarget(targetId: string): Promise<void> {
+    const attaching = this.#targetAttachments.get(targetId);
+    if (attaching !== undefined) {
+      try {
+        await attaching.promise;
+      } catch {
+        this.#reapTarget(targetId);
+        return;
+      }
+    }
+    const sessionId = this.#targetSessions.get(targetId);
+    if (sessionId === undefined) {
+      this.#reapTarget(targetId);
+      return;
+    }
+    try {
+      await this.#send("Target.detachFromTarget", { sessionId });
+    } finally {
+      this.#reapTarget(targetId);
+    }
   }
 
   close(): void {
@@ -669,27 +886,56 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
   async #attach(targetId: string, signal?: AbortSignal): Promise<string> {
     const existing = this.#targetSessions.get(targetId);
     if (existing !== undefined) return existing;
-    const response = asRecord(
-      await this.#send(
-        "Target.attachToTarget",
-        { targetId, flatten: true },
-        undefined,
-        signal,
-      ),
-    );
-    if (typeof response?.sessionId !== "string")
-      throw new Error("User browser CDP attach response is invalid");
-    this.#targetSessions.set(targetId, response.sessionId);
-    this.#sessionTargets.set(response.sessionId, targetId);
-    this.#targetDocuments.set(targetId, {
-      revision: 0,
-      frameId: "",
-      loaderId: "",
-      url: "",
-      alive: true,
-    });
-    await this.#send("Page.enable", {}, response.sessionId, signal);
-    return response.sessionId;
+    const pending = this.#targetAttachments.get(targetId);
+    if (pending !== undefined) return await pending.promise;
+    const attachment = { promise: Promise.resolve(""), invalidated: false };
+    const attaching = (async () => {
+      const response = asRecord(
+        await this.#send(
+          "Target.attachToTarget",
+          { targetId, flatten: true },
+          undefined,
+          signal,
+        ),
+      );
+      if (typeof response?.sessionId !== "string")
+        throw new Error("User browser CDP attach response is invalid");
+      if (attachment.invalidated) {
+        try {
+          await this.#send("Target.detachFromTarget", {
+            sessionId: response.sessionId,
+          });
+        } catch {
+          // The target already disappeared; the local tombstone is authoritative.
+        }
+        throw new Error("User browser target detached during attachment");
+      }
+      this.#targetSessions.set(targetId, response.sessionId);
+      this.#sessionTargets.set(response.sessionId, targetId);
+      this.#targetDocuments.set(targetId, {
+        revision: 0,
+        frameId: "",
+        loaderId: "",
+        url: "",
+        alive: true,
+      });
+      try {
+        await this.#send("Page.enable", {}, response.sessionId, signal);
+        return response.sessionId;
+      } catch (error) {
+        this.#reapTarget(targetId);
+        throw error;
+      }
+    })();
+    attachment.promise = attaching;
+    this.#targetAttachments.set(targetId, attachment);
+    try {
+      return await attaching;
+    } finally {
+      if (this.#targetAttachments.get(targetId) === attachment) {
+        this.#targetAttachments.delete(targetId);
+      }
+    }
   }
 
   async #send(
@@ -773,15 +1019,17 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       method === "Target.targetDestroyed" &&
       typeof params.targetId === "string"
     ) {
-      this.#invalidateTarget(params.targetId, true);
+      this.#reapTarget(params.targetId);
       return;
     }
     if (
       method === "Target.detachedFromTarget" &&
       typeof params.sessionId === "string"
     ) {
-      const targetId = this.#sessionTargets.get(params.sessionId);
-      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      const targetId =
+        this.#sessionTargets.get(params.sessionId) ??
+        (typeof params.targetId === "string" ? params.targetId : undefined);
+      if (targetId !== undefined) this.#reapTarget(targetId);
       return;
     }
     if (
@@ -789,7 +1037,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       typeof message.sessionId === "string"
     ) {
       const targetId = this.#sessionTargets.get(message.sessionId);
-      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      if (targetId !== undefined) this.#reapTarget(targetId);
       return;
     }
     if (typeof message.sessionId !== "string") return;
@@ -819,10 +1067,21 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     this.#targetDocuments.set(targetId, state);
   }
 
+  #reapTarget(targetId: string): void {
+    const attaching = this.#targetAttachments.get(targetId);
+    if (attaching !== undefined) attaching.invalidated = true;
+    const sessionId = this.#targetSessions.get(targetId);
+    if (sessionId !== undefined) this.#sessionTargets.delete(sessionId);
+    this.#targetSessions.delete(targetId);
+    this.#targetDocuments.delete(targetId);
+  }
+
   #failAll(error: Error): void {
-    for (const targetId of this.#targetSessions.keys()) {
-      this.#invalidateTarget(targetId, true);
-    }
+    this.#closed = true;
+    this.#targetSessions.clear();
+    this.#sessionTargets.clear();
+    this.#targetDocuments.clear();
+    this.#targetAttachments.clear();
     for (const pending of this.#pending.values()) pending.reject(error);
     this.#pending.clear();
   }
@@ -836,6 +1095,14 @@ export function userBrowserDocumentEventInvalidates(
   if (method === "Page.frameNavigated") {
     const frame = asRecord(params.frame);
     return frame !== undefined && frame.parentId === undefined;
+  }
+  if (method === "Page.lifecycleEvent") {
+    return (
+      typeof params.frameId === "string" &&
+      params.frameId === mainFrameId &&
+      (params.name === "backForwardCacheRestore" ||
+        params.name === "bfCacheRestore")
+    );
   }
   if (
     method !== "Page.navigatedWithinDocument" &&
@@ -894,7 +1161,17 @@ function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-class DocumentChangedError extends Error {}
+export class UserBrowserDocumentChangedBeforeDispatchError extends Error {
+  constructor() {
+    super("User browser document changed before action dispatch");
+  }
+}
+
+export class UserBrowserDocumentChangedAfterDispatchError extends Error {
+  constructor(detail = "document identity changed") {
+    super(detail);
+  }
+}
 class ActionRejectedError extends Error {}
 
 async function raceAbort<T>(

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -31,12 +31,14 @@ export interface UserBrowserCdpClient {
     expression: string,
     signal?: AbortSignal,
   ): Promise<unknown>;
+  documentIdentity(targetId: string, signal?: AbortSignal): Promise<string>;
   close(): Promise<void> | void;
 }
 
 interface UserBrowserSession {
   targetIds: Set<string>;
   ignoredTargetIds: Set<string>;
+  detaching: boolean;
 }
 
 interface UserBrowserTabState {
@@ -44,26 +46,15 @@ interface UserBrowserTabState {
   url: string;
   documentIdentity?: string;
   observation?: BrowserObservation;
-  actionInFlight: boolean;
+  operation?: Promise<void>;
+  detaching: boolean;
 }
-
-export const userBrowserDocumentIdentityScript = `(() => {
-    const key = "__zenxCapabilityDocumentIdentity";
-    let state = document[key];
-    if (typeof state !== "object" || state === null || typeof state.id !== "string" || typeof state.activation !== "number") {
-      state = { id: String(Date.now()) + ":" + String(Math.random()), activation: 0 };
-      Object.defineProperty(document, key, { value: state, configurable: false, enumerable: false });
-      addEventListener("pageshow", (event) => { if (event.persisted) state.activation += 1; });
-      addEventListener("popstate", () => { state.activation += 1; });
-      addEventListener("hashchange", () => { state.activation += 1; });
-    }
-    return JSON.stringify({ href: location.href, origin: location.origin, id: state.id, activation: state.activation });
-  })()`;
 
 export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #client: UserBrowserCdpClient;
   readonly #sessions = new Map<string, UserBrowserSession>();
   readonly #tabs = new Map<string, UserBrowserTabState>();
+  #closing = false;
 
   constructor(client: UserBrowserCdpClient) {
     this.#client = client;
@@ -74,6 +65,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary[]> {
     const session = this.#session(sessionId);
+    this.#assertSessionIdle(session);
     const targets = (await this.#client.listTargets(signal)).filter(
       (target) =>
         target.type === "page" &&
@@ -94,7 +86,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         this.#tabs.set(target.targetId, {
           documentVersion: 1,
           url: target.url,
-          actionInFlight: false,
+          detaching: false,
         });
       } else if (tab.url !== target.url) {
         tab.url = target.url;
@@ -119,7 +111,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     this.#tabs.set(targetId, {
       documentVersion: 1,
       url,
-      actionInFlight: false,
+      detaching: false,
     });
     return await this.#summary(sessionId, targetId, signal);
   }
@@ -130,16 +122,23 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     url: string,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
+    const operation = this.#startOperation(tab, async () => {
+      await this.#client.navigate(tabId, url);
+      tab.documentVersion += 1;
+      tab.url = url;
+      tab.documentIdentity = undefined;
+      tab.observation = undefined;
+      return await this.#summary(sessionId, tabId);
+    });
+    try {
+      return await raceAbort(operation, signal);
+    } catch (error) {
+      throw new Error(
+        `User browser navigation outcome is unknown after cancellation or connection failure (${describeError(error)})`,
+      );
     }
-    await this.#client.navigate(tabId, url, signal);
-    tab.documentVersion += 1;
-    tab.url = url;
-    tab.documentIdentity = undefined;
-    tab.observation = undefined;
-    return await this.#summary(sessionId, tabId, signal);
   }
 
   async inspect(
@@ -147,59 +146,59 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     tabId: string,
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
-    }
-    const envelope = asRecord(
-      await this.#client.evaluate(
-        tabId,
-        `(() => ({ documentIdentity: ${userBrowserDocumentIdentityScript}, inspection: ${browserInspectScript} }))()`,
-        signal,
-      ),
-    );
-    const raw = asRecord(envelope?.inspection);
-    if (
-      typeof envelope?.documentIdentity !== "string" ||
-      raw === undefined ||
-      typeof raw.visibleText !== "string" ||
-      !Array.isArray(raw.targets)
-    ) {
-      throw new Error(
-        "User browser CDP inspection returned an unsupported shape",
+    const operation = this.#startOperation(tab, async () => {
+      const before = await this.#client.documentIdentity(tabId);
+      const raw = asRecord(
+        await this.#client.evaluate(tabId, browserInspectScript),
       );
-    }
-    const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
-    const targets = new Map<string, BrowserTargetFingerprint>();
-    const projected = fingerprints.map((fingerprint) => {
-      const targetId = randomUUID();
-      targets.set(targetId, fingerprint);
+      const after = await this.#client.documentIdentity(tabId);
+      if (before !== after) {
+        throw new Error("User browser document changed during inspection");
+      }
+      if (
+        raw === undefined ||
+        typeof raw.visibleText !== "string" ||
+        !Array.isArray(raw.targets)
+      ) {
+        throw new Error(
+          "User browser CDP inspection returned an unsupported shape",
+        );
+      }
+      const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
+      const targets = new Map<string, BrowserTargetFingerprint>();
+      const projected = fingerprints.map((fingerprint) => {
+        const targetId = randomUUID();
+        targets.set(targetId, fingerprint);
+        return {
+          targetId,
+          role: fingerprint.role,
+          name: fingerprint.name,
+          actions: [...fingerprint.actions],
+          ...(fingerprint.secure ? { secure: true as const } : {}),
+          ...(fingerprint.value === undefined
+            ? {}
+            : { value: fingerprint.value }),
+        };
+      });
+      const observationId = randomUUID();
+      tab.documentIdentity = after;
+      tab.observation = {
+        id: observationId,
+        documentVersion: tab.documentVersion,
+        targets,
+      };
+      const summary = await this.#summary(sessionId, tabId);
       return {
-        targetId,
-        role: fingerprint.role,
-        name: fingerprint.name,
-        actions: [...fingerprint.actions],
-        ...(fingerprint.secure ? { secure: true as const } : {}),
-        ...(fingerprint.value === undefined
-          ? {}
-          : { value: fingerprint.value }),
+        ...summary,
+        observationId,
+        documentVersion: tab.documentVersion,
+        visibleText: raw.visibleText.slice(0, 8_000),
+        targets: projected,
       };
     });
-    const observationId = randomUUID();
-    tab.documentIdentity = envelope.documentIdentity;
-    tab.observation = {
-      id: observationId,
-      documentVersion: tab.documentVersion,
-      targets,
-    };
-    const summary = await this.#summary(sessionId, tabId, signal);
-    return {
-      ...summary,
-      observationId,
-      documentVersion: tab.documentVersion,
-      visibleText: raw.visibleText.slice(0, 8_000),
-      targets: projected,
-    };
+    return await raceAbort(operation, signal);
   }
 
   async click(
@@ -242,27 +241,44 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     );
   }
 
-  closeTab(sessionId: string, tabId: string): void {
+  async closeTab(sessionId: string, tabId: string): Promise<void> {
     const session = this.#requireSession(sessionId);
-    if (!session.targetIds.delete(tabId)) {
+    if (!session.targetIds.has(tabId)) {
       throw new Error(`Unknown user browser tab: ${tabId}`);
     }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    tab.detaching = true;
+    await tab.operation;
+    session.targetIds.delete(tabId);
     session.ignoredTargetIds.add(tabId);
     this.#tabs.delete(tabId);
   }
 
-  closeSession(sessionId: string): number {
+  async closeSession(sessionId: string): Promise<number> {
     const session = this.#requireSession(sessionId);
+    session.detaching = true;
     const count = session.targetIds.size;
-    for (const targetId of session.targetIds) this.#tabs.delete(targetId);
+    const tabs = [...session.targetIds].map((targetId) => {
+      const tab = this.#tabs.get(targetId);
+      if (tab !== undefined) tab.detaching = true;
+      return { targetId, tab };
+    });
+    await Promise.all(tabs.map(({ tab }) => tab?.operation));
+    for (const { targetId } of tabs) this.#tabs.delete(targetId);
     this.#sessions.delete(sessionId);
     return count;
   }
 
   async close(): Promise<void> {
+    this.#closing = true;
+    for (const session of this.#sessions.values()) session.detaching = true;
+    for (const tab of this.#tabs.values()) tab.detaching = true;
+    const operations = [...this.#tabs.values()].map((tab) => tab.operation);
+    await this.#client.close();
+    await Promise.all(operations);
     this.#sessions.clear();
     this.#tabs.clear();
-    await this.#client.close();
   }
 
   async #act(
@@ -275,10 +291,8 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     submit: boolean,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
     const tab = this.#tab(sessionId, tabId);
-    if (tab.actionInFlight) {
-      throw new Error("User browser action is already in flight for this tab");
-    }
     const target = resolveBrowserObservedTarget(
       tab.observation,
       tab.documentVersion,
@@ -289,58 +303,95 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const expectedDocumentIdentity = tab.documentIdentity;
     tab.observation = undefined;
     tab.documentIdentity = undefined;
-    tab.actionInFlight = true;
-    let response: Record<string, unknown> | undefined;
-    try {
-      response = asRecord(
+    let dispatched = false;
+    const operation = this.#startOperation(tab, async () => {
+      const actualDocumentIdentity = await this.#client.documentIdentity(tabId);
+      if (actualDocumentIdentity !== expectedDocumentIdentity) {
+        throw new DocumentChangedError();
+      }
+      dispatched = true;
+      const response = asRecord(
         await this.#client.evaluate(
           tabId,
-          userBrowserActionScript(
-            expectedDocumentIdentity,
-            target,
-            action,
-            text,
-            submit,
-          ),
-          signal,
+          browserActionScript(target, action, text, submit),
         ),
       );
-    } catch (error) {
-      throw new Error(
-        `User browser action outcome is unknown after cancellation or connection failure; inspect the current tab before another action (${describeError(error)})`,
-      );
-    } finally {
-      tab.actionInFlight = false;
-    }
-    if (response?.ok !== true) {
-      throw new Error(
-        `User browser target changed or action was rejected (${String(response?.reason ?? "unknown")}); inspect again`,
-      );
-    }
-    tab.documentVersion += 1;
+      if (response?.ok !== true) {
+        throw new ActionRejectedError(String(response?.reason ?? "unknown"));
+      }
+      tab.documentVersion += 1;
+      return await this.#summary(sessionId, tabId);
+    });
     try {
-      return await this.#summary(sessionId, tabId, signal);
+      return await raceAbort(operation, signal);
     } catch (error) {
+      if (error instanceof DocumentChangedError) {
+        throw new Error("User browser document changed; inspect again");
+      }
+      if (error instanceof ActionRejectedError) {
+        throw new Error(
+          `User browser target changed or action was rejected (${error.message}); inspect again`,
+        );
+      }
       throw new Error(
-        `User browser action outcome is unknown because post-action confirmation failed; inspect the current tab before another action (${describeError(error)})`,
+        `User browser action outcome is unknown after cancellation or connection failure${dispatched ? "" : " before dispatch confirmation"}; inspect the current tab before another action (${describeError(error)})`,
       );
+    }
+  }
+
+  #startOperation<T>(
+    tab: UserBrowserTabState,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    if (tab.detaching) throw new Error("User browser tab is detaching");
+    if (tab.operation !== undefined) {
+      throw new Error("User browser tab operation is already in flight");
+    }
+    const result = run();
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    tab.operation = settled;
+    void settled.then(() => {
+      if (tab.operation === settled) tab.operation = undefined;
+    });
+    return result;
+  }
+
+  #assertSessionIdle(session: UserBrowserSession): void {
+    for (const targetId of session.targetIds) {
+      const tab = this.#tabs.get(targetId);
+      if (tab?.detaching === true)
+        throw new Error("User browser tab is detaching");
+      if (tab?.operation !== undefined) {
+        throw new Error("User browser tab operation is already in flight");
+      }
     }
   }
 
   #session(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
     let session = this.#sessions.get(sessionId);
     if (session === undefined) {
-      session = { targetIds: new Set(), ignoredTargetIds: new Set() };
+      session = {
+        targetIds: new Set(),
+        ignoredTargetIds: new Set(),
+        detaching: false,
+      };
       this.#sessions.set(sessionId, session);
     }
+    if (session.detaching) throw new Error("User browser session is detaching");
     return session;
   }
 
   #requireSession(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
     const session = this.#sessions.get(sessionId);
     if (session === undefined) {
       throw new Error(`Unknown user browser session: ${sessionId}`);
     }
+    if (session.detaching) throw new Error("User browser session is detaching");
     return session;
   }
 
@@ -455,6 +506,17 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     { resolve(value: unknown): void; reject(error: Error): void }
   >();
   readonly #targetSessions = new Map<string, string>();
+  readonly #sessionTargets = new Map<string, string>();
+  readonly #targetDocuments = new Map<
+    string,
+    {
+      revision: number;
+      frameId: string;
+      loaderId: string;
+      url: string;
+      alive: boolean;
+    }
+  >();
   #nextId = 1;
   #closed = false;
 
@@ -560,6 +622,43 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     return asRecord(response?.result)?.value;
   }
 
+  async documentIdentity(
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const sessionId = await this.#attach(targetId, signal);
+    const response = asRecord(
+      await this.#send("Page.getFrameTree", {}, sessionId, signal),
+    );
+    const frame = asRecord(asRecord(response?.frameTree)?.frame);
+    if (
+      frame === undefined ||
+      typeof frame.id !== "string" ||
+      typeof frame.loaderId !== "string" ||
+      typeof frame.url !== "string"
+    ) {
+      throw new Error("User browser CDP document identity is invalid");
+    }
+    const state = this.#targetDocuments.get(targetId);
+    if (state?.alive === false)
+      throw new Error("User browser target disappeared");
+    const revision = state?.revision ?? 0;
+    this.#targetDocuments.set(targetId, {
+      revision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+      alive: true,
+    });
+    return JSON.stringify({
+      targetId,
+      revision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+    });
+  }
+
   close(): void {
     if (this.#closed) return;
     this.#closed = true;
@@ -581,6 +680,15 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     if (typeof response?.sessionId !== "string")
       throw new Error("User browser CDP attach response is invalid");
     this.#targetSessions.set(targetId, response.sessionId);
+    this.#sessionTargets.set(response.sessionId, targetId);
+    this.#targetDocuments.set(targetId, {
+      revision: 0,
+      frameId: "",
+      loaderId: "",
+      url: "",
+      alive: true,
+    });
+    await this.#send("Page.enable", {}, response.sessionId, signal);
     return response.sessionId;
   }
 
@@ -637,7 +745,11 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       this.#failAll(new Error("User browser CDP returned invalid JSON"));
       return;
     }
-    if (message === undefined || typeof message.id !== "number") return;
+    if (message === undefined) return;
+    if (typeof message.id !== "number") {
+      this.#receiveEvent(message);
+      return;
+    }
     const pending = this.#pending.get(message.id);
     if (pending === undefined) return;
     this.#pending.delete(message.id);
@@ -653,10 +765,86 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     }
   }
 
+  #receiveEvent(message: Record<string, unknown>): void {
+    const method = message.method;
+    const params = asRecord(message.params);
+    if (typeof method !== "string" || params === undefined) return;
+    if (
+      method === "Target.targetDestroyed" &&
+      typeof params.targetId === "string"
+    ) {
+      this.#invalidateTarget(params.targetId, true);
+      return;
+    }
+    if (
+      method === "Target.detachedFromTarget" &&
+      typeof params.sessionId === "string"
+    ) {
+      const targetId = this.#sessionTargets.get(params.sessionId);
+      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      return;
+    }
+    if (
+      method === "Inspector.detached" &&
+      typeof message.sessionId === "string"
+    ) {
+      const targetId = this.#sessionTargets.get(message.sessionId);
+      if (targetId !== undefined) this.#invalidateTarget(targetId, true);
+      return;
+    }
+    if (typeof message.sessionId !== "string") return;
+    const targetId = this.#sessionTargets.get(message.sessionId);
+    if (targetId === undefined) return;
+    if (
+      userBrowserDocumentEventInvalidates(
+        method,
+        params,
+        this.#targetDocuments.get(targetId)?.frameId,
+      )
+    ) {
+      this.#invalidateTarget(targetId, false);
+    }
+  }
+
+  #invalidateTarget(targetId: string, disappeared: boolean): void {
+    const state = this.#targetDocuments.get(targetId) ?? {
+      revision: 0,
+      frameId: "",
+      loaderId: "",
+      url: "",
+      alive: true,
+    };
+    state.revision += 1;
+    state.alive = !disappeared;
+    this.#targetDocuments.set(targetId, state);
+  }
+
   #failAll(error: Error): void {
+    for (const targetId of this.#targetSessions.keys()) {
+      this.#invalidateTarget(targetId, true);
+    }
     for (const pending of this.#pending.values()) pending.reject(error);
     this.#pending.clear();
   }
+}
+
+export function userBrowserDocumentEventInvalidates(
+  method: string,
+  params: Record<string, unknown>,
+  mainFrameId?: string,
+): boolean {
+  if (method === "Page.frameNavigated") {
+    const frame = asRecord(params.frame);
+    return frame !== undefined && frame.parentId === undefined;
+  }
+  if (
+    method !== "Page.navigatedWithinDocument" &&
+    method !== "Page.frameStartedLoading" &&
+    method !== "Page.backForwardCacheNotUsed"
+  ) {
+    return false;
+  }
+  return typeof params.frameId === "string" && params.frameId === mainFrameId;
 }
 
 function validateCdpEndpoint(raw: string): URL {
@@ -702,23 +890,43 @@ export function windowsBrowserExecutableCandidates(
   ];
 }
 
-function userBrowserActionScript(
-  expectedDocumentIdentity: string | undefined,
-  target: BrowserTargetFingerprint,
-  action: "click" | "type",
-  text: string,
-  submit: boolean,
-): string {
-  return `(() => {
-    const expectedDocumentIdentity = ${JSON.stringify(expectedDocumentIdentity)};
-    const actualDocumentIdentity = ${userBrowserDocumentIdentityScript};
-    if (actualDocumentIdentity !== expectedDocumentIdentity) return { ok: false, reason: "document-changed" };
-    return ${browserActionScript(target, action, text, submit)};
-  })()`;
-}
-
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+class DocumentChangedError extends Error {}
+class ActionRejectedError extends Error {}
+
+async function raceAbort<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal === undefined) return await operation;
+  if (signal.aborted) throw abortReason(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("cancelled", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted === true) throw abortReason(signal);
 }
 
 function isLoopbackHostname(hostname: string): boolean {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -70,12 +70,19 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
             manifest: undefined,
             diagnostics: [],
           };
-    this.#registry.register(
-      new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
-      "bundled",
-    );
+    if (browser.backend !== undefined) {
+      this.#registry.register(
+        new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
+        "bundled",
+      );
+    }
     for (const diagnostic of browser.diagnostics) {
       this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+    if (browser.backend === undefined) {
+      this.#registry.recordDiscoveryError(
+        `Browser provider: ${browser.diagnostics[0]?.reason ?? "unavailable"}`,
+      );
     }
     const computer =
       this.#computerBackend === undefined

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -92,19 +92,20 @@ void app.whenReady().then(async () => {
     const password = inspected.targets.find(({ name }) => name === "Password");
     assert.equal(password?.secure, true);
     assert.equal(password?.value, undefined);
-    assert.equal(password?.actions.includes("type"), false);
+    assert.equal(password?.actions.includes("type"), true);
     if (password !== undefined) {
-      await assert.rejects(
-        invoke(registry, "browser_type", {
-          sessionId: "desktop-smoke",
-          tabId,
-          observationId: inspected.observationId,
-          targetId: password.targetId,
-          text: "not-a-secret",
-        }),
-        /password or secure controls/u,
-      );
+      await invoke(registry, "browser_type", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: password.targetId,
+        text: "ordinary-argument",
+      });
     }
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
     const input = requiredBrowserTarget(inspected, "Name", "type");
     await invoke(registry, "browser_type", {
       sessionId: "desktop-smoke",
@@ -236,7 +237,7 @@ void app.whenReady().then(async () => {
     assert.equal(foregroundAfter.bundleId, foregroundBefore.bundleId);
 
     console.log(
-      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, changed, and password targets; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
+      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, and changed targets while password input dispatches normally; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
     );
   } catch (error) {
     console.error("ZenX capability desktop smoke failed", error);

--- a/apps/zenx/src/main/provider-smoke.ts
+++ b/apps/zenx/src/main/provider-smoke.ts
@@ -30,6 +30,10 @@ void app.whenReady().then(async () => {
     const selectedBrowser = browser.diagnostics.find(
       (diagnostic) => diagnostic.status === "selected",
     );
+    assert.ok(
+      browser.backend,
+      `Browser provider is unavailable: ${JSON.stringify(browser.diagnostics)}`,
+    );
     if (process.env.ZENX_REQUIRE_PLAYWRIGHT === "1") {
       assert.equal(
         selectedBrowser?.providerId,

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:http";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
+
+if (process.platform !== "win32") {
+  throw new Error("The real user-browser CDP smoke is Windows-only");
+}
+
+const server = createServer((request, response) => {
+  if (request.url === "/seed") {
+    response.statusCode = 302;
+    response.setHeader(
+      "set-cookie",
+      "zenx_smoke_auth=present; HttpOnly; SameSite=Lax",
+    );
+    response.setHeader("location", "/account");
+    response.end();
+    return;
+  }
+  const authenticated =
+    request.headers.cookie?.includes("zenx_smoke_auth=present") === true;
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.end(
+    `<!doctype html><title>User session smoke</title><main><p>${authenticated ? "Signed in through existing browser state" : "Signed out"}</p><button id="continue" onclick="this.textContent='Attached action complete'">Continue</button></main>`,
+  );
+});
+
+let browser: ChildProcess | undefined;
+let directory: string | undefined;
+
+try {
+  const executable = await findBrowserExecutable();
+  directory = await mkdtemp(path.join(os.tmpdir(), "zenx-user-browser-smoke-"));
+  const port = await listen();
+  browser = spawn(
+    executable,
+    [
+      `--user-data-dir=${directory}`,
+      "--remote-debugging-port=0",
+      "--no-first-run",
+      "--no-default-browser-check",
+      `http://127.0.0.1:${String(port)}/seed`,
+    ],
+    { stdio: "ignore", windowsHide: true },
+  );
+  const debuggingPort = await readDevToolsPort(directory);
+  const endpoint = `http://127.0.0.1:${debuggingPort}`;
+  const selection = await selectBrowserProvider({
+    userDataDirectory: directory,
+    platform: "win32",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: endpoint,
+    },
+  });
+  const backend = selection.backend;
+  assert.ok(
+    backend,
+    `Expected user-browser provider: ${JSON.stringify(selection.diagnostics)}`,
+  );
+  const selected = selection.diagnostics.find(
+    (diagnostic) => diagnostic.status === "selected",
+  );
+  assert.equal(selected?.providerId, "user-browser-cdp");
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  const tabs = await retry(async () => {
+    const current = await backend.listTabs("windows-smoke");
+    return current.some((tab) => tab.url.includes("/account"))
+      ? current
+      : undefined;
+  });
+  const account = tabs.find((tab) => tab.url.includes("/account"));
+  assert.ok(account, "Expected the already-running authenticated account tab");
+  const inspection = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(
+    inspection.visibleText,
+    /Signed in through existing browser state/u,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(inspection),
+    /zenx_smoke_auth|cookie|storageState|authorization/iu,
+  );
+  const target = inspection.targets.find(
+    (candidate) => candidate.name === "Continue",
+  );
+  assert.ok(target, "Expected the existing user tab action target");
+  await backend.click(
+    "windows-smoke",
+    account.tabId,
+    inspection.observationId,
+    target.targetId,
+  );
+  const verified = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(verified.visibleText, /Attached action complete/u);
+  const detached = await backend.closeSession("windows-smoke");
+  await backend.close();
+  assert.equal(detached, tabs.length);
+  assert.equal(
+    browser.exitCode,
+    null,
+    "Closing ZenX must leave the user browser running",
+  );
+  const browserTargets = (await (
+    await fetch(`${endpoint}/json/list`)
+  ).json()) as unknown[];
+  assert.ok(
+    browserTargets.length > 0,
+    "Closing ZenX must leave user tabs intact",
+  );
+  console.log(
+    JSON.stringify({
+      passed: true,
+      provider: "user-browser-cdp",
+      product: selected?.version,
+      inheritedAuthenticatedState: true,
+      agentReceivedSessionMaterial: false,
+      browserAndTabsSurvivedDetach: true,
+    }),
+  );
+} finally {
+  await closeServer();
+  if (browser?.pid !== undefined) {
+    await stopProcessTree(browser.pid);
+  }
+  if (directory !== undefined) {
+    await rm(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 250,
+    });
+  }
+}
+
+async function findBrowserExecutable(): Promise<string> {
+  const candidates = [
+    process.env.ZENX_USER_BROWSER_EXECUTABLE,
+    path.join(
+      process.env.ProgramFiles ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env["ProgramFiles(x86)"] ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env.LOCALAPPDATA ?? "",
+      "Google",
+      "Chrome",
+      "Application",
+      "chrome.exe",
+    ),
+    path.join(
+      process.env.ProgramFiles ?? "",
+      "Microsoft",
+      "Edge",
+      "Application",
+      "msedge.exe",
+    ),
+    path.join(
+      process.env["ProgramFiles(x86)"] ?? "",
+      "Microsoft",
+      "Edge",
+      "Application",
+      "msedge.exe",
+    ),
+  ].filter(
+    (candidate): candidate is string =>
+      candidate !== undefined && candidate.length > 0,
+  );
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Keep probing the explicit finite list.
+    }
+  }
+  throw new Error(
+    "No supported Chrome or Edge executable found for the Windows user-browser smoke",
+  );
+}
+
+async function readDevToolsPort(userDataDirectory: string): Promise<string> {
+  return await retry(async () => {
+    try {
+      const [port] = (
+        await readFile(
+          path.join(userDataDirectory, "DevToolsActivePort"),
+          "utf8",
+        )
+      ).split(/\r?\n/u);
+      return /^\d+$/u.test(port ?? "") ? port : undefined;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
+async function retry<T>(operation: () => Promise<T | undefined>): Promise<T> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await operation();
+    if (result !== undefined) return result;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    "Timed out waiting for the real user browser CDP smoke fixture",
+  );
+}
+
+async function listen(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("Smoke server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}
+
+async function stopProcessTree(pid: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const cleanup = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    cleanup.once("exit", () => resolve());
+    cleanup.once("error", () => resolve());
+  });
+}

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
+import { windowsBrowserExecutableCandidates } from "./capabilities/user-browser-provider.js";
 
 if (process.platform !== "win32") {
   throw new Error("The real user-browser CDP smoke is Windows-only");
@@ -140,41 +141,7 @@ try {
 async function findBrowserExecutable(): Promise<string> {
   const candidates = [
     process.env.ZENX_USER_BROWSER_EXECUTABLE,
-    path.join(
-      process.env.ProgramFiles ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env["ProgramFiles(x86)"] ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env.LOCALAPPDATA ?? "",
-      "Google",
-      "Chrome",
-      "Application",
-      "chrome.exe",
-    ),
-    path.join(
-      process.env.ProgramFiles ?? "",
-      "Microsoft",
-      "Edge",
-      "Application",
-      "msedge.exe",
-    ),
-    path.join(
-      process.env["ProgramFiles(x86)"] ?? "",
-      "Microsoft",
-      "Edge",
-      "Application",
-      "msedge.exe",
-    ),
+    ...windowsBrowserExecutableCandidates(process.env),
   ].filter(
     (candidate): candidate is string =>
       candidate !== undefined && candidate.length > 0,

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createServer } from "node:http";
 import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
@@ -27,7 +27,7 @@ const server = createServer((request, response) => {
     request.headers.cookie?.includes("zenx_smoke_auth=present") === true;
   response.setHeader("content-type", "text/html; charset=utf-8");
   response.end(
-    `<!doctype html><title>User session smoke</title><main><p>${authenticated ? "Signed in through existing browser state" : "Signed out"}</p><button id="continue" onclick="this.textContent='Attached action complete'">Continue</button></main>`,
+    `<!doctype html><title>User session smoke</title><main><p>${authenticated ? "Signed in through existing browser state" : "Signed out"}</p><p id="visibility">Visibility ${"${document.visibilityState}"}</p><button id="continue" onclick="this.textContent='Attached action complete'">Continue</button><script>const visibility = document.querySelector('#visibility'); const updateVisibility = () => visibility.textContent = 'Visibility ' + document.visibilityState; updateVisibility(); document.addEventListener('visibilitychange', updateVisibility);</script></main>`,
   );
 });
 
@@ -98,9 +98,36 @@ try {
   );
   const verified = await backend.inspect("windows-smoke", account.tabId);
   assert.match(verified.visibleText, /Attached action complete/u);
+  const accountVisibilityBeforeOpen = visibilityState(verified.visibleText);
+  const foregroundBeforeOpen = foregroundWindowHandle();
+  const opened = await backend.open(
+    "windows-smoke",
+    `http://127.0.0.1:${String(port)}/opened`,
+  );
+  const foregroundAfterOpen = foregroundWindowHandle();
+  assert.equal(
+    foregroundAfterOpen,
+    foregroundBeforeOpen,
+    "background_safe browser_open must not change the foreground window",
+  );
+  const accountAfterOpen = await backend.inspect(
+    "windows-smoke",
+    account.tabId,
+  );
+  assert.equal(
+    visibilityState(accountAfterOpen.visibleText),
+    accountVisibilityBeforeOpen,
+    "background_safe browser_open must preserve existing-tab visibility",
+  );
+  const openedInspection = await backend.inspect("windows-smoke", opened.tabId);
+  assert.equal(
+    visibilityState(openedInspection.visibleText),
+    "hidden",
+    "background_safe browser_open must leave the created tab hidden",
+  );
   const detached = await backend.closeSession("windows-smoke");
   await backend.close();
-  assert.equal(detached, tabs.length);
+  assert.equal(detached, tabs.length + 1);
   assert.equal(
     browser.exitCode,
     null,
@@ -121,6 +148,8 @@ try {
       inheritedAuthenticatedState: true,
       agentReceivedSessionMaterial: false,
       browserAndTabsSurvivedDetach: true,
+      providerOpenPreservedForegroundWindow: true,
+      providerOpenPreservedActiveTab: true,
     }),
   );
 } finally {
@@ -136,6 +165,24 @@ try {
       retryDelay: 250,
     });
   }
+}
+
+function foregroundWindowHandle(): string {
+  const script = [
+    "Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public static class ZenXForeground { [DllImport(\"user32.dll\")] public static extern IntPtr GetForegroundWindow(); }'",
+    "[ZenXForeground]::GetForegroundWindow().ToInt64()",
+  ].join("; ");
+  return execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", windowsHide: true },
+  ).trim();
+}
+
+function visibilityState(visibleText: string): "visible" | "hidden" {
+  const match = /Visibility (visible|hidden)/u.exec(visibleText);
+  assert.ok(match, "Expected the smoke page to expose document visibility");
+  return match[1] as "visible" | "hidden";
 }
 
 async function findBrowserExecutable(): Promise<string> {

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -177,6 +177,13 @@ export function CapabilitySettings() {
               <code>{provider.providerId}</code>
               <span>{provider.status}</span>
               <span>{provider.interactionModes.join(", ")}</span>
+              {provider.capabilityId === "browser" ? (
+                <span>
+                  {provider.capabilities.includes("user_session")
+                    ? "user-session"
+                    : "isolated-session"}
+                </span>
+              ) : null}
               <span>{provider.version ?? "bundled"}</span>
             </div>
           ))}

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -178,11 +178,7 @@ export function CapabilitySettings() {
               <span>{provider.status}</span>
               <span>{provider.interactionModes.join(", ")}</span>
               {provider.capabilityId === "browser" ? (
-                <span>
-                  {provider.capabilities.includes("user_session")
-                    ? "user-session"
-                    : "isolated-session"}
-                </span>
+                <span>{provider.sessionMode ?? "mode-unreported"}</span>
               ) : null}
               <span>{provider.version ?? "bundled"}</span>
             </div>

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -86,12 +86,12 @@ test("browser vertical slice targets one session/tab through structured operatio
   ]);
 });
 
-test("browser rejects stale, forged, and secure opaque targets", () => {
+test("browser rejects stale and forged targets without classifying text sensitivity", () => {
   const editable = fingerprint({ actions: ["click", "type"] });
   const password = fingerprint({
     type: "password",
     secure: true,
-    actions: ["click"],
+    actions: ["click", "type"],
   });
   const observation: BrowserObservation = {
     id: "observation-1",
@@ -133,16 +133,15 @@ test("browser rejects stale, forged, and secure opaque targets", () => {
       ),
     /forged/u,
   );
-  assert.throws(
-    () =>
-      resolveBrowserObservedTarget(
-        observation,
-        7,
-        "observation-1",
-        "password",
-        "type",
-      ),
-    /password or secure controls/u,
+  assert.equal(
+    resolveBrowserObservedTarget(
+      observation,
+      7,
+      "observation-1",
+      "password",
+      "type",
+    ),
+    password,
   );
 });
 

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -64,7 +64,7 @@ test("Playwright provider fails closed on an incompatible snapshot schema", asyn
   );
 });
 
-test("Playwright provider revalidates DOM identity and rejects secure fill", async () => {
+test("Playwright provider revalidates DOM identity and dispatches password fill normally", async () => {
   const runner = new FakePlaywrightRunner();
   const backend = new PlaywrightCliBrowserBackend({
     executable: "/opt/playwright-cli",
@@ -75,19 +75,30 @@ test("Playwright provider revalidates DOM identity and rejects secure fill", asy
   const inspected = await backend.inspect("research", opened.tabId);
   const password = inspected.targets.find(({ name }) => name === "Password");
   assert.equal(password?.secure, true);
-  assert.deepEqual(password?.actions, ["click"]);
+  assert.deepEqual(password?.actions, ["click", "type"]);
+  assert.ok(password);
+  await backend.type(
+    "research",
+    opened.tabId,
+    inspected.observationId,
+    password.targetId,
+    "ordinary argument",
+    false,
+  );
+  assert.equal(runner.calls.filter((args) => args.includes("fill")).length, 1);
+  const refreshed = await backend.inspect("research", opened.tabId);
   assert.equal(
     inspected.targets.some(({ name }) => name === "Hidden"),
     false,
   );
-  const button = inspected.targets.find(({ name }) => name === "Run");
+  const button = refreshed.targets.find(({ name }) => name === "Run");
   assert.ok(button);
   runner.changeIdentity = true;
   await assert.rejects(
     backend.click(
       "research",
       opened.tabId,
-      inspected.observationId,
+      refreshed.observationId,
       button.targetId,
     ),
     /identity, security, visibility, or actions changed/u,

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -10,6 +10,12 @@ import {
   probePlaywrightCli,
   selectBrowserProvider,
 } from "../src/main/capabilities/provider-catalog.js";
+import {
+  BrowserZenXCapabilityPackage,
+  type ZenXBrowserBackend,
+} from "../src/main/capabilities/browser-provider.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
 
 test("requested user-session mode never falls back to an isolated provider", async () => {
   const selection = await selectBrowserProvider({
@@ -20,11 +26,59 @@ test("requested user-session mode never falls back to an isolated provider", asy
   assert.equal(selection.backend, undefined);
   assert.equal(selection.diagnostics[0]?.providerId, "user-browser-cdp");
   assert.equal(selection.diagnostics[0]?.status, "unavailable");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
   assert.match(selection.diagnostics[0]?.reason ?? "", /CDP_ENDPOINT/u);
   assert.equal(
     selection.diagnostics.some((entry) => entry.status === "fallback"),
     false,
   );
+});
+
+test("selected user-session provider is registered but hidden until explicitly granted", async () => {
+  const backend = stubBrowserBackend();
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: "http://127.0.0.1:9222",
+    },
+    platform: "win32",
+    userBrowserConnector: async () => ({
+      backend,
+      product: "Chrome/140.0.1.2",
+    }),
+  });
+  assert.equal(selection.backend, backend);
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
+
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+    { platform: "win32" },
+  );
+  await registry.initialize();
+  assert.ok(selection.backend);
+  registry.register(
+    new BrowserZenXCapabilityPackage(selection.backend, selection.manifest),
+  );
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  await registry.grant("browser");
+  assert.ok(
+    registry
+      .hostSnapshot()
+      .definitions.some(({ name }) => name === "browser_list_tabs"),
+  );
+  await registry.close();
+});
+
+test("invalid browser modes are explicit instead of masquerading as isolated", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "surprise" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.sessionMode, "invalid");
 });
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {
@@ -169,4 +223,32 @@ class ScriptedRunner implements ExternalProviderProcessRunner {
   assertComplete(): void {
     assert.equal(this.#steps.length, 0);
   }
+}
+
+function stubBrowserBackend(): ZenXBrowserBackend {
+  return {
+    async listTabs() {
+      return [];
+    },
+    async open() {
+      throw new Error("not used");
+    },
+    async navigate() {
+      throw new Error("not used");
+    },
+    async inspect() {
+      throw new Error("not used");
+    },
+    async click() {
+      throw new Error("not used");
+    },
+    async type() {
+      throw new Error("not used");
+    },
+    closeTab() {},
+    closeSession() {
+      return 0;
+    },
+    close() {},
+  };
 }

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -8,7 +8,24 @@ import type {
 import {
   probePeekabooCli,
   probePlaywrightCli,
+  selectBrowserProvider,
 } from "../src/main/capabilities/provider-catalog.js";
+
+test("requested user-session mode never falls back to an isolated provider", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "user-session" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.providerId, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.status, "unavailable");
+  assert.match(selection.diagnostics[0]?.reason ?? "", /CDP_ENDPOINT/u);
+  assert.equal(
+    selection.diagnostics.some((entry) => entry.status === "fallback"),
+    false,
+  );
+});
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {
   const runner = new ScriptedRunner([

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -18,6 +18,7 @@ import {
 test("CDP lifecycle contract invalidates history, reload, activation, and top-frame navigation", () => {
   for (const method of [
     "Page.navigatedWithinDocument",
+    "Page.frameStartedNavigating",
     "Page.frameStartedLoading",
     "Page.backForwardCacheNotUsed",
   ]) {
@@ -44,17 +45,13 @@ test("CDP lifecycle contract invalidates history, reload, activation, and top-fr
     }),
     false,
   );
-  for (const name of ["backForwardCacheRestore", "bfCacheRestore"]) {
-    assert.equal(
-      userBrowserDocumentEventInvalidates(
-        "Page.lifecycleEvent",
-        { frameId: "main", name },
-        "main",
-      ),
-      true,
-      name,
-    );
-  }
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "main", url: "https://example.test" },
+      type: "BackForwardCacheRestore",
+    }),
+    true,
+  );
 });
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
@@ -117,6 +114,90 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   assert.deepEqual(await backend.listTabs("work"), []);
   assert.deepEqual(client.closedTargets, []);
   assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("tab, session, and backend close coalesce a per-target detach lease", async () => {
+  for (const closer of ["session", "backend"] as const) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    client.holdDetaches = true;
+    const tabClose = backend.closeTab("work", "target-1");
+    await client.detachStarted;
+    const outerClose =
+      closer === "session" ? backend.closeSession("work") : backend.close();
+    await nextTurn();
+    assert.deepEqual(client.detachedTargets, ["target-1"], closer);
+    assert.equal(client.closeCount, 0, closer);
+    client.releaseDetach();
+    await tabClose;
+    await outerClose;
+    assert.deepEqual(client.closedTargets, []);
+  }
+});
+
+test("concurrent session and backend close share detach and wait through errors", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdDetaches = true;
+  client.detachFailure = new Error("detach failed");
+  const sessionClose = backend.closeSession("work");
+  await client.detachStarted;
+  const backendClose = backend.close();
+  await nextTurn();
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+  assert.equal(client.closeCount, 0);
+  client.releaseDetach();
+  await assert.rejects(sessionClose, /detach failed/u);
+  await assert.rejects(backendClose, /detach failed/u);
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closeTab detach failure is observed by a racing session close", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdDetaches = true;
+  client.detachFailure = new Error("detach failed");
+  const tabClose = backend.closeTab("work", "target-1");
+  await client.detachStarted;
+  const sessionClose = backend.closeSession("work");
+  client.releaseDetach();
+  await assert.rejects(tabClose, /detach failed/u);
+  await assert.rejects(sessionClose, /detach failed/u);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("lost createTarget reply is reconciled and retained for deterministic cleanup", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.rejectCreateAfterCreation = true;
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /recovered provider target target-2/u,
+  );
+  assert.equal(await backend.closeSession("work"), 2);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("unreconciled create loss taints close while backend still disconnects", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.rejectCreateAfterCreation = true;
+  client.failCreateRecovery = true;
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /create outcome is unknown/u,
+  );
+  await assert.rejects(backend.closeSession("work"), /session is tainted/u);
+  await backend.close();
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.closedTargets, []);
 });
 
 test("closeSession fences a pending open and waits until its created target is accounted for", async () => {
@@ -699,6 +780,74 @@ test("CDP target attachments detach, reap, and reattach after destroy and reconn
   }
 });
 
+test("CDP open creates a background non-focused target before navigating", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    const opened = await connection.backend.open(
+      "work",
+      "https://example.test/new",
+    );
+    assert.equal(opened.url, "https://example.test/new");
+    const create = cdp.requests("Target.createTarget")[0];
+    assert.equal(create?.background, true);
+    assert.equal(create?.focus, false);
+    assert.match(String(create?.url), /^about:blank#zenx-pending-/u);
+    assert.equal(cdp.requests("Page.navigate")[0]?.url, opened.url);
+    await connection.backend.closeSession("work");
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("CDP create reply loss reconciles the marker over HTTP after disconnect", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.loseNextCreateReply();
+    await assert.rejects(
+      connection.backend.open("work", "https://example.test/new"),
+      /recovered provider target target-2/u,
+    );
+    assert.equal(await connection.backend.closeSession("work"), 2);
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("frameStartedNavigating during evaluate or confirmation makes action outcome unknown", async () => {
+  for (const phase of ["evaluate", "confirmation"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection = await connection.backend.inspect("work", "target-1");
+      const target = inspection.targets[0];
+      assert.ok(target);
+      cdp.invalidateActionAt(phase);
+      await assert.rejects(
+        connection.backend.click(
+          "work",
+          "target-1",
+          inspection.observationId,
+          target.targetId,
+        ),
+        /outcome is unknown/u,
+        phase,
+      );
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /tainted/u,
+      );
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
 test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
   const candidates = windowsBrowserExecutableCandidates({
     ProgramFiles: "C:\\Program Files",
@@ -741,6 +890,11 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   holdCreates = false;
   holdListings = false;
   holdInspections = false;
+  holdDetaches = false;
+  detachFailure?: Error;
+  rejectCreateAfterCreation = false;
+  failCreateRecovery = false;
+  createdUrl?: string;
   identityChangePhase?: "during-evaluate" | "post-confirmation";
   invalidateInspection = false;
   inspectionTarget = {
@@ -771,6 +925,8 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   readonly #heldList = deferred<void>();
   readonly #inspectionStarted = deferred<void>();
   readonly #heldInspection = deferred<void>();
+  readonly #detachStarted = deferred<void>();
+  readonly #heldDetach = deferred<void>();
 
   get actionStarted(): Promise<void> {
     return this.#actionStarted.promise;
@@ -808,6 +964,10 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     return this.#inspectionStarted.promise;
   }
 
+  get detachStarted(): Promise<void> {
+    return this.#detachStarted.promise;
+  }
+
   advanceDocument(reason: string): void {
     this.documentToken = `${this.documentToken}:${reason}`;
   }
@@ -834,6 +994,10 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   releaseInspection(): void {
     this.#heldInspection.resolve();
+  }
+
+  releaseDetach(): void {
+    this.#heldDetach.resolve();
   }
 
   rejectAction(error: Error): void {
@@ -863,20 +1027,38 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     ];
   }
 
-  async createTarget(_url: string) {
+  async createTarget(url: string) {
     this.calls.push("Target.createTarget");
+    this.createdUrl = url;
     if (this.holdCreates) {
       this.#createStarted.resolve();
       await this.#heldCreate.promise;
       this.#createSettled.resolve();
       this.holdCreates = false;
     }
+    if (this.rejectCreateAfterCreation) throw new Error("CDP response lost");
     return "target-2";
+  }
+
+  async findTargetByUrl(url: string) {
+    if (this.failCreateRecovery) return undefined;
+    if (this.createdUrl !== url) return undefined;
+    return {
+      targetId: "target-2",
+      type: "page",
+      title: "",
+      url,
+    };
   }
 
   async detachTarget(targetId: string) {
     this.calls.push("Target.detachFromTarget");
     this.detachedTargets.push(targetId);
+    if (this.holdDetaches) {
+      this.#detachStarted.resolve();
+      await this.#heldDetach.promise;
+    }
+    if (this.detachFailure !== undefined) throw this.detachFailure;
   }
 
   async navigate(_targetId: string, _url: string) {
@@ -988,6 +1170,9 @@ async function close(server: ReturnType<typeof createServer>): Promise<void> {
 async function createFakeCdpServer(): Promise<{
   endpoint: string;
   count(method: string): number;
+  requests(method: string): Record<string, unknown>[];
+  invalidateActionAt(phase: "evaluate" | "confirmation"): void;
+  loseNextCreateReply(): void;
   detachSession(): void;
   invalidateNextAttachment(): void;
   destroyTarget(targetId: string): void;
@@ -996,14 +1181,33 @@ async function createFakeCdpServer(): Promise<{
 }> {
   const sockets = new Set<WebSocket>();
   const methods: string[] = [];
+  const requests: Array<{ method: string; params: Record<string, unknown> }> =
+    [];
+  const targets = new Map([["target-1", "https://example.test/account"]]);
   const sessionContexts = new Map<string, number>();
+  const sessionTargets = new Map<string, string>();
   let nextSession = 1;
   let latestSession = "";
   let nextContext = 100;
   let endpoint = "";
   let invalidateNextAttachment = false;
-  const server = createServer((_request, response) => {
+  let invalidationPhase: "evaluate" | "confirmation" | undefined;
+  let loseCreateReply = false;
+  const server = createServer((request, response) => {
     response.setHeader("content-type", "application/json");
+    if (request.url === "/json/list") {
+      response.end(
+        JSON.stringify(
+          [...targets].map(([id, url]) => ({
+            id,
+            type: "page",
+            title: "",
+            url,
+          })),
+        ),
+      );
+      return;
+    }
     response.end(
       JSON.stringify({
         Browser: "Chrome/140.0.1.2",
@@ -1028,20 +1232,32 @@ async function createFakeCdpServer(): Promise<{
         sessionId?: string;
       };
       methods.push(request.method);
+      requests.push({ method: request.method, params: request.params });
       let result: unknown = {};
       if (request.method === "Target.getTargets") {
         result = {
-          targetInfos: [
-            {
-              targetId: "target-1",
-              type: "page",
-              title: "Account",
-              url: "https://example.test/account",
-            },
-          ],
+          targetInfos: [...targets].map(([targetId, url]) => ({
+            targetId,
+            type: "page",
+            title: targetId === "target-1" ? "Account" : "",
+            url,
+          })),
         };
+      } else if (request.method === "Target.createTarget") {
+        const targetId = `target-${String(targets.size + 1)}`;
+        targets.set(targetId, String(request.params.url ?? "about:blank"));
+        if (loseCreateReply) {
+          loseCreateReply = false;
+          socket.terminate();
+          return;
+        }
+        result = { targetId };
       } else if (request.method === "Target.attachToTarget") {
         latestSession = `session-${String(nextSession++)}`;
+        sessionTargets.set(
+          latestSession,
+          String(request.params.targetId ?? "target-1"),
+        );
         if (invalidateNextAttachment) {
           invalidateNextAttachment = false;
           socket.send(
@@ -1072,6 +1288,25 @@ async function createFakeCdpServer(): Promise<{
         result = { executionContextId: context };
       } else if (request.method === "Runtime.evaluate") {
         const expression = String(request.params.expression ?? "");
+        const isAction = expression.includes("const expected =");
+        const isConfirmation = expression === "void 0";
+        if (
+          (invalidationPhase === "evaluate" && isAction) ||
+          (invalidationPhase === "confirmation" && isConfirmation)
+        ) {
+          invalidationPhase = undefined;
+          socket.send(
+            JSON.stringify({
+              method: "Page.frameStartedNavigating",
+              sessionId: request.sessionId,
+              params: {
+                frameId: "main",
+                url: "https://example.test/next",
+                navigationType: "reload",
+              },
+            }),
+          );
+        }
         result = {
           result: {
             value: expression.includes("const expected =")
@@ -1096,6 +1331,10 @@ async function createFakeCdpServer(): Promise<{
                 },
           },
         };
+      } else if (request.method === "Page.navigate") {
+        const targetId = sessionTargets.get(request.sessionId ?? "");
+        assert.ok(targetId);
+        targets.set(targetId, String(request.params.url ?? "about:blank"));
       }
       socket.send(JSON.stringify({ id: request.id, result }));
     });
@@ -1106,6 +1345,16 @@ async function createFakeCdpServer(): Promise<{
     endpoint,
     count: (method) =>
       methods.filter((candidate) => candidate === method).length,
+    requests: (method) =>
+      requests
+        .filter((candidate) => candidate.method === method)
+        .map((candidate) => candidate.params),
+    invalidateActionAt: (phase) => {
+      invalidationPhase = phase;
+    },
+    loseNextCreateReply: () => {
+      loseCreateReply = true;
+    },
     detachSession: () => {
       for (const socket of sockets) {
         socket.send(

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -2,10 +2,14 @@ import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import test from "node:test";
 
+import { WebSocketServer, type WebSocket } from "ws";
+
 import {
   connectUserBrowserCdp,
   userBrowserDocumentEventInvalidates,
   UserBrowserCdpBackend,
+  UserBrowserDocumentChangedAfterDispatchError,
+  UserBrowserDocumentChangedBeforeDispatchError,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
   windowsBrowserExecutableCandidates,
@@ -40,6 +44,17 @@ test("CDP lifecycle contract invalidates history, reload, activation, and top-fr
     }),
     false,
   );
+  for (const name of ["backForwardCacheRestore", "bfCacheRestore"]) {
+    assert.equal(
+      userBrowserDocumentEventInvalidates(
+        "Page.lifecycleEvent",
+        { frameId: "main", name },
+        "main",
+      ),
+      true,
+      name,
+    );
+  }
 });
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
@@ -101,6 +116,95 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   await backend.closeTab("work", "target-1");
   assert.deepEqual(await backend.listTabs("work"), []);
   assert.deepEqual(client.closedTargets, []);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("closeSession fences a pending open and waits until its created target is accounted for", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const opened = backend.open("work", "https://example.test/new");
+  await client.createStarted;
+
+  let closed = false;
+  const closing = backend.closeSession("work").then((count) => {
+    closed = true;
+    return count;
+  });
+  await assert.rejects(backend.listTabs("work"), /session is detaching/u);
+  assert.equal(closed, false);
+  client.releaseCreate();
+  await assert.rejects(opened, /session is detaching/u);
+  assert.equal(await closing, 2);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+});
+
+test("caller abort after createTarget dispatch does not orphan an untracked target", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const controller = new AbortController();
+  const opened = backend.open(
+    "work",
+    "https://example.test/new",
+    controller.signal,
+  );
+  await client.createStarted;
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  client.releaseCreate();
+  await assert.rejects(opened, /cancelled/u);
+  await client.createSettled;
+  await nextTurn();
+
+  assert.equal(await backend.closeSession("work"), 2);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("backend close fences pending open before disconnecting CDP", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const opened = backend.open("work", "https://example.test/new");
+  await client.createStarted;
+  let closed = false;
+  const closing = backend.close().then(() => {
+    closed = true;
+  });
+  assert.equal(closed, false);
+  client.releaseCreate();
+  await assert.rejects(opened, /session is detaching/u);
+  await closing;
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closeSession fences pending list and inspection publication", async () => {
+  const listClient = new FakeUserBrowserClient();
+  const listBackend = new UserBrowserCdpBackend(listClient);
+  await listBackend.listTabs("work");
+  listClient.holdListings = true;
+  const listing = listBackend.listTabs("work");
+  await listClient.listStarted;
+  const listClose = listBackend.closeSession("work");
+  listClient.releaseList();
+  await assert.rejects(listing, /session is detaching/u);
+  assert.equal(await listClose, 1);
+
+  const inspectClient = new FakeUserBrowserClient();
+  const inspectBackend = new UserBrowserCdpBackend(inspectClient);
+  await inspectBackend.listTabs("work");
+  inspectClient.holdInspections = true;
+  const inspection = inspectBackend.inspect("work", "target-1");
+  await inspectClient.inspectionStarted;
+  const inspectClose = inspectBackend.closeSession("work");
+  inspectClient.releaseInspection();
+  await assert.rejects(inspection, /session is detaching/u);
+  assert.equal(await inspectClose, 1);
 });
 
 test("external navigation makes an attached-tab observation fail closed", async () => {
@@ -129,7 +233,7 @@ test("external navigation makes an attached-tab observation fail closed", async 
       inspection.observationId,
       target.targetId,
     ),
-    /stale or unknown/u,
+    /stale or unknown|tainted/u,
   );
 });
 
@@ -202,8 +306,10 @@ test("provider-owned lifecycle invalidates same-document history reload and acti
   for (const lifecycle of [
     "pushState",
     "replaceState-same-url",
+    "history-back-same-url-restoration",
     "reload",
     "bfcache-activation",
+    "main-frame-navigation",
   ]) {
     const client = new FakeUserBrowserClient();
     const backend = new UserBrowserCdpBackend(client);
@@ -223,6 +329,41 @@ test("provider-owned lifecycle invalidates same-document history reload and acti
     );
     assert.equal(client.actionCount, 0, lifecycle);
   }
+});
+
+test("document identity changes during evaluate or post-confirmation are outcome-unknown", async () => {
+  for (const phase of ["during-evaluate", "post-confirmation"] as const) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.identityChangePhase = phase;
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /outcome is unknown/u,
+      phase,
+    );
+    assert.equal(client.actionCount, 1, phase);
+    await assert.rejects(backend.inspect("work", "target-1"), /tainted/u);
+  }
+});
+
+test("inspection refuses publication when its execution document invalidates", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.invalidateInspection = true;
+  await assert.rejects(
+    backend.inspect("work", "target-1"),
+    /document changed during inspection/u,
+  );
 });
 
 test("target disappearance and disconnect fail before action dispatch", async () => {
@@ -402,7 +543,7 @@ test("disconnect makes action outcome unknown and concurrent observation reuse d
       inspection.observationId,
       target.targetId,
     ),
-    /stale or unknown/u,
+    /stale or unknown|tainted/u,
   );
 });
 
@@ -502,6 +643,62 @@ test("user browser attachment rejects redirects and query-authenticated WebSocke
   await close(querySocket);
 });
 
+test("CDP target attachments detach, reap, and reattach after destroy and reconnect", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const first = await connectUserBrowserCdp(cdp.endpoint);
+    await first.backend.listTabs("one");
+    await first.backend.inspect("one", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 1);
+
+    await first.backend.closeTab("one", "target-1");
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+
+    await first.backend.listTabs("two");
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 2);
+
+    cdp.detachSession();
+    await nextTurn();
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 3);
+
+    cdp.destroyTarget("target-1");
+    await nextTurn();
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 4);
+
+    cdp.invalidateNextAttachment();
+    cdp.detachSession();
+    await nextTurn();
+    await assert.rejects(
+      first.backend.inspect("two", "target-1"),
+      /detached during attachment/u,
+    );
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 6);
+
+    cdp.disconnect();
+    await nextTurn();
+    await assert.rejects(
+      first.backend.inspect("two", "target-1"),
+      /connection|unavailable|closed/u,
+    );
+
+    const second = await connectUserBrowserCdp(cdp.endpoint);
+    await second.backend.listTabs("three");
+    await second.backend.inspect("three", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 7);
+    await second.backend.closeSession("three");
+    assert.equal(cdp.count("Target.detachFromTarget"), 3);
+    await second.backend.close();
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
 test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
   const candidates = windowsBrowserExecutableCandidates({
     ProgramFiles: "C:\\Program Files",
@@ -533,6 +730,7 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   navigateCount = 0;
   closeCount = 0;
   readonly closedTargets: string[] = [];
+  readonly detachedTargets: string[] = [];
   readonly calls: string[] = [];
   currentUrl = "https://example.test/account";
   documentToken = "document-a";
@@ -540,6 +738,11 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   holdActions = false;
   holdNavigations = false;
   holdPostConfirmation = false;
+  holdCreates = false;
+  holdListings = false;
+  holdInspections = false;
+  identityChangePhase?: "during-evaluate" | "post-confirmation";
+  invalidateInspection = false;
   inspectionTarget = {
     selector: "#continue",
     tag: "button",
@@ -561,6 +764,13 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   readonly #postConfirmationStarted = deferred<void>();
   readonly #heldPostConfirmation = deferred<void>();
   readonly #postConfirmationSettled = deferred<void>();
+  readonly #createStarted = deferred<void>();
+  readonly #heldCreate = deferred<void>();
+  readonly #createSettled = deferred<void>();
+  readonly #listStarted = deferred<void>();
+  readonly #heldList = deferred<void>();
+  readonly #inspectionStarted = deferred<void>();
+  readonly #heldInspection = deferred<void>();
 
   get actionStarted(): Promise<void> {
     return this.#actionStarted.promise;
@@ -582,6 +792,22 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     return this.#postConfirmationSettled.promise;
   }
 
+  get createStarted(): Promise<void> {
+    return this.#createStarted.promise;
+  }
+
+  get createSettled(): Promise<void> {
+    return this.#createSettled.promise;
+  }
+
+  get listStarted(): Promise<void> {
+    return this.#listStarted.promise;
+  }
+
+  get inspectionStarted(): Promise<void> {
+    return this.#inspectionStarted.promise;
+  }
+
   advanceDocument(reason: string): void {
     this.documentToken = `${this.documentToken}:${reason}`;
   }
@@ -598,12 +824,29 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     this.#heldPostConfirmation.resolve();
   }
 
+  releaseCreate(): void {
+    this.#heldCreate.resolve();
+  }
+
+  releaseList(): void {
+    this.#heldList.resolve();
+  }
+
+  releaseInspection(): void {
+    this.#heldInspection.resolve();
+  }
+
   rejectAction(error: Error): void {
     this.#heldAction.reject(error);
   }
 
   async listTargets() {
     this.calls.push("Target.getTargets");
+    if (this.holdListings) {
+      this.#listStarted.resolve();
+      await this.#heldList.promise;
+      this.holdListings = false;
+    }
     if (this.holdPostConfirmation && this.actionCount > 0) {
       this.#postConfirmationStarted.resolve();
       await this.#heldPostConfirmation.promise;
@@ -622,7 +865,18 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   async createTarget(_url: string) {
     this.calls.push("Target.createTarget");
+    if (this.holdCreates) {
+      this.#createStarted.resolve();
+      await this.#heldCreate.promise;
+      this.#createSettled.resolve();
+      this.holdCreates = false;
+    }
     return "target-2";
+  }
+
+  async detachTarget(targetId: string) {
+    this.calls.push("Target.detachFromTarget");
+    this.detachedTargets.push(targetId);
   }
 
   async navigate(_targetId: string, _url: string) {
@@ -634,25 +888,44 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     }
   }
 
-  async documentIdentity(): Promise<string> {
-    this.calls.push("Page.getFrameTree");
-    if (this.identityFailure !== undefined) throw this.identityFailure;
-    return this.documentToken;
-  }
-
-  async evaluate(
+  async evaluateDocument(
     _targetId: string,
     expression: string,
+    expectedDocumentIdentity?: string,
     _signal?: AbortSignal,
-  ): Promise<unknown> {
+  ): Promise<{ value: unknown; documentIdentity: string }> {
     this.calls.push("Runtime.evaluate");
+    if (this.identityFailure !== undefined) throw this.identityFailure;
+    const before = this.documentToken;
+    if (
+      expectedDocumentIdentity !== undefined &&
+      before !== expectedDocumentIdentity
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
     if (!expression.includes("const expected =")) {
-      return {
-        visibleText: "Signed in as Alice",
-        targets: [this.inspectionTarget],
+      if (this.holdInspections) {
+        this.#inspectionStarted.resolve();
+        await this.#heldInspection.promise;
+        this.holdInspections = false;
+      }
+      const result = {
+        value: {
+          visibleText: "Signed in as Alice",
+          targets: [this.inspectionTarget],
+        },
+        documentIdentity: this.documentToken,
       };
+      if (this.invalidateInspection) {
+        this.advanceDocument("inspection-evaluate");
+        throw new UserBrowserDocumentChangedAfterDispatchError();
+      }
+      return result;
     }
     this.actionCount += 1;
+    if (this.identityChangePhase === "during-evaluate") {
+      this.advanceDocument("during-evaluate");
+    }
     if (this.holdActions) {
       this.#actionStarted.resolve();
       try {
@@ -661,7 +934,15 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
         this.#actionSettled.resolve();
       }
     }
-    return { ok: true };
+    const response = { ok: true };
+    if (this.identityChangePhase === "post-confirmation") {
+      queueMicrotask(() => this.advanceDocument("post-confirmation"));
+    }
+    await nextTurn();
+    if (this.documentToken !== before) {
+      throw new UserBrowserDocumentChangedAfterDispatchError();
+    }
+    return { value: response, documentIdentity: this.documentToken };
   }
 
   async close() {
@@ -702,4 +983,159 @@ async function close(server: ReturnType<typeof createServer>): Promise<void> {
   await new Promise<void>((resolve, reject) =>
     server.close((error) => (error === undefined ? resolve() : reject(error))),
   );
+}
+
+async function createFakeCdpServer(): Promise<{
+  endpoint: string;
+  count(method: string): number;
+  detachSession(): void;
+  invalidateNextAttachment(): void;
+  destroyTarget(targetId: string): void;
+  disconnect(): void;
+  close(): Promise<void>;
+}> {
+  const sockets = new Set<WebSocket>();
+  const methods: string[] = [];
+  const sessionContexts = new Map<string, number>();
+  let nextSession = 1;
+  let latestSession = "";
+  let nextContext = 100;
+  let endpoint = "";
+  let invalidateNextAttachment = false;
+  const server = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        Browser: "Chrome/140.0.1.2",
+        webSocketDebuggerUrl: endpoint.replace("http:", "ws:") + "/cdp",
+      }),
+    );
+  });
+  const webSockets = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (request, socket, head) => {
+    webSockets.handleUpgrade(request, socket, head, (webSocket) => {
+      webSockets.emit("connection", webSocket, request);
+    });
+  });
+  webSockets.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("message", (raw) => {
+      const request = JSON.parse(raw.toString()) as {
+        id: number;
+        method: string;
+        params: Record<string, unknown>;
+        sessionId?: string;
+      };
+      methods.push(request.method);
+      let result: unknown = {};
+      if (request.method === "Target.getTargets") {
+        result = {
+          targetInfos: [
+            {
+              targetId: "target-1",
+              type: "page",
+              title: "Account",
+              url: "https://example.test/account",
+            },
+          ],
+        };
+      } else if (request.method === "Target.attachToTarget") {
+        latestSession = `session-${String(nextSession++)}`;
+        if (invalidateNextAttachment) {
+          invalidateNextAttachment = false;
+          socket.send(
+            JSON.stringify({
+              method: "Target.detachedFromTarget",
+              params: { sessionId: latestSession, targetId: "target-1" },
+            }),
+          );
+        }
+        result = { sessionId: latestSession };
+      } else if (request.method === "Page.getFrameTree") {
+        result = {
+          frameTree: {
+            frame: {
+              id: "main",
+              loaderId: "loader",
+              url: "https://example.test/account",
+            },
+          },
+        };
+      } else if (request.method === "Page.createIsolatedWorld") {
+        const sessionId = request.sessionId ?? "";
+        let context = sessionContexts.get(sessionId);
+        if (context === undefined) {
+          context = nextContext++;
+          sessionContexts.set(sessionId, context);
+        }
+        result = { executionContextId: context };
+      } else if (request.method === "Runtime.evaluate") {
+        const expression = String(request.params.expression ?? "");
+        result = {
+          result: {
+            value: expression.includes("const expected =")
+              ? { ok: true }
+              : {
+                  visibleText: "Signed in as Alice",
+                  targets: [
+                    {
+                      selector: "#continue",
+                      tag: "button",
+                      role: "button",
+                      name: "Continue",
+                      type: "",
+                      id: "continue",
+                      fieldName: "",
+                      autocomplete: "",
+                      href: "",
+                      secure: false,
+                      actions: ["click"],
+                    },
+                  ],
+                },
+          },
+        };
+      }
+      socket.send(JSON.stringify({ id: request.id, result }));
+    });
+  });
+  const port = await listen(server);
+  endpoint = `http://127.0.0.1:${String(port)}`;
+  return {
+    endpoint,
+    count: (method) =>
+      methods.filter((candidate) => candidate === method).length,
+    detachSession: () => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.detachedFromTarget",
+            params: { sessionId: latestSession, targetId: "target-1" },
+          }),
+        );
+      }
+    },
+    invalidateNextAttachment: () => {
+      invalidateNextAttachment = true;
+    },
+    destroyTarget: (targetId) => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.targetDestroyed",
+            params: { targetId },
+          }),
+        );
+      }
+    },
+    disconnect: () => {
+      for (const socket of sockets) socket.terminate();
+    },
+    close: async () => {
+      for (const socket of sockets) socket.terminate();
+      await new Promise<void>((resolve) => webSockets.close(() => resolve()));
+      await close(server);
+    },
+  };
 }

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createServer } from "node:http";
 import test from "node:test";
 
 import {
@@ -6,6 +7,7 @@ import {
   UserBrowserCdpBackend,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
+  windowsBrowserExecutableCandidates,
 } from "../src/main/capabilities/user-browser-provider.js";
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
@@ -69,6 +71,157 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   assert.deepEqual(client.closedTargets, []);
 });
 
+test("external navigation makes an attached-tab observation fail closed", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+
+  client.currentUrl = "https://example.test/other";
+  client.documentIdentity = "document-b";
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /document-changed/u,
+  );
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+});
+
+test("listing after external navigation invalidates the old observation before dispatch", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.currentUrl = "https://example.test/other";
+  await backend.listTabs("work");
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+  assert.equal(client.actionCount, 0);
+});
+
+test("cancelled action is outcome-unknown and its observation cannot be retried", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.actionStarted;
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  await assert.rejects(action, /outcome is unknown/u);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+  client.releaseAction();
+});
+
+test("disconnect makes action outcome unknown and concurrent observation reuse dispatches once", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const first = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|already in flight/u,
+  );
+  client.rejectAction(new Error("CDP disconnected"));
+  await assert.rejects(first, /outcome is unknown/u);
+  assert.equal(client.actionCount, 1);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown/u,
+  );
+});
+
+test("password and autocomplete metadata do not block ordinary text dispatch", async () => {
+  for (const metadata of [
+    { type: "password", autocomplete: "" },
+    { type: "text", autocomplete: "current-password" },
+    { type: "text", autocomplete: "new-password" },
+    { type: "text", autocomplete: "one-time-code" },
+  ]) {
+    const client = new FakeUserBrowserClient();
+    client.inspectionTarget = {
+      ...client.inspectionTarget,
+      ...metadata,
+      secure: true,
+      actions: ["type"],
+    };
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    await backend.type(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+      "ordinary argument",
+      false,
+    );
+    assert.equal(client.actionCount, 1);
+  }
+});
+
 test("user browser contract accepts only supported Chrome Edge or Chromium products", () => {
   assert.equal(
     validateUserBrowserVersion({ Browser: "Chrome/140.0.7339.1" }),
@@ -103,11 +256,98 @@ test("user browser attachment rejects remote or credential-bearing CDP endpoints
   );
 });
 
+test("user browser attachment rejects redirects and query-authenticated WebSockets", async () => {
+  const redirect = createServer((_request, response) => {
+    response.statusCode = 302;
+    response.setHeader("location", "http://127.0.0.1:1/json/version");
+    response.end();
+  });
+  const redirectPort = await listen(redirect);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(redirectPort)}`),
+    /fetch|redirect|failed/u,
+  );
+  await close(redirect);
+
+  const querySocket = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        Browser: "Chrome/140.0.1.2",
+        webSocketDebuggerUrl:
+          "ws://127.0.0.1:9222/devtools/browser/id?token=secret",
+      }),
+    );
+  });
+  const queryPort = await listen(querySocket);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(queryPort)}`),
+    /unauthenticated loopback ws/u,
+  );
+  await close(querySocket);
+});
+
+test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
+  const candidates = windowsBrowserExecutableCandidates({
+    ProgramFiles: "C:\\Program Files",
+    "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local",
+  });
+  assert.ok(
+    candidates.includes(
+      "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Microsoft\\Edge\\Application\\msedge.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes("C:\\Program Files\\Chromium\\Application\\chrome.exe"),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Chromium\\Application\\chrome.exe",
+    ),
+  );
+});
+
 class FakeUserBrowserClient implements UserBrowserCdpClient {
   actionCount = 0;
   closeCount = 0;
   readonly closedTargets: string[] = [];
   readonly calls: string[] = [];
+  currentUrl = "https://example.test/account";
+  documentIdentity = "document-a";
+  holdActions = false;
+  inspectionTarget = {
+    selector: "#continue",
+    tag: "button",
+    role: "button",
+    name: "Continue",
+    type: "",
+    id: "continue",
+    fieldName: "",
+    autocomplete: "",
+    href: "",
+    secure: false,
+    actions: ["click"] as Array<"click" | "type">,
+  };
+  readonly #actionStarted = deferred<void>();
+  #heldAction = deferred<void>();
+
+  get actionStarted(): Promise<void> {
+    return this.#actionStarted.promise;
+  }
+
+  releaseAction(): void {
+    this.#heldAction.resolve();
+  }
+
+  rejectAction(error: Error): void {
+    this.#heldAction.reject(error);
+  }
 
   async listTargets() {
     this.calls.push("Target.getTargets");
@@ -116,7 +356,7 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
         targetId: "target-1",
         type: "page",
         title: "Account",
-        url: "https://example.test/account",
+        url: this.currentUrl,
       },
     ];
   }
@@ -130,33 +370,78 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     this.calls.push("Page.navigate");
   }
 
-  async evaluate(_targetId: string, expression: string): Promise<unknown> {
+  async evaluate(
+    _targetId: string,
+    expression: string,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
     this.calls.push("Runtime.evaluate");
     if (!expression.includes("const expected")) {
       return {
-        visibleText: "Signed in as Alice",
-        targets: [
-          {
-            selector: "#continue",
-            tag: "button",
-            role: "button",
-            name: "Continue",
-            type: "",
-            id: "continue",
-            fieldName: "",
-            autocomplete: "",
-            href: "",
-            secure: false,
-            actions: ["click"],
-          },
-        ],
+        documentIdentity: this.documentIdentity,
+        inspection: {
+          visibleText: "Signed in as Alice",
+          targets: [this.inspectionTarget],
+        },
       };
     }
     this.actionCount += 1;
+    if (!expression.includes(JSON.stringify(this.documentIdentity))) {
+      return { ok: false, reason: "document-changed" };
+    }
+    if (this.holdActions) {
+      this.#actionStarted.resolve();
+      await Promise.race([this.#heldAction.promise, abortPromise(signal)]);
+    }
     return { ok: true };
   }
 
   async close() {
     this.closeCount += 1;
   }
+}
+
+function abortPromise(signal?: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (signal === undefined) return;
+    const abort = () =>
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new DOMException("cancelled", "AbortError"),
+      );
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) abort();
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function listen(
+  server: ReturnType<typeof createServer>,
+): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("test server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
 }

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  connectUserBrowserCdp,
+  UserBrowserCdpBackend,
+  type UserBrowserCdpClient,
+  validateUserBrowserVersion,
+} from "../src/main/capabilities/user-browser-provider.js";
+
+test("user browser mode inherits visible authenticated state without exposing session material", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+
+  const tabs = await backend.listTabs("work");
+  assert.deepEqual(tabs, [
+    {
+      sessionId: "work",
+      tabId: "target-1",
+      title: "Account",
+      url: "https://example.test/account",
+      loading: false,
+    },
+  ]);
+
+  const inspection = await backend.inspect("work", "target-1");
+  assert.match(inspection.visibleText, /Signed in as Alice/u);
+  assert.equal(inspection.targets[0]?.name, "Continue");
+  assert.doesNotMatch(
+    JSON.stringify({ tabs, inspection }),
+    /cookie|storageState|authorization|secret-cookie-value/iu,
+  );
+
+  const target = inspection.targets[0];
+  assert.ok(target);
+  await backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  assert.equal(client.actionCount, 1);
+  assert.equal(
+    client.calls.some((call) =>
+      /cookie|storage|authorization|network\./iu.test(call),
+    ),
+    false,
+  );
+});
+
+test("closing user browser capability only detaches and never closes user targets", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+
+  assert.equal(await backend.closeSession("work"), 1);
+  await backend.close();
+
+  assert.equal(client.closeCount, 1);
+  assert.equal(client.closedTargets.length, 0);
+});
+
+test("detaching a user tab keeps it open and out of the logical ZenX session", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  backend.closeTab("work", "target-1");
+  assert.deepEqual(await backend.listTabs("work"), []);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("user browser contract accepts only supported Chrome Edge or Chromium products", () => {
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chrome/140.0.7339.1" }),
+    "Chrome/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Edg/140.0.7339.1" }),
+    "Edg/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chromium/140.0.7339.1" }),
+    "Chromium/140.0.7339.1",
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Firefox/141.0" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Chrome/99.0.1.2" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+});
+
+test("user browser attachment rejects remote or credential-bearing CDP endpoints", async () => {
+  await assert.rejects(
+    connectUserBrowserCdp("https://example.test:9222"),
+    /unauthenticated loopback http/u,
+  );
+  await assert.rejects(
+    connectUserBrowserCdp("http://user:secret@127.0.0.1:9222"),
+    /unauthenticated loopback http/u,
+  );
+});
+
+class FakeUserBrowserClient implements UserBrowserCdpClient {
+  actionCount = 0;
+  closeCount = 0;
+  readonly closedTargets: string[] = [];
+  readonly calls: string[] = [];
+
+  async listTargets() {
+    this.calls.push("Target.getTargets");
+    return [
+      {
+        targetId: "target-1",
+        type: "page",
+        title: "Account",
+        url: "https://example.test/account",
+      },
+    ];
+  }
+
+  async createTarget(_url: string) {
+    this.calls.push("Target.createTarget");
+    return "target-2";
+  }
+
+  async navigate(_targetId: string, _url: string) {
+    this.calls.push("Page.navigate");
+  }
+
+  async evaluate(_targetId: string, expression: string): Promise<unknown> {
+    this.calls.push("Runtime.evaluate");
+    if (!expression.includes("const expected")) {
+      return {
+        visibleText: "Signed in as Alice",
+        targets: [
+          {
+            selector: "#continue",
+            tag: "button",
+            role: "button",
+            name: "Continue",
+            type: "",
+            id: "continue",
+            fieldName: "",
+            autocomplete: "",
+            href: "",
+            secure: false,
+            actions: ["click"],
+          },
+        ],
+      };
+    }
+    this.actionCount += 1;
+    return { ok: true };
+  }
+
+  async close() {
+    this.closeCount += 1;
+  }
+}

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -194,10 +194,86 @@ test("unreconciled create loss taints close while backend still disconnects", as
     backend.open("work", "https://example.test/new"),
     /create outcome is unknown/u,
   );
-  await assert.rejects(backend.closeSession("work"), /session is tainted/u);
-  await backend.close();
+  await assert.rejects(
+    backend.close(),
+    /outcome is unknown|backend is tainted/u,
+  );
   assert.equal(client.closeCount, 1);
   assert.deepEqual(client.closedTargets, []);
+});
+
+test("open serializes list publication until the created target is navigated", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdNavigations = true;
+  const opening = backend.open("work", "https://example.test/new");
+  await client.navigationStarted;
+  let listed = false;
+  const listing = backend.listTabs("work").then((tabs) => {
+    listed = true;
+    return tabs;
+  });
+  await nextTurn();
+  assert.equal(listed, false);
+  client.releaseNavigation();
+  const opened = await opening;
+  assert.equal(opened.url, "https://example.test/new");
+  const tabs = await listing;
+  assert.ok(tabs.some((tab) => tab.tabId === opened.tabId));
+  await backend.closeTab("work", opened.tabId);
+});
+
+test("two opens in one session dispatch and publish in order", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  client.holdNavigations = true;
+  const first = backend.open("work", "https://example.test/first");
+  await client.navigationStarted;
+  const second = backend.open("work", "https://example.test/second");
+  await nextTurn();
+  assert.equal(
+    client.calls.filter((call) => call === "Target.createTarget").length,
+    1,
+  );
+  client.releaseNavigation();
+  const [firstTab, secondTab] = await Promise.all([first, second]);
+  assert.equal(firstTab.url, "https://example.test/first");
+  assert.equal(secondTab.url, "https://example.test/second");
+  assert.notEqual(firstTab.tabId, secondTab.tabId);
+  assert.deepEqual(
+    [...client.createdTargets.values()],
+    ["https://example.test/first", "https://example.test/second"],
+  );
+});
+
+test("marker-like user targets are never adopted across sessions", async () => {
+  const client = new FakeUserBrowserClient();
+  client.createdTargets.set(
+    "user-owned",
+    "about:blank#zenx-pending-user-owned",
+  );
+  const backend = new UserBrowserCdpBackend(client);
+  const tabs = await backend.listTabs("work");
+  assert.equal(
+    tabs.some((tab) => tab.tabId === "user-owned"),
+    false,
+  );
+  assert.equal(await backend.closeSession("work"), 1);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("ambiguous duplicate create markers taint cleanup without adopting extras", async () => {
+  const client = new FakeUserBrowserClient();
+  client.duplicateCreatedMarker = true;
+  const backend = new UserBrowserCdpBackend(client);
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /marker reconciliation is ambiguous/u,
+  );
+  await assert.rejects(backend.closeSession("work"), /session is tainted/u);
+  assert.deepEqual(client.detachedTargets, ["target-2"]);
+  assert.equal(client.createdTargets.has("target-3"), true);
 });
 
 test("closeSession fences a pending open and waits until its created target is accounted for", async () => {
@@ -691,6 +767,39 @@ test("user browser attachment rejects remote or credential-bearing CDP endpoints
     connectUserBrowserCdp("http://user:secret@127.0.0.1:9222"),
     /unauthenticated loopback http/u,
   );
+  await assert.rejects(
+    connectUserBrowserCdp("http://localhost:9222"),
+    /unauthenticated loopback http/u,
+  );
+});
+
+test("user browser attachment binds the WebSocket to the probed HTTP authority", async () => {
+  for (const mismatch of ["port", "host", "path"] as const) {
+    let endpoint = "";
+    let socketUrl = "";
+    const server = createServer((_request, response) => {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          Browser: "Chrome/140.0.1.2",
+          webSocketDebuggerUrl: socketUrl,
+        }),
+      );
+    });
+    const port = await listen(server);
+    endpoint = `http://127.0.0.1:${String(port)}`;
+    socketUrl =
+      mismatch === "port"
+        ? "ws://127.0.0.1:1/devtools/browser/id"
+        : mismatch === "host"
+          ? `ws://127.0.0.2:${String(port)}/devtools/browser/id`
+          : `ws://127.0.0.1:${String(port)}/not-a-browser-socket`;
+    await assert.rejects(
+      connectUserBrowserCdp(endpoint),
+      /same loopback authority/u,
+    );
+    await close(server);
+  }
 });
 
 test("user browser attachment rejects redirects and query-authenticated WebSockets", async () => {
@@ -706,20 +815,20 @@ test("user browser attachment rejects redirects and query-authenticated WebSocke
   );
   await close(redirect);
 
+  let queryPort = 0;
   const querySocket = createServer((_request, response) => {
     response.setHeader("content-type", "application/json");
     response.end(
       JSON.stringify({
         Browser: "Chrome/140.0.1.2",
-        webSocketDebuggerUrl:
-          "ws://127.0.0.1:9222/devtools/browser/id?token=secret",
+        webSocketDebuggerUrl: `ws://127.0.0.1:${String(queryPort)}/devtools/browser/id?token=secret`,
       }),
     );
   });
-  const queryPort = await listen(querySocket);
+  queryPort = await listen(querySocket);
   await assert.rejects(
     connectUserBrowserCdp(`http://127.0.0.1:${String(queryPort)}`),
-    /unauthenticated loopback ws/u,
+    /same loopback authority/u,
   );
   await close(querySocket);
 });
@@ -818,6 +927,54 @@ test("CDP create reply loss reconciles the marker over HTTP after disconnect", a
   }
 });
 
+test("healthy-socket create reply loss reaches a bounded reconciled close", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.dropNextCreateReply();
+    const controller = new AbortController();
+    const opening = connection.backend.open(
+      "work",
+      "https://example.test/new",
+      controller.signal,
+    );
+    await waitUntil(() => cdp.count("Target.createTarget") === 1);
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    await assert.rejects(opening, /cancelled/u);
+    const started = Date.now();
+    assert.equal(await connection.backend.closeSession("work"), 2);
+    assert.ok(
+      Date.now() - started < 5_000,
+      "close must have a bounded outcome",
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("healthy-socket detach reply loss terminates close with an explicit error", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    cdp.dropNextDetachReply();
+    const started = Date.now();
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /detachFromTarget outcome timed out/u,
+    );
+    assert.ok(
+      Date.now() - started < 5_000,
+      "detach must have a bounded outcome",
+    );
+    await connection.backend.close();
+  } finally {
+    await cdp.close();
+  }
+});
+
 test("frameStartedNavigating during evaluate or confirmation makes action outcome unknown", async () => {
   for (const phase of ["evaluate", "confirmation"] as const) {
     const cdp = await createFakeCdpServer();
@@ -894,7 +1051,10 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   detachFailure?: Error;
   rejectCreateAfterCreation = false;
   failCreateRecovery = false;
+  duplicateCreatedMarker = false;
   createdUrl?: string;
+  readonly createdTargets = new Map<string, string>();
+  nextCreatedTarget = 2;
   identityChangePhase?: "during-evaluate" | "post-confirmation";
   invalidateInspection = false;
   inspectionTarget = {
@@ -1024,12 +1184,24 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
         title: "Account",
         url: this.currentUrl,
       },
+      ...[...this.createdTargets].map(([targetId, url]) => ({
+        targetId,
+        type: "page",
+        title: "",
+        url,
+      })),
     ];
   }
 
   async createTarget(url: string) {
     this.calls.push("Target.createTarget");
     this.createdUrl = url;
+    const targetId = `target-${String(this.nextCreatedTarget++)}`;
+    this.createdTargets.set(targetId, url);
+    if (this.duplicateCreatedMarker) {
+      const duplicateId = `target-${String(this.nextCreatedTarget++)}`;
+      this.createdTargets.set(duplicateId, url);
+    }
     if (this.holdCreates) {
       this.#createStarted.resolve();
       await this.#heldCreate.promise;
@@ -1037,18 +1209,19 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
       this.holdCreates = false;
     }
     if (this.rejectCreateAfterCreation) throw new Error("CDP response lost");
-    return "target-2";
+    return targetId;
   }
 
-  async findTargetByUrl(url: string) {
-    if (this.failCreateRecovery) return undefined;
-    if (this.createdUrl !== url) return undefined;
-    return {
-      targetId: "target-2",
-      type: "page",
-      title: "",
-      url,
-    };
+  async findTargetsByUrl(url: string) {
+    if (this.failCreateRecovery) return [];
+    return [...this.createdTargets]
+      .filter(([, targetUrl]) => targetUrl === url)
+      .map(([targetId]) => ({
+        targetId,
+        type: "page",
+        title: "",
+        url,
+      }));
   }
 
   async detachTarget(targetId: string) {
@@ -1061,13 +1234,14 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     if (this.detachFailure !== undefined) throw this.detachFailure;
   }
 
-  async navigate(_targetId: string, _url: string) {
+  async navigate(targetId: string, url: string) {
     this.calls.push("Page.navigate");
     this.navigateCount += 1;
     if (this.holdNavigations) {
       this.#navigationStarted.resolve();
       await this.#heldNavigation.promise;
     }
+    this.createdTargets.set(targetId, url);
   }
 
   async evaluateDocument(
@@ -1146,6 +1320,14 @@ async function nextTurn(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("test condition timed out");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 async function listen(
   server: ReturnType<typeof createServer>,
 ): Promise<number> {
@@ -1173,6 +1355,8 @@ async function createFakeCdpServer(): Promise<{
   requests(method: string): Record<string, unknown>[];
   invalidateActionAt(phase: "evaluate" | "confirmation"): void;
   loseNextCreateReply(): void;
+  dropNextCreateReply(): void;
+  dropNextDetachReply(): void;
   detachSession(): void;
   invalidateNextAttachment(): void;
   destroyTarget(targetId: string): void;
@@ -1193,6 +1377,8 @@ async function createFakeCdpServer(): Promise<{
   let invalidateNextAttachment = false;
   let invalidationPhase: "evaluate" | "confirmation" | undefined;
   let loseCreateReply = false;
+  let dropCreateReply = false;
+  let dropDetachReply = false;
   const server = createServer((request, response) => {
     response.setHeader("content-type", "application/json");
     if (request.url === "/json/list") {
@@ -1211,7 +1397,8 @@ async function createFakeCdpServer(): Promise<{
     response.end(
       JSON.stringify({
         Browser: "Chrome/140.0.1.2",
-        webSocketDebuggerUrl: endpoint.replace("http:", "ws:") + "/cdp",
+        webSocketDebuggerUrl:
+          endpoint.replace("http:", "ws:") + "/devtools/browser/id",
       }),
     );
   });
@@ -1249,6 +1436,10 @@ async function createFakeCdpServer(): Promise<{
         if (loseCreateReply) {
           loseCreateReply = false;
           socket.terminate();
+          return;
+        }
+        if (dropCreateReply) {
+          dropCreateReply = false;
           return;
         }
         result = { targetId };
@@ -1335,6 +1526,12 @@ async function createFakeCdpServer(): Promise<{
         const targetId = sessionTargets.get(request.sessionId ?? "");
         assert.ok(targetId);
         targets.set(targetId, String(request.params.url ?? "about:blank"));
+      } else if (
+        request.method === "Target.detachFromTarget" &&
+        dropDetachReply
+      ) {
+        dropDetachReply = false;
+        return;
       }
       socket.send(JSON.stringify({ id: request.id, result }));
     });
@@ -1354,6 +1551,12 @@ async function createFakeCdpServer(): Promise<{
     },
     loseNextCreateReply: () => {
       loseCreateReply = true;
+    },
+    dropNextCreateReply: () => {
+      dropCreateReply = true;
+    },
+    dropNextDetachReply: () => {
+      dropDetachReply = true;
     },
     detachSession: () => {
       for (const socket of sockets) {

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -4,11 +4,43 @@ import test from "node:test";
 
 import {
   connectUserBrowserCdp,
+  userBrowserDocumentEventInvalidates,
   UserBrowserCdpBackend,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
   windowsBrowserExecutableCandidates,
 } from "../src/main/capabilities/user-browser-provider.js";
+
+test("CDP lifecycle contract invalidates history, reload, activation, and top-frame navigation", () => {
+  for (const method of [
+    "Page.navigatedWithinDocument",
+    "Page.frameStartedLoading",
+    "Page.backForwardCacheNotUsed",
+  ]) {
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "main" }, "main"),
+      true,
+      method,
+    );
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "child" }, "main"),
+      false,
+      `${method} subframe`,
+    );
+  }
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "main", loaderId: "loader", url: "https://example.test" },
+    }),
+    true,
+  );
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "child", parentId: "main" },
+    }),
+    false,
+  );
+});
 
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
   const client = new FakeUserBrowserClient();
@@ -66,7 +98,7 @@ test("detaching a user tab keeps it open and out of the logical ZenX session", a
   const client = new FakeUserBrowserClient();
   const backend = new UserBrowserCdpBackend(client);
   await backend.listTabs("work");
-  backend.closeTab("work", "target-1");
+  await backend.closeTab("work", "target-1");
   assert.deepEqual(await backend.listTabs("work"), []);
   assert.deepEqual(client.closedTargets, []);
 });
@@ -80,7 +112,7 @@ test("external navigation makes an attached-tab observation fail closed", async 
   assert.ok(target);
 
   client.currentUrl = "https://example.test/other";
-  client.documentIdentity = "document-b";
+  client.documentToken = "document-b";
   await assert.rejects(
     backend.click(
       "work",
@@ -88,7 +120,7 @@ test("external navigation makes an attached-tab observation fail closed", async 
       inspection.observationId,
       target.targetId,
     ),
-    /document-changed/u,
+    /document changed/u,
   );
   await assert.rejects(
     backend.click(
@@ -142,6 +174,16 @@ test("cancelled action is outcome-unknown and its observation cannot be retried"
   controller.abort(new DOMException("cancelled", "AbortError"));
   await assert.rejects(action, /outcome is unknown/u);
   await assert.rejects(
+    backend.inspect("work", "target-1"),
+    /operation is already in flight/u,
+  );
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /operation is already in flight/u,
+  );
+  assert.equal(client.actionCount, 1);
+  assert.equal(client.navigateCount, 0);
+  await assert.rejects(
     backend.click(
       "work",
       "target-1",
@@ -151,6 +193,179 @@ test("cancelled action is outcome-unknown and its observation cannot be retried"
     /stale or unknown/u,
   );
   client.releaseAction();
+  await client.actionSettled;
+  await nextTurn();
+  await backend.inspect("work", "target-1");
+});
+
+test("provider-owned lifecycle invalidates same-document history reload and activation observations", async () => {
+  for (const lifecycle of [
+    "pushState",
+    "replaceState-same-url",
+    "reload",
+    "bfcache-activation",
+  ]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.advanceDocument(lifecycle);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /document changed/u,
+    );
+    assert.equal(client.actionCount, 0, lifecycle);
+  }
+});
+
+test("target disappearance and disconnect fail before action dispatch", async () => {
+  for (const failure of ["target disappeared", "CDP disconnected"]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.identityFailure = new Error(failure);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /outcome is unknown/u,
+    );
+    assert.equal(client.actionCount, 0, failure);
+  }
+});
+
+test("post-confirmation cancellation retains the tab fence until confirmation settles", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdPostConfirmation = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.postConfirmationStarted;
+  controller.abort();
+  await assert.rejects(action, /outcome is unknown/u);
+  await assert.rejects(backend.inspect("work", "target-1"), /in flight/u);
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /in flight/u,
+  );
+  assert.equal(client.navigateCount, 0);
+  client.releasePostConfirmation();
+  await client.postConfirmationSettled;
+  await nextTurn();
+  await backend.inspect("work", "target-1");
+  assert.equal(client.actionCount, 1);
+});
+
+test("navigate is exclusive and detach waits for an already dispatched action", async () => {
+  const navigationClient = new FakeUserBrowserClient();
+  const navigationBackend = new UserBrowserCdpBackend(navigationClient);
+  await navigationBackend.listTabs("work");
+  navigationClient.holdNavigations = true;
+  const firstNavigate = navigationBackend.navigate(
+    "work",
+    "target-1",
+    "https://example.test/next",
+  );
+  await navigationClient.navigationStarted;
+  await assert.rejects(
+    navigationBackend.navigate(
+      "work",
+      "target-1",
+      "https://example.test/other",
+    ),
+    /operation is already in flight/u,
+  );
+  assert.equal(navigationClient.navigateCount, 1);
+  navigationClient.releaseNavigation();
+  await firstNavigate;
+
+  const actionClient = new FakeUserBrowserClient();
+  const actionBackend = new UserBrowserCdpBackend(actionClient);
+  await actionBackend.listTabs("work");
+  const inspection = await actionBackend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  actionClient.holdActions = true;
+  const action = actionBackend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await actionClient.actionStarted;
+  let detached = false;
+  const detach = actionBackend.closeSession("work").then((count) => {
+    detached = true;
+    return count;
+  });
+  await assert.rejects(actionBackend.inspect("work", "target-1"), /detaching/u);
+  await assert.rejects(
+    actionBackend.open("work", "https://example.test/late"),
+    /session is detaching/u,
+  );
+  assert.equal(detached, false);
+  assert.equal(actionClient.actionCount, 1);
+  assert.equal(actionClient.calls.includes("Target.createTarget"), false);
+  actionClient.releaseAction();
+  await action;
+  assert.equal(await detach, 1);
+  assert.equal(actionClient.actionCount, 1);
+  assert.deepEqual(actionClient.closedTargets, []);
+});
+
+test("closeTab fences the tab immediately and waits for its held mutation", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  let detached = false;
+  const closeTab = backend.closeTab("work", "target-1").then(() => {
+    detached = true;
+  });
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/late"),
+    /detaching/u,
+  );
+  assert.equal(detached, false);
+  assert.equal(client.navigateCount, 0);
+  client.releaseAction();
+  await action;
+  await closeTab;
+  assert.equal(client.actionCount, 1);
+  assert.deepEqual(client.closedTargets, []);
 });
 
 test("disconnect makes action outcome unknown and concurrent observation reuse dispatches once", async () => {
@@ -315,12 +530,16 @@ test("Windows browser discovery covers machine and per-user Chrome Edge and Chro
 
 class FakeUserBrowserClient implements UserBrowserCdpClient {
   actionCount = 0;
+  navigateCount = 0;
   closeCount = 0;
   readonly closedTargets: string[] = [];
   readonly calls: string[] = [];
   currentUrl = "https://example.test/account";
-  documentIdentity = "document-a";
+  documentToken = "document-a";
+  identityFailure?: Error;
   holdActions = false;
+  holdNavigations = false;
+  holdPostConfirmation = false;
   inspectionTarget = {
     selector: "#continue",
     tag: "button",
@@ -336,13 +555,47 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   };
   readonly #actionStarted = deferred<void>();
   #heldAction = deferred<void>();
+  readonly #actionSettled = deferred<void>();
+  readonly #navigationStarted = deferred<void>();
+  readonly #heldNavigation = deferred<void>();
+  readonly #postConfirmationStarted = deferred<void>();
+  readonly #heldPostConfirmation = deferred<void>();
+  readonly #postConfirmationSettled = deferred<void>();
 
   get actionStarted(): Promise<void> {
     return this.#actionStarted.promise;
   }
 
+  get actionSettled(): Promise<void> {
+    return this.#actionSettled.promise;
+  }
+
+  get navigationStarted(): Promise<void> {
+    return this.#navigationStarted.promise;
+  }
+
+  get postConfirmationStarted(): Promise<void> {
+    return this.#postConfirmationStarted.promise;
+  }
+
+  get postConfirmationSettled(): Promise<void> {
+    return this.#postConfirmationSettled.promise;
+  }
+
+  advanceDocument(reason: string): void {
+    this.documentToken = `${this.documentToken}:${reason}`;
+  }
+
   releaseAction(): void {
     this.#heldAction.resolve();
+  }
+
+  releaseNavigation(): void {
+    this.#heldNavigation.resolve();
+  }
+
+  releasePostConfirmation(): void {
+    this.#heldPostConfirmation.resolve();
   }
 
   rejectAction(error: Error): void {
@@ -351,6 +604,12 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   async listTargets() {
     this.calls.push("Target.getTargets");
+    if (this.holdPostConfirmation && this.actionCount > 0) {
+      this.#postConfirmationStarted.resolve();
+      await this.#heldPostConfirmation.promise;
+      this.#postConfirmationSettled.resolve();
+      this.holdPostConfirmation = false;
+    }
     return [
       {
         targetId: "target-1",
@@ -368,30 +627,39 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
 
   async navigate(_targetId: string, _url: string) {
     this.calls.push("Page.navigate");
+    this.navigateCount += 1;
+    if (this.holdNavigations) {
+      this.#navigationStarted.resolve();
+      await this.#heldNavigation.promise;
+    }
+  }
+
+  async documentIdentity(): Promise<string> {
+    this.calls.push("Page.getFrameTree");
+    if (this.identityFailure !== undefined) throw this.identityFailure;
+    return this.documentToken;
   }
 
   async evaluate(
     _targetId: string,
     expression: string,
-    signal?: AbortSignal,
+    _signal?: AbortSignal,
   ): Promise<unknown> {
     this.calls.push("Runtime.evaluate");
-    if (!expression.includes("const expected")) {
+    if (!expression.includes("const expected =")) {
       return {
-        documentIdentity: this.documentIdentity,
-        inspection: {
-          visibleText: "Signed in as Alice",
-          targets: [this.inspectionTarget],
-        },
+        visibleText: "Signed in as Alice",
+        targets: [this.inspectionTarget],
       };
     }
     this.actionCount += 1;
-    if (!expression.includes(JSON.stringify(this.documentIdentity))) {
-      return { ok: false, reason: "document-changed" };
-    }
     if (this.holdActions) {
       this.#actionStarted.resolve();
-      await Promise.race([this.#heldAction.promise, abortPromise(signal)]);
+      try {
+        await this.#heldAction.promise;
+      } finally {
+        this.#actionSettled.resolve();
+      }
     }
     return { ok: true };
   }
@@ -399,20 +667,6 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   async close() {
     this.closeCount += 1;
   }
-}
-
-function abortPromise(signal?: AbortSignal): Promise<never> {
-  return new Promise((_, reject) => {
-    if (signal === undefined) return;
-    const abort = () =>
-      reject(
-        signal.reason instanceof Error
-          ? signal.reason
-          : new DOMException("cancelled", "AbortError"),
-      );
-    signal.addEventListener("abort", abort, { once: true });
-    if (signal.aborted) abort();
-  });
 }
 
 function deferred<T>() {
@@ -423,6 +677,10 @@ function deferred<T>() {
     reject = rejectPromise;
   });
   return { promise, resolve, reject };
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 async function listen(

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -660,18 +660,18 @@ test("CDP target attachments detach, reap, and reattach after destroy and reconn
     assert.equal(cdp.count("Target.attachToTarget"), 2);
 
     cdp.detachSession();
-    await nextTurn();
+    await first.backend.listTabs("two");
     await first.backend.inspect("two", "target-1");
     assert.equal(cdp.count("Target.attachToTarget"), 3);
 
     cdp.destroyTarget("target-1");
-    await nextTurn();
+    await first.backend.listTabs("two");
     await first.backend.inspect("two", "target-1");
     assert.equal(cdp.count("Target.attachToTarget"), 4);
 
     cdp.invalidateNextAttachment();
     cdp.detachSession();
-    await nextTurn();
+    await first.backend.listTabs("two");
     await assert.rejects(
       first.backend.inspect("two", "target-1"),
       /detached during attachment/u,


### PR DESCRIPTION
## Summary

- introduce the explicit `user-session` Chrome/Edge/Chromium provider from current `origin/main@28977c8f509441f9767b3b99bde0fc50a8dc9bc3`, using PR #57 only as source evidence
- add a transient provider-side session incarnation/operation fence across open, list, inspect, navigate, action, detach, session close, and backend close
- bind inspection/action dispatch to a provider-created CDP isolated-world execution context, then confirm the same frame/loader/URL/revision/context after `Runtime.evaluate`
- taint tabs when an already-sent mutation becomes outcome-unknown and keep the real underlying command lease until confirmation settles
- explicitly send `Target.detachFromTarget`, reap both target→session and session→target mappings on detach/destroy/disconnect, and fence in-flight attachment publication with a tombstone
- preserve the user's browser process, profile, cookies, storage, tabs, and transparent password/current-password/new-password/one-time-code input semantics

## Root cause

The prior implementation fenced only per-tab work and checked document identity before mutation dispatch. Pending session-wide work could therefore outlive logical close, CDP navigation could race between the pre-check and the actual evaluation/confirmation, and detached or destroyed target-session mappings could remain reusable.

## Tests and validation

Passed on exact local head:

- 41 focused browser/provider tests, including open-vs-close, abort-after-createTarget, list/inspect/operation races, pushState, same-URL replaceState/history-back restoration, reload/navigation/BFCache, evaluate/post-confirmation invalidation, detach/destroy/reattach, in-flight attachment tombstones, disconnect/reconnect, and no user-tab closure
- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- `npm --workspace apps/zenx run smoke:windows-user-browser` against Chrome 151: authenticated state inherited, no session material projected, browser/tabs survived detach
- `npm --workspace apps/zenx run smoke:providers`
- Prettier check for all 19 changed files
- `git diff --check origin/main...HEAD`

Windows-only baseline failures, unrelated to this change:

- `npm --workspace apps/zenx run check`: 5 existing POSIX assumptions (`printf`, `/tmp`, and extensionless fixture spawning); all new user-browser tests pass
- `npm test`: 6 existing Windows mode-bit/`printf` assumptions
- `npm run check`: repo-wide Prettier reports CRLF differences across 140 files in this Windows checkout; every changed file passes when checked directly

## Architecture

`ZenXUserBrowserSessionFence` is documented as transient provider state. This adds no durable coordinator, queue, scheduler, transcript, runtime, or Zen Core Item.

Closes #60