### PR TITLE
fix(zenx): own Trigger transient correlation by generation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,7 +68,8 @@
 - **ZenXTriggerAppServerPort** — ZenX Trigger 服务观察 completed Item/Turn 并发起普通
   `turn/start` 所需的最小 host-local App Server 边界；它不引入另一套 Runtime、队列或重试器。
 - **ZenXTriggerLifecycleGeneration** — ZenX Trigger 服务每段 start→stop 生命周期独占 notification、timer、
-  in-flight wakeup 与有界 completion correlation 容器的内存 fence；旧 generation 只能退休或清理自己的瞬态状态，且只有当前 generation 能修改外层审计历史或 Room。
+  in-flight wakeup、有界 completion correlation 容器与可取消 title observation 的内存 fence；退休以 best-effort
+  清理该 generation 并等待已经进入的 durable/title mutation boundary，且只有当前 generation 能继续修改外层审计历史、Room 或 title projection。
 - **ZenXExternalLinkPolicy** — ZenX renderer 与 Electron 主进程共同执行的外链 allowlist；
   只有 `http:`、`https:`、`mailto:` 可交给操作系统，页内锚点留在 renderer 处理。
 - **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,8 @@
   新 Turn 输入投影；它不是第二份权威 transcript，canonical `user_message` 仍是唯一输入事实。
 - **ZenXTriggerAppServerPort** — ZenX Trigger 服务观察 completed Item/Turn 并发起普通
   `turn/start` 所需的最小 host-local App Server 边界；它不引入另一套 Runtime、队列或重试器。
+- **ZenXTriggerLifecycleGeneration** — ZenX Trigger 服务每段 start→stop 生命周期独占 notification、timer、
+  in-flight wakeup 与有界 completion correlation 容器的内存 fence；旧 generation 只能退休或清理自己的瞬态状态，且只有当前 generation 能修改外层审计历史或 Room。
 - **ZenXExternalLinkPolicy** — ZenX renderer 与 Electron 主进程共同执行的外链 allowlist；
   只有 `http:`、`https:`、`mailto:` 可交给操作系统，页内锚点留在 renderer 处理。
 - **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -190,9 +190,8 @@ app.on("before-quit", (event) => {
   if (quitting || appServerManager === undefined) return;
   event.preventDefault();
   quitting = true;
-  triggerService?.stop();
-  void appServerManager
-    .stop()
+  void Promise.resolve(triggerService?.stop())
+    .then(async () => await appServerManager!.stop())
     .then(async () => {
       selfControlPort.detach();
       await capabilityService?.close();

--- a/apps/zenx/src/main/real-smoke.ts
+++ b/apps/zenx/src/main/real-smoke.ts
@@ -486,7 +486,7 @@ void app.whenReady().then(async () => {
       durationMs: 0,
     });
   } finally {
-    triggers?.stop();
+    await triggers?.stop();
     await closeServer(webServer).catch(() => {
       cleanup = "failed";
     });

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -9,6 +9,12 @@ const MAX_TITLE_LENGTH = 64;
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
 
+export interface ZenXThreadTitleObservationFence {
+  readonly signal: AbortSignal;
+  isCurrent(): boolean;
+  track(operation: Promise<void>): void;
+}
+
 export class ZenXThreadTitleCoordinator {
   readonly #store: ZenXThreadTitleStore;
   readonly #inference: ThreadTitleInference;
@@ -17,6 +23,13 @@ export class ZenXThreadTitleCoordinator {
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
   readonly #expectedNativeMirrors = new Map<string, string[]>();
   readonly #nativeAuthorityVersions = new Map<string, number>();
+  readonly #generationOwners = new Map<
+    string,
+    {
+      version: number;
+      fence: ZenXThreadTitleObservationFence | undefined;
+    }
+  >();
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
@@ -71,14 +84,39 @@ export class ZenXThreadTitleCoordinator {
   async observe(
     threadId: string,
     input: string,
+    fence?: ZenXThreadTitleObservationFence,
   ): Promise<ThreadTitleProjection | undefined> {
     this.#assertAvailable();
+    if (!observationIsCurrent(fence)) return undefined;
     const source = meaningfulTitleSource(input);
     if (source === null) return undefined;
     const result = await this.#serial(async () => {
+      if (!observationIsCurrent(fence)) return undefined;
       const existing = this.#snapshot[threadId];
-      if (existing !== undefined)
-        return { projection: existing, created: false };
+      if (existing !== undefined) {
+        if (
+          fence === undefined ||
+          !["provisional", "generating"].includes(existing.status) ||
+          this.#hasCurrentGenerationOwner(existing)
+        ) {
+          return { projection: existing, created: false };
+        }
+        const generating = {
+          ...existing,
+          status: "generating" as const,
+          version:
+            existing.status === "provisional"
+              ? existing.version + 1
+              : existing.version,
+        };
+        if (
+          existing.status === "provisional" &&
+          !(await this.#commit(generating, fence))
+        ) {
+          return { projection: existing, created: false };
+        }
+        return { projection: generating, created: true };
+      }
       const provisional: ThreadTitleProjection = {
         threadId,
         title: normalizeThreadTitle(source),
@@ -86,17 +124,24 @@ export class ZenXThreadTitleCoordinator {
         version: 1,
         source,
       };
-      await this.#commit(provisional);
-      await this.#mirror(threadId, provisional.title);
+      if (!(await this.#commit(provisional, fence))) return undefined;
+      if (!observationIsCurrent(fence))
+        return { projection: provisional, created: false };
+      await this.#mirror(threadId, provisional.title, fence);
+      if (!observationIsCurrent(fence))
+        return { projection: provisional, created: false };
       const generating = {
         ...provisional,
         status: "generating" as const,
         version: 2,
       };
-      await this.#commit(generating);
+      if (!(await this.#commit(generating, fence)))
+        return { projection: provisional, created: false };
       return { projection: generating, created: true };
     });
-    if (result.created) this.#startGeneration(result.projection);
+    if (result === undefined) return undefined;
+    if (result.created && observationIsCurrent(fence))
+      this.#startGeneration(result.projection, fence);
     return result.projection;
   }
 
@@ -171,16 +216,22 @@ export class ZenXThreadTitleCoordinator {
     return generating;
   }
 
-  async #generate(started: ThreadTitleProjection): Promise<void> {
+  async #generate(
+    started: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<void> {
     try {
+      if (!observationIsCurrent(fence)) return;
       const generated = normalizeGeneratedTitle(
         await this.#inference.generate(
           started.source,
           this.#titleModel(),
-          new AbortController().signal,
+          fence?.signal ?? new AbortController().signal,
         ),
       );
+      if (!observationIsCurrent(fence)) return;
       await this.#serial(async () => {
+        if (!observationIsCurrent(fence)) return;
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
@@ -196,40 +247,57 @@ export class ZenXThreadTitleCoordinator {
         const nativeAuthorityVersion = this.#nativeAuthorityVersion(
           started.threadId,
         );
-        await this.#commit(projection);
+        if (!(await this.#commit(projection, fence))) return;
         if (
+          observationIsCurrent(fence) &&
           this.#nativeAuthorityVersion(started.threadId) ===
-          nativeAuthorityVersion
+            nativeAuthorityVersion
         ) {
-          await this.#mirror(started.threadId, generated);
+          await this.#mirror(started.threadId, generated, fence);
         }
       });
     } catch (error) {
+      if (!observationIsCurrent(fence)) return;
       await this.#serial(async () => {
+        if (!observationIsCurrent(fence)) return;
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
           current.version !== started.version
         )
           return;
-        await this.#commit({
-          ...current,
-          status: "failed",
-          version: current.version + 1,
-          error: describeError(error),
-        });
+        await this.#commit(
+          {
+            ...current,
+            status: "failed",
+            version: current.version + 1,
+            error: describeError(error),
+          },
+          fence,
+        );
       });
     }
   }
 
-  async #commit(projection: ThreadTitleProjection): Promise<void> {
+  async #commit(
+    projection: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<boolean> {
+    if (!observationIsCurrent(fence)) return false;
     const next = { ...this.#snapshot, [projection.threadId]: projection };
     await this.#store.write(next);
+    if (!observationIsCurrent(fence)) return false;
     this.#snapshot = next;
     for (const listener of this.#listeners) listener(this.snapshot());
+    return true;
   }
 
-  async #mirror(threadId: string, title: string): Promise<void> {
+  async #mirror(
+    threadId: string,
+    title: string,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<void> {
+    if (!observationIsCurrent(fence)) return;
     const expected = this.#expectedNativeMirrors.get(threadId) ?? [];
     expected.push(title);
     this.#expectedNativeMirrors.set(threadId, expected);
@@ -267,12 +335,30 @@ export class ZenXThreadTitleCoordinator {
     return this.#nativeAuthorityVersions.get(threadId) ?? 0;
   }
 
-  #startGeneration(projection: ThreadTitleProjection): void {
-    void this.#generate(projection).catch((error: unknown) => {
+  #startGeneration(
+    projection: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): void {
+    if (!observationIsCurrent(fence)) return;
+    const owner = { version: projection.version, fence };
+    this.#generationOwners.set(projection.threadId, owner);
+    const operation = this.#generate(projection, fence).finally(() => {
+      if (this.#generationOwners.get(projection.threadId) === owner)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    fence?.track(operation);
+    void operation.catch((error: unknown) => {
       console.error(
         `Could not persist title generation result: ${asError(error).message}`,
       );
     });
+  }
+
+  #hasCurrentGenerationOwner(projection: ThreadTitleProjection): boolean {
+    const owner = this.#generationOwners.get(projection.threadId);
+    return (
+      owner?.version === projection.version && observationIsCurrent(owner.fence)
+    );
   }
 
   #assertAvailable(): void {
@@ -350,4 +436,10 @@ function describeError(error: unknown): string {
 
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function observationIsCurrent(
+  fence?: ZenXThreadTitleObservationFence,
+): boolean {
+  return fence === undefined || (!fence.signal.aborted && fence.isCurrent());
 }

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -37,19 +37,86 @@ export interface ZenXTriggerTitlePort {
   observe(threadId: string, input: string): Promise<unknown>;
 }
 
+const MAX_TRANSIENT_TURNS = 64;
+const MAX_COMPLETED_ITEMS_PER_TURN = 64;
+
+interface InFlightWakeup {
+  historyId: string;
+  threadId: string;
+  clientUserMessageId: string;
+}
+
+interface PendingCompletion {
+  event: ServerNotificationParams["turn/completed"];
+  clientUserMessageId: string | null;
+  rejected: boolean;
+}
+
+interface CompletedItemBuffer {
+  threadId: string;
+  items: ThreadItem[];
+}
+
+class ZenXTriggerLifecycleGeneration {
+  readonly timers = new Map<string, unknown>();
+  readonly completedTurnItems = new Map<string, CompletedItemBuffer>();
+  readonly pendingCompletedTurns = new Map<string, PendingCompletion>();
+  readonly inFlightWakeups = new Map<string, InFlightWakeup>();
+  #active = true;
+  #disposeNotifications: (() => void) | undefined;
+
+  get active(): boolean {
+    return this.#active;
+  }
+
+  attachNotifications(dispose: () => void): void {
+    if (!this.#active) {
+      dispose();
+      return;
+    }
+    this.#disposeNotifications?.();
+    this.#disposeNotifications = dispose;
+  }
+
+  retire(cancelScheduled: (handle: unknown) => void): void {
+    if (!this.#active) return;
+    this.#active = false;
+    this.#disposeNotifications?.();
+    this.#disposeNotifications = undefined;
+    for (const timer of this.timers.values()) cancelScheduled(timer);
+    this.timers.clear();
+    this.clearTransientState();
+  }
+
+  clearTransientState(): void {
+    this.completedTurnItems.clear();
+    this.pendingCompletedTurns.clear();
+    this.inFlightWakeups.clear();
+  }
+
+  clearTransientTurn(turnId: string): void {
+    this.completedTurnItems.delete(turnId);
+    this.pendingCompletedTurns.delete(turnId);
+  }
+}
+
+class StaleTriggerGenerationError extends Error {
+  constructor() {
+    super("ZenX Trigger service lifecycle changed");
+  }
+}
+
 export class ZenXTriggerService {
   readonly #manager: ZenXTriggerAppServerPort;
   readonly #store: ZenXTriggerStore;
   readonly #titles: ZenXTriggerTitlePort | undefined;
   readonly #listeners = new Set<(snapshot: TriggerSnapshot) => void>();
-  readonly #timers = new Map<string, unknown>();
-  readonly #completedAgentMessages = new Map<string, string>();
-  readonly #completedTurnItems = new Map<string, ThreadItem[]>();
   readonly #now: () => number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
   #snapshot: TriggerSnapshot = { triggers: [], history: [], rooms: [] };
   #mutation: Promise<void> = Promise.resolve();
+  #activeGeneration: ZenXTriggerLifecycleGeneration | null = null;
 
   constructor(
     manager: ZenXTriggerAppServerPort,
@@ -72,38 +139,73 @@ export class ZenXTriggerService {
   }
 
   async start(): Promise<void> {
-    this.#snapshot = await this.#store.read();
-    for (const entry of this.#snapshot.history) {
-      if (entry.status === "starting" || entry.status === "running") {
-        entry.status = "failed";
-        entry.completedAt = this.#now();
-        entry.error =
-          "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
-      }
-    }
-    await this.#persist();
-    this.#rescheduleTimers();
-    this.#manager.onNotification((method, params) => {
-      if (method === "item/completed") {
-        const event = params as ServerNotificationParams["item/completed"];
-        const items = this.#completedTurnItems.get(event.turnId) ?? [];
-        const next = items.filter((item) => item.id !== event.item.id);
-        next.push(event.item);
-        this.#completedTurnItems.set(event.turnId, next);
-        if (event.item.type === "agentMessage") {
-          this.#completedAgentMessages.set(event.turnId, event.item.text);
-        }
-      } else if (method === "turn/completed") {
-        void this.#handleTurnCompleted(
-          params as ServerNotificationParams["turn/completed"],
-        );
-      }
+    const generation = this.#beginGeneration();
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
     });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = await this.#store.read();
+      this.#assertGeneration(generation);
+      for (const entry of snapshot.history) {
+        if (entry.status === "starting" || entry.status === "running") {
+          entry.status = "failed";
+          entry.completedAt = this.#now();
+          entry.error =
+            "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
+        }
+      }
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      this.#rescheduleTimers(generation);
+      const listener = (
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ): void => {
+        if (!this.#isActive(generation)) return;
+        if (method === "item/completed") {
+          this.#handleItemCompleted(
+            generation,
+            params as ServerNotificationParams["item/completed"],
+          );
+        } else if (method === "turn/completed") {
+          void this.#handleTurnCompleted(
+            generation,
+            params as ServerNotificationParams["turn/completed"],
+          ).catch((error: unknown) => {
+            if (this.#isActive(generation)) {
+              console.warn(
+                `Could not process Trigger completion: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+          });
+        }
+      };
+      generation.attachNotifications(this.#manager.onNotification(listener));
+    } catch (error) {
+      if (!(error instanceof StaleTriggerGenerationError)) throw error;
+    } finally {
+      release();
+    }
   }
 
-  stop(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async stop(): Promise<void> {
+    const drain = this.#mutation;
+    const generation = this.#activeGeneration;
+    this.#activeGeneration = null;
+    generation?.retire(this.#cancelScheduled);
+    await drain;
+  }
+
+  async close(): Promise<void> {
+    await this.stop();
+    this.#listeners.clear();
   }
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
@@ -114,7 +216,8 @@ export class ZenXTriggerService {
   }
 
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const trigger = await this.#mutate(generation, async (snapshot) => {
       const common = {
         id: randomUUID(),
         threadId: required(input.threadId, "thread"),
@@ -156,28 +259,27 @@ export class ZenXTriggerService {
                   ...common,
                   signal: { name: required(input.signalName, "signal name") },
                 };
-      this.#snapshot.triggers.push(trigger);
-      return trigger;
-    }).then((trigger) => {
-      this.#rescheduleTimers();
+      snapshot.triggers.push(trigger);
       return trigger;
     });
+    this.#rescheduleTimers(generation);
+    return structuredClone(trigger);
   }
 
   async cancel(triggerId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const trigger = this.#snapshot.triggers.find(
-        (item) => item.id === triggerId,
-      );
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const trigger = snapshot.triggers.find((item) => item.id === triggerId);
       if (trigger === undefined) throw new Error("Trigger was not found");
       trigger.active = false;
-      const timer = this.#timers.get(trigger.id);
+      const timer = generation.timers.get(trigger.id);
       if (timer !== undefined) this.#cancelScheduled(timer);
-      this.#timers.delete(trigger.id);
+      generation.timers.delete(trigger.id);
     });
   }
 
   async signal(name: string, detail: string): Promise<void> {
+    const generation = this.#runningGeneration();
     const signalName = required(name, "signal name");
     const signalDetail = detail.trim();
     const matches = this.#snapshot.triggers.filter(
@@ -187,7 +289,7 @@ export class ZenXTriggerService {
         trigger.signal?.name === signalName,
     );
     for (const trigger of matches)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `External signal ${signalName}: ${signalDetail}`,
         occurrenceKey: `signal:${randomUUID()}`,
         projection: `Signal name: ${signalName}\nSignal detail: ${bounded(signalDetail, 4_000)}`,
@@ -195,7 +297,8 @@ export class ZenXTriggerService {
   }
 
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const room = await this.#mutate(generation, async (snapshot) => {
       const members = validateMembers(input.members);
       const room: ZenXRoom = {
         id: randomUUID(),
@@ -204,14 +307,16 @@ export class ZenXTriggerService {
         messages: [],
         createdAt: this.#now(),
       };
-      this.#snapshot.rooms.push(room);
+      snapshot.rooms.push(room);
       return room;
     });
+    return structuredClone(room);
   }
 
   async addRoomMember(roomId: string, member: RoomMember): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -220,8 +325,9 @@ export class ZenXTriggerService {
   }
 
   async removeRoomMember(roomId: string, threadId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -241,20 +347,25 @@ export class ZenXTriggerService {
     author: string,
     text: string,
   ): Promise<void> {
-    const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
-    if (room === undefined) throw new Error("Room was not found");
-    const posted = message(
-      room.id,
-      required(author, "author"),
-      required(text, "message"),
-      "human",
-      null,
-      null,
-      this.#now(),
+    const generation = this.#runningGeneration();
+    const { posted, room } = await this.#mutate(
+      generation,
+      async (snapshot) => {
+        const room = snapshot.rooms.find((entry) => entry.id === roomId);
+        if (room === undefined) throw new Error("Room was not found");
+        const posted = message(
+          room.id,
+          required(author, "author"),
+          required(text, "message"),
+          "human",
+          null,
+          null,
+          this.#now(),
+        );
+        room.messages.push(posted);
+        return { posted, room: structuredClone(room) };
+      },
     );
-    await this.#mutate(async () => {
-      room.messages.push(posted);
-    });
     const mentions = room.members.filter((member) =>
       new RegExp(
         `(^|\\s)@${escapeRegExp(member.name)}(?=\\s|$|[,.!?])`,
@@ -272,7 +383,7 @@ export class ZenXTriggerService {
             member.name.toLocaleLowerCase(),
       );
       for (const trigger of matches)
-        await this.#fire(trigger.id, {
+        await this.#fire(generation, trigger.id, {
           reason: `Room #${room.name} mention from ${posted.author}: ${posted.text}`,
           occurrenceKey: `room:${room.id}:${posted.id}`,
           sourceRoomId: room.id,
@@ -283,53 +394,34 @@ export class ZenXTriggerService {
   }
 
   async #handleTurnCompleted(
+    generation: ZenXTriggerLifecycleGeneration,
     event: ServerNotificationParams["turn/completed"],
   ): Promise<void> {
+    if (!this.#isActive(generation)) return;
     const completedItems = mergeCompletedItems(
       event.turn.items,
-      this.#completedTurnItems.get(event.turn.id) ?? [],
+      generation.completedTurnItems.get(event.turn.id)?.items ?? [],
     );
-    await this.#mutate(async () => {
-      const entry = this.#snapshot.history.find(
-        (item) => item.turnId === event.turn.id && item.status === "running",
-      );
-      if (entry !== undefined) {
-        entry.status =
-          event.turn.status === "completed" ? "completed" : "failed";
-        entry.completedAt = this.#now();
-        entry.error = event.turn.error?.message ?? null;
-        const trigger = this.#snapshot.triggers.find(
-          (item) => item.id === entry.triggerId,
+    const running = this.#snapshot.history.find(
+      (item) => item.turnId === event.turn.id && item.status === "running",
+    );
+    if (running !== undefined) {
+      await this.#mutateMaybe(generation, async (snapshot) => {
+        const current = snapshot.history.find(
+          (entry) =>
+            entry.id === running.id &&
+            entry.turnId === event.turn.id &&
+            entry.status === "running",
         );
-        if (trigger?.kind === "roomMention" && trigger.room !== undefined) {
-          const room = this.#snapshot.rooms.find(
-            (item) => item.id === trigger.room?.roomId,
-          );
-          const projectedAnswer = [...completedItems]
-            .reverse()
-            .find((item) => item.type === "agentMessage");
-          const answer =
-            projectedAnswer?.type === "agentMessage"
-              ? projectedAnswer.text
-              : (this.#completedAgentMessages.get(event.turn.id) ?? "");
-          if (room !== undefined && answer.length > 0) {
-            room.messages.push(
-              message(
-                room.id,
-                trigger.room.mention,
-                answer,
-                "agent",
-                entry.threadId,
-                event.turn.id,
-                this.#now(),
-              ),
-            );
-          }
-        }
-      }
-    });
-    this.#completedAgentMessages.delete(event.turn.id);
-    this.#completedTurnItems.delete(event.turn.id);
+        if (current === undefined) return undefined;
+        this.#applyCompletion(snapshot, running.id, event, completedItems);
+        return true;
+      });
+      generation.clearTransientTurn(event.turn.id);
+    } else {
+      this.#bufferEarlyCompletion(generation, event, completedItems);
+    }
+    if (!this.#isActive(generation)) return;
     const watchers = this.#snapshot.triggers.filter(
       (trigger) =>
         trigger.active &&
@@ -337,7 +429,7 @@ export class ZenXTriggerService {
         trigger.watch?.threadId === event.threadId,
     );
     for (const trigger of watchers)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `Thread ${event.threadId} emitted turn_completed for ${event.turn.id}`,
         occurrenceKey: `thread:${event.threadId}:${event.turn.id}`,
         sourceThreadId: event.threadId,
@@ -350,6 +442,7 @@ export class ZenXTriggerService {
   }
 
   async #fire(
+    generation: ZenXTriggerLifecycleGeneration,
     triggerId: string,
     wakeup: {
       reason: string;
@@ -362,50 +455,63 @@ export class ZenXTriggerService {
       scheduledAt?: number;
     },
   ): Promise<void> {
-    const trigger = this.#snapshot.triggers.find(
-      (item) => item.id === triggerId && item.active,
-    );
-    if (trigger === undefined) return;
-    const clientUserMessageId = stableWakeupId(
-      trigger.id,
-      wakeup.occurrenceKey,
-    );
-    if (
-      this.#snapshot.history.some(
-        (entry) => entry.clientUserMessageId === clientUserMessageId,
-      )
-    )
-      return;
-    const history: TriggerHistoryEntry = {
-      id: randomUUID(),
-      triggerId: trigger.id,
-      threadId: trigger.threadId,
-      kind: trigger.kind,
-      reason: wakeup.reason,
-      prompt: trigger.prompt,
-      clientUserMessageId,
-      startedAt: this.#now(),
-      completedAt: null,
-      status: "starting",
-      turnId: null,
-      error: null,
-      sourceThreadId: wakeup.sourceThreadId ?? null,
-      sourceTurnId: wakeup.sourceTurnId ?? null,
-      sourceRoomId: wakeup.sourceRoomId ?? null,
-      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-    };
-    await this.#mutate(async () => {
-      this.#snapshot.history.unshift(history);
-      if (trigger.timer !== undefined) {
-        if (trigger.timer.intervalMinutes === null) trigger.active = false;
-        else
-          trigger.timer.nextRunAt =
-            Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-            trigger.timer.intervalMinutes * 60_000;
-      }
-    });
-    this.#rescheduleTimers();
+    let activeWakeup: InFlightWakeup | undefined;
     try {
+      const committed = await this.#mutateMaybe(
+        generation,
+        async (snapshot) => {
+          const trigger = snapshot.triggers.find(
+            (item) => item.id === triggerId && item.active,
+          );
+          if (trigger === undefined) return undefined;
+          const clientUserMessageId = stableWakeupId(
+            trigger.id,
+            wakeup.occurrenceKey,
+          );
+          if (
+            snapshot.history.some(
+              (entry) => entry.clientUserMessageId === clientUserMessageId,
+            )
+          )
+            return undefined;
+          const history: TriggerHistoryEntry = {
+            id: randomUUID(),
+            triggerId: trigger.id,
+            threadId: trigger.threadId,
+            kind: trigger.kind,
+            reason: wakeup.reason,
+            prompt: trigger.prompt,
+            clientUserMessageId,
+            startedAt: this.#now(),
+            completedAt: null,
+            status: "starting",
+            turnId: null,
+            error: null,
+            sourceThreadId: wakeup.sourceThreadId ?? null,
+            sourceTurnId: wakeup.sourceTurnId ?? null,
+            sourceRoomId: wakeup.sourceRoomId ?? null,
+            sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+            replyRoomId: trigger.room?.roomId ?? null,
+            replyAuthor: trigger.room?.mention ?? null,
+          };
+          snapshot.history.unshift(history);
+          if (trigger.timer !== undefined) {
+            if (trigger.timer.intervalMinutes === null) trigger.active = false;
+            else
+              trigger.timer.nextRunAt =
+                Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
+                trigger.timer.intervalMinutes * 60_000;
+          }
+          return {
+            trigger: structuredClone(trigger),
+            historyId: history.id,
+            clientUserMessageId,
+          };
+        },
+      );
+      if (committed === undefined) return;
+      const { trigger, historyId, clientUserMessageId } = committed;
+      this.#rescheduleTimers(generation);
       await this.#titles
         ?.observe(
           trigger.threadId,
@@ -416,81 +522,397 @@ export class ZenXTriggerService {
             `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
           ),
         );
+      if (!this.#isActive(generation)) return;
+      activeWakeup = {
+        historyId,
+        threadId: trigger.threadId,
+        clientUserMessageId,
+      };
+      generation.inFlightWakeups.set(clientUserMessageId, activeWakeup);
       const result = await this.#manager.request("turn/start", {
         threadId: trigger.threadId,
         clientUserMessageId,
         input: [
           {
             type: "text",
-            text: wakeupInput(trigger, history, wakeup.projection),
+            text: wakeupInput(
+              trigger,
+              this.#history(historyId),
+              wakeup.projection,
+            ),
           },
         ],
       });
-      await this.#mutate(async () => {
+      if (!this.#isActive(generation)) return;
+      const pending = generation.pendingCompletedTurns.get(result.turn.id);
+      const bufferedItems = generation.completedTurnItems.get(
+        result.turn.id,
+      )?.items;
+      await this.#mutate(generation, async (snapshot) => {
+        const history = snapshot.history.find(
+          (entry) => entry.id === historyId,
+        );
+        if (history === undefined || history.status !== "starting") return;
         history.status = "running";
         history.turnId = result.turn.id;
+        if (
+          pending !== undefined &&
+          !pending.rejected &&
+          pending.event.threadId === trigger.threadId &&
+          pending.clientUserMessageId === clientUserMessageId
+        ) {
+          this.#applyCompletion(
+            snapshot,
+            historyId,
+            pending.event,
+            mergeCompletedItems(pending.event.turn.items, bufferedItems ?? []),
+          );
+        }
       });
+      if (pending !== undefined) generation.clearTransientTurn(result.turn.id);
     } catch (error) {
-      await this.#mutate(async () => {
-        history.status = "failed";
-        history.completedAt = this.#now();
-        history.error = error instanceof Error ? error.message : String(error);
-      });
+      if (error instanceof StaleTriggerGenerationError) return;
+      if (activeWakeup === undefined) throw error;
+      if (this.#isActive(generation)) {
+        const failedWakeup = activeWakeup;
+        await this.#mutate(generation, async (snapshot) => {
+          const history = snapshot.history.find(
+            (entry) => entry.id === failedWakeup.historyId,
+          );
+          if (history === undefined || history.status !== "starting") return;
+          history.status = "failed";
+          history.completedAt = this.#now();
+          history.error =
+            error instanceof Error ? error.message : String(error);
+        });
+      }
+    } finally {
+      if (
+        activeWakeup !== undefined &&
+        generation.inFlightWakeups.get(activeWakeup.clientUserMessageId) ===
+          activeWakeup
+      ) {
+        generation.inFlightWakeups.delete(activeWakeup.clientUserMessageId);
+      }
+      this.#evictUnmatchablePending(generation);
     }
   }
 
-  #rescheduleTimers(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  #rescheduleTimers(generation: ZenXTriggerLifecycleGeneration): void {
+    if (!this.#isActive(generation)) return;
+    this.#cancelTimers(generation);
     for (const trigger of this.#snapshot.triggers) {
       if (!trigger.active || trigger.timer === undefined) continue;
-      this.#scheduleTimer(trigger.id, trigger.timer.nextRunAt);
+      this.#scheduleTimer(generation, trigger.id, trigger.timer.nextRunAt);
     }
   }
 
-  #scheduleTimer(triggerId: string, scheduledAt: number): void {
+  #scheduleTimer(
+    generation: ZenXTriggerLifecycleGeneration,
+    triggerId: string,
+    scheduledAt: number,
+  ): void {
     const delay = Math.max(
       0,
       Math.min(2_147_000_000, scheduledAt - this.#now()),
     );
     const timer = this.#schedule(() => {
-      this.#timers.delete(triggerId);
+      if (!this.#isActive(generation)) return;
+      generation.timers.delete(triggerId);
       if (this.#now() < scheduledAt) {
-        this.#scheduleTimer(triggerId, scheduledAt);
+        this.#scheduleTimer(generation, triggerId, scheduledAt);
         return;
       }
-      void this.#fire(triggerId, {
+      void this.#fire(generation, triggerId, {
         reason: `Timer reached ${new Date(scheduledAt).toISOString()}`,
         occurrenceKey: `timer:${scheduledAt}`,
         scheduledAt,
       });
     }, delay);
-    this.#timers.set(triggerId, timer);
+    generation.timers.set(triggerId, timer);
   }
 
-  async #mutate<T>(operation: () => Promise<T>): Promise<T> {
+  async #mutate<T>(
+    generation: ZenXTriggerLifecycleGeneration,
+    operation: (snapshot: TriggerSnapshot) => Promise<T>,
+  ): Promise<T> {
+    this.#assertGeneration(generation);
     const previous = this.#mutation;
     let release!: () => void;
     this.#mutation = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
-    const previousSnapshot = structuredClone(this.#snapshot);
     try {
-      const result = await operation();
-      await this.#persist();
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
       return result;
-    } catch (error) {
-      this.#snapshot = previousSnapshot;
-      throw error;
     } finally {
       release();
     }
   }
 
-  async #persist(): Promise<void> {
-    await this.#store.write(this.#snapshot);
+  async #mutateMaybe<T>(
+    generation: ZenXTriggerLifecycleGeneration,
+    operation: (snapshot: TriggerSnapshot) => Promise<T | undefined>,
+  ): Promise<T | undefined> {
+    this.#assertGeneration(generation);
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      if (result === undefined) return undefined;
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      return result;
+    } finally {
+      release();
+    }
+  }
+
+  #notifyListeners(): void {
     for (const listener of this.#listeners) listener(this.snapshot());
+  }
+
+  #beginGeneration(): ZenXTriggerLifecycleGeneration {
+    const previous = this.#activeGeneration;
+    const generation = new ZenXTriggerLifecycleGeneration();
+    this.#activeGeneration = generation;
+    previous?.retire(this.#cancelScheduled);
+    return generation;
+  }
+
+  #runningGeneration(): ZenXTriggerLifecycleGeneration {
+    if (this.#activeGeneration === null)
+      throw new Error("ZenX Trigger service is not running");
+    return this.#activeGeneration;
+  }
+
+  #isActive(generation: ZenXTriggerLifecycleGeneration): boolean {
+    return generation.active && this.#activeGeneration === generation;
+  }
+
+  #assertGeneration(generation: ZenXTriggerLifecycleGeneration): void {
+    if (!this.#isActive(generation)) throw new StaleTriggerGenerationError();
+  }
+
+  #cancelTimers(generation: ZenXTriggerLifecycleGeneration): void {
+    for (const timer of generation.timers.values())
+      this.#cancelScheduled(timer);
+    generation.timers.clear();
+  }
+
+  #handleItemCompleted(
+    generation: ZenXTriggerLifecycleGeneration,
+    event: ServerNotificationParams["item/completed"],
+  ): void {
+    if (!this.#isPotentialWakeupTurn(generation, event.threadId, event.turnId))
+      return;
+    const current = generation.completedTurnItems.get(event.turnId);
+    const items = (current?.items ?? []).filter(
+      (item) => item.id !== event.item.id,
+    );
+    items.push(event.item);
+    this.#setBounded(
+      generation.completedTurnItems,
+      event.turnId,
+      {
+        threadId: event.threadId,
+        items: items.slice(-MAX_COMPLETED_ITEMS_PER_TURN),
+      },
+      (turnId) => generation.pendingCompletedTurns.delete(turnId),
+    );
+  }
+
+  #isPotentialWakeupTurn(
+    generation: ZenXTriggerLifecycleGeneration,
+    threadId: string,
+    turnId: string,
+  ): boolean {
+    return (
+      this.#snapshot.history.some(
+        (entry) => entry.turnId === turnId && entry.status === "running",
+      ) ||
+      generation.pendingCompletedTurns.has(turnId) ||
+      this.#snapshot.triggers.some(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "thread" &&
+          trigger.watch?.threadId === threadId,
+      ) ||
+      [...generation.inFlightWakeups.values()].some(
+        (entry) => entry.threadId === threadId,
+      )
+    );
+  }
+
+  #bufferEarlyCompletion(
+    generation: ZenXTriggerLifecycleGeneration,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const sameThreadWakeups = [...generation.inFlightWakeups.values()].filter(
+      (entry) => entry.threadId === event.threadId,
+    );
+    if (sameThreadWakeups.length === 0) {
+      generation.clearTransientTurn(event.turn.id);
+      return;
+    }
+    const clientIds = completedItems
+      .filter((item) => item.type === "userMessage")
+      .map((item) => item.clientId)
+      .filter((clientId): clientId is string => clientId !== null);
+    const soleClientId = clientIds.length === 1 ? clientIds[0]! : null;
+    const soleWakeup =
+      soleClientId === null
+        ? undefined
+        : generation.inFlightWakeups.get(soleClientId);
+    const clientUserMessageId =
+      soleWakeup?.threadId === event.threadId ? soleClientId : null;
+    const existing = generation.pendingCompletedTurns.get(event.turn.id);
+    if (existing?.rejected === true) return;
+    if (
+      clientIds.length === 0 &&
+      existing !== undefined &&
+      existing.clientUserMessageId !== null
+    ) {
+      return;
+    }
+    if (clientIds.length !== 1 || clientUserMessageId === null) {
+      generation.completedTurnItems.delete(event.turn.id);
+      this.#setBounded(
+        generation.pendingCompletedTurns,
+        event.turn.id,
+        {
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+        },
+        (turnId) => generation.completedTurnItems.delete(turnId),
+      );
+      return;
+    }
+    if (existing !== undefined) {
+      if (existing.clientUserMessageId === clientUserMessageId) {
+        return;
+      }
+      generation.completedTurnItems.delete(event.turn.id);
+      this.#setBounded(
+        generation.pendingCompletedTurns,
+        event.turn.id,
+        {
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+        },
+        (turnId) => generation.completedTurnItems.delete(turnId),
+      );
+      return;
+    }
+    this.#setBounded(
+      generation.pendingCompletedTurns,
+      event.turn.id,
+      { event, clientUserMessageId, rejected: false },
+      (turnId) => generation.completedTurnItems.delete(turnId),
+    );
+  }
+
+  #applyCompletion(
+    snapshot: TriggerSnapshot,
+    historyId: string,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const entry = snapshot.history.find((item) => item.id === historyId);
+    if (
+      entry === undefined ||
+      (entry.status !== "running" && entry.status !== "starting")
+    )
+      return;
+    entry.status = event.turn.status === "completed" ? "completed" : "failed";
+    entry.completedAt = this.#now();
+    entry.error = event.turn.error?.message ?? null;
+    if (entry.replyRoomId === null || entry.replyAuthor === null) return;
+    const room = snapshot.rooms.find((item) => item.id === entry.replyRoomId);
+    const answer = [...completedItems]
+      .reverse()
+      .find((item) => item.type === "agentMessage");
+    if (
+      room !== undefined &&
+      answer?.type === "agentMessage" &&
+      answer.text.length > 0
+    ) {
+      room.messages.push(
+        message(
+          room.id,
+          entry.replyAuthor,
+          answer.text,
+          "agent",
+          entry.threadId,
+          event.turn.id,
+          this.#now(),
+        ),
+      );
+    }
+  }
+
+  #history(historyId: string): TriggerHistoryEntry {
+    const history = this.#snapshot.history.find(
+      (entry) => entry.id === historyId,
+    );
+    if (history === undefined) throw new StaleTriggerGenerationError();
+    return history;
+  }
+
+  #evictUnmatchablePending(generation: ZenXTriggerLifecycleGeneration): void {
+    const activeClientIds = new Set(
+      [...generation.inFlightWakeups.values()].map(
+        (entry) => entry.clientUserMessageId,
+      ),
+    );
+    const activeThreads = new Set(
+      [...generation.inFlightWakeups.values()].map((entry) => entry.threadId),
+    );
+    for (const [turnId, pending] of generation.pendingCompletedTurns) {
+      if (
+        pending.clientUserMessageId === null
+          ? !activeThreads.has(pending.event.threadId)
+          : !activeClientIds.has(pending.clientUserMessageId)
+      ) {
+        generation.clearTransientTurn(turnId);
+      }
+    }
+  }
+
+  #setBounded<K, V>(
+    map: Map<K, V>,
+    key: K,
+    value: V,
+    onEvict: (key: K) => void,
+  ): void {
+    map.delete(key);
+    map.set(key, value);
+    while (map.size > MAX_TRANSIENT_TURNS) {
+      const oldest = map.keys().next().value as K | undefined;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+      onEvict(oldest);
+    }
   }
 }
 

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -50,6 +50,7 @@ interface PendingCompletion {
   event: ServerNotificationParams["turn/completed"];
   clientUserMessageId: string | null;
   rejected: boolean;
+  claimed: boolean;
 }
 
 interface CompletedItemBuffer {
@@ -94,9 +95,10 @@ class ZenXTriggerLifecycleGeneration {
     this.inFlightWakeups.clear();
   }
 
-  clearTransientTurn(turnId: string): void {
-    this.completedTurnItems.delete(turnId);
-    this.pendingCompletedTurns.delete(turnId);
+  clearTransientTurn(threadId: string, turnId: string): void {
+    const key = transientTurnKey(threadId, turnId);
+    this.completedTurnItems.delete(key);
+    this.pendingCompletedTurns.delete(key);
   }
 }
 
@@ -189,6 +191,7 @@ export class ZenXTriggerService {
       };
       generation.attachNotifications(this.#manager.onNotification(listener));
     } catch (error) {
+      this.#retireGeneration(generation);
       if (!(error instanceof StaleTriggerGenerationError)) throw error;
     } finally {
       release();
@@ -398,12 +401,17 @@ export class ZenXTriggerService {
     event: ServerNotificationParams["turn/completed"],
   ): Promise<void> {
     if (!this.#isActive(generation)) return;
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const buffered = generation.completedTurnItems.get(key);
     const completedItems = mergeCompletedItems(
       event.turn.items,
-      generation.completedTurnItems.get(event.turn.id)?.items ?? [],
+      buffered?.threadId === event.threadId ? buffered.items : [],
     );
     const running = this.#snapshot.history.find(
-      (item) => item.turnId === event.turn.id && item.status === "running",
+      (item) =>
+        item.turnId === event.turn.id &&
+        item.threadId === event.threadId &&
+        item.status === "running",
     );
     if (running !== undefined) {
       await this.#mutateMaybe(generation, async (snapshot) => {
@@ -411,13 +419,14 @@ export class ZenXTriggerService {
           (entry) =>
             entry.id === running.id &&
             entry.turnId === event.turn.id &&
+            entry.threadId === event.threadId &&
             entry.status === "running",
         );
         if (current === undefined) return undefined;
         this.#applyCompletion(snapshot, running.id, event, completedItems);
         return true;
       });
-      generation.clearTransientTurn(event.turn.id);
+      generation.clearTransientTurn(event.threadId, event.turn.id);
     } else {
       this.#bufferEarlyCompletion(generation, event, completedItems);
     }
@@ -512,6 +521,7 @@ export class ZenXTriggerService {
       if (committed === undefined) return;
       const { trigger, historyId, clientUserMessageId } = committed;
       this.#rescheduleTimers(generation);
+      if (!this.#isActive(generation)) return;
       await this.#titles
         ?.observe(
           trigger.threadId,
@@ -544,10 +554,6 @@ export class ZenXTriggerService {
         ],
       });
       if (!this.#isActive(generation)) return;
-      const pending = generation.pendingCompletedTurns.get(result.turn.id);
-      const bufferedItems = generation.completedTurnItems.get(
-        result.turn.id,
-      )?.items;
       await this.#mutate(generation, async (snapshot) => {
         const history = snapshot.history.find(
           (entry) => entry.id === historyId,
@@ -555,21 +561,14 @@ export class ZenXTriggerService {
         if (history === undefined || history.status !== "starting") return;
         history.status = "running";
         history.turnId = result.turn.id;
-        if (
-          pending !== undefined &&
-          !pending.rejected &&
-          pending.event.threadId === trigger.threadId &&
-          pending.clientUserMessageId === clientUserMessageId
-        ) {
-          this.#applyCompletion(
-            snapshot,
-            historyId,
-            pending.event,
-            mergeCompletedItems(pending.event.turn.items, bufferedItems ?? []),
-          );
-        }
       });
-      if (pending !== undefined) generation.clearTransientTurn(result.turn.id);
+      await this.#consumePendingCompletion(
+        generation,
+        historyId,
+        trigger.threadId,
+        clientUserMessageId,
+        result.turn.id,
+      );
     } catch (error) {
       if (error instanceof StaleTriggerGenerationError) return;
       if (activeWakeup === undefined) throw error;
@@ -697,6 +696,11 @@ export class ZenXTriggerService {
     return generation;
   }
 
+  #retireGeneration(generation: ZenXTriggerLifecycleGeneration): void {
+    if (this.#activeGeneration === generation) this.#activeGeneration = null;
+    generation.retire(this.#cancelScheduled);
+  }
+
   #runningGeneration(): ZenXTriggerLifecycleGeneration {
     if (this.#activeGeneration === null)
       throw new Error("ZenX Trigger service is not running");
@@ -721,21 +725,22 @@ export class ZenXTriggerService {
     generation: ZenXTriggerLifecycleGeneration,
     event: ServerNotificationParams["item/completed"],
   ): void {
+    const key = transientTurnKey(event.threadId, event.turnId);
+    const current = generation.completedTurnItems.get(key);
     if (!this.#isPotentialWakeupTurn(generation, event.threadId, event.turnId))
       return;
-    const current = generation.completedTurnItems.get(event.turnId);
     const items = (current?.items ?? []).filter(
       (item) => item.id !== event.item.id,
     );
     items.push(event.item);
     this.#setBounded(
       generation.completedTurnItems,
-      event.turnId,
+      key,
       {
         threadId: event.threadId,
         items: items.slice(-MAX_COMPLETED_ITEMS_PER_TURN),
       },
-      (turnId) => generation.pendingCompletedTurns.delete(turnId),
+      (evictedKey) => generation.pendingCompletedTurns.delete(evictedKey),
     );
   }
 
@@ -744,11 +749,16 @@ export class ZenXTriggerService {
     threadId: string,
     turnId: string,
   ): boolean {
+    const key = transientTurnKey(threadId, turnId);
     return (
       this.#snapshot.history.some(
-        (entry) => entry.turnId === turnId && entry.status === "running",
+        (entry) =>
+          entry.turnId === turnId &&
+          entry.threadId === threadId &&
+          entry.status === "running",
       ) ||
-      generation.pendingCompletedTurns.has(turnId) ||
+      generation.pendingCompletedTurns.has(key) ||
+      generation.completedTurnItems.has(key) ||
       this.#snapshot.triggers.some(
         (trigger) =>
           trigger.active &&
@@ -766,11 +776,13 @@ export class ZenXTriggerService {
     event: ServerNotificationParams["turn/completed"],
     completedItems: readonly ThreadItem[],
   ): void {
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const existing = generation.pendingCompletedTurns.get(key);
     const sameThreadWakeups = [...generation.inFlightWakeups.values()].filter(
       (entry) => entry.threadId === event.threadId,
     );
     if (sameThreadWakeups.length === 0) {
-      generation.clearTransientTurn(event.turn.id);
+      generation.clearTransientTurn(event.threadId, event.turn.id);
       return;
     }
     const clientIds = completedItems
@@ -784,7 +796,7 @@ export class ZenXTriggerService {
         : generation.inFlightWakeups.get(soleClientId);
     const clientUserMessageId =
       soleWakeup?.threadId === event.threadId ? soleClientId : null;
-    const existing = generation.pendingCompletedTurns.get(event.turn.id);
+    if (existing?.claimed === true) return;
     if (existing?.rejected === true) return;
     if (
       clientIds.length === 0 &&
@@ -794,16 +806,17 @@ export class ZenXTriggerService {
       return;
     }
     if (clientIds.length !== 1 || clientUserMessageId === null) {
-      generation.completedTurnItems.delete(event.turn.id);
+      generation.completedTurnItems.delete(key);
       this.#setBounded(
         generation.pendingCompletedTurns,
-        event.turn.id,
+        key,
         {
           event,
           clientUserMessageId: null,
           rejected: true,
+          claimed: false,
         },
-        (turnId) => generation.completedTurnItems.delete(turnId),
+        (evictedKey) => generation.completedTurnItems.delete(evictedKey),
       );
       return;
     }
@@ -811,25 +824,74 @@ export class ZenXTriggerService {
       if (existing.clientUserMessageId === clientUserMessageId) {
         return;
       }
-      generation.completedTurnItems.delete(event.turn.id);
+      generation.completedTurnItems.delete(key);
       this.#setBounded(
         generation.pendingCompletedTurns,
-        event.turn.id,
+        key,
         {
           event,
           clientUserMessageId: null,
           rejected: true,
+          claimed: false,
         },
-        (turnId) => generation.completedTurnItems.delete(turnId),
+        (evictedKey) => generation.completedTurnItems.delete(evictedKey),
       );
       return;
     }
     this.#setBounded(
       generation.pendingCompletedTurns,
-      event.turn.id,
-      { event, clientUserMessageId, rejected: false },
-      (turnId) => generation.completedTurnItems.delete(turnId),
+      key,
+      { event, clientUserMessageId, rejected: false, claimed: false },
+      (evictedKey) => generation.completedTurnItems.delete(evictedKey),
     );
+  }
+
+  async #consumePendingCompletion(
+    generation: ZenXTriggerLifecycleGeneration,
+    historyId: string,
+    threadId: string,
+    clientUserMessageId: string,
+    turnId: string,
+  ): Promise<void> {
+    const key = transientTurnKey(threadId, turnId);
+    const consumed = await this.#mutateMaybe(generation, async (snapshot) => {
+      const history = snapshot.history.find(
+        (entry) =>
+          entry.id === historyId &&
+          entry.threadId === threadId &&
+          entry.turnId === turnId &&
+          entry.status === "running",
+      );
+      if (history === undefined) return undefined;
+      const pending = generation.pendingCompletedTurns.get(key);
+      if (
+        pending === undefined ||
+        pending.claimed ||
+        pending.rejected ||
+        pending.event.threadId !== threadId ||
+        pending.clientUserMessageId !== clientUserMessageId
+      )
+        return undefined;
+      const buffer = generation.completedTurnItems.get(key);
+      if (buffer !== undefined && buffer.threadId !== threadId)
+        return undefined;
+      pending.claimed = true;
+      this.#applyCompletion(
+        snapshot,
+        historyId,
+        pending.event,
+        mergeCompletedItems(pending.event.turn.items, buffer?.items ?? []),
+      );
+      return { pending, buffer };
+    });
+    if (consumed === undefined) return;
+    if (generation.pendingCompletedTurns.get(key) === consumed.pending)
+      generation.pendingCompletedTurns.delete(key);
+    if (
+      consumed.buffer !== undefined &&
+      generation.completedTurnItems.get(key) === consumed.buffer
+    )
+      generation.completedTurnItems.delete(key);
   }
 
   #applyCompletion(
@@ -888,13 +950,16 @@ export class ZenXTriggerService {
     const activeThreads = new Set(
       [...generation.inFlightWakeups.values()].map((entry) => entry.threadId),
     );
-    for (const [turnId, pending] of generation.pendingCompletedTurns) {
+    for (const pending of generation.pendingCompletedTurns.values()) {
       if (
         pending.clientUserMessageId === null
           ? !activeThreads.has(pending.event.threadId)
           : !activeClientIds.has(pending.clientUserMessageId)
       ) {
-        generation.clearTransientTurn(turnId);
+        generation.clearTransientTurn(
+          pending.event.threadId,
+          pending.event.turn.id,
+        );
       }
     }
   }
@@ -994,6 +1059,10 @@ function stableWakeupId(triggerId: string, occurrenceKey: string): string {
     .digest("hex")
     .slice(0, 24);
   return `zenx-wakeup:${triggerId}:${occurrence}`;
+}
+
+function transientTurnKey(threadId: string, turnId: string): string {
+  return `${String(threadId.length)}:${threadId}${turnId}`;
 }
 
 function wakeupInput(

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -9,6 +9,7 @@ import type {
   Turn,
 } from "../protocol-client/index.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
+import type { ZenXThreadTitleObservationFence } from "./thread-title-coordinator.js";
 import type {
   CreateRoomInput,
   CreateTriggerInput,
@@ -34,7 +35,11 @@ export interface ZenXTriggerAppServerPort {
 }
 
 export interface ZenXTriggerTitlePort {
-  observe(threadId: string, input: string): Promise<unknown>;
+  observe(
+    threadId: string,
+    input: string,
+    fence: ZenXThreadTitleObservationFence,
+  ): Promise<unknown>;
 }
 
 const MAX_TRANSIENT_TURNS = 64;
@@ -63,11 +68,17 @@ class ZenXTriggerLifecycleGeneration {
   readonly completedTurnItems = new Map<string, CompletedItemBuffer>();
   readonly pendingCompletedTurns = new Map<string, PendingCompletion>();
   readonly inFlightWakeups = new Map<string, InFlightWakeup>();
+  readonly #titleAbort = new AbortController();
+  readonly #titleObservations = new Set<Promise<void>>();
   #active = true;
   #disposeNotifications: (() => void) | undefined;
 
   get active(): boolean {
     return this.#active;
+  }
+
+  get titleSignal(): AbortSignal {
+    return this.#titleAbort.signal;
   }
 
   attachNotifications(dispose: () => void): void {
@@ -82,11 +93,51 @@ class ZenXTriggerLifecycleGeneration {
   retire(cancelScheduled: (handle: unknown) => void): void {
     if (!this.#active) return;
     this.#active = false;
-    this.#disposeNotifications?.();
+    const errors: unknown[] = [];
+    try {
+      this.#titleAbort.abort();
+    } catch (error) {
+      errors.push(error);
+    }
+    const dispose = this.#disposeNotifications;
     this.#disposeNotifications = undefined;
-    for (const timer of this.timers.values()) cancelScheduled(timer);
-    this.timers.clear();
-    this.clearTransientState();
+    try {
+      dispose?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      for (const timer of this.timers.values()) {
+        try {
+          cancelScheduled(timer);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    } finally {
+      this.timers.clear();
+      this.clearTransientState();
+    }
+    if (errors.length > 0)
+      throw new AggregateError(
+        errors,
+        `Could not fully retire Trigger generation: ${errors.map(describeError).join("; ")}`,
+      );
+  }
+
+  trackTitleObservation<T>(operation: Promise<T>): Promise<T> {
+    const drained = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#titleObservations.add(drained);
+    void drained.finally(() => this.#titleObservations.delete(drained));
+    return operation;
+  }
+
+  async drainTitleObservations(): Promise<void> {
+    while (this.#titleObservations.size > 0)
+      await Promise.all([...this.#titleObservations]);
   }
 
   clearTransientState(): void {
@@ -118,6 +169,7 @@ export class ZenXTriggerService {
   readonly #cancelScheduled: (handle: unknown) => void;
   #snapshot: TriggerSnapshot = { triggers: [], history: [], rooms: [] };
   #mutation: Promise<void> = Promise.resolve();
+  readonly #retirements = new Set<Promise<void>>();
   #activeGeneration: ZenXTriggerLifecycleGeneration | null = null;
 
   constructor(
@@ -141,7 +193,7 @@ export class ZenXTriggerService {
   }
 
   async start(): Promise<void> {
-    const generation = this.#beginGeneration();
+    const generation = await this.#beginGeneration();
     const previous = this.#mutation;
     let release!: () => void;
     this.#mutation = new Promise<void>((resolve) => {
@@ -191,8 +243,18 @@ export class ZenXTriggerService {
       };
       generation.attachNotifications(this.#manager.onNotification(listener));
     } catch (error) {
-      this.#retireGeneration(generation);
-      if (!(error instanceof StaleTriggerGenerationError)) throw error;
+      let retirementError: unknown;
+      try {
+        this.#retireGeneration(generation);
+      } catch (retireError) {
+        retirementError = retireError;
+      }
+      const retirement = generation.drainTitleObservations();
+      this.#trackRetirement(retirement);
+      await retirement;
+      if (!(error instanceof StaleTriggerGenerationError))
+        throw combinedError(error, retirementError);
+      if (retirementError !== undefined) throw retirementError;
     } finally {
       release();
     }
@@ -202,14 +264,29 @@ export class ZenXTriggerService {
     const drain = this.#mutation;
     const generation = this.#activeGeneration;
     this.#activeGeneration = null;
-    generation?.retire(this.#cancelScheduled);
-    await drain;
+    let retirementError: unknown;
+    try {
+      generation?.retire(this.#cancelScheduled);
+    } catch (error) {
+      retirementError = error;
+    }
+    const retirement = Promise.all([
+      drain,
+      generation?.drainTitleObservations(),
+    ]).then(() => undefined);
+    this.#trackRetirement(retirement);
+    await retirement;
+    if (retirementError !== undefined) throw retirementError;
   }
 
   async close(): Promise<void> {
-    await this.stop();
-    this.#listeners.clear();
+    try {
+      await this.stop();
+    } finally {
+      this.#listeners.clear();
+    }
   }
+
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
   }
@@ -522,16 +599,7 @@ export class ZenXTriggerService {
       const { trigger, historyId, clientUserMessageId } = committed;
       this.#rescheduleTimers(generation);
       if (!this.#isActive(generation)) return;
-      await this.#titles
-        ?.observe(
-          trigger.threadId,
-          meaningfulWakeupTitleInput(trigger, wakeup.projection),
-        )
-        .catch((error: unknown) =>
-          console.warn(
-            `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
-          ),
-        );
+      await this.#observeTitle(generation, trigger, wakeup.projection);
       if (!this.#isActive(generation)) return;
       activeWakeup = {
         historyId,
@@ -594,6 +662,37 @@ export class ZenXTriggerService {
         generation.inFlightWakeups.delete(activeWakeup.clientUserMessageId);
       }
       this.#evictUnmatchablePending(generation);
+    }
+  }
+
+  async #observeTitle(
+    generation: ZenXTriggerLifecycleGeneration,
+    trigger: ZenXTrigger,
+    projection?: string,
+  ): Promise<void> {
+    if (this.#titles === undefined || !this.#isActive(generation)) return;
+    const fence = {
+      signal: generation.titleSignal,
+      isCurrent: (): boolean => this.#isActive(generation),
+      track: (operation: Promise<void>): void => {
+        generation.trackTitleObservation(operation);
+      },
+    };
+    const observation = (async () => {
+      if (!fence.isCurrent()) return;
+      await this.#titles!.observe(
+        trigger.threadId,
+        meaningfulWakeupTitleInput(trigger, projection),
+        fence,
+      );
+    })();
+    try {
+      await generation.trackTitleObservation(observation);
+    } catch (error) {
+      if (fence.isCurrent())
+        console.warn(
+          `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
+        );
     }
   }
 
@@ -688,12 +787,37 @@ export class ZenXTriggerService {
     for (const listener of this.#listeners) listener(this.snapshot());
   }
 
-  #beginGeneration(): ZenXTriggerLifecycleGeneration {
+  async #beginGeneration(): Promise<ZenXTriggerLifecycleGeneration> {
+    await this.#awaitRetirement();
     const previous = this.#activeGeneration;
+    this.#activeGeneration = null;
+    let retirementError: unknown;
+    try {
+      previous?.retire(this.#cancelScheduled);
+    } catch (error) {
+      retirementError = error;
+    }
+    const retirement = previous?.drainTitleObservations() ?? Promise.resolve();
+    this.#trackRetirement(retirement);
+    await retirement;
+    if (retirementError !== undefined) throw retirementError;
     const generation = new ZenXTriggerLifecycleGeneration();
     this.#activeGeneration = generation;
-    previous?.retire(this.#cancelScheduled);
     return generation;
+  }
+
+  async #awaitRetirement(): Promise<void> {
+    while (this.#retirements.size > 0)
+      await Promise.all([...this.#retirements]);
+  }
+
+  #trackRetirement(operation: Promise<void>): void {
+    const drained = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#retirements.add(drained);
+    void drained.finally(() => this.#retirements.delete(drained));
   }
 
   #retireGeneration(generation: ZenXTriggerLifecycleGeneration): void {
@@ -1165,4 +1289,16 @@ function mergeCompletedItems(
 function bounded(value: string, limit: number): string {
   if (value.length <= limit) return value;
   return `${value.slice(0, Math.max(0, limit - 24))}\n…[truncated by ZenX]`;
+}
+
+function combinedError(primary: unknown, secondary: unknown): unknown {
+  if (secondary === undefined) return primary;
+  return new AggregateError(
+    [primary, secondary],
+    `${describeError(primary)}; cleanup also failed: ${describeError(secondary)}`,
+  );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -11,7 +11,12 @@ import type {
 } from "./trigger-types.js";
 
 interface StoredState extends TriggerSnapshot {
+  version: 3;
+}
+
+interface Version2StoredState extends Omit<TriggerSnapshot, "history"> {
   version: 2;
+  history: Array<Omit<TriggerHistoryEntry, "replyRoomId" | "replyAuthor">>;
 }
 
 interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
@@ -19,7 +24,12 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
   history: Array<
     Omit<
       TriggerHistoryEntry,
-      "sourceThreadId" | "sourceTurnId" | "sourceRoomId" | "sourceRoomMessageId"
+      | "sourceThreadId"
+      | "sourceTurnId"
+      | "sourceRoomId"
+      | "sourceRoomMessageId"
+      | "replyRoomId"
+      | "replyAuthor"
     >
   >;
 }
@@ -42,6 +52,17 @@ export class ZenXTriggerStore {
     try {
       const value = JSON.parse(await handle.readFile("utf8")) as unknown;
       if (isStoredState(value)) return snapshotFrom(value);
+      if (isVersion2StoredState(value)) {
+        return {
+          triggers: value.triggers,
+          history: value.history.map((entry) => ({
+            ...entry,
+            replyRoomId: null,
+            replyAuthor: null,
+          })),
+          rooms: value.rooms,
+        };
+      }
       if (isLegacyStoredState(value)) {
         return {
           triggers: value.triggers,
@@ -51,6 +72,8 @@ export class ZenXTriggerStore {
             sourceTurnId: null,
             sourceRoomId: null,
             sourceRoomMessageId: null,
+            replyRoomId: null,
+            replyAuthor: null,
           })),
           rooms: value.rooms,
         };
@@ -71,7 +94,7 @@ export class ZenXTriggerStore {
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    const value: StoredState = { version: 2, ...snapshot };
+    const value: StoredState = { version: 3, ...snapshot };
     if (!isStoredState(value))
       throw new Error("ZenX refused to persist an invalid trigger registry");
     await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
@@ -98,9 +121,20 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
-    state["version"] === 2 &&
+    state["version"] === 3 &&
     arrayOf(state["triggers"], isTrigger) &&
     arrayOf(state["history"], isHistory) &&
+    arrayOf(state["rooms"], isRoom)
+  );
+}
+
+function isVersion2StoredState(value: unknown): value is Version2StoredState {
+  const state = record(value);
+  return (
+    state !== null &&
+    state["version"] === 2 &&
+    arrayOf(state["triggers"], isTrigger) &&
+    arrayOf(state["history"], isVersion2History) &&
     arrayOf(state["rooms"], isRoom)
   );
 }
@@ -156,6 +190,18 @@ function isTrigger(value: unknown): value is ZenXTrigger {
 }
 
 function isHistory(value: unknown): value is TriggerHistoryEntry {
+  const entry = record(value);
+  return (
+    isVersion2History(value) &&
+    entry !== null &&
+    nullableString(entry["replyRoomId"]) &&
+    nullableString(entry["replyAuthor"])
+  );
+}
+
+function isVersion2History(
+  value: unknown,
+): value is Version2StoredState["history"][number] {
   const entry = record(value);
   return (
     isLegacyHistory(value) &&

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -31,6 +31,8 @@ export interface TriggerHistoryEntry {
   sourceTurnId: string | null;
   sourceRoomId: string | null;
   sourceRoomMessageId: string | null;
+  replyRoomId: string | null;
+  replyAuthor: string | null;
 }
 
 export interface RoomMember {

--- a/apps/zenx/test/thread-title-coordinator.test.ts
+++ b/apps/zenx/test/thread-title-coordinator.test.ts
@@ -93,6 +93,91 @@ test("duplicate first messages launch only one generation", async () => {
   });
 });
 
+test("a retired observation queued behind a title mutation cannot commit or mirror", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-title-fence-"));
+  try {
+    const store = new BlockingTitleStore(path.join(directory, "titles.json"));
+    const inference = new ControlledInference();
+    const names: string[] = [];
+    const instance = coordinator(store, inference, names);
+    await instance.initialize();
+
+    store.blockNextWrite();
+    const first = instance.observe("thread-a", "Current generation title");
+    await store.writeEntered;
+    const controller = new AbortController();
+    let current = true;
+    const retired = instance.observe("thread-b", "Retired generation title", {
+      signal: controller.signal,
+      isCurrent: () => current,
+      track: () => undefined,
+    });
+    current = false;
+    controller.abort();
+    store.releaseWrite();
+
+    await first;
+    assert.equal(await retired, undefined);
+    assert.equal(instance.snapshot()["thread-b"], undefined);
+    assert.equal(names.includes("Retired generation title"), false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("retirement aborts background title generation before commit and mirror", async () => {
+  await withCoordinator(async ({ coordinator, inference, events, names }) => {
+    const controller = new AbortController();
+    let current = true;
+    const background: Promise<void>[] = [];
+    const observed = await coordinator.observe(
+      "thread-a",
+      "Generation-owned title",
+      {
+        signal: controller.signal,
+        isCurrent: () => current,
+        track: (operation) => background.push(operation),
+      },
+    );
+    assert.equal(observed?.status, "generating");
+    current = false;
+    controller.abort();
+    inference.resolve("Retired generated title");
+    await Promise.all(background);
+
+    assert.equal(coordinator.snapshot()["thread-a"]?.status, "generating");
+    assert.equal(
+      events.some(
+        (snapshot) => snapshot["thread-a"]?.title === "Retired generated title",
+      ),
+      false,
+    );
+    assert.equal(names.includes("Retired generated title"), false);
+    assert.equal(inference.signals[0]?.aborted, true);
+
+    const restartedController = new AbortController();
+    const restartedBackground: Promise<void>[] = [];
+    const restarted = await coordinator.observe(
+      "thread-a",
+      "Generation-owned title",
+      {
+        signal: restartedController.signal,
+        isCurrent: () => true,
+        track: (operation) => restartedBackground.push(operation),
+      },
+    );
+    assert.equal(restarted?.status, "generating");
+    assert.equal(inference.calls, 2);
+    inference.resolve("Restarted generated title");
+    await Promise.all(restartedBackground);
+    assert.equal(
+      coordinator.snapshot()["thread-a"]?.title,
+      "Restarted generated title",
+    );
+    assert.equal(names.includes("Restarted generated title"), true);
+  });
+});
+
 test("trigger envelopes and IDs are excluded from fallback title input", () => {
   const source = meaningfulTitleSource(
     [
@@ -193,13 +278,19 @@ function coordinator(
 
 class ControlledInference implements ThreadTitleInference {
   calls = 0;
+  readonly signals: AbortSignal[] = [];
   #pending: Array<{
     resolve(value: string): void;
     reject(error: Error): void;
   }> = [];
 
-  async generate(): Promise<string> {
+  async generate(
+    _source: string,
+    _model: string,
+    signal: AbortSignal,
+  ): Promise<string> {
     this.calls += 1;
+    this.signals.push(signal);
     return await new Promise<string>((resolve, reject) =>
       this.#pending.push({ resolve, reject }),
     );
@@ -210,6 +301,39 @@ class ControlledInference implements ThreadTitleInference {
   }
   reject(error: Error): void {
     this.#pending.shift()?.reject(error);
+  }
+}
+
+class BlockingTitleStore extends ZenXThreadTitleStore {
+  #block = false;
+  #releaseWrite: (() => void) | undefined;
+  #writeEntered: Promise<void> = Promise.resolve();
+  #markWriteEntered: (() => void) | undefined;
+
+  get writeEntered(): Promise<void> {
+    return this.#writeEntered;
+  }
+
+  blockNextWrite(): void {
+    this.#block = true;
+    this.#writeEntered = new Promise<void>((resolve) => {
+      this.#markWriteEntered = resolve;
+    });
+  }
+
+  releaseWrite(): void {
+    this.#releaseWrite?.();
+  }
+
+  override async write(snapshot: ThreadTitleSnapshot): Promise<void> {
+    if (this.#block) {
+      this.#block = false;
+      this.#markWriteEntered?.();
+      await new Promise<void>((resolve) => {
+        this.#releaseWrite = resolve;
+      });
+    }
+    await super.write(snapshot);
   }
 }
 

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -20,6 +20,842 @@ import type {
   Turn,
 } from "../src/protocol-client/index.js";
 
+test("stop unsubscribes and fences stale callbacks and in-flight start responses", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-stop-fence-"));
+  const manager = new ControlledManager();
+  const startResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await startResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    const writesBeforeStop = store.writes;
+
+    await triggers.stop();
+    assert.equal(manager.activeListeners, 0);
+    assert.equal(manager.disposeCount, 1);
+    manager.completeStale(
+      "thread-target",
+      completedTurn("turn-after-stop", "late", [], wakeup.clientUserMessageId),
+    );
+    startResponse.resolve(startResult("turn-after-stop"));
+    await firing;
+    await settle();
+
+    assert.equal(store.writes, writesBeforeStop);
+    assert.equal(triggers.snapshot().history[0]?.status, "starting");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a stale generation cannot overwrite state loaded by a restarted service", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-restart-fence-"),
+  );
+  const manager = new ControlledManager();
+  const firstResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await firstResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await triggers.stop();
+    await triggers.start();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    const writesAfterRestart = store.writes;
+
+    firstResponse.resolve(startResult("stale-turn"));
+    await firing;
+    manager.completeStale("thread-target", completedTurn("stale-turn", "late"));
+    await settle();
+
+    assert.equal(store.writes, writesAfterRestart);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(triggers.snapshot().history[0]?.turnId, null);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stale generation cleanup cannot erase a restarted generation exact candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-generation-owned-correlation-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const generationOne = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const firstWakeup = generationOne.history[0]!;
+    await until(() => responses.has(firstWakeup.clientUserMessageId));
+
+    await triggers.stop();
+    await triggers.start();
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const generationTwo = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history[0]?.status === "starting" &&
+        snapshot.history[0]?.id !== firstWakeup.id,
+    );
+    const secondWakeup = generationTwo.history[0]!;
+    await until(() => responses.has(secondWakeup.clientUserMessageId));
+
+    manager.completeItem(
+      "thread-target",
+      "generation-two-turn",
+      canonicalUserMessage(
+        "generation-two-buffered-user",
+        secondWakeup.clientUserMessageId,
+      ),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("generation-two-turn", "exact current completion"),
+    );
+    manager.completeRetained(
+      0,
+      "thread-target",
+      completedTurn(
+        "generation-one-retained-turn",
+        "stale retained callback",
+        [],
+        firstWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(firstWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-one-turn"));
+    await first;
+    responses
+      .get(secondWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-two-turn"));
+    await second;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "completed");
+    assert.equal(snapshot.history[0]?.turnId, "generation-two-turn");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    assert.equal(
+      snapshot.rooms[0]?.messages.find((message) => message.kind === "agent")
+        ?.text,
+      "Conclusion for exact current completion",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stale failure timer and retained callback cannot erase a current rejected tombstone", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-generation-owned-rejection-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const now = 1_000;
+  const scheduled: Array<{ callback(): void; cancelled: boolean }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      now: () => now,
+      schedule: (callback) => {
+        const task = { callback, cancelled: false };
+        scheduled.push(task);
+        return task;
+      },
+      cancelScheduled: (handle) => {
+        (handle as { cancelled: boolean }).cancelled = true;
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.create({
+      threadId: "timer-thread",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: 10_000,
+    });
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const generationOne = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const firstWakeup = generationOne.history[0]!;
+    await until(() => responses.has(firstWakeup.clientUserMessageId));
+    const staleTimer = scheduled.at(-1)!;
+
+    await triggers.stop();
+    assert.equal(staleTimer.cancelled, true);
+    await triggers.start();
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const generationTwo = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history[0]?.status === "starting" &&
+        snapshot.history[0]?.id !== firstWakeup.id,
+    );
+    const secondWakeup = generationTwo.history[0]!;
+    await until(() => responses.has(secondWakeup.clientUserMessageId));
+
+    manager.complete(
+      "thread-target",
+      completedTurn("generation-two-rejected", "missing identity"),
+    );
+    staleTimer.callback();
+    manager.completeRetained(
+      0,
+      "thread-target",
+      completedTurn(
+        "generation-one-retained",
+        "stale retained callback",
+        [],
+        firstWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(firstWakeup.clientUserMessageId)!
+      .reject(new Error("stale start failure"));
+    await first;
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "generation-two-rejected",
+        "late exact evidence",
+        [],
+        secondWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(secondWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-two-rejected"));
+    await second;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(snapshot.history[0]?.turnId, "generation-two-rejected");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+    assert.equal(manager.requests.length, 2);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stop invalidates synchronously while awaiting an entered store write", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-stop-durable-boundary-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const entered = store.blockNextWrite();
+    const firing = triggers.signal("deploy", "ready");
+    await entered;
+
+    const stopping = triggers.stop();
+    await assert.rejects(
+      async () => await triggers.signal("deploy", "after stop"),
+      /not running/u,
+    );
+    store.releaseWrite();
+    await Promise.all([firing, stopping]);
+    assert.equal(manager.requests.length, 0);
+
+    await triggers.start();
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "failed");
+    assert.match(snapshot.history[0]?.error ?? "", /ZenX stopped/u);
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion uses canonical client identity and replies to the captured Room once", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-early-exact-"));
+  const manager = new ControlledManager();
+  manager.requestHandler = async (params) => {
+    manager.complete(
+      params.threadId,
+      completedTurn(
+        "early-turn",
+        "room wakeup",
+        [],
+        params.clientUserMessageId ?? null,
+      ),
+    );
+    return startResult("early-turn");
+  };
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+
+    assert.equal(terminal.history[0]?.turnId, "early-turn");
+    assert.equal(
+      terminal.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    const writesBeforeDuplicate = store.writes;
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "early-turn",
+        "duplicate",
+        [],
+        terminal.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await settle();
+    assert.equal(store.writes, writesBeforeDuplicate);
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects matching plus unrelated canonical client IDs", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-contradictory-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "contradictory-turn",
+        "matching",
+        [canonicalUserMessage("unrelated-user", "unrelated-client")],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("contradictory-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("contradictory-turn", "exact late", [], clientId),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects duplicate canonical occurrences of one client ID", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-duplicate-evidence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "duplicate-evidence-turn",
+        "matching",
+        [canonicalUserMessage("duplicate-user", clientId)],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("duplicate-evidence-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects zero non-null canonical identity for one wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn("turn-no-identity", "missing identity"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "turn-no-identity",
+        "late exact evidence",
+        [],
+        starting.history[0]!.clientUserMessageId,
+      ),
+    );
+    response.resolve(startResult("turn-no-identity"));
+    await firing;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(snapshot.history[0]?.turnId, "turn-no-identity");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects zero identity with concurrent same-thread wakeups", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-concurrent-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "shared-thread" }],
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-no-identity", "ambiguous identity"),
+    );
+    const [firstEntry, secondEntry] = starting.history;
+    responses
+      .get(firstEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-no-identity"));
+    responses
+      .get(secondEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-other"));
+    await Promise.all([first, second]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.filter((entry) => entry.status === "running").length,
+      2,
+    );
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("late unidentifiable duplicate preserves an exact concurrent same-thread candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-late-unidentified-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "exact", [], betaEntry.clientUserMessageId),
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "late without identity"),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === betaEntry.id)?.status,
+      "completed",
+    );
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("concurrent same-thread starts correlate only by exact completion evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-concurrent-correlation-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "beta", [], betaEntry.clientUserMessageId),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const correlated = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.find((entry) => entry.id === betaEntry.id)?.status ===
+        "completed",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === betaEntry.id)?.turnId,
+      "turn-beta",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-alpha", "alpha", [], alphaEntry.clientUserMessageId),
+    );
+    await snapshotWhen(triggers, (snapshot) =>
+      snapshot.history.every((entry) => entry.status === "completed"),
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("timer expiry creates one explicit App Server turn and auditable history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-"));
   const manager = managerFor(directory);
@@ -388,6 +1224,195 @@ test("failed relay is terminal and is not hidden, queued, or retried", async () 
   }
 });
 
+test("failed start evicts early candidates and ignores late unrelated completion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-failed-start-cleanup-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "candidate-turn",
+        "candidate",
+        [],
+        starting.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    response.reject(new Error("App Server connection closed"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(
+      triggers.snapshot().history[0]?.error,
+      "App Server connection closed",
+    );
+
+    manager.complete(
+      "unrelated-thread",
+      completedTurn("candidate-turn", "late duplicate"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("unknown-turn", "unrelated"),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    await triggers.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ambiguous early completions are bounded and require the returned turn id", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-early-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    for (let index = 0; index < 65; index += 1) {
+      manager.completeItem("thread-target", `ambiguous-${String(index)}`, {
+        type: "agentMessage",
+        id: `agent-${String(index)}`,
+        text: `candidate ${String(index)}`,
+        phase: "final_answer",
+        memoryCitation: null,
+      });
+      manager.complete(
+        "thread-target",
+        completedTurn(`ambiguous-${String(index)}`, "no client identity"),
+      );
+    }
+    await settle();
+    response.resolve(startResult("ambiguous-0"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "ambiguous-0",
+        "exact late completion",
+        [],
+        triggers.snapshot().history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+  } finally {
+    await triggers.close();
+    assert.equal(manager.activeListeners, 0);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("completed item buffers retain only the latest bounded generation-owned evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-completed-items-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    manager.completeItem(
+      "thread-target",
+      "bounded-item-turn",
+      canonicalUserMessage("oldest-exact-user", clientId),
+    );
+    for (let index = 0; index < 64; index += 1) {
+      manager.completeItem("thread-target", "bounded-item-turn", {
+        type: "agentMessage",
+        id: `bounded-agent-${String(index)}`,
+        text: `candidate ${String(index)}`,
+        phase: "final_answer",
+        memoryCitation: null,
+      });
+    }
+    manager.complete(
+      "thread-target",
+      completedTurn("bounded-item-turn", "no retained exact identity"),
+    );
+    response.resolve(startResult("bounded-item-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "bounded-item-turn",
+        "ordinary late completion",
+        [],
+        clientId,
+      ),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+  } finally {
+    await triggers.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("long timers reschedule at the clamp boundary instead of firing early", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-long-timer-"));
   const manager = new ControlledManager();
@@ -470,12 +1495,34 @@ test("completed Turn projection is bounded and includes commands/results", () =>
 class ControlledManager implements ZenXTriggerAppServerPort {
   readonly requests: ClientRequestParams["turn/start"][] = [];
   requestError: Error | null = null;
-  #listener:
+  requestHandler:
+    | ((
+        params: ClientRequestParams["turn/start"],
+      ) => Promise<ClientRequestResults["turn/start"]>)
+    | undefined;
+  disposeCount = 0;
+  readonly #listeners = new Set<
+    (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void
+  >();
+  readonly #retainedListeners: Array<
+    (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void
+  > = [];
+  #lastListener:
     | ((
         method: ServerNotificationMethod,
         params: ServerNotificationParams[ServerNotificationMethod],
       ) => void)
     | undefined;
+
+  get activeListeners(): number {
+    return this.#listeners.size;
+  }
 
   async request(
     _method: "turn/start",
@@ -483,18 +1530,9 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   ): Promise<ClientRequestResults["turn/start"]> {
     this.requests.push(params);
     if (this.requestError !== null) throw this.requestError;
-    return {
-      turn: {
-        id: `wakeup-turn-${this.requests.length}`,
-        items: [],
-        itemsView: "full",
-        status: "inProgress",
-        error: null,
-        startedAt: Date.now(),
-        completedAt: null,
-        durationMs: null,
-      },
-    };
+    return this.requestHandler === undefined
+      ? startResult(`wakeup-turn-${this.requests.length}`)
+      : await this.requestHandler(params);
   }
 
   onNotification(
@@ -503,21 +1541,95 @@ class ControlledManager implements ZenXTriggerAppServerPort {
       params: ServerNotificationParams[ServerNotificationMethod],
     ) => void,
   ): () => void {
-    this.#listener = listener;
+    this.#listeners.add(listener);
+    this.#retainedListeners.push(listener);
+    this.#lastListener = listener;
     return () => {
-      if (this.#listener === listener) this.#listener = undefined;
+      if (this.#listeners.delete(listener)) this.disposeCount += 1;
     };
   }
 
   complete(threadId: string, turn: Turn): void {
-    this.#listener?.("turn/completed", { threadId, turn });
+    for (const listener of this.#listeners) {
+      listener("turn/completed", { threadId, turn });
+    }
   }
+
+  completeItem(threadId: string, turnId: string, item: ThreadItem): void {
+    for (const listener of this.#listeners) {
+      listener("item/completed", {
+        threadId,
+        turnId,
+        item,
+        completedAtMs: Date.now(),
+      });
+    }
+  }
+
+  completeStale(threadId: string, turn: Turn): void {
+    this.#lastListener?.("turn/completed", { threadId, turn });
+  }
+
+  completeRetained(index: number, threadId: string, turn: Turn): void {
+    this.#retainedListeners[index]?.("turn/completed", { threadId, turn });
+  }
+}
+
+class CountingTriggerStore extends ZenXTriggerStore {
+  writes = 0;
+  override async write(snapshot: Parameters<ZenXTriggerStore["write"]>[0]) {
+    this.writes += 1;
+    await super.write(snapshot);
+  }
+}
+
+class BlockingTriggerStore extends ZenXTriggerStore {
+  #entered: ReturnType<typeof deferred<void>> | undefined;
+  #release: ReturnType<typeof deferred<void>> | undefined;
+
+  blockNextWrite(): Promise<void> {
+    this.#entered = deferred<void>();
+    this.#release = deferred<void>();
+    return this.#entered.promise;
+  }
+
+  releaseWrite(): void {
+    this.#release?.resolve();
+    this.#release = undefined;
+  }
+
+  override async write(snapshot: Parameters<ZenXTriggerStore["write"]>[0]) {
+    const entered = this.#entered;
+    const release = this.#release;
+    this.#entered = undefined;
+    if (entered !== undefined && release !== undefined) {
+      entered.resolve();
+      await release.promise;
+    }
+    await super.write(snapshot);
+  }
+}
+
+function startResult(id: string): ClientRequestResults["turn/start"] {
+  return {
+    turn: {
+      id,
+      items: [],
+      itemsView: "full",
+      status: "inProgress",
+      error: null,
+      startedAt: Date.now(),
+      completedAt: null,
+      durationMs: null,
+    },
+  };
 }
 
 function completedTurn(
   id: string,
   userText: string,
   extra: ThreadItem[] = [],
+  clientId: string | null = null,
 ): Turn {
   return {
     id,
@@ -525,7 +1637,7 @@ function completedTurn(
       {
         type: "userMessage",
         id: `${id}-user`,
-        clientId: null,
+        clientId,
         content: [{ type: "text", text: userText, text_elements: [] }],
       },
       ...extra,
@@ -546,6 +1658,25 @@ function completedTurn(
   };
 }
 
+function canonicalUserMessage(id: string, clientId: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id,
+    clientId,
+    content: [{ type: "text", text: id, text_elements: [] }],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function userInputForClientId(
   turns: readonly Turn[],
   clientId: string | null | undefined,
@@ -564,6 +1695,15 @@ function userInputForClientId(
 
 async function settle(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 20));
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await settle();
+  }
 }
 
 function managerFor(directory: string): AppServerManager {
@@ -593,7 +1733,11 @@ async function snapshotWhen(
     (resolve, reject) => {
       const timeout = setTimeout(() => {
         dispose();
-        reject(new Error("Timed out waiting for trigger"));
+        reject(
+          new Error(
+            `Timed out waiting for trigger: ${JSON.stringify(service.snapshot())}`,
+          ),
+        );
       }, 10_000);
       const dispose = service.onChange((snapshot) => {
         if (predicate(snapshot)) {

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -602,6 +602,262 @@ test("failed start retires its generation and a clean retry can run", async () =
   }
 });
 
+test("stop cleanup faults still drain the durable boundary and leave no active generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-stop-cleanup-fault-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const entered = store.blockNextWrite();
+    const firing = triggers.signal("deploy", "ready");
+    await entered;
+    manager.disposeError = new Error("dispose failed");
+    let stopSettled = false;
+    const stopping = triggers
+      .stop()
+      .then(
+        () => null,
+        (error: unknown) => error,
+      )
+      .finally(() => {
+        stopSettled = true;
+      });
+    await settle();
+    assert.equal(stopSettled, false);
+    await assert.rejects(
+      async () => await triggers.signal("deploy", "after stop"),
+      /not running/u,
+    );
+
+    store.releaseWrite();
+    await firing;
+    assert.match(String(await stopping), /dispose failed/u);
+    assert.equal(manager.activeListeners, 0);
+
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("restart cancellation faults retire the old generation completely before retry", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-restart-cancel-fault-"),
+  );
+  const manager = new ControlledManager();
+  let failCancellation = true;
+  const scheduled: Array<{ callback(): void }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      schedule: (callback) => {
+        const task = { callback };
+        scheduled.push(task);
+        return task;
+      },
+      cancelScheduled: () => {
+        if (failCancellation) {
+          failCancellation = false;
+          throw new Error("cancel failed");
+        }
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: Date.now() + 60_000,
+    });
+    assert.equal(scheduled.length, 1);
+
+    await assert.rejects(async () => await triggers.start(), /cancel failed/u);
+    await assert.rejects(
+      async () =>
+        await triggers.create({
+          threadId: "thread-target",
+          kind: "signal",
+          label: "Unavailable",
+          prompt: "Must not persist.",
+          signalName: "unavailable",
+        }),
+      /not running/u,
+    );
+    scheduled[0]!.callback();
+    await settle();
+    assert.equal(manager.requests.length, 0);
+
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("timer scheduling failure during start retires the partial generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-start-schedule-fault-"),
+  );
+  const manager = new ControlledManager();
+  let failSchedule = false;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      schedule: (callback) => {
+        if (failSchedule) throw new Error("schedule failed");
+        return { callback };
+      },
+      cancelScheduled: () => undefined,
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: Date.now() + 60_000,
+    });
+    await triggers.stop();
+
+    failSchedule = true;
+    await assert.rejects(
+      async () => await triggers.start(),
+      /schedule failed/u,
+    );
+    await assert.rejects(
+      async () => await triggers.signal("anything", "after failed start"),
+      /not running/u,
+    );
+    assert.equal(manager.activeListeners, 0);
+
+    failSchedule = false;
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("slow title observation cannot write after its generation is stopped and restarted", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-slow-title-fence-"),
+  );
+  const manager = new ControlledManager();
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  const writes: string[] = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async (threadId, _input, fence?: { isCurrent(): boolean }) => {
+          entered.resolve();
+          await release.promise;
+          if (fence?.isCurrent() === false) return;
+          writes.push(threadId);
+        },
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await entered.promise;
+
+    const stopping = triggers.stop();
+    const restarting = triggers.start();
+    release.resolve();
+    await Promise.all([firing, stopping, restarting]);
+
+    assert.deepEqual(writes, []);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+  } finally {
+    release.resolve();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a slow throwing title observation cannot poison the restarted generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-throwing-title-fence-"),
+  );
+  const manager = new ControlledManager();
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  let attempts = 0;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async () => {
+          attempts += 1;
+          if (attempts !== 1) return;
+          entered.resolve();
+          await release.promise;
+          throw new Error("stale title failed");
+        },
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const staleFiring = triggers.signal("deploy", "first");
+    await entered.promise;
+    const stopping = triggers.stop();
+    const restarting = triggers.start();
+    release.resolve();
+    await Promise.all([staleFiring, stopping, restarting]);
+
+    await triggers.signal("deploy", "second");
+    assert.equal(attempts, 2);
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    release.resolve();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("early completion uses canonical client identity and replies to the captured Room once", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-early-exact-"));
   const manager = new ControlledManager();
@@ -1847,6 +2103,7 @@ test("completed Turn projection is bounded and includes commands/results", () =>
 class ControlledManager implements ZenXTriggerAppServerPort {
   readonly requests: ClientRequestParams["turn/start"][] = [];
   requestError: Error | null = null;
+  disposeError: Error | null = null;
   requestHandler:
     | ((
         params: ClientRequestParams["turn/start"],
@@ -1897,7 +2154,12 @@ class ControlledManager implements ZenXTriggerAppServerPort {
     this.#retainedListeners.push(listener);
     this.#lastListener = listener;
     return () => {
-      if (this.#listeners.delete(listener)) this.disposeCount += 1;
+      if (this.#listeners.delete(listener)) {
+        this.disposeCount += 1;
+        const error = this.disposeError;
+        this.disposeError = null;
+        if (error !== null) throw error;
+      }
     };
   }
 

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -370,6 +370,238 @@ test("stop invalidates synchronously while awaiting an entered store write", asy
   }
 });
 
+test("post-start reconciliation reads an exact candidate after the mutation queue unblocks", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-post-start-exact-fence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+
+    const entered = store.blockNextWrite();
+    const blockingMutation = triggers.create({
+      threadId: "other-thread",
+      kind: "signal",
+      label: "Block",
+      prompt: "Hold the durable boundary.",
+      signalName: "block",
+    });
+    await entered;
+    response.resolve(startResult("queued-exact-turn"));
+    await settle();
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-exact-turn",
+        "exact while queued",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    store.releaseWrite();
+    await Promise.all([blockingMutation, firing]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "completed");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("post-start reconciliation honors a conflicting tombstone created while queued", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-post-start-rejected-fence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-rejected-turn",
+        "initial exact",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+
+    const entered = store.blockNextWrite();
+    const blockingMutation = triggers.create({
+      threadId: "other-thread",
+      kind: "signal",
+      label: "Block",
+      prompt: "Hold the durable boundary.",
+      signalName: "block",
+    });
+    await entered;
+    response.resolve(startResult("queued-rejected-turn"));
+    await settle();
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-rejected-turn",
+        "conflicting evidence",
+        [canonicalUserMessage("unrelated-user", "unrelated-client")],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    store.releaseWrite();
+    await Promise.all([blockingMutation, firing]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stop and restart at the history boundary fences title observation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-generation-fence-"),
+  );
+  const manager = new ControlledManager();
+  const titleWrites: Array<{ threadId: string; input: string }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async (threadId, input) => {
+          titleWrites.push({ threadId, input });
+        },
+      },
+    },
+  );
+  let restart: Promise<void> | undefined;
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const dispose = triggers.onChange((snapshot) => {
+      if (restart !== undefined || snapshot.history[0]?.status !== "starting")
+        return;
+      const stopping = triggers.stop();
+      restart = Promise.all([stopping, triggers.start()]).then(() => undefined);
+    });
+    await triggers.signal("deploy", "ready");
+    await restart;
+    dispose();
+
+    assert.deepEqual(titleWrites, []);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("failed start retires its generation and a clean retry can run", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-failed-start-generation-"),
+  );
+  const manager = new ControlledManager();
+  const store = new FailOnceReadTriggerStore(
+    path.join(directory, "triggers.json"),
+  );
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await assert.rejects(async () => await triggers.start(), /read failed/u);
+    await assert.rejects(
+      async () =>
+        await triggers.create({
+          threadId: "thread-target",
+          kind: "signal",
+          label: "Deploy",
+          prompt: "Inspect once.",
+          signalName: "deploy",
+        }),
+      /not running/u,
+    );
+    assert.equal(manager.activeListeners, 0);
+
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    await triggers.signal("deploy", "ready");
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("early completion uses canonical client identity and replies to the captured Room once", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-early-exact-"));
   const manager = new ControlledManager();
@@ -432,6 +664,126 @@ test("early completion uses canonical client identity and replies to the capture
         .length,
       1,
     );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("cross-thread turn and item notifications cannot terminalize or pollute a wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-cross-thread-completion-"),
+  );
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    const wakeup = running.history[0]!;
+    const turnId = wakeup.turnId!;
+
+    manager.completeItem("thread-other", turnId, {
+      type: "agentMessage",
+      id: "cross-thread-agent",
+      text: "cross-thread injected answer",
+      phase: "final_answer",
+      memoryCitation: null,
+    });
+    manager.complete(
+      "thread-other",
+      completedTurn(turnId, "wrong thread", [], wakeup.clientUserMessageId),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+
+    manager.complete(
+      "thread-target",
+      completedTurn(turnId, "correct thread", [], wakeup.clientUserMessageId),
+    );
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    const reply = terminal.rooms[0]?.messages.find(
+      (message) => message.kind === "agent",
+    );
+    assert.equal(reply?.text, "Conclusion for correct thread");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a reused turn id from another thread cannot erase an exact early candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-cross-thread-reused-turn-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "reused-turn",
+        "exact target evidence",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    manager.complete(
+      "thread-other",
+      completedTurn("reused-turn", "wrong thread reused id"),
+    );
+    response.resolve(startResult("reused-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "completed");
   } finally {
     await triggers.stop();
     await rm(directory, { recursive: true, force: true });
@@ -1607,6 +1959,18 @@ class BlockingTriggerStore extends ZenXTriggerStore {
       await release.promise;
     }
     await super.write(snapshot);
+  }
+}
+
+class FailOnceReadTriggerStore extends ZenXTriggerStore {
+  #failed = false;
+
+  override async read() {
+    if (!this.#failed) {
+      this.#failed = true;
+      throw new Error("read failed");
+    }
+    return await super.read();
   }
 }
 

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -53,6 +53,8 @@ test("migrates fully validated version 1 history to nullable source metadata", a
       sourceTurnId: _sourceTurnId,
       sourceRoomId: _sourceRoomId,
       sourceRoomMessageId: _sourceRoomMessageId,
+      replyRoomId: _replyRoomId,
+      replyAuthor: _replyAuthor,
       ...entry
     }) => entry,
   );
@@ -66,16 +68,39 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     const migrated = await store.read();
     assert.equal(migrated.history[0]?.sourceThreadId, null);
     assert.equal(migrated.history[0]?.sourceTurnId, null);
+    assert.equal(migrated.history[0]?.replyRoomId, null);
     await store.write(migrated);
-    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 2);
+    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 3);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
 
-function validState(): TriggerSnapshot & { version: 2 } {
+test("migrates version 2 history to nullable immutable reply routing", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-store-v2-"));
+  const file = path.join(directory, "triggers.json");
+  const state = validState();
+  const history = state.history.map(
+    ({ replyRoomId: _replyRoomId, replyAuthor: _replyAuthor, ...entry }) =>
+      entry,
+  );
+  try {
+    await writeFile(
+      file,
+      JSON.stringify({ ...state, version: 2, history }),
+      "utf8",
+    );
+    const migrated = await new ZenXTriggerStore(file).read();
+    assert.equal(migrated.history[0]?.replyRoomId, null);
+    assert.equal(migrated.history[0]?.replyAuthor, null);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function validState(): TriggerSnapshot & { version: 3 } {
   return {
-    version: 2,
+    version: 3,
     triggers: [
       {
         id: "trigger-a",
@@ -106,6 +131,8 @@ function validState(): TriggerSnapshot & { version: 2 } {
         sourceTurnId: "turn-b",
         sourceRoomId: null,
         sourceRoomMessageId: null,
+        replyRoomId: null,
+        replyAuthor: null,
       },
     ],
     rooms: [


### PR DESCRIPTION
## Motivation

Draft PR #59 exhausted final Review round 3 with a generation-ownership race: a stale generation's shared-map cleanup could erase a current generation's exact completion candidate. This is the new Issue #62 architectural successor from `origin/main@28977c8f509441f9767b3b99bde0fc50a8dc9bc3`; PRs #49 and #59 remain draft/unmerged evidence only.

## What changed

- Add the documented `ZenXTriggerLifecycleGeneration` object. Each start→stop generation exclusively owns its notification disposer, timers, in-flight wakeups, bounded completed-item buffers, and accepted/rejected completion candidates.
- Retire only the captured generation on stop/restart. Stale start success/failure, completion, finally/eviction, retained notification, and timer callbacks have no API that can enumerate or mutate a newer generation's transient state.
- Make `stop()` synchronously invalidate the active generation, unsubscribe, cancel its timers, clear its transient containers, and then await the already-entered durable mutation boundary.
- Preserve exact early-completion correlation: exactly one canonical non-null `clientUserMessageId` occurrence for exactly one same-generation/same-thread wakeup. Zero, contradictory, duplicate, unrelated, and multi-wakeup-ambiguous evidence remains bounded rejected state and cannot resurrect.
- Preserve one ordinary `turn/start` attempt with stable idempotency, at-most-one terminal history transition, at-most-one Room reply, immutable reply routing, and bounded state (64 turns; 64 completed items per turn).
- Persist immutable Room routing in Trigger store v3 and migrate fully validated v1/v2 state.
- Await Trigger shutdown before App Server shutdown in the ZenX quit and real-smoke paths.

No scheduler, durable queue, retry engine, transcript, Runtime, protocol method, Agent CRUD surface, or Zen Core Item was added.

## Deterministic TDD

- Reproduced the final-review race: hold generation-1 start; stop/restart; buffer generation-2 exact canonical evidence and completion; invoke retained generation-1 notification; release generation-1 response before generation-2 response. Generation 2 terminalizes once and emits one correctly routed Room reply.
- Covers stale start success and failure, finally/cleanup, retained completion callback, cancelled timer callback, accepted candidates, rejected tombstones, and stop during an already-entered store write.
- Preserves concurrent same-thread isolation, exact/zero/contradictory/duplicate/late evidence, bounded turn/item buffers, disconnect/failure, close/restart, immutable routing, migrations, and ordinary successful/failed wakeups.

## Validation

Passed locally on Windows:

- `npx tsx --test test/trigger-service.test.ts test/trigger-store.test.ts` — 26/26
- `npm --workspace apps/zenx run typecheck`
- root `npm run typecheck`
- root `npm run build`
- `npm --workspace apps/zenx run build`
- root `npm run lint`
- changed-file Prettier and `git diff --check`

Honest platform-only baseline limitations:

- Full ZenX: 142/147; five existing Windows-host failures require POSIX `printf`, POSIX path expectations, or Unix local-process spawning.
- Root Node: 86/93 with six Windows permission/POSIX-shell failures and one platform skip.
- IMZen: 37/38; the remaining test relies on POSIX chmod semantics.

GitHub Linux CI on this exact head is the authoritative full-platform gate.

Closes #62