### PR TITLE
fix(zenx): bound Trigger generation quiescence

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,8 @@
 - **ZenXTitleInference** — ZenX 主进程使用独立配置的标题模型执行一次不写 journal、
   不创建 Turn 的辅助推理；credential 仍只在主进程内存中按当前 Provider 解析。
 - **ZenXThreadTitleCoordinator** — ZenX 主进程从首条有意义的来源标注输入立即建立
-  provisional 投影，并异步协调生成、显式重试与 authoritative manual rename。
+  provisional 投影，以 owner-fenced durable replacement 持久化，并异步协调生成、显式重试与
+  authoritative manual rename。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,11 @@
   新 Turn 输入投影；它不是第二份权威 transcript，canonical `user_message` 仍是唯一输入事实。
 - **ZenXTriggerAppServerPort** — ZenX Trigger 服务观察 completed Item/Turn 并发起普通
   `turn/start` 所需的最小 host-local App Server 边界；它不引入另一套 Runtime、队列或重试器。
+- **ZenXTriggerLifecycleGeneration** — ZenX Trigger 服务每段 start→stop 生命周期独占 notification、timer、
+  in-flight wakeup、有界 completion correlation 容器与可取消 title observation 的内存 fence；退休以 best-effort
+  清理该 generation，且只有当前 generation 能继续修改外层审计历史、Room 或 title projection。
+- **ZenXTriggerGenerationQuiescence** — Trigger generation 的瞬时 owner fence 会立即 abort/隔离退休工作、在默认
+  250ms deadline 内等待已派发的 title/mirror 边界后 detach，并让迟到结果永远不能提交 projection、native mirror 或较新 owner 状态。
 - **ZenXExternalLinkPolicy** — ZenX renderer 与 Electron 主进程共同执行的外链 allowlist；
   只有 `http:`、`https:`、`mailto:` 可交给操作系统，页内锚点留在 renderer 处理。
 - **ZenXCapabilityRegistry** — ZenX 主进程注册 bundled/local capability package 的 manifest、

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -190,14 +190,30 @@ app.on("before-quit", (event) => {
   if (quitting || appServerManager === undefined) return;
   event.preventDefault();
   quitting = true;
-  triggerService?.stop();
-  void appServerManager
-    .stop()
-    .then(async () => {
+  void (async () => {
+    const errors: unknown[] = [];
+    try {
+      await triggerService?.close();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await appServerManager!.stop();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
       selfControlPort.detach();
       await capabilityService?.close();
-    })
-    .finally(() => app.quit());
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0)
+      console.error(
+        "Could not fully stop ZenX before quit",
+        new AggregateError(errors),
+      );
+  })().finally(() => app.quit());
 });
 
 app.on("window-all-closed", () => {

--- a/apps/zenx/src/main/real-smoke.ts
+++ b/apps/zenx/src/main/real-smoke.ts
@@ -486,7 +486,9 @@ void app.whenReady().then(async () => {
       durationMs: 0,
     });
   } finally {
-    triggers?.stop();
+    await triggers?.close().catch(() => {
+      cleanup = "failed";
+    });
     await closeServer(webServer).catch(() => {
       cleanup = "failed";
     });

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -6,8 +6,27 @@ import type {
 import { ZenXThreadTitleStore } from "./thread-title-store.js";
 
 const MAX_TITLE_LENGTH = 64;
+const MAX_NATIVE_MIRROR_RECORDS = 64;
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
+
+export interface ZenXThreadTitleObservationFence {
+  readonly signal: AbortSignal;
+  isCurrent(): boolean;
+  track(operation: Promise<void>): void;
+  onRetire?(callback: () => void): () => void;
+}
+
+interface NativeMirrorRecord {
+  readonly title: string;
+  readonly owner: ZenXThreadTitleObservationFence | undefined;
+  consumed: boolean;
+}
+
+interface NativeMirrorDispatch {
+  readonly owner: ZenXThreadTitleObservationFence | undefined;
+  readonly tail: Promise<void>;
+}
 
 export class ZenXThreadTitleCoordinator {
   readonly #store: ZenXThreadTitleStore;
@@ -15,8 +34,18 @@ export class ZenXThreadTitleCoordinator {
   readonly #titleModel: () => string;
   readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
-  readonly #expectedNativeMirrors = new Map<string, string[]>();
+  readonly #expectedNativeMirrors = new Map<string, NativeMirrorRecord[]>();
+  readonly #quarantinedNativeMirrors = new Map<string, NativeMirrorRecord[]>();
+  readonly #nativeMirrorTails = new Map<string, NativeMirrorDispatch>();
+  readonly #registeredMirrorOwners = new WeakSet<object>();
   readonly #nativeAuthorityVersions = new Map<string, number>();
+  readonly #generationOwners = new Map<
+    string,
+    {
+      version: number;
+      fence: ZenXThreadTitleObservationFence | undefined;
+    }
+  >();
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
@@ -71,14 +100,39 @@ export class ZenXThreadTitleCoordinator {
   async observe(
     threadId: string,
     input: string,
+    fence?: ZenXThreadTitleObservationFence,
   ): Promise<ThreadTitleProjection | undefined> {
     this.#assertAvailable();
+    if (!observationIsCurrent(fence)) return undefined;
     const source = meaningfulTitleSource(input);
     if (source === null) return undefined;
     const result = await this.#serial(async () => {
+      if (!observationIsCurrent(fence)) return undefined;
       const existing = this.#snapshot[threadId];
-      if (existing !== undefined)
-        return { projection: existing, created: false };
+      if (existing !== undefined) {
+        if (
+          fence === undefined ||
+          !["provisional", "generating"].includes(existing.status) ||
+          this.#hasCurrentGenerationOwner(existing)
+        ) {
+          return { projection: existing, created: false };
+        }
+        const generating = {
+          ...existing,
+          status: "generating" as const,
+          version:
+            existing.status === "provisional"
+              ? existing.version + 1
+              : existing.version,
+        };
+        if (
+          existing.status === "provisional" &&
+          !(await this.#commit(generating, fence))
+        ) {
+          return { projection: existing, created: false };
+        }
+        return { projection: generating, created: true };
+      }
       const provisional: ThreadTitleProjection = {
         threadId,
         title: normalizeThreadTitle(source),
@@ -86,17 +140,24 @@ export class ZenXThreadTitleCoordinator {
         version: 1,
         source,
       };
-      await this.#commit(provisional);
-      await this.#mirror(threadId, provisional.title);
+      if (!(await this.#commit(provisional, fence))) return undefined;
+      if (!observationIsCurrent(fence))
+        return { projection: provisional, created: false };
+      this.#startMirror(threadId, provisional.title, fence);
+      if (!observationIsCurrent(fence))
+        return { projection: provisional, created: false };
       const generating = {
         ...provisional,
         status: "generating" as const,
         version: 2,
       };
-      await this.#commit(generating);
+      if (!(await this.#commit(generating, fence)))
+        return { projection: provisional, created: false };
       return { projection: generating, created: true };
     });
-    if (result.created) this.#startGeneration(result.projection);
+    if (result === undefined) return undefined;
+    if (result.created && observationIsCurrent(fence))
+      this.#startGeneration(result.projection, fence);
     return result.projection;
   }
 
@@ -106,7 +167,7 @@ export class ZenXThreadTitleCoordinator {
   ): Promise<ThreadTitleProjection> {
     this.#assertAvailable();
     const normalized = normalizeManualTitle(title);
-    return await this.#serial(async () => {
+    const projection = await this.#serial(async () => {
       const current = this.#snapshot[threadId];
       const projection: ThreadTitleProjection = {
         threadId,
@@ -116,9 +177,10 @@ export class ZenXThreadTitleCoordinator {
         source: current?.source ?? normalized,
       };
       await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
       return projection;
     });
+    await this.#mirror(threadId, normalized);
+    return projection;
   }
 
   async synchronizeNativeName(
@@ -131,12 +193,12 @@ export class ZenXThreadTitleCoordinator {
       const current = this.#snapshot[threadId];
       if (current !== undefined) return current;
     }
+    const unchanged = this.#snapshot[threadId];
+    if (unchanged?.title === normalized) return unchanged;
     this.#recordNativeAuthority(threadId);
-    return await this.#serial(async () => {
+    const projection = await this.#serial(async () => {
       const current = this.#snapshot[threadId];
-      if (current?.status === "manual" && current.title === normalized) {
-        return current;
-      }
+      if (current?.title === normalized) return current;
       const projection: ThreadTitleProjection = {
         threadId,
         title: normalized,
@@ -145,9 +207,10 @@ export class ZenXThreadTitleCoordinator {
         source: current?.source ?? normalized,
       };
       await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
       return projection;
     });
+    await this.#mirror(threadId, normalized);
+    return projection;
   }
 
   async retry(threadId: string): Promise<ThreadTitleProjection> {
@@ -171,16 +234,22 @@ export class ZenXThreadTitleCoordinator {
     return generating;
   }
 
-  async #generate(started: ThreadTitleProjection): Promise<void> {
+  async #generate(
+    started: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<void> {
     try {
+      if (!observationIsCurrent(fence)) return;
       const generated = normalizeGeneratedTitle(
         await this.#inference.generate(
           started.source,
           this.#titleModel(),
-          new AbortController().signal,
+          fence?.signal ?? new AbortController().signal,
         ),
       );
+      if (!observationIsCurrent(fence)) return;
       await this.#serial(async () => {
+        if (!observationIsCurrent(fence)) return;
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
@@ -196,64 +265,255 @@ export class ZenXThreadTitleCoordinator {
         const nativeAuthorityVersion = this.#nativeAuthorityVersion(
           started.threadId,
         );
-        await this.#commit(projection);
+        if (!(await this.#commit(projection, fence))) return;
         if (
+          observationIsCurrent(fence) &&
           this.#nativeAuthorityVersion(started.threadId) ===
-          nativeAuthorityVersion
+            nativeAuthorityVersion
         ) {
-          await this.#mirror(started.threadId, generated);
+          this.#startMirror(started.threadId, generated, fence);
         }
       });
     } catch (error) {
+      if (!observationIsCurrent(fence)) return;
       await this.#serial(async () => {
+        if (!observationIsCurrent(fence)) return;
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
           current.version !== started.version
         )
           return;
-        await this.#commit({
-          ...current,
-          status: "failed",
-          version: current.version + 1,
-          error: describeError(error),
-        });
+        await this.#commit(
+          {
+            ...current,
+            status: "failed",
+            version: current.version + 1,
+            error: describeError(error),
+          },
+          fence,
+        );
       });
     }
   }
 
-  async #commit(projection: ThreadTitleProjection): Promise<void> {
+  async #commit(
+    projection: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<boolean> {
+    if (!observationIsCurrent(fence)) return false;
     const next = { ...this.#snapshot, [projection.threadId]: projection };
     await this.#store.write(next);
+    if (!observationIsCurrent(fence)) return false;
     this.#snapshot = next;
     for (const listener of this.#listeners) listener(this.snapshot());
+    return true;
   }
 
-  async #mirror(threadId: string, title: string): Promise<void> {
-    const expected = this.#expectedNativeMirrors.get(threadId) ?? [];
-    expected.push(title);
-    this.#expectedNativeMirrors.set(threadId, expected);
-    try {
-      await this.#setNativeName(threadId, title);
-    } catch (error) {
-      this.#removeExpectedNativeMirror(threadId, title);
-      console.warn(
-        `Could not mirror ZenX thread title: ${describeError(error)}`,
+  async #mirror(
+    threadId: string,
+    title: string,
+    fence?: ZenXThreadTitleObservationFence,
+  ): Promise<void> {
+    this.#registerMirrorOwner(fence);
+    const previous =
+      this.#nativeMirrorTails.get(threadId)?.tail ?? Promise.resolve();
+    const operation = previous
+      .catch(() => undefined)
+      .then(async () => {
+        if (!observationIsCurrent(fence)) return;
+        const record = { title, owner: fence, consumed: false };
+        if (
+          !this.#appendMirrorRecord(
+            this.#expectedNativeMirrors,
+            threadId,
+            record,
+          )
+        ) {
+          console.warn(
+            `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_RECORDS)} unresolved native mirror outcomes are already quarantined`,
+          );
+          return;
+        }
+        try {
+          if (!observationIsCurrent(fence)) return;
+          await this.#setNativeName(threadId, title);
+          if (!observationIsCurrent(fence)) return;
+        } catch (error) {
+          if (observationIsCurrent(fence)) {
+            console.warn(
+              `Could not mirror ZenX thread title: ${describeError(error)}`,
+            );
+          }
+        } finally {
+          if (
+            fence !== undefined &&
+            !observationIsCurrent(fence) &&
+            !record.consumed
+          ) {
+            this.#moveMirrorRecordToQuarantine(threadId, record);
+          } else {
+            this.#removeMirrorRecord(threadId, record);
+          }
+        }
+      });
+    const tail = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    const dispatch = { owner: fence, tail };
+    this.#nativeMirrorTails.set(threadId, dispatch);
+    void tail.finally(() => {
+      if (this.#nativeMirrorTails.get(threadId) === dispatch)
+        this.#nativeMirrorTails.delete(threadId);
+    });
+    fence?.track(operation);
+    await operation;
+  }
+
+  #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
+    this.#quarantineRetiredExpectedMirrors(threadId);
+    return (
+      this.#consumeMirrorRecord(
+        this.#quarantinedNativeMirrors,
+        threadId,
+        title,
+      ) ||
+      this.#consumeMirrorRecord(this.#expectedNativeMirrors, threadId, title)
+    );
+  }
+
+  #startMirror(
+    threadId: string,
+    title: string,
+    fence?: ZenXThreadTitleObservationFence,
+  ): void {
+    const operation = this.#mirror(threadId, title, fence);
+    void operation.catch((error: unknown) => {
+      if (observationIsCurrent(fence)) {
+        console.warn(
+          `Could not mirror ZenX thread title: ${describeError(error)}`,
+        );
+      }
+    });
+  }
+
+  #registerMirrorOwner(
+    owner: ZenXThreadTitleObservationFence | undefined,
+  ): void {
+    if (
+      owner === undefined ||
+      owner.onRetire === undefined ||
+      this.#registeredMirrorOwners.has(owner)
+    )
+      return;
+    this.#registeredMirrorOwners.add(owner);
+    owner.onRetire(() => this.#retireMirrorOwner(owner));
+  }
+
+  #retireMirrorOwner(owner: ZenXThreadTitleObservationFence): void {
+    for (const [threadId, dispatch] of this.#nativeMirrorTails) {
+      if (dispatch.owner === owner) this.#nativeMirrorTails.delete(threadId);
+    }
+    for (const [threadId, records] of this.#expectedNativeMirrors) {
+      const retired = records.filter((record) => record.owner === owner);
+      if (retired.length === 0) continue;
+      const retained = records.filter((record) => record.owner !== owner);
+      if (retained.length === 0) this.#expectedNativeMirrors.delete(threadId);
+      else this.#expectedNativeMirrors.set(threadId, retained);
+      for (const record of retired) {
+        this.#appendMirrorRecord(
+          this.#quarantinedNativeMirrors,
+          threadId,
+          record,
+        );
+      }
+    }
+  }
+
+  #quarantineRetiredExpectedMirrors(threadId: string): void {
+    const expected = this.#expectedNativeMirrors.get(threadId);
+    if (expected === undefined) return;
+    const retired = expected.filter(
+      (record) => !observationIsCurrent(record.owner),
+    );
+    if (retired.length === 0) return;
+    const retained = expected.filter((record) =>
+      observationIsCurrent(record.owner),
+    );
+    if (retained.length === 0) this.#expectedNativeMirrors.delete(threadId);
+    else this.#expectedNativeMirrors.set(threadId, retained);
+    for (const record of retired) {
+      this.#appendMirrorRecord(
+        this.#quarantinedNativeMirrors,
+        threadId,
+        record,
       );
     }
   }
 
-  #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
-    const expected = this.#expectedNativeMirrors.get(threadId);
-    const index = expected?.indexOf(title) ?? -1;
-    if (expected === undefined || index < 0) return false;
-    expected.splice(index, 1);
-    if (expected.length === 0) this.#expectedNativeMirrors.delete(threadId);
+  #appendMirrorRecord(
+    recordsByThread: Map<string, NativeMirrorRecord[]>,
+    threadId: string,
+    record: NativeMirrorRecord,
+  ): boolean {
+    if (
+      mirrorRecordCount(this.#expectedNativeMirrors) +
+        mirrorRecordCount(this.#quarantinedNativeMirrors) >=
+      MAX_NATIVE_MIRROR_RECORDS
+    )
+      return false;
+    const records = recordsByThread.get(threadId) ?? [];
+    records.push(record);
+    recordsByThread.set(threadId, records);
     return true;
   }
 
-  #removeExpectedNativeMirror(threadId: string, title: string): void {
-    this.#consumeExpectedNativeMirror(threadId, title);
+  #consumeMirrorRecord(
+    recordsByThread: Map<string, NativeMirrorRecord[]>,
+    threadId: string,
+    title: string,
+  ): boolean {
+    const records = recordsByThread.get(threadId);
+    const index = records?.findIndex((record) => record.title === title) ?? -1;
+    if (records === undefined || index < 0) return false;
+    records[index]!.consumed = true;
+    records.splice(index, 1);
+    if (records.length === 0) recordsByThread.delete(threadId);
+    return true;
+  }
+
+  #removeMirrorRecord(threadId: string, record: NativeMirrorRecord): void {
+    for (const recordsByThread of [
+      this.#expectedNativeMirrors,
+      this.#quarantinedNativeMirrors,
+    ]) {
+      const records = recordsByThread.get(threadId);
+      const index = records?.indexOf(record) ?? -1;
+      if (records === undefined || index < 0) continue;
+      records.splice(index, 1);
+      if (records.length === 0) recordsByThread.delete(threadId);
+    }
+  }
+
+  #moveMirrorRecordToQuarantine(
+    threadId: string,
+    record: NativeMirrorRecord,
+  ): void {
+    const expected = this.#expectedNativeMirrors.get(threadId);
+    const expectedIndex = expected?.indexOf(record) ?? -1;
+    if (expected !== undefined && expectedIndex >= 0) {
+      expected.splice(expectedIndex, 1);
+      if (expected.length === 0) this.#expectedNativeMirrors.delete(threadId);
+    }
+    const quarantined = this.#quarantinedNativeMirrors.get(threadId) ?? [];
+    if (!quarantined.includes(record)) {
+      this.#appendMirrorRecord(
+        this.#quarantinedNativeMirrors,
+        threadId,
+        record,
+      );
+    }
   }
 
   #recordNativeAuthority(threadId: string): void {
@@ -267,12 +527,35 @@ export class ZenXThreadTitleCoordinator {
     return this.#nativeAuthorityVersions.get(threadId) ?? 0;
   }
 
-  #startGeneration(projection: ThreadTitleProjection): void {
-    void this.#generate(projection).catch((error: unknown) => {
+  #startGeneration(
+    projection: ThreadTitleProjection,
+    fence?: ZenXThreadTitleObservationFence,
+  ): void {
+    if (!observationIsCurrent(fence)) return;
+    const owner = { version: projection.version, fence };
+    this.#generationOwners.set(projection.threadId, owner);
+    const disposeRetirement = fence?.onRetire?.(() => {
+      if (this.#generationOwners.get(projection.threadId) === owner)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    const operation = this.#generate(projection, fence).finally(() => {
+      disposeRetirement?.();
+      if (this.#generationOwners.get(projection.threadId) === owner)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    fence?.track(operation);
+    void operation.catch((error: unknown) => {
       console.error(
         `Could not persist title generation result: ${asError(error).message}`,
       );
     });
+  }
+
+  #hasCurrentGenerationOwner(projection: ThreadTitleProjection): boolean {
+    const owner = this.#generationOwners.get(projection.threadId);
+    return (
+      owner?.version === projection.version && observationIsCurrent(owner.fence)
+    );
   }
 
   #assertAvailable(): void {
@@ -344,10 +627,24 @@ function normalizeManualTitle(input: string): string {
   return title;
 }
 
+function mirrorRecordCount(
+  recordsByThread: Map<string, NativeMirrorRecord[]>,
+): number {
+  let count = 0;
+  for (const records of recordsByThread.values()) count += records.length;
+  return count;
+}
+
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function observationIsCurrent(
+  fence?: ZenXThreadTitleObservationFence,
+): boolean {
+  return fence === undefined || (!fence.signal.aborted && fence.isCurrent());
 }

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -49,6 +49,7 @@ export class ZenXThreadTitleCoordinator {
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
+  #nativeMirrorCapacityWarned = false;
 
   constructor(options: {
     store: ZenXThreadTitleStore;
@@ -330,9 +331,7 @@ export class ZenXThreadTitleCoordinator {
             record,
           )
         ) {
-          console.warn(
-            `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_RECORDS)} unresolved native mirror outcomes are already quarantined`,
-          );
+          this.#warnNativeMirrorCapacity();
           return;
         }
         try {
@@ -373,13 +372,10 @@ export class ZenXThreadTitleCoordinator {
 
   #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
     this.#quarantineRetiredExpectedMirrors(threadId);
-    return (
-      this.#consumeMirrorRecord(
-        this.#quarantinedNativeMirrors,
-        threadId,
-        title,
-      ) ||
-      this.#consumeMirrorRecord(this.#expectedNativeMirrors, threadId, title)
+    return this.#consumeMirrorRecord(
+      this.#expectedNativeMirrors,
+      threadId,
+      title,
     );
   }
 
@@ -480,6 +476,7 @@ export class ZenXThreadTitleCoordinator {
     records[index]!.consumed = true;
     records.splice(index, 1);
     if (records.length === 0) recordsByThread.delete(threadId);
+    this.#refreshNativeMirrorCapacityWarning();
     return true;
   }
 
@@ -494,6 +491,7 @@ export class ZenXThreadTitleCoordinator {
       records.splice(index, 1);
       if (records.length === 0) recordsByThread.delete(threadId);
     }
+    this.#refreshNativeMirrorCapacityWarning();
   }
 
   #moveMirrorRecordToQuarantine(
@@ -513,6 +511,25 @@ export class ZenXThreadTitleCoordinator {
         threadId,
         record,
       );
+    }
+    this.#refreshNativeMirrorCapacityWarning();
+  }
+
+  #warnNativeMirrorCapacity(): void {
+    if (this.#nativeMirrorCapacityWarned) return;
+    this.#nativeMirrorCapacityWarned = true;
+    console.warn(
+      `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_RECORDS)} unresolved native mirror outcomes are already quarantined`,
+    );
+  }
+
+  #refreshNativeMirrorCapacityWarning(): void {
+    if (
+      mirrorRecordCount(this.#expectedNativeMirrors) +
+        mirrorRecordCount(this.#quarantinedNativeMirrors) <
+      MAX_NATIVE_MIRROR_RECORDS
+    ) {
+      this.#nativeMirrorCapacityWarned = false;
     }
   }
 

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -50,6 +50,7 @@ export class ZenXThreadTitleCoordinator {
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
   #nativeMirrorCapacityWarned = false;
+  #pendingNativeMirrorAdmissions = 0;
 
   constructor(options: {
     store: ZenXThreadTitleStore;
@@ -194,12 +195,9 @@ export class ZenXThreadTitleCoordinator {
       const current = this.#snapshot[threadId];
       if (current !== undefined) return current;
     }
-    const unchanged = this.#snapshot[threadId];
-    if (unchanged?.title === normalized) return unchanged;
     this.#recordNativeAuthority(threadId);
     const projection = await this.#serial(async () => {
       const current = this.#snapshot[threadId];
-      if (current?.title === normalized) return current;
       const projection: ThreadTitleProjection = {
         threadId,
         title: normalized,
@@ -303,9 +301,13 @@ export class ZenXThreadTitleCoordinator {
     fence?: ZenXThreadTitleObservationFence,
   ): Promise<boolean> {
     if (!observationIsCurrent(fence)) return false;
+    const previous = this.#snapshot;
     const next = { ...this.#snapshot, [projection.threadId]: projection };
-    await this.#store.write(next);
-    if (!observationIsCurrent(fence)) return false;
+    await this.#store.write(next, () => observationIsCurrent(fence));
+    if (!observationIsCurrent(fence)) {
+      await this.#store.write(previous);
+      return false;
+    }
     this.#snapshot = next;
     for (const listener of this.#listeners) listener(this.snapshot());
     return true;
@@ -316,13 +318,21 @@ export class ZenXThreadTitleCoordinator {
     title: string,
     fence?: ZenXThreadTitleObservationFence,
   ): Promise<void> {
+    if (!this.#reserveNativeMirrorAdmission()) {
+      this.#warnNativeMirrorCapacity();
+      return;
+    }
     this.#registerMirrorOwner(fence);
     const previous =
       this.#nativeMirrorTails.get(threadId)?.tail ?? Promise.resolve();
     const operation = previous
       .catch(() => undefined)
       .then(async () => {
-        if (!observationIsCurrent(fence)) return;
+        this.#pendingNativeMirrorAdmissions -= 1;
+        if (!observationIsCurrent(fence)) {
+          this.#refreshNativeMirrorCapacityWarning();
+          return;
+        }
         const record = { title, owner: fence, consumed: false };
         if (
           !this.#appendMirrorRecord(
@@ -331,6 +341,7 @@ export class ZenXThreadTitleCoordinator {
             record,
           )
         ) {
+          this.#refreshNativeMirrorCapacityWarning();
           this.#warnNativeMirrorCapacity();
           return;
         }
@@ -453,11 +464,7 @@ export class ZenXThreadTitleCoordinator {
     threadId: string,
     record: NativeMirrorRecord,
   ): boolean {
-    if (
-      mirrorRecordCount(this.#expectedNativeMirrors) +
-        mirrorRecordCount(this.#quarantinedNativeMirrors) >=
-      MAX_NATIVE_MIRROR_RECORDS
-    )
+    if (this.#nativeMirrorOutstandingCount() >= MAX_NATIVE_MIRROR_RECORDS)
       return false;
     const records = recordsByThread.get(threadId) ?? [];
     records.push(record);
@@ -524,13 +531,24 @@ export class ZenXThreadTitleCoordinator {
   }
 
   #refreshNativeMirrorCapacityWarning(): void {
-    if (
-      mirrorRecordCount(this.#expectedNativeMirrors) +
-        mirrorRecordCount(this.#quarantinedNativeMirrors) <
-      MAX_NATIVE_MIRROR_RECORDS
-    ) {
+    if (this.#nativeMirrorOutstandingCount() < MAX_NATIVE_MIRROR_RECORDS) {
       this.#nativeMirrorCapacityWarned = false;
     }
+  }
+
+  #reserveNativeMirrorAdmission(): boolean {
+    if (this.#nativeMirrorOutstandingCount() >= MAX_NATIVE_MIRROR_RECORDS)
+      return false;
+    this.#pendingNativeMirrorAdmissions += 1;
+    return true;
+  }
+
+  #nativeMirrorOutstandingCount(): number {
+    return (
+      mirrorRecordCount(this.#expectedNativeMirrors) +
+      mirrorRecordCount(this.#quarantinedNativeMirrors) +
+      this.#pendingNativeMirrorAdmissions
+    );
   }
 
   #recordNativeAuthority(threadId: string): void {

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, open, rename, writeFile } from "node:fs/promises";
+import { mkdir, open, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type {
@@ -40,7 +40,10 @@ export class ZenXThreadTitleStore {
     }
   }
 
-  async write(snapshot: ThreadTitleSnapshot): Promise<void> {
+  async write(
+    snapshot: ThreadTitleSnapshot,
+    isCurrent: () => boolean = () => true,
+  ): Promise<void> {
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const temporary = `${this.#filePath}.${process.pid}.tmp`;
@@ -48,6 +51,10 @@ export class ZenXThreadTitleStore {
       encoding: "utf8",
       mode: 0o600,
     });
+    if (!isCurrent()) {
+      await rm(temporary, { force: true });
+      return;
+    }
     await rename(temporary, this.#filePath);
   }
 }

--- a/apps/zenx/src/main/trigger-generation-quiescence.ts
+++ b/apps/zenx/src/main/trigger-generation-quiescence.ts
@@ -1,0 +1,124 @@
+const DEFAULT_QUIESCENCE_DEADLINE_MS = 250;
+
+export interface ZenXTriggerGenerationQuiescenceOptions {
+  deadlineMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => unknown;
+  cancelScheduled?: (handle: unknown) => void;
+}
+
+export class ZenXTriggerGenerationQuiescence {
+  readonly #abort = new AbortController();
+  readonly #deadlineMs: number;
+  readonly #schedule: (callback: () => void, delayMs: number) => unknown;
+  readonly #cancelScheduled: (handle: unknown) => void;
+  readonly #tracked = new Set<Promise<void>>();
+  readonly #retirementHooks = new Set<() => void>();
+  #active = true;
+  #retirement: Promise<void> | undefined;
+
+  constructor(options: ZenXTriggerGenerationQuiescenceOptions = {}) {
+    this.#deadlineMs = validDeadline(
+      options.deadlineMs ?? DEFAULT_QUIESCENCE_DEADLINE_MS,
+    );
+    this.#schedule = options.schedule ?? setTimeout;
+    this.#cancelScheduled =
+      options.cancelScheduled ??
+      ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+  }
+
+  get signal(): AbortSignal {
+    return this.#abort.signal;
+  }
+
+  isCurrent(): boolean {
+    return this.#active;
+  }
+
+  track<T>(operation: Promise<T>): Promise<T> {
+    if (!this.#active) return operation;
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#tracked.add(settled);
+    void settled.finally(() => this.#tracked.delete(settled));
+    return operation;
+  }
+
+  onRetire(callback: () => void): () => void {
+    if (!this.#active) {
+      callback();
+      return () => undefined;
+    }
+    this.#retirementHooks.add(callback);
+    return () => this.#retirementHooks.delete(callback);
+  }
+
+  retire(): Promise<void> {
+    if (this.#retirement !== undefined) return this.#retirement;
+    this.#active = false;
+    const errors: unknown[] = [];
+    try {
+      this.#abort.abort();
+    } catch (error) {
+      errors.push(error);
+    }
+    for (const hook of this.#retirementHooks) {
+      try {
+        hook();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.#retirementHooks.clear();
+    this.#retirement = this.#finishRetirement(errors);
+    return this.#retirement;
+  }
+
+  async #finishRetirement(errors: unknown[]): Promise<void> {
+    const work = Promise.all([...this.#tracked]).then(() => undefined);
+    let deadlineHandle: unknown;
+    let resolveDeadline!: () => void;
+    const deadline = new Promise<void>((resolve) => {
+      resolveDeadline = resolve;
+    });
+    try {
+      deadlineHandle = this.#schedule(resolveDeadline, this.#deadlineMs);
+    } catch (error) {
+      errors.push(error);
+      resolveDeadline();
+    }
+    const outcome = await Promise.race([
+      work.then(() => "settled" as const),
+      deadline.then(() => "deadline" as const),
+    ]);
+    if (outcome === "settled" && deadlineHandle !== undefined) {
+      try {
+        this.#cancelScheduled(deadlineHandle);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.#tracked.clear();
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        `Could not fully retire Trigger generation: ${errors
+          .map(describeError)
+          .join("; ")}`,
+      );
+    }
+  }
+}
+
+function validDeadline(value: number): number {
+  if (!Number.isFinite(value) || value < 0)
+    throw new Error(
+      "Trigger quiescence deadline must be a finite non-negative number",
+    );
+  return value;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -9,6 +9,8 @@ import type {
   Turn,
 } from "../protocol-client/index.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
+import { ZenXTriggerGenerationQuiescence } from "./trigger-generation-quiescence.js";
+import type { ZenXThreadTitleObservationFence } from "./thread-title-coordinator.js";
 import type {
   CreateRoomInput,
   CreateTriggerInput,
@@ -34,7 +36,128 @@ export interface ZenXTriggerAppServerPort {
 }
 
 export interface ZenXTriggerTitlePort {
-  observe(threadId: string, input: string): Promise<unknown>;
+  observe(
+    threadId: string,
+    input: string,
+    fence: ZenXThreadTitleObservationFence,
+  ): Promise<unknown>;
+}
+
+const MAX_TRANSIENT_TURNS = 64;
+const MAX_COMPLETED_ITEMS_PER_TURN = 64;
+const MAX_IN_FLIGHT_WAKEUPS = 64;
+
+interface InFlightWakeup {
+  historyId: string;
+  threadId: string;
+  clientUserMessageId: string;
+}
+
+interface PendingCompletion {
+  event: ServerNotificationParams["turn/completed"];
+  clientUserMessageId: string | null;
+  rejected: boolean;
+  claimed: boolean;
+}
+
+interface CompletedItemBuffer {
+  threadId: string;
+  items: ThreadItem[];
+}
+
+class ZenXTriggerLifecycleGeneration {
+  readonly timers = new Map<string, unknown>();
+  readonly completedTurnItems = new Map<string, CompletedItemBuffer>();
+  readonly pendingCompletedTurns = new Map<string, PendingCompletion>();
+  readonly inFlightWakeups = new Map<string, InFlightWakeup>();
+  readonly #quiescence: ZenXTriggerGenerationQuiescence;
+  #disposeNotifications: (() => void) | undefined;
+
+  constructor(quiescenceDeadlineMs: number | undefined) {
+    this.#quiescence = new ZenXTriggerGenerationQuiescence({
+      ...(quiescenceDeadlineMs === undefined
+        ? {}
+        : { deadlineMs: quiescenceDeadlineMs }),
+    });
+  }
+
+  get active(): boolean {
+    return this.#quiescence.isCurrent();
+  }
+
+  get titleSignal(): AbortSignal {
+    return this.#quiescence.signal;
+  }
+
+  attachNotifications(dispose: () => void): void {
+    if (!this.active) {
+      dispose();
+      return;
+    }
+    this.#disposeNotifications?.();
+    this.#disposeNotifications = dispose;
+  }
+
+  retire(cancelScheduled: (handle: unknown) => void): Promise<void> {
+    const quiescence = this.#quiescence.retire();
+    const errors: unknown[] = [];
+    const dispose = this.#disposeNotifications;
+    this.#disposeNotifications = undefined;
+    try {
+      dispose?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      for (const timer of this.timers.values()) {
+        try {
+          cancelScheduled(timer);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    } finally {
+      this.timers.clear();
+      this.clearTransientState();
+    }
+    return quiescence
+      .catch((error: unknown) => {
+        errors.push(error);
+      })
+      .then(() => {
+        if (errors.length > 0)
+          throw new AggregateError(
+            errors,
+            `Could not fully retire Trigger generation: ${errors.map(describeError).join("; ")}`,
+          );
+      });
+  }
+
+  trackTitleObservation<T>(operation: Promise<T>): Promise<T> {
+    return this.#quiescence.track(operation);
+  }
+
+  get titleOwner(): ZenXTriggerGenerationQuiescence {
+    return this.#quiescence;
+  }
+
+  clearTransientState(): void {
+    this.completedTurnItems.clear();
+    this.pendingCompletedTurns.clear();
+    this.inFlightWakeups.clear();
+  }
+
+  clearTransientTurn(threadId: string, turnId: string): void {
+    const key = transientTurnKey(threadId, turnId);
+    this.completedTurnItems.delete(key);
+    this.pendingCompletedTurns.delete(key);
+  }
+}
+
+class StaleTriggerGenerationError extends Error {
+  constructor() {
+    super("ZenX Trigger service lifecycle changed");
+  }
 }
 
 export class ZenXTriggerService {
@@ -42,14 +165,14 @@ export class ZenXTriggerService {
   readonly #store: ZenXTriggerStore;
   readonly #titles: ZenXTriggerTitlePort | undefined;
   readonly #listeners = new Set<(snapshot: TriggerSnapshot) => void>();
-  readonly #timers = new Map<string, unknown>();
-  readonly #completedAgentMessages = new Map<string, string>();
-  readonly #completedTurnItems = new Map<string, ThreadItem[]>();
   readonly #now: () => number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
+  readonly #quiescenceDeadlineMs: number | undefined;
   #snapshot: TriggerSnapshot = { triggers: [], history: [], rooms: [] };
   #mutation: Promise<void> = Promise.resolve();
+  readonly #retirements = new Set<Promise<void>>();
+  #activeGeneration: ZenXTriggerLifecycleGeneration | null = null;
 
   constructor(
     manager: ZenXTriggerAppServerPort,
@@ -58,6 +181,7 @@ export class ZenXTriggerService {
       now?: () => number;
       schedule?: (callback: () => void, delayMs: number) => unknown;
       cancelScheduled?: (handle: unknown) => void;
+      quiescenceDeadlineMs?: number;
       titles?: ZenXTriggerTitlePort;
     } = {},
   ) {
@@ -69,42 +193,102 @@ export class ZenXTriggerService {
     this.#cancelScheduled =
       options.cancelScheduled ??
       ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+    this.#quiescenceDeadlineMs = options.quiescenceDeadlineMs;
   }
 
   async start(): Promise<void> {
-    this.#snapshot = await this.#store.read();
-    for (const entry of this.#snapshot.history) {
-      if (entry.status === "starting" || entry.status === "running") {
-        entry.status = "failed";
-        entry.completedAt = this.#now();
-        entry.error =
-          "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
-      }
-    }
-    await this.#persist();
-    this.#rescheduleTimers();
-    this.#manager.onNotification((method, params) => {
-      if (method === "item/completed") {
-        const event = params as ServerNotificationParams["item/completed"];
-        const items = this.#completedTurnItems.get(event.turnId) ?? [];
-        const next = items.filter((item) => item.id !== event.item.id);
-        next.push(event.item);
-        this.#completedTurnItems.set(event.turnId, next);
-        if (event.item.type === "agentMessage") {
-          this.#completedAgentMessages.set(event.turnId, event.item.text);
-        }
-      } else if (method === "turn/completed") {
-        void this.#handleTurnCompleted(
-          params as ServerNotificationParams["turn/completed"],
-        );
-      }
+    const generation = await this.#beginGeneration();
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
     });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = await this.#store.read();
+      this.#assertGeneration(generation);
+      for (const entry of snapshot.history) {
+        if (entry.status === "starting" || entry.status === "running") {
+          entry.status = "failed";
+          entry.completedAt = this.#now();
+          entry.error =
+            "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
+        }
+      }
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      this.#rescheduleTimers(generation);
+      const listener = (
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ): void => {
+        if (!this.#isActive(generation)) return;
+        if (method === "item/completed") {
+          this.#handleItemCompleted(
+            generation,
+            params as ServerNotificationParams["item/completed"],
+          );
+        } else if (method === "turn/completed") {
+          void this.#handleTurnCompleted(
+            generation,
+            params as ServerNotificationParams["turn/completed"],
+          ).catch((error: unknown) => {
+            if (this.#isActive(generation)) {
+              console.warn(
+                `Could not process Trigger completion: ${error instanceof Error ? error.message : String(error)}`,
+              );
+            }
+          });
+        }
+      };
+      generation.attachNotifications(this.#manager.onNotification(listener));
+    } catch (error) {
+      const retirement = this.#retireGeneration(generation);
+      this.#trackRetirement(retirement);
+      let retirementError: unknown;
+      await retirement.catch((retireError: unknown) => {
+        retirementError = retireError;
+      });
+      if (!(error instanceof StaleTriggerGenerationError))
+        throw combinedError(error, retirementError);
+      if (retirementError !== undefined) throw retirementError;
+    } finally {
+      release();
+    }
   }
 
-  stop(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async stop(): Promise<void> {
+    const drain = this.#mutation;
+    const generation = this.#activeGeneration;
+    this.#activeGeneration = null;
+    const generationRetirement =
+      generation?.retire(this.#cancelScheduled) ?? Promise.resolve();
+    let generationRetirementError: unknown;
+    const retirement = Promise.all([
+      drain,
+      generationRetirement.catch((error: unknown) => {
+        generationRetirementError = error;
+      }),
+    ]).then(() => {
+      if (generationRetirementError !== undefined)
+        throw generationRetirementError;
+    });
+    this.#trackRetirement(retirement);
+    await retirement;
   }
+
+  async close(): Promise<void> {
+    try {
+      await this.stop();
+    } finally {
+      this.#listeners.clear();
+    }
+  }
+
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
   }
@@ -114,7 +298,8 @@ export class ZenXTriggerService {
   }
 
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const trigger = await this.#mutate(generation, async (snapshot) => {
       const common = {
         id: randomUUID(),
         threadId: required(input.threadId, "thread"),
@@ -156,28 +341,27 @@ export class ZenXTriggerService {
                   ...common,
                   signal: { name: required(input.signalName, "signal name") },
                 };
-      this.#snapshot.triggers.push(trigger);
-      return trigger;
-    }).then((trigger) => {
-      this.#rescheduleTimers();
+      snapshot.triggers.push(trigger);
       return trigger;
     });
+    this.#rescheduleTimers(generation);
+    return structuredClone(trigger);
   }
 
   async cancel(triggerId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const trigger = this.#snapshot.triggers.find(
-        (item) => item.id === triggerId,
-      );
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const trigger = snapshot.triggers.find((item) => item.id === triggerId);
       if (trigger === undefined) throw new Error("Trigger was not found");
       trigger.active = false;
-      const timer = this.#timers.get(trigger.id);
+      const timer = generation.timers.get(trigger.id);
       if (timer !== undefined) this.#cancelScheduled(timer);
-      this.#timers.delete(trigger.id);
+      generation.timers.delete(trigger.id);
     });
   }
 
   async signal(name: string, detail: string): Promise<void> {
+    const generation = this.#runningGeneration();
     const signalName = required(name, "signal name");
     const signalDetail = detail.trim();
     const matches = this.#snapshot.triggers.filter(
@@ -187,7 +371,7 @@ export class ZenXTriggerService {
         trigger.signal?.name === signalName,
     );
     for (const trigger of matches)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `External signal ${signalName}: ${signalDetail}`,
         occurrenceKey: `signal:${randomUUID()}`,
         projection: `Signal name: ${signalName}\nSignal detail: ${bounded(signalDetail, 4_000)}`,
@@ -195,7 +379,8 @@ export class ZenXTriggerService {
   }
 
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
-    return await this.#mutate(async () => {
+    const generation = this.#runningGeneration();
+    const room = await this.#mutate(generation, async (snapshot) => {
       const members = validateMembers(input.members);
       const room: ZenXRoom = {
         id: randomUUID(),
@@ -204,14 +389,16 @@ export class ZenXTriggerService {
         messages: [],
         createdAt: this.#now(),
       };
-      this.#snapshot.rooms.push(room);
+      snapshot.rooms.push(room);
       return room;
     });
+    return structuredClone(room);
   }
 
   async addRoomMember(roomId: string, member: RoomMember): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -220,8 +407,9 @@ export class ZenXTriggerService {
   }
 
   async removeRoomMember(roomId: string, threadId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -241,20 +429,25 @@ export class ZenXTriggerService {
     author: string,
     text: string,
   ): Promise<void> {
-    const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
-    if (room === undefined) throw new Error("Room was not found");
-    const posted = message(
-      room.id,
-      required(author, "author"),
-      required(text, "message"),
-      "human",
-      null,
-      null,
-      this.#now(),
+    const generation = this.#runningGeneration();
+    const { posted, room } = await this.#mutate(
+      generation,
+      async (snapshot) => {
+        const room = snapshot.rooms.find((entry) => entry.id === roomId);
+        if (room === undefined) throw new Error("Room was not found");
+        const posted = message(
+          room.id,
+          required(author, "author"),
+          required(text, "message"),
+          "human",
+          null,
+          null,
+          this.#now(),
+        );
+        room.messages.push(posted);
+        return { posted, room: structuredClone(room) };
+      },
     );
-    await this.#mutate(async () => {
-      room.messages.push(posted);
-    });
     const mentions = room.members.filter((member) =>
       new RegExp(
         `(^|\\s)@${escapeRegExp(member.name)}(?=\\s|$|[,.!?])`,
@@ -272,7 +465,7 @@ export class ZenXTriggerService {
             member.name.toLocaleLowerCase(),
       );
       for (const trigger of matches)
-        await this.#fire(trigger.id, {
+        await this.#fire(generation, trigger.id, {
           reason: `Room #${room.name} mention from ${posted.author}: ${posted.text}`,
           occurrenceKey: `room:${room.id}:${posted.id}`,
           sourceRoomId: room.id,
@@ -283,53 +476,40 @@ export class ZenXTriggerService {
   }
 
   async #handleTurnCompleted(
+    generation: ZenXTriggerLifecycleGeneration,
     event: ServerNotificationParams["turn/completed"],
   ): Promise<void> {
+    if (!this.#isActive(generation)) return;
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const buffered = generation.completedTurnItems.get(key);
     const completedItems = mergeCompletedItems(
       event.turn.items,
-      this.#completedTurnItems.get(event.turn.id) ?? [],
+      buffered?.threadId === event.threadId ? buffered.items : [],
     );
-    await this.#mutate(async () => {
-      const entry = this.#snapshot.history.find(
-        (item) => item.turnId === event.turn.id && item.status === "running",
-      );
-      if (entry !== undefined) {
-        entry.status =
-          event.turn.status === "completed" ? "completed" : "failed";
-        entry.completedAt = this.#now();
-        entry.error = event.turn.error?.message ?? null;
-        const trigger = this.#snapshot.triggers.find(
-          (item) => item.id === entry.triggerId,
+    const running = this.#snapshot.history.find(
+      (item) =>
+        item.turnId === event.turn.id &&
+        item.threadId === event.threadId &&
+        item.status === "running",
+    );
+    if (running !== undefined) {
+      await this.#mutateMaybe(generation, async (snapshot) => {
+        const current = snapshot.history.find(
+          (entry) =>
+            entry.id === running.id &&
+            entry.turnId === event.turn.id &&
+            entry.threadId === event.threadId &&
+            entry.status === "running",
         );
-        if (trigger?.kind === "roomMention" && trigger.room !== undefined) {
-          const room = this.#snapshot.rooms.find(
-            (item) => item.id === trigger.room?.roomId,
-          );
-          const projectedAnswer = [...completedItems]
-            .reverse()
-            .find((item) => item.type === "agentMessage");
-          const answer =
-            projectedAnswer?.type === "agentMessage"
-              ? projectedAnswer.text
-              : (this.#completedAgentMessages.get(event.turn.id) ?? "");
-          if (room !== undefined && answer.length > 0) {
-            room.messages.push(
-              message(
-                room.id,
-                trigger.room.mention,
-                answer,
-                "agent",
-                entry.threadId,
-                event.turn.id,
-                this.#now(),
-              ),
-            );
-          }
-        }
-      }
-    });
-    this.#completedAgentMessages.delete(event.turn.id);
-    this.#completedTurnItems.delete(event.turn.id);
+        if (current === undefined) return undefined;
+        this.#applyCompletion(snapshot, running.id, event, completedItems);
+        return true;
+      });
+      generation.clearTransientTurn(event.threadId, event.turn.id);
+    } else {
+      this.#bufferEarlyCompletion(generation, event, completedItems);
+    }
+    if (!this.#isActive(generation)) return;
     const watchers = this.#snapshot.triggers.filter(
       (trigger) =>
         trigger.active &&
@@ -337,7 +517,7 @@ export class ZenXTriggerService {
         trigger.watch?.threadId === event.threadId,
     );
     for (const trigger of watchers)
-      await this.#fire(trigger.id, {
+      await this.#fire(generation, trigger.id, {
         reason: `Thread ${event.threadId} emitted turn_completed for ${event.turn.id}`,
         occurrenceKey: `thread:${event.threadId}:${event.turn.id}`,
         sourceThreadId: event.threadId,
@@ -350,6 +530,7 @@ export class ZenXTriggerService {
   }
 
   async #fire(
+    generation: ZenXTriggerLifecycleGeneration,
     triggerId: string,
     wakeup: {
       reason: string;
@@ -362,135 +543,570 @@ export class ZenXTriggerService {
       scheduledAt?: number;
     },
   ): Promise<void> {
-    const trigger = this.#snapshot.triggers.find(
-      (item) => item.id === triggerId && item.active,
-    );
-    if (trigger === undefined) return;
-    const clientUserMessageId = stableWakeupId(
-      trigger.id,
-      wakeup.occurrenceKey,
-    );
-    if (
-      this.#snapshot.history.some(
-        (entry) => entry.clientUserMessageId === clientUserMessageId,
-      )
-    )
-      return;
-    const history: TriggerHistoryEntry = {
-      id: randomUUID(),
-      triggerId: trigger.id,
-      threadId: trigger.threadId,
-      kind: trigger.kind,
-      reason: wakeup.reason,
-      prompt: trigger.prompt,
-      clientUserMessageId,
-      startedAt: this.#now(),
-      completedAt: null,
-      status: "starting",
-      turnId: null,
-      error: null,
-      sourceThreadId: wakeup.sourceThreadId ?? null,
-      sourceTurnId: wakeup.sourceTurnId ?? null,
-      sourceRoomId: wakeup.sourceRoomId ?? null,
-      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-    };
-    await this.#mutate(async () => {
-      this.#snapshot.history.unshift(history);
-      if (trigger.timer !== undefined) {
-        if (trigger.timer.intervalMinutes === null) trigger.active = false;
-        else
-          trigger.timer.nextRunAt =
-            Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-            trigger.timer.intervalMinutes * 60_000;
-      }
-    });
-    this.#rescheduleTimers();
+    let activeWakeup: InFlightWakeup | undefined;
+    let admissionCommitted = false;
     try {
-      await this.#titles
-        ?.observe(
-          trigger.threadId,
-          meaningfulWakeupTitleInput(trigger, wakeup.projection),
-        )
-        .catch((error: unknown) =>
-          console.warn(
-            `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
-          ),
-        );
+      const committed = await this.#mutateMaybe(
+        generation,
+        async (snapshot) => {
+          const trigger = snapshot.triggers.find(
+            (item) => item.id === triggerId && item.active,
+          );
+          if (trigger === undefined) return undefined;
+          const clientUserMessageId = stableWakeupId(
+            trigger.id,
+            wakeup.occurrenceKey,
+          );
+          if (
+            snapshot.history.some(
+              (entry) => entry.clientUserMessageId === clientUserMessageId,
+            )
+          )
+            return undefined;
+          const rejected =
+            generation.inFlightWakeups.size >= MAX_IN_FLIGHT_WAKEUPS;
+          const history: TriggerHistoryEntry = {
+            id: randomUUID(),
+            triggerId: trigger.id,
+            threadId: trigger.threadId,
+            kind: trigger.kind,
+            reason: wakeup.reason,
+            prompt: trigger.prompt,
+            clientUserMessageId,
+            startedAt: this.#now(),
+            completedAt: rejected ? this.#now() : null,
+            status: rejected ? "failed" : "starting",
+            turnId: null,
+            error: rejected
+              ? `Trigger generation already has ${String(MAX_IN_FLIGHT_WAKEUPS)} in-flight wakeups; this wakeup was not dispatched.`
+              : null,
+            sourceThreadId: wakeup.sourceThreadId ?? null,
+            sourceTurnId: wakeup.sourceTurnId ?? null,
+            sourceRoomId: wakeup.sourceRoomId ?? null,
+            sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+            replyRoomId: trigger.room?.roomId ?? null,
+            replyAuthor: trigger.room?.mention ?? null,
+          };
+          snapshot.history.unshift(history);
+          if (!rejected) {
+            activeWakeup = {
+              historyId: history.id,
+              threadId: trigger.threadId,
+              clientUserMessageId,
+            };
+            generation.inFlightWakeups.set(clientUserMessageId, activeWakeup);
+          }
+          if (trigger.timer !== undefined) {
+            if (trigger.timer.intervalMinutes === null) trigger.active = false;
+            else
+              trigger.timer.nextRunAt =
+                Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
+                trigger.timer.intervalMinutes * 60_000;
+          }
+          return {
+            trigger: structuredClone(trigger),
+            historyId: history.id,
+            clientUserMessageId,
+            rejected,
+          };
+        },
+      );
+      if (committed === undefined) return;
+      admissionCommitted = true;
+      const { trigger, historyId, clientUserMessageId, rejected } = committed;
+      this.#rescheduleTimers(generation);
+      if (rejected) return;
+      if (!this.#isActive(generation)) return;
+      await this.#observeTitle(generation, trigger, wakeup.projection);
+      if (!this.#isActive(generation)) return;
       const result = await this.#manager.request("turn/start", {
         threadId: trigger.threadId,
         clientUserMessageId,
         input: [
           {
             type: "text",
-            text: wakeupInput(trigger, history, wakeup.projection),
+            text: wakeupInput(
+              trigger,
+              this.#history(historyId),
+              wakeup.projection,
+            ),
           },
         ],
       });
-      await this.#mutate(async () => {
+      if (!this.#isActive(generation)) return;
+      await this.#mutate(generation, async (snapshot) => {
+        const history = snapshot.history.find(
+          (entry) => entry.id === historyId,
+        );
+        if (history === undefined || history.status !== "starting") return;
         history.status = "running";
         history.turnId = result.turn.id;
       });
+      await this.#consumePendingCompletion(
+        generation,
+        historyId,
+        trigger.threadId,
+        clientUserMessageId,
+        result.turn.id,
+      );
     } catch (error) {
-      await this.#mutate(async () => {
-        history.status = "failed";
-        history.completedAt = this.#now();
-        history.error = error instanceof Error ? error.message : String(error);
-      });
+      if (error instanceof StaleTriggerGenerationError) return;
+      if (activeWakeup === undefined || !admissionCommitted) throw error;
+      if (this.#isActive(generation)) {
+        const failedWakeup = activeWakeup;
+        await this.#mutate(generation, async (snapshot) => {
+          const history = snapshot.history.find(
+            (entry) => entry.id === failedWakeup.historyId,
+          );
+          if (history === undefined || history.status !== "starting") return;
+          history.status = "failed";
+          history.completedAt = this.#now();
+          history.error =
+            error instanceof Error ? error.message : String(error);
+        });
+      }
+    } finally {
+      if (
+        activeWakeup !== undefined &&
+        generation.inFlightWakeups.get(activeWakeup.clientUserMessageId) ===
+          activeWakeup
+      ) {
+        generation.inFlightWakeups.delete(activeWakeup.clientUserMessageId);
+      }
+      this.#evictUnmatchablePending(generation);
     }
   }
 
-  #rescheduleTimers(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async #observeTitle(
+    generation: ZenXTriggerLifecycleGeneration,
+    trigger: ZenXTrigger,
+    projection?: string,
+  ): Promise<void> {
+    if (this.#titles === undefined || !this.#isActive(generation)) return;
+    const fence = generation.titleOwner;
+    const observation = (async () => {
+      if (!fence.isCurrent()) return;
+      await this.#titles!.observe(
+        trigger.threadId,
+        meaningfulWakeupTitleInput(trigger, projection),
+        fence,
+      );
+    })();
+    try {
+      await generation.trackTitleObservation(observation);
+    } catch (error) {
+      if (fence.isCurrent())
+        console.warn(
+          `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
+        );
+    }
+  }
+
+  #rescheduleTimers(generation: ZenXTriggerLifecycleGeneration): void {
+    if (!this.#isActive(generation)) return;
+    this.#cancelTimers(generation);
     for (const trigger of this.#snapshot.triggers) {
       if (!trigger.active || trigger.timer === undefined) continue;
-      this.#scheduleTimer(trigger.id, trigger.timer.nextRunAt);
+      this.#scheduleTimer(generation, trigger.id, trigger.timer.nextRunAt);
     }
   }
 
-  #scheduleTimer(triggerId: string, scheduledAt: number): void {
+  #scheduleTimer(
+    generation: ZenXTriggerLifecycleGeneration,
+    triggerId: string,
+    scheduledAt: number,
+  ): void {
     const delay = Math.max(
       0,
       Math.min(2_147_000_000, scheduledAt - this.#now()),
     );
     const timer = this.#schedule(() => {
-      this.#timers.delete(triggerId);
+      if (!this.#isActive(generation)) return;
+      generation.timers.delete(triggerId);
       if (this.#now() < scheduledAt) {
-        this.#scheduleTimer(triggerId, scheduledAt);
+        this.#scheduleTimer(generation, triggerId, scheduledAt);
         return;
       }
-      void this.#fire(triggerId, {
+      void this.#fire(generation, triggerId, {
         reason: `Timer reached ${new Date(scheduledAt).toISOString()}`,
         occurrenceKey: `timer:${scheduledAt}`,
         scheduledAt,
       });
     }, delay);
-    this.#timers.set(triggerId, timer);
+    generation.timers.set(triggerId, timer);
   }
 
-  async #mutate<T>(operation: () => Promise<T>): Promise<T> {
+  async #mutate<T>(
+    generation: ZenXTriggerLifecycleGeneration,
+    operation: (snapshot: TriggerSnapshot) => Promise<T>,
+  ): Promise<T> {
+    this.#assertGeneration(generation);
     const previous = this.#mutation;
     let release!: () => void;
     this.#mutation = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
-    const previousSnapshot = structuredClone(this.#snapshot);
     try {
-      const result = await operation();
-      await this.#persist();
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
       return result;
-    } catch (error) {
-      this.#snapshot = previousSnapshot;
-      throw error;
     } finally {
       release();
     }
   }
 
-  async #persist(): Promise<void> {
-    await this.#store.write(this.#snapshot);
+  async #mutateMaybe<T>(
+    generation: ZenXTriggerLifecycleGeneration,
+    operation: (snapshot: TriggerSnapshot) => Promise<T | undefined>,
+  ): Promise<T | undefined> {
+    this.#assertGeneration(generation);
+    const previous = this.#mutation;
+    let release!: () => void;
+    this.#mutation = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      this.#assertGeneration(generation);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      if (result === undefined) return undefined;
+      this.#assertGeneration(generation);
+      await this.#store.write(snapshot);
+      this.#assertGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notifyListeners();
+      return result;
+    } finally {
+      release();
+    }
+  }
+
+  #notifyListeners(): void {
     for (const listener of this.#listeners) listener(this.snapshot());
+  }
+
+  async #beginGeneration(): Promise<ZenXTriggerLifecycleGeneration> {
+    await this.#awaitRetirement();
+    const previous = this.#activeGeneration;
+    this.#activeGeneration = null;
+    let retirementError: unknown;
+    try {
+      await previous?.retire(this.#cancelScheduled);
+    } catch (error) {
+      retirementError = error;
+    }
+    if (retirementError !== undefined) throw retirementError;
+    const generation = new ZenXTriggerLifecycleGeneration(
+      this.#quiescenceDeadlineMs,
+    );
+    this.#activeGeneration = generation;
+    return generation;
+  }
+
+  async #awaitRetirement(): Promise<void> {
+    while (this.#retirements.size > 0)
+      await Promise.all([...this.#retirements]);
+  }
+
+  #trackRetirement(operation: Promise<void>): void {
+    const drained = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#retirements.add(drained);
+    void drained.finally(() => this.#retirements.delete(drained));
+  }
+
+  #retireGeneration(generation: ZenXTriggerLifecycleGeneration): Promise<void> {
+    if (this.#activeGeneration === generation) this.#activeGeneration = null;
+    return generation.retire(this.#cancelScheduled);
+  }
+
+  #runningGeneration(): ZenXTriggerLifecycleGeneration {
+    if (this.#activeGeneration === null)
+      throw new Error("ZenX Trigger service is not running");
+    return this.#activeGeneration;
+  }
+
+  #isActive(generation: ZenXTriggerLifecycleGeneration): boolean {
+    return generation.active && this.#activeGeneration === generation;
+  }
+
+  #assertGeneration(generation: ZenXTriggerLifecycleGeneration): void {
+    if (!this.#isActive(generation)) throw new StaleTriggerGenerationError();
+  }
+
+  #cancelTimers(generation: ZenXTriggerLifecycleGeneration): void {
+    for (const timer of generation.timers.values())
+      this.#cancelScheduled(timer);
+    generation.timers.clear();
+  }
+
+  #handleItemCompleted(
+    generation: ZenXTriggerLifecycleGeneration,
+    event: ServerNotificationParams["item/completed"],
+  ): void {
+    const key = transientTurnKey(event.threadId, event.turnId);
+    const current = generation.completedTurnItems.get(key);
+    if (!this.#isPotentialWakeupTurn(generation, event.threadId, event.turnId))
+      return;
+    const items = (current?.items ?? []).filter(
+      (item) => item.id !== event.item.id,
+    );
+    items.push(event.item);
+    this.#setBounded(
+      generation.completedTurnItems,
+      key,
+      {
+        threadId: event.threadId,
+        items: items.slice(-MAX_COMPLETED_ITEMS_PER_TURN),
+      },
+      (evictedKey) => generation.pendingCompletedTurns.delete(evictedKey),
+    );
+  }
+
+  #isPotentialWakeupTurn(
+    generation: ZenXTriggerLifecycleGeneration,
+    threadId: string,
+    turnId: string,
+  ): boolean {
+    const key = transientTurnKey(threadId, turnId);
+    return (
+      this.#snapshot.history.some(
+        (entry) =>
+          entry.turnId === turnId &&
+          entry.threadId === threadId &&
+          entry.status === "running",
+      ) ||
+      generation.pendingCompletedTurns.has(key) ||
+      generation.completedTurnItems.has(key) ||
+      this.#snapshot.triggers.some(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "thread" &&
+          trigger.watch?.threadId === threadId,
+      ) ||
+      [...generation.inFlightWakeups.values()].some(
+        (entry) => entry.threadId === threadId,
+      )
+    );
+  }
+
+  #bufferEarlyCompletion(
+    generation: ZenXTriggerLifecycleGeneration,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const existing = generation.pendingCompletedTurns.get(key);
+    const sameThreadWakeups = [...generation.inFlightWakeups.values()].filter(
+      (entry) => entry.threadId === event.threadId,
+    );
+    if (sameThreadWakeups.length === 0) {
+      generation.clearTransientTurn(event.threadId, event.turn.id);
+      return;
+    }
+    const clientIds = completedItems
+      .filter((item) => item.type === "userMessage")
+      .map((item) => item.clientId)
+      .filter((clientId): clientId is string => clientId !== null);
+    const soleClientId = clientIds.length === 1 ? clientIds[0]! : null;
+    const soleWakeup =
+      soleClientId === null
+        ? undefined
+        : generation.inFlightWakeups.get(soleClientId);
+    const clientUserMessageId =
+      soleWakeup?.threadId === event.threadId ? soleClientId : null;
+    if (existing?.claimed === true) return;
+    if (existing?.rejected === true) return;
+    if (
+      clientIds.length === 0 &&
+      existing !== undefined &&
+      existing.clientUserMessageId !== null
+    ) {
+      return;
+    }
+    if (clientIds.length !== 1 || clientUserMessageId === null) {
+      generation.completedTurnItems.delete(key);
+      this.#setBounded(
+        generation.pendingCompletedTurns,
+        key,
+        {
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+          claimed: false,
+        },
+        (evictedKey) => generation.completedTurnItems.delete(evictedKey),
+      );
+      return;
+    }
+    if (existing !== undefined) {
+      if (existing.clientUserMessageId === clientUserMessageId) {
+        return;
+      }
+      generation.completedTurnItems.delete(key);
+      this.#setBounded(
+        generation.pendingCompletedTurns,
+        key,
+        {
+          event,
+          clientUserMessageId: null,
+          rejected: true,
+          claimed: false,
+        },
+        (evictedKey) => generation.completedTurnItems.delete(evictedKey),
+      );
+      return;
+    }
+    this.#setBounded(
+      generation.pendingCompletedTurns,
+      key,
+      { event, clientUserMessageId, rejected: false, claimed: false },
+      (evictedKey) => generation.completedTurnItems.delete(evictedKey),
+    );
+  }
+
+  async #consumePendingCompletion(
+    generation: ZenXTriggerLifecycleGeneration,
+    historyId: string,
+    threadId: string,
+    clientUserMessageId: string,
+    turnId: string,
+  ): Promise<void> {
+    const key = transientTurnKey(threadId, turnId);
+    const consumed = await this.#mutateMaybe(generation, async (snapshot) => {
+      const history = snapshot.history.find(
+        (entry) =>
+          entry.id === historyId &&
+          entry.threadId === threadId &&
+          entry.turnId === turnId &&
+          entry.status === "running",
+      );
+      if (history === undefined) return undefined;
+      const pending = generation.pendingCompletedTurns.get(key);
+      if (
+        pending === undefined ||
+        pending.claimed ||
+        pending.rejected ||
+        pending.event.threadId !== threadId ||
+        pending.clientUserMessageId !== clientUserMessageId
+      )
+        return undefined;
+      const buffer = generation.completedTurnItems.get(key);
+      if (buffer !== undefined && buffer.threadId !== threadId)
+        return undefined;
+      pending.claimed = true;
+      this.#applyCompletion(
+        snapshot,
+        historyId,
+        pending.event,
+        mergeCompletedItems(pending.event.turn.items, buffer?.items ?? []),
+      );
+      return { pending, buffer };
+    });
+    if (consumed === undefined) return;
+    if (generation.pendingCompletedTurns.get(key) === consumed.pending)
+      generation.pendingCompletedTurns.delete(key);
+    if (
+      consumed.buffer !== undefined &&
+      generation.completedTurnItems.get(key) === consumed.buffer
+    )
+      generation.completedTurnItems.delete(key);
+  }
+
+  #applyCompletion(
+    snapshot: TriggerSnapshot,
+    historyId: string,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const entry = snapshot.history.find((item) => item.id === historyId);
+    if (
+      entry === undefined ||
+      (entry.status !== "running" && entry.status !== "starting")
+    )
+      return;
+    entry.status = event.turn.status === "completed" ? "completed" : "failed";
+    entry.completedAt = this.#now();
+    entry.error = event.turn.error?.message ?? null;
+    if (entry.replyRoomId === null || entry.replyAuthor === null) return;
+    const room = snapshot.rooms.find((item) => item.id === entry.replyRoomId);
+    const answer = [...completedItems]
+      .reverse()
+      .find((item) => item.type === "agentMessage");
+    if (
+      room !== undefined &&
+      answer?.type === "agentMessage" &&
+      answer.text.length > 0
+    ) {
+      room.messages.push(
+        message(
+          room.id,
+          entry.replyAuthor,
+          answer.text,
+          "agent",
+          entry.threadId,
+          event.turn.id,
+          this.#now(),
+        ),
+      );
+    }
+  }
+
+  #history(historyId: string): TriggerHistoryEntry {
+    const history = this.#snapshot.history.find(
+      (entry) => entry.id === historyId,
+    );
+    if (history === undefined) throw new StaleTriggerGenerationError();
+    return history;
+  }
+
+  #evictUnmatchablePending(generation: ZenXTriggerLifecycleGeneration): void {
+    const activeClientIds = new Set(
+      [...generation.inFlightWakeups.values()].map(
+        (entry) => entry.clientUserMessageId,
+      ),
+    );
+    const activeThreads = new Set(
+      [...generation.inFlightWakeups.values()].map((entry) => entry.threadId),
+    );
+    for (const pending of generation.pendingCompletedTurns.values()) {
+      if (
+        pending.clientUserMessageId === null
+          ? !activeThreads.has(pending.event.threadId)
+          : !activeClientIds.has(pending.clientUserMessageId)
+      ) {
+        generation.clearTransientTurn(
+          pending.event.threadId,
+          pending.event.turn.id,
+        );
+      }
+    }
+  }
+
+  #setBounded<K, V>(
+    map: Map<K, V>,
+    key: K,
+    value: V,
+    onEvict: (key: K) => void,
+  ): void {
+    map.delete(key);
+    map.set(key, value);
+    while (map.size > MAX_TRANSIENT_TURNS) {
+      const oldest = map.keys().next().value as K | undefined;
+      if (oldest === undefined) break;
+      map.delete(oldest);
+      onEvict(oldest);
+    }
   }
 }
 
@@ -572,6 +1188,10 @@ function stableWakeupId(triggerId: string, occurrenceKey: string): string {
     .digest("hex")
     .slice(0, 24);
   return `zenx-wakeup:${triggerId}:${occurrence}`;
+}
+
+function transientTurnKey(threadId: string, turnId: string): string {
+  return `${String(threadId.length)}:${threadId}${turnId}`;
 }
 
 function wakeupInput(
@@ -674,4 +1294,16 @@ function mergeCompletedItems(
 function bounded(value: string, limit: number): string {
   if (value.length <= limit) return value;
   return `${value.slice(0, Math.max(0, limit - 24))}\n…[truncated by ZenX]`;
+}
+
+function combinedError(primary: unknown, secondary: unknown): unknown {
+  if (secondary === undefined) return primary;
+  return new AggregateError(
+    [primary, secondary],
+    `${describeError(primary)}; cleanup also failed: ${describeError(secondary)}`,
+  );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -11,7 +11,12 @@ import type {
 } from "./trigger-types.js";
 
 interface StoredState extends TriggerSnapshot {
+  version: 3;
+}
+
+interface Version2StoredState extends Omit<TriggerSnapshot, "history"> {
   version: 2;
+  history: Array<Omit<TriggerHistoryEntry, "replyRoomId" | "replyAuthor">>;
 }
 
 interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
@@ -19,7 +24,12 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
   history: Array<
     Omit<
       TriggerHistoryEntry,
-      "sourceThreadId" | "sourceTurnId" | "sourceRoomId" | "sourceRoomMessageId"
+      | "sourceThreadId"
+      | "sourceTurnId"
+      | "sourceRoomId"
+      | "sourceRoomMessageId"
+      | "replyRoomId"
+      | "replyAuthor"
     >
   >;
 }
@@ -42,6 +52,17 @@ export class ZenXTriggerStore {
     try {
       const value = JSON.parse(await handle.readFile("utf8")) as unknown;
       if (isStoredState(value)) return snapshotFrom(value);
+      if (isVersion2StoredState(value)) {
+        return {
+          triggers: value.triggers,
+          history: value.history.map((entry) => ({
+            ...entry,
+            replyRoomId: null,
+            replyAuthor: null,
+          })),
+          rooms: value.rooms,
+        };
+      }
       if (isLegacyStoredState(value)) {
         return {
           triggers: value.triggers,
@@ -51,6 +72,8 @@ export class ZenXTriggerStore {
             sourceTurnId: null,
             sourceRoomId: null,
             sourceRoomMessageId: null,
+            replyRoomId: null,
+            replyAuthor: null,
           })),
           rooms: value.rooms,
         };
@@ -71,7 +94,7 @@ export class ZenXTriggerStore {
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    const value: StoredState = { version: 2, ...snapshot };
+    const value: StoredState = { version: 3, ...snapshot };
     if (!isStoredState(value))
       throw new Error("ZenX refused to persist an invalid trigger registry");
     await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
@@ -98,9 +121,20 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
-    state["version"] === 2 &&
+    state["version"] === 3 &&
     arrayOf(state["triggers"], isTrigger) &&
     arrayOf(state["history"], isHistory) &&
+    arrayOf(state["rooms"], isRoom)
+  );
+}
+
+function isVersion2StoredState(value: unknown): value is Version2StoredState {
+  const state = record(value);
+  return (
+    state !== null &&
+    state["version"] === 2 &&
+    arrayOf(state["triggers"], isTrigger) &&
+    arrayOf(state["history"], isVersion2History) &&
     arrayOf(state["rooms"], isRoom)
   );
 }
@@ -156,6 +190,18 @@ function isTrigger(value: unknown): value is ZenXTrigger {
 }
 
 function isHistory(value: unknown): value is TriggerHistoryEntry {
+  const entry = record(value);
+  return (
+    isVersion2History(value) &&
+    entry !== null &&
+    nullableString(entry["replyRoomId"]) &&
+    nullableString(entry["replyAuthor"])
+  );
+}
+
+function isVersion2History(
+  value: unknown,
+): value is Version2StoredState["history"][number] {
   const entry = record(value);
   return (
     isLegacyHistory(value) &&

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -31,6 +31,8 @@ export interface TriggerHistoryEntry {
   sourceTurnId: string | null;
   sourceRoomId: string | null;
   sourceRoomMessageId: string | null;
+  replyRoomId: string | null;
+  replyAuthor: string | null;
 }
 
 export interface RoomMember {

--- a/apps/zenx/test/thread-title-coordinator.test.ts
+++ b/apps/zenx/test/thread-title-coordinator.test.ts
@@ -179,14 +179,16 @@ test("retirement aborts background title generation before commit and mirror", a
   });
 });
 
-test("retired held native mirror cannot poison the same-title successor owner", async () => {
+test("quarantined stale title cannot swallow a newer authoritative native rename", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-mirror-owner-"),
   );
   try {
     const inference = new ControlledInference();
     const firstMirror = deferred<void>();
+    const secondMirror = deferred<void>();
     const mirrorEntered = deferred<void>();
+    const successorMirrorEntered = deferred<void>();
     const mirrored: string[] = [];
     let instance!: ZenXThreadTitleCoordinator;
     let mirrorCalls = 0;
@@ -202,6 +204,10 @@ test("retired held native mirror cannot poison the same-title successor owner", 
           await firstMirror.promise;
           return;
         }
+        if (mirrorCalls === 2) {
+          successorMirrorEntered.resolve();
+          await secondMirror.promise;
+        }
         await instance.synchronizeNativeName(threadId, title);
       },
     });
@@ -211,7 +217,7 @@ test("retired held native mirror cannot poison the same-title successor owner", 
     });
     const firstObservation = instance.observe(
       "thread-a",
-      "Shared generation title",
+      "Old source",
       firstOwner,
     );
     await mirrorEntered.promise;
@@ -222,32 +228,34 @@ test("retired held native mirror cannot poison the same-title successor owner", 
     });
     const second = await instance.observe(
       "thread-a",
-      "Shared generation title",
+      "Old source",
       secondOwner,
     );
     assert.equal(second?.status, "generating");
-    inference.resolve("Shared generation title");
-    await until(() => mirrorCalls === 2);
+    inference.resolve("New title");
+    await until(() => instance.snapshot()["thread-a"]?.status === "generated");
+    await successorMirrorEntered.promise;
+    const generatedVersion = instance.snapshot()["thread-a"]?.version ?? 0;
+
+    const authoritativeRename = instance.synchronizeNativeName(
+      "thread-a",
+      "Old source",
+    );
+    await until(() => instance.snapshot()["thread-a"]?.status === "manual");
+    assert.equal(instance.snapshot()["thread-a"]?.title, "Old source");
+    assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
+    assert.equal(
+      instance.snapshot()["thread-a"]?.version,
+      generatedVersion + 1,
+    );
+
+    secondMirror.resolve();
+    await authoritativeRename;
+    assert.equal(instance.snapshot()["thread-a"]?.title, "Old source");
+    assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
     firstMirror.resolve();
     await firstObservation;
-    await until(() => instance.snapshot()["thread-a"]?.status === "generated");
-    const beforeStaleNotification = instance.snapshot()["thread-a"];
-    await instance.synchronizeNativeName("thread-a", "Shared generation title");
-    assert.deepEqual(instance.snapshot()["thread-a"], beforeStaleNotification);
-
-    await instance.synchronizeNativeName(
-      "thread-a",
-      "Authoritative native rename",
-    );
-    assert.equal(
-      instance.snapshot()["thread-a"]?.title,
-      "Authoritative native rename",
-    );
-    assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
-    assert.deepEqual(mirrored.slice(0, 2), [
-      "Shared generation title",
-      "Shared generation title",
-    ]);
+    assert.deepEqual(mirrored.slice(0, 2), ["Old source", "New title"]);
     await secondOwner.retire();
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -286,6 +294,11 @@ test("native mirror quarantine fails closed at 64 without evicting stale evidenc
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-mirror-bound-"),
   );
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...arguments_: unknown[]) => {
+    warnings.push(arguments_.map(String).join(" "));
+  };
   try {
     let mirrorCalls = 0;
     const instance = new ZenXThreadTitleCoordinator({
@@ -298,7 +311,7 @@ test("native mirror quarantine fails closed at 64 without evicting stale evidenc
       },
     });
     await instance.initialize();
-    for (let index = 0; index < 65; index += 1) {
+    for (let index = 0; index < 96; index += 1) {
       const owner = new ZenXTriggerGenerationQuiescence({ deadlineMs: 0 });
       await instance.observe(
         `thread-${String(index)}`,
@@ -310,15 +323,23 @@ test("native mirror quarantine fails closed at 64 without evicting stale evidenc
     }
     assert.equal(mirrorCalls, 64);
     await instance.synchronizeNativeName(
-      "thread-64",
+      "thread-95",
       "Authoritative after capacity",
     );
     assert.equal(
-      instance.snapshot()["thread-64"]?.title,
+      instance.snapshot()["thread-95"]?.title,
       "Authoritative after capacity",
     );
+    assert.equal(instance.snapshot()["thread-95"]?.status, "manual");
     assert.equal(mirrorCalls, 64);
+    assert.equal(
+      warnings.filter((warning) =>
+        warning.includes("unresolved native mirror outcomes"),
+      ).length,
+      1,
+    );
   } finally {
+    console.warn = originalWarn;
     await rm(directory, { recursive: true, force: true });
   }
 });

--- a/apps/zenx/test/thread-title-coordinator.test.ts
+++ b/apps/zenx/test/thread-title-coordinator.test.ts
@@ -8,6 +8,7 @@ import {
   meaningfulTitleSource,
   ZenXThreadTitleCoordinator,
 } from "../src/main/thread-title-coordinator.js";
+import { ZenXTriggerGenerationQuiescence } from "../src/main/trigger-generation-quiescence.js";
 import { ZenXThreadTitleStore } from "../src/main/thread-title-store.js";
 import type {
   ThreadTitleInference,
@@ -91,6 +92,235 @@ test("duplicate first messages launch only one generation", async () => {
     inference.resolve("Done");
     await waitFor(events, "thread-a", "generated");
   });
+});
+
+test("a retired observation queued behind a title mutation cannot commit or mirror", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-title-fence-"));
+  try {
+    const store = new BlockingTitleStore(path.join(directory, "titles.json"));
+    const inference = new ControlledInference();
+    const names: string[] = [];
+    const instance = coordinator(store, inference, names);
+    await instance.initialize();
+
+    store.blockNextWrite();
+    const first = instance.observe("thread-a", "Current generation title");
+    await store.writeEntered;
+    const controller = new AbortController();
+    let current = true;
+    const retired = instance.observe("thread-b", "Retired generation title", {
+      signal: controller.signal,
+      isCurrent: () => current,
+      track: () => undefined,
+    });
+    current = false;
+    controller.abort();
+    store.releaseWrite();
+
+    await first;
+    assert.equal(await retired, undefined);
+    assert.equal(instance.snapshot()["thread-b"], undefined);
+    assert.equal(names.includes("Retired generation title"), false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("retirement aborts background title generation before commit and mirror", async () => {
+  await withCoordinator(async ({ coordinator, inference, events, names }) => {
+    const controller = new AbortController();
+    let current = true;
+    const background: Promise<void>[] = [];
+    const observed = await coordinator.observe(
+      "thread-a",
+      "Generation-owned title",
+      {
+        signal: controller.signal,
+        isCurrent: () => current,
+        track: (operation) => background.push(operation),
+      },
+    );
+    assert.equal(observed?.status, "generating");
+    current = false;
+    controller.abort();
+    inference.resolve("Retired generated title");
+    await Promise.all(background);
+
+    assert.equal(coordinator.snapshot()["thread-a"]?.status, "generating");
+    assert.equal(
+      events.some(
+        (snapshot) => snapshot["thread-a"]?.title === "Retired generated title",
+      ),
+      false,
+    );
+    assert.equal(names.includes("Retired generated title"), false);
+    assert.equal(inference.signals[0]?.aborted, true);
+
+    const restartedController = new AbortController();
+    const restartedBackground: Promise<void>[] = [];
+    const restarted = await coordinator.observe(
+      "thread-a",
+      "Generation-owned title",
+      {
+        signal: restartedController.signal,
+        isCurrent: () => true,
+        track: (operation) => restartedBackground.push(operation),
+      },
+    );
+    assert.equal(restarted?.status, "generating");
+    assert.equal(inference.calls, 2);
+    inference.resolve("Restarted generated title");
+    await Promise.all(restartedBackground);
+    assert.equal(
+      coordinator.snapshot()["thread-a"]?.title,
+      "Restarted generated title",
+    );
+    assert.equal(names.includes("Restarted generated title"), true);
+  });
+});
+
+test("retired held native mirror cannot poison the same-title successor owner", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-mirror-owner-"),
+  );
+  try {
+    const inference = new ControlledInference();
+    const firstMirror = deferred<void>();
+    const mirrorEntered = deferred<void>();
+    const mirrored: string[] = [];
+    let instance!: ZenXThreadTitleCoordinator;
+    let mirrorCalls = 0;
+    instance = new ZenXThreadTitleCoordinator({
+      store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+      inference,
+      titleModel: () => "gpt-5.6-luna",
+      setNativeName: async (threadId, title) => {
+        mirrorCalls += 1;
+        mirrored.push(title);
+        if (mirrorCalls === 1) {
+          mirrorEntered.resolve();
+          await firstMirror.promise;
+          return;
+        }
+        await instance.synchronizeNativeName(threadId, title);
+      },
+    });
+    await instance.initialize();
+    const firstOwner = new ZenXTriggerGenerationQuiescence({
+      deadlineMs: 20,
+    });
+    const firstObservation = instance.observe(
+      "thread-a",
+      "Shared generation title",
+      firstOwner,
+    );
+    await mirrorEntered.promise;
+    await firstOwner.retire();
+
+    const secondOwner = new ZenXTriggerGenerationQuiescence({
+      deadlineMs: 20,
+    });
+    const second = await instance.observe(
+      "thread-a",
+      "Shared generation title",
+      secondOwner,
+    );
+    assert.equal(second?.status, "generating");
+    inference.resolve("Shared generation title");
+    await until(() => mirrorCalls === 2);
+    firstMirror.resolve();
+    await firstObservation;
+    await until(() => instance.snapshot()["thread-a"]?.status === "generated");
+    const beforeStaleNotification = instance.snapshot()["thread-a"];
+    await instance.synchronizeNativeName("thread-a", "Shared generation title");
+    assert.deepEqual(instance.snapshot()["thread-a"], beforeStaleNotification);
+
+    await instance.synchronizeNativeName(
+      "thread-a",
+      "Authoritative native rename",
+    );
+    assert.equal(
+      instance.snapshot()["thread-a"]?.title,
+      "Authoritative native rename",
+    );
+    assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
+    assert.deepEqual(mirrored.slice(0, 2), [
+      "Shared generation title",
+      "Shared generation title",
+    ]);
+    await secondOwner.retire();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("throwing native mirrors do not block generation or later authoritative rename", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-mirror-throw-"),
+  );
+  try {
+    const inference = new ControlledInference();
+    let mirrorCalls = 0;
+    const instance = new ZenXThreadTitleCoordinator({
+      store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+      inference,
+      titleModel: () => "gpt-5.6-luna",
+      setNativeName: async () => {
+        mirrorCalls += 1;
+        throw new Error("native mirror failed");
+      },
+    });
+    await instance.initialize();
+    await instance.observe("thread-a", "Mirror failure title");
+    inference.resolve("Generated despite mirror failure");
+    await until(() => instance.snapshot()["thread-a"]?.status === "generated");
+    await instance.synchronizeNativeName("thread-a", "Native authority");
+    assert.equal(instance.snapshot()["thread-a"]?.title, "Native authority");
+    assert(mirrorCalls >= 2);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("native mirror quarantine fails closed at 64 without evicting stale evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-mirror-bound-"),
+  );
+  try {
+    let mirrorCalls = 0;
+    const instance = new ZenXThreadTitleCoordinator({
+      store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+      inference: { generate: async () => await new Promise<string>(() => {}) },
+      titleModel: () => "gpt-5.6-luna",
+      setNativeName: async () => {
+        mirrorCalls += 1;
+        await new Promise<void>(() => {});
+      },
+    });
+    await instance.initialize();
+    for (let index = 0; index < 65; index += 1) {
+      const owner = new ZenXTriggerGenerationQuiescence({ deadlineMs: 0 });
+      await instance.observe(
+        `thread-${String(index)}`,
+        `Bounded mirror ${String(index)}`,
+        owner,
+      );
+      await tick();
+      await owner.retire();
+    }
+    assert.equal(mirrorCalls, 64);
+    await instance.synchronizeNativeName(
+      "thread-64",
+      "Authoritative after capacity",
+    );
+    assert.equal(
+      instance.snapshot()["thread-64"]?.title,
+      "Authoritative after capacity",
+    );
+    assert.equal(mirrorCalls, 64);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test("trigger envelopes and IDs are excluded from fallback title input", () => {
@@ -193,13 +423,19 @@ function coordinator(
 
 class ControlledInference implements ThreadTitleInference {
   calls = 0;
+  readonly signals: AbortSignal[] = [];
   #pending: Array<{
     resolve(value: string): void;
     reject(error: Error): void;
   }> = [];
 
-  async generate(): Promise<string> {
+  async generate(
+    _source: string,
+    _model: string,
+    signal: AbortSignal,
+  ): Promise<string> {
     this.calls += 1;
+    this.signals.push(signal);
     return await new Promise<string>((resolve, reject) =>
       this.#pending.push({ resolve, reject }),
     );
@@ -210,6 +446,58 @@ class ControlledInference implements ThreadTitleInference {
   }
   reject(error: Error): void {
     this.#pending.shift()?.reject(error);
+  }
+}
+
+class BlockingTitleStore extends ZenXThreadTitleStore {
+  #block = false;
+  #releaseWrite: (() => void) | undefined;
+  #writeEntered: Promise<void> = Promise.resolve();
+  #markWriteEntered: (() => void) | undefined;
+
+  get writeEntered(): Promise<void> {
+    return this.#writeEntered;
+  }
+
+  blockNextWrite(): void {
+    this.#block = true;
+    this.#writeEntered = new Promise<void>((resolve) => {
+      this.#markWriteEntered = resolve;
+    });
+  }
+
+  releaseWrite(): void {
+    this.#releaseWrite?.();
+  }
+
+  override async write(snapshot: ThreadTitleSnapshot): Promise<void> {
+    if (this.#block) {
+      this.#block = false;
+      this.#markWriteEntered?.();
+      await new Promise<void>((resolve) => {
+        this.#releaseWrite = resolve;
+      });
+    }
+    await super.write(snapshot);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await tick();
   }
 }
 

--- a/apps/zenx/test/thread-title-coordinator.test.ts
+++ b/apps/zenx/test/thread-title-coordinator.test.ts
@@ -126,6 +126,45 @@ test("a retired observation queued behind a title mutation cannot commit or mirr
   }
 });
 
+test("retirement during an entered title-store write leaves no durable projection", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-durable-fence-"),
+  );
+  try {
+    const store = new BlockingTitleStore(path.join(directory, "titles.json"));
+    const owner = new ZenXTriggerGenerationQuiescence({ deadlineMs: 20 });
+    const instance = coordinator(store, new ControlledInference());
+    await instance.initialize();
+
+    store.blockNextWrite();
+    const staleObservation = instance.observe("thread-a", "Stale title", owner);
+    await store.writeEntered;
+    const retirement = owner.retire();
+    store.releaseWrite();
+    assert.equal(await staleObservation, undefined);
+    await retirement;
+
+    assert.equal(instance.snapshot()["thread-a"], undefined);
+    assert.deepEqual(await store.read(), {});
+
+    const successorOwner = new ZenXTriggerGenerationQuiescence({
+      deadlineMs: 20,
+    });
+    const successor = coordinator(store, new ControlledInference());
+    await successor.initialize();
+    assert.equal(successor.snapshot()["thread-a"], undefined);
+    const observed = await successor.observe(
+      "thread-a",
+      "Successor title",
+      successorOwner,
+    );
+    assert.equal(observed?.source, "Successor title");
+    await successorOwner.retire();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("retirement aborts background title generation before commit and mirror", async () => {
   await withCoordinator(async ({ coordinator, inference, events, names }) => {
     const controller = new AbortController();
@@ -189,6 +228,7 @@ test("quarantined stale title cannot swallow a newer authoritative native rename
     const secondMirror = deferred<void>();
     const mirrorEntered = deferred<void>();
     const successorMirrorEntered = deferred<void>();
+    const firstMirrorDone = deferred<void>();
     const mirrored: string[] = [];
     let instance!: ZenXThreadTitleCoordinator;
     let mirrorCalls = 0;
@@ -198,17 +238,18 @@ test("quarantined stale title cannot swallow a newer authoritative native rename
       titleModel: () => "gpt-5.6-luna",
       setNativeName: async (threadId, title) => {
         mirrorCalls += 1;
+        const call = mirrorCalls;
         mirrored.push(title);
-        if (mirrorCalls === 1) {
+        if (call === 1) {
           mirrorEntered.resolve();
           await firstMirror.promise;
-          return;
         }
-        if (mirrorCalls === 2) {
+        if (call === 2) {
           successorMirrorEntered.resolve();
           await secondMirror.promise;
         }
         await instance.synchronizeNativeName(threadId, title);
+        if (call === 1) firstMirrorDone.resolve();
       },
     });
     await instance.initialize();
@@ -254,8 +295,80 @@ test("quarantined stale title cannot swallow a newer authoritative native rename
     assert.equal(instance.snapshot()["thread-a"]?.title, "Old source");
     assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
     firstMirror.resolve();
-    await firstObservation;
+    await Promise.all([firstObservation, firstMirrorDone.promise]);
     assert.deepEqual(mirrored.slice(0, 2), ["Old source", "New title"]);
+    await secondOwner.retire();
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("same-title native notification is authoritative after successor mirror completion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-same-native-authority-"),
+  );
+  try {
+    const inference = new ControlledInference();
+    const firstMirror = deferred<void>();
+    const secondMirror = deferred<void>();
+    const firstMirrorEntered = deferred<void>();
+    const secondMirrorEntered = deferred<void>();
+    const firstMirrorDone = deferred<void>();
+    const secondMirrorDone = deferred<void>();
+    let mirrorCalls = 0;
+    let instance!: ZenXThreadTitleCoordinator;
+    instance = new ZenXThreadTitleCoordinator({
+      store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+      inference,
+      titleModel: () => "gpt-5.6-luna",
+      setNativeName: async (threadId, title) => {
+        mirrorCalls += 1;
+        const call = mirrorCalls;
+        if (call === 1) {
+          firstMirrorEntered.resolve();
+          await firstMirror.promise;
+        } else if (call === 2) {
+          secondMirrorEntered.resolve();
+          await secondMirror.promise;
+        }
+        await instance.synchronizeNativeName(threadId, title);
+        if (call === 1) firstMirrorDone.resolve();
+        if (call === 2) secondMirrorDone.resolve();
+      },
+    });
+    await instance.initialize();
+
+    const firstOwner = new ZenXTriggerGenerationQuiescence({ deadlineMs: 20 });
+    const firstObservation = instance.observe(
+      "thread-a",
+      "Old source",
+      firstOwner,
+    );
+    await firstMirrorEntered.promise;
+    await firstOwner.retire();
+
+    const secondOwner = new ZenXTriggerGenerationQuiescence({
+      deadlineMs: 20,
+    });
+    await instance.observe("thread-a", "Old source", secondOwner);
+    inference.resolve("Old source");
+    await until(() => instance.snapshot()["thread-a"]?.status === "generated");
+    await secondMirrorEntered.promise;
+    secondMirror.resolve();
+    await secondMirrorDone.promise;
+    const generated = instance.snapshot()["thread-a"]!;
+
+    const authoritative = await instance.synchronizeNativeName(
+      "thread-a",
+      "Old source",
+    );
+    assert.equal(authoritative.status, "manual");
+    assert.equal(authoritative.version, generated.version + 1);
+
+    firstMirror.resolve();
+    await Promise.all([firstObservation, firstMirrorDone.promise]);
+    assert.equal(instance.snapshot()["thread-a"]?.title, "Old source");
+    assert.equal(instance.snapshot()["thread-a"]?.status, "manual");
     await secondOwner.retire();
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -322,15 +435,24 @@ test("native mirror quarantine fails closed at 64 without evicting stale evidenc
       await owner.retire();
     }
     assert.equal(mirrorCalls, 64);
-    await instance.synchronizeNativeName(
-      "thread-95",
-      "Authoritative after capacity",
+    const overflow = Array.from({ length: 96 }, (_, index) =>
+      instance.synchronizeNativeName(
+        "thread-0",
+        `Authoritative after capacity ${String(index)}`,
+      ),
     );
+    const overflowOutcome = await Promise.race([
+      Promise.all(overflow).then(() => "settled" as const),
+      new Promise<"timeout">((resolve) =>
+        setTimeout(() => resolve("timeout"), 500),
+      ),
+    ]);
+    assert.equal(overflowOutcome, "settled");
     assert.equal(
-      instance.snapshot()["thread-95"]?.title,
-      "Authoritative after capacity",
+      instance.snapshot()["thread-0"]?.title,
+      "Authoritative after capacity 95",
     );
-    assert.equal(instance.snapshot()["thread-95"]?.status, "manual");
+    assert.equal(instance.snapshot()["thread-0"]?.status, "manual");
     assert.equal(mirrorCalls, 64);
     assert.equal(
       warnings.filter((warning) =>

--- a/apps/zenx/test/trigger-generation-quiescence.test.ts
+++ b/apps/zenx/test/trigger-generation-quiescence.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ZenXTriggerGenerationQuiescence } from "../src/main/trigger-generation-quiescence.js";
+
+test("retirement aborts immediately and detaches unresolved work at the deadline", async () => {
+  const held = deferred<void>();
+  const owner = new ZenXTriggerGenerationQuiescence({ deadlineMs: 10 });
+  owner.track(held.promise);
+
+  const startedAt = Date.now();
+  await owner.retire();
+  assert.equal(owner.signal.aborted, true);
+  assert.equal(owner.isCurrent(), false);
+  assert(Date.now() - startedAt < 250);
+  held.resolve();
+});
+
+test("retirement cleanup and deadline timer faults are reported after fencing", async () => {
+  const owner = new ZenXTriggerGenerationQuiescence({
+    deadlineMs: 10,
+    schedule: (callback) => {
+      const handle = { callback };
+      return handle;
+    },
+    cancelScheduled: () => {
+      throw new Error("deadline cancellation failed");
+    },
+  });
+  owner.track(Promise.resolve());
+  owner.onRetire(() => {
+    throw new Error("retirement hook failed");
+  });
+
+  await assert.rejects(
+    async () => await owner.retire(),
+    /retirement hook failed.*deadline cancellation failed/u,
+  );
+  assert.equal(owner.isCurrent(), false);
+});
+
+test("a throwing deadline scheduler detaches work and fails deterministically", async () => {
+  const held = deferred<void>();
+  const owner = new ZenXTriggerGenerationQuiescence({
+    deadlineMs: 10,
+    schedule: () => {
+      throw new Error("deadline scheduling failed");
+    },
+  });
+  owner.track(held.promise);
+  await assert.rejects(async () => await owner.retire(), /scheduling failed/u);
+  assert.equal(owner.isCurrent(), false);
+  held.resolve();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -5,12 +5,15 @@ import path from "node:path";
 import test from "node:test";
 
 import { AppServerManager } from "../src/main/app-server-manager.js";
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleStore } from "../src/main/thread-title-store.js";
 import {
   projectCompletedTurn,
   ZenXTriggerService,
   type ZenXTriggerAppServerPort,
 } from "../src/main/trigger-service.js";
 import { ZenXTriggerStore } from "../src/main/trigger-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
 import type {
   ClientRequestParams,
   ClientRequestResults,
@@ -19,6 +22,1552 @@ import type {
   ThreadItem,
   Turn,
 } from "../src/protocol-client/index.js";
+
+test("stop unsubscribes and fences stale callbacks and in-flight start responses", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-stop-fence-"));
+  const manager = new ControlledManager();
+  const startResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await startResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    const writesBeforeStop = store.writes;
+
+    await triggers.stop();
+    assert.equal(manager.activeListeners, 0);
+    assert.equal(manager.disposeCount, 1);
+    manager.completeStale(
+      "thread-target",
+      completedTurn("turn-after-stop", "late", [], wakeup.clientUserMessageId),
+    );
+    startResponse.resolve(startResult("turn-after-stop"));
+    await firing;
+    await settle();
+
+    assert.equal(store.writes, writesBeforeStop);
+    assert.equal(triggers.snapshot().history[0]?.status, "starting");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a stale generation cannot overwrite state loaded by a restarted service", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-restart-fence-"),
+  );
+  const manager = new ControlledManager();
+  const firstResponse = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await firstResponse.promise;
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await triggers.stop();
+    await triggers.start();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    const writesAfterRestart = store.writes;
+
+    firstResponse.resolve(startResult("stale-turn"));
+    await firing;
+    manager.completeStale("thread-target", completedTurn("stale-turn", "late"));
+    await settle();
+
+    assert.equal(store.writes, writesAfterRestart);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(triggers.snapshot().history[0]?.turnId, null);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stale generation cleanup cannot erase a restarted generation exact candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-generation-owned-correlation-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const generationOne = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const firstWakeup = generationOne.history[0]!;
+    await until(() => responses.has(firstWakeup.clientUserMessageId));
+
+    await triggers.stop();
+    await triggers.start();
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const generationTwo = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history[0]?.status === "starting" &&
+        snapshot.history[0]?.id !== firstWakeup.id,
+    );
+    const secondWakeup = generationTwo.history[0]!;
+    await until(() => responses.has(secondWakeup.clientUserMessageId));
+
+    manager.completeItem(
+      "thread-target",
+      "generation-two-turn",
+      canonicalUserMessage(
+        "generation-two-buffered-user",
+        secondWakeup.clientUserMessageId,
+      ),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("generation-two-turn", "exact current completion"),
+    );
+    manager.completeRetained(
+      0,
+      "thread-target",
+      completedTurn(
+        "generation-one-retained-turn",
+        "stale retained callback",
+        [],
+        firstWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(firstWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-one-turn"));
+    await first;
+    responses
+      .get(secondWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-two-turn"));
+    await second;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "completed");
+    assert.equal(snapshot.history[0]?.turnId, "generation-two-turn");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    assert.equal(
+      snapshot.rooms[0]?.messages.find((message) => message.kind === "agent")
+        ?.text,
+      "Conclusion for exact current completion",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stale failure timer and retained callback cannot erase a current rejected tombstone", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-generation-owned-rejection-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const now = 1_000;
+  const scheduled: Array<{ callback(): void; cancelled: boolean }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      now: () => now,
+      schedule: (callback) => {
+        const task = { callback, cancelled: false };
+        scheduled.push(task);
+        return task;
+      },
+      cancelScheduled: (handle) => {
+        (handle as { cancelled: boolean }).cancelled = true;
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.create({
+      threadId: "timer-thread",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: 10_000,
+    });
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const generationOne = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const firstWakeup = generationOne.history[0]!;
+    await until(() => responses.has(firstWakeup.clientUserMessageId));
+    const staleTimer = scheduled.at(-1)!;
+
+    await triggers.stop();
+    assert.equal(staleTimer.cancelled, true);
+    await triggers.start();
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const generationTwo = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history[0]?.status === "starting" &&
+        snapshot.history[0]?.id !== firstWakeup.id,
+    );
+    const secondWakeup = generationTwo.history[0]!;
+    await until(() => responses.has(secondWakeup.clientUserMessageId));
+
+    manager.complete(
+      "thread-target",
+      completedTurn("generation-two-rejected", "missing identity"),
+    );
+    staleTimer.callback();
+    manager.completeRetained(
+      0,
+      "thread-target",
+      completedTurn(
+        "generation-one-retained",
+        "stale retained callback",
+        [],
+        firstWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(firstWakeup.clientUserMessageId)!
+      .reject(new Error("stale start failure"));
+    await first;
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "generation-two-rejected",
+        "late exact evidence",
+        [],
+        secondWakeup.clientUserMessageId,
+      ),
+    );
+    responses
+      .get(secondWakeup.clientUserMessageId)!
+      .resolve(startResult("generation-two-rejected"));
+    await second;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(snapshot.history[0]?.turnId, "generation-two-rejected");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+    assert.equal(manager.requests.length, 2);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stop invalidates synchronously while awaiting an entered store write", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-stop-durable-boundary-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const entered = store.blockNextWrite();
+    const firing = triggers.signal("deploy", "ready");
+    await entered;
+
+    const stopping = triggers.stop();
+    await assert.rejects(
+      async () => await triggers.signal("deploy", "after stop"),
+      /not running/u,
+    );
+    store.releaseWrite();
+    await Promise.all([firing, stopping]);
+    assert.equal(manager.requests.length, 0);
+
+    await triggers.start();
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "failed");
+    assert.match(snapshot.history[0]?.error ?? "", /ZenX stopped/u);
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("post-start reconciliation reads an exact candidate after the mutation queue unblocks", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-post-start-exact-fence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+
+    const entered = store.blockNextWrite();
+    const blockingMutation = triggers.create({
+      threadId: "other-thread",
+      kind: "signal",
+      label: "Block",
+      prompt: "Hold the durable boundary.",
+      signalName: "block",
+    });
+    await entered;
+    response.resolve(startResult("queued-exact-turn"));
+    await settle();
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-exact-turn",
+        "exact while queued",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    store.releaseWrite();
+    await Promise.all([blockingMutation, firing]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "completed");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("post-start reconciliation honors a conflicting tombstone created while queued", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-post-start-rejected-fence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-rejected-turn",
+        "initial exact",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+
+    const entered = store.blockNextWrite();
+    const blockingMutation = triggers.create({
+      threadId: "other-thread",
+      kind: "signal",
+      label: "Block",
+      prompt: "Hold the durable boundary.",
+      signalName: "block",
+    });
+    await entered;
+    response.resolve(startResult("queued-rejected-turn"));
+    await settle();
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "queued-rejected-turn",
+        "conflicting evidence",
+        [canonicalUserMessage("unrelated-user", "unrelated-client")],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    store.releaseWrite();
+    await Promise.all([blockingMutation, firing]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stop and restart at the history boundary fences title observation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-generation-fence-"),
+  );
+  const manager = new ControlledManager();
+  const titleWrites: Array<{ threadId: string; input: string }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async (threadId, input) => {
+          titleWrites.push({ threadId, input });
+        },
+      },
+    },
+  );
+  let restart: Promise<void> | undefined;
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const dispose = triggers.onChange((snapshot) => {
+      if (restart !== undefined || snapshot.history[0]?.status !== "starting")
+        return;
+      const stopping = triggers.stop();
+      restart = Promise.all([stopping, triggers.start()]).then(() => undefined);
+    });
+    await triggers.signal("deploy", "ready");
+    await restart;
+    dispose();
+
+    assert.deepEqual(titleWrites, []);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("failed start retires its generation and a clean retry can run", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-failed-start-generation-"),
+  );
+  const manager = new ControlledManager();
+  const store = new FailOnceReadTriggerStore(
+    path.join(directory, "triggers.json"),
+  );
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await assert.rejects(async () => await triggers.start(), /read failed/u);
+    await assert.rejects(
+      async () =>
+        await triggers.create({
+          threadId: "thread-target",
+          kind: "signal",
+          label: "Deploy",
+          prompt: "Inspect once.",
+          signalName: "deploy",
+        }),
+      /not running/u,
+    );
+    assert.equal(manager.activeListeners, 0);
+
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    await triggers.signal("deploy", "ready");
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("stop cleanup faults still drain the durable boundary and leave no active generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-stop-cleanup-fault-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const entered = store.blockNextWrite();
+    const firing = triggers.signal("deploy", "ready");
+    await entered;
+    manager.disposeError = new Error("dispose failed");
+    let stopSettled = false;
+    const stopping = triggers
+      .stop()
+      .then(
+        () => null,
+        (error: unknown) => error,
+      )
+      .finally(() => {
+        stopSettled = true;
+      });
+    await settle();
+    assert.equal(stopSettled, false);
+    await assert.rejects(
+      async () => await triggers.signal("deploy", "after stop"),
+      /not running/u,
+    );
+
+    store.releaseWrite();
+    await firing;
+    assert.match(String(await stopping), /dispose failed/u);
+    assert.equal(manager.activeListeners, 0);
+
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    store.releaseWrite();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("restart cancellation faults retire the old generation completely before retry", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-restart-cancel-fault-"),
+  );
+  const manager = new ControlledManager();
+  let failCancellation = true;
+  const scheduled: Array<{ callback(): void }> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      schedule: (callback) => {
+        const task = { callback };
+        scheduled.push(task);
+        return task;
+      },
+      cancelScheduled: () => {
+        if (failCancellation) {
+          failCancellation = false;
+          throw new Error("cancel failed");
+        }
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: Date.now() + 60_000,
+    });
+    assert.equal(scheduled.length, 1);
+
+    await assert.rejects(async () => await triggers.start(), /cancel failed/u);
+    await assert.rejects(
+      async () =>
+        await triggers.create({
+          threadId: "thread-target",
+          kind: "signal",
+          label: "Unavailable",
+          prompt: "Must not persist.",
+          signalName: "unavailable",
+        }),
+      /not running/u,
+    );
+    scheduled[0]!.callback();
+    await settle();
+    assert.equal(manager.requests.length, 0);
+
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("timer scheduling failure during start retires the partial generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-start-schedule-fault-"),
+  );
+  const manager = new ControlledManager();
+  let failSchedule = false;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      schedule: (callback) => {
+        if (failSchedule) throw new Error("schedule failed");
+        return { callback };
+      },
+      cancelScheduled: () => undefined,
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "timer",
+      label: "Later",
+      prompt: "Run later.",
+      runAt: Date.now() + 60_000,
+    });
+    await triggers.stop();
+
+    failSchedule = true;
+    await assert.rejects(
+      async () => await triggers.start(),
+      /schedule failed/u,
+    );
+    await assert.rejects(
+      async () => await triggers.signal("anything", "after failed start"),
+      /not running/u,
+    );
+    assert.equal(manager.activeListeners, 0);
+
+    failSchedule = false;
+    await triggers.start();
+    assert.equal(manager.activeListeners, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("slow title observation cannot write after its generation is stopped and restarted", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-slow-title-fence-"),
+  );
+  const manager = new ControlledManager();
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  const writes: string[] = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async (threadId, _input, fence?: { isCurrent(): boolean }) => {
+          entered.resolve();
+          await release.promise;
+          if (fence?.isCurrent() === false) return;
+          writes.push(threadId);
+        },
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await entered.promise;
+
+    const stopping = triggers.stop();
+    const restarting = triggers.start();
+    release.resolve();
+    await Promise.all([firing, stopping, restarting]);
+
+    assert.deepEqual(writes, []);
+    assert.equal(manager.requests.length, 0);
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+  } finally {
+    release.resolve();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a slow throwing title observation cannot poison the restarted generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-throwing-title-fence-"),
+  );
+  const manager = new ControlledManager();
+  const entered = deferred<void>();
+  const release = deferred<void>();
+  let attempts = 0;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      titles: {
+        observe: async () => {
+          attempts += 1;
+          if (attempts !== 1) return;
+          entered.resolve();
+          await release.promise;
+          throw new Error("stale title failed");
+        },
+      },
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const staleFiring = triggers.signal("deploy", "first");
+    await entered.promise;
+    const stopping = triggers.stop();
+    const restarting = triggers.start();
+    release.resolve();
+    await Promise.all([staleFiring, stopping, restarting]);
+
+    await triggers.signal("deploy", "second");
+    assert.equal(attempts, 2);
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    release.resolve();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("never-settling real title inference cannot block stop restart or close", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-title-quiescence-"),
+  );
+  const manager = new ControlledManager();
+  const inference = new HeldTitleInference();
+  const nativeNames: string[] = [];
+  const titles = new ZenXThreadTitleCoordinator({
+    store: new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+    inference,
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName: async (_threadId, title) => {
+      nativeNames.push(title);
+    },
+  });
+  const triggerStore = new ZenXTriggerStore(
+    path.join(directory, "triggers.json"),
+  );
+  const triggers = new ZenXTriggerService(manager, triggerStore, {
+    titles,
+    quiescenceDeadlineMs: 20,
+  });
+  try {
+    await titles.initialize();
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect bounded title retirement.",
+      signalName: "deploy",
+    });
+    await triggers.signal("deploy", "first");
+    assert.equal(inference.calls, 1);
+
+    await settlesWithin(triggers.stop(), 500);
+    await settlesWithin(triggers.start(), 500);
+    await triggers.signal("deploy", "second");
+    assert.equal(inference.calls, 2);
+    const beforeRelease = titles.snapshot()["thread-target"];
+    inference.resolveAt(0, "Stale detached title");
+    await settle();
+    assert.deepEqual(titles.snapshot()["thread-target"], beforeRelease);
+    assert.equal(nativeNames.includes("Stale detached title"), false);
+
+    inference.resolveAt(1, "Current generation title");
+    await until(
+      () =>
+        titles.snapshot()["thread-target"]?.title ===
+        "Current generation title",
+    );
+    await settlesWithin(triggers.close(), 500);
+  } finally {
+    inference.resolveAll("cleanup");
+    await triggers.stop().catch(() => undefined);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("the 65th held wakeup is failed without another turn start", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-wakeup-cap-"));
+  const manager = new ControlledManager();
+  const held = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await held.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Burst",
+      prompt: "Process bounded wakeup.",
+      signalName: "burst",
+    });
+    const wakeups = Array.from({ length: 65 }, (_, index) =>
+      triggers.signal("burst", String(index)),
+    );
+    await until(() => triggers.snapshot().history.length === 65);
+    assert.equal(manager.requests.length, 64);
+    const rejected = triggers
+      .snapshot()
+      .history.filter((entry) => entry.status === "failed");
+    assert.equal(rejected.length, 1);
+    assert.match(rejected[0]?.error ?? "", /64 in-flight wakeups/u);
+    assert.equal(
+      new Set(
+        triggers.snapshot().history.map((entry) => entry.clientUserMessageId),
+      ).size,
+      65,
+    );
+    held.resolve(startResult("held-turn"));
+    await Promise.all(wakeups);
+  } finally {
+    held.resolve(startResult("cleanup-turn"));
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion uses canonical client identity and replies to the captured Room once", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-early-exact-"));
+  const manager = new ControlledManager();
+  manager.requestHandler = async (params) => {
+    manager.complete(
+      params.threadId,
+      completedTurn(
+        "early-turn",
+        "room wakeup",
+        [],
+        params.clientUserMessageId ?? null,
+      ),
+    );
+    return startResult("early-turn");
+  };
+  const store = new CountingTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+
+    assert.equal(terminal.history[0]?.turnId, "early-turn");
+    assert.equal(
+      terminal.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    const writesBeforeDuplicate = store.writes;
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "early-turn",
+        "duplicate",
+        [],
+        terminal.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await settle();
+    assert.equal(store.writes, writesBeforeDuplicate);
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("cross-thread turn and item notifications cannot terminalize or pollute a wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-cross-thread-completion-"),
+  );
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    const wakeup = running.history[0]!;
+    const turnId = wakeup.turnId!;
+
+    manager.completeItem("thread-other", turnId, {
+      type: "agentMessage",
+      id: "cross-thread-agent",
+      text: "cross-thread injected answer",
+      phase: "final_answer",
+      memoryCitation: null,
+    });
+    manager.complete(
+      "thread-other",
+      completedTurn(turnId, "wrong thread", [], wakeup.clientUserMessageId),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+
+    manager.complete(
+      "thread-target",
+      completedTurn(turnId, "correct thread", [], wakeup.clientUserMessageId),
+    );
+    const terminal = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    const reply = terminal.rooms[0]?.messages.find(
+      (message) => message.kind === "agent",
+    );
+    assert.equal(reply?.text, "Conclusion for correct thread");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a reused turn id from another thread cannot erase an exact early candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-cross-thread-reused-turn-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const wakeup = starting.history[0]!;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "reused-turn",
+        "exact target evidence",
+        [],
+        wakeup.clientUserMessageId,
+      ),
+    );
+    manager.complete(
+      "thread-other",
+      completedTurn("reused-turn", "wrong thread reused id"),
+    );
+    response.resolve(startResult("reused-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "completed");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects matching plus unrelated canonical client IDs", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-contradictory-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "contradictory-turn",
+        "matching",
+        [canonicalUserMessage("unrelated-user", "unrelated-client")],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("contradictory-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("contradictory-turn", "exact late", [], clientId),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(
+      triggers
+        .snapshot()
+        .rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects duplicate canonical occurrences of one client ID", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-duplicate-evidence-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "duplicate-evidence-turn",
+        "matching",
+        [canonicalUserMessage("duplicate-user", clientId)],
+        clientId,
+      ),
+    );
+    response.resolve(startResult("duplicate-evidence-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects zero non-null canonical identity for one wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "thread-target" }],
+    });
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const firing = triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    await until(() => manager.requests.length === 1);
+    manager.complete(
+      "thread-target",
+      completedTurn("turn-no-identity", "missing identity"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "turn-no-identity",
+        "late exact evidence",
+        [],
+        starting.history[0]!.clientUserMessageId,
+      ),
+    );
+    response.resolve(startResult("turn-no-identity"));
+    await firing;
+
+    const snapshot = triggers.snapshot();
+    assert.equal(snapshot.history[0]?.status, "running");
+    assert.equal(snapshot.history[0]?.turnId, "turn-no-identity");
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion rejects zero identity with concurrent same-thread wakeups", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-no-identity-concurrent-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "shared-thread" }],
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    const first = triggers.postRoomMessage(room.id, "One", "@Bot first?");
+    const second = triggers.postRoomMessage(room.id, "Two", "@Bot second?");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-no-identity", "ambiguous identity"),
+    );
+    const [firstEntry, secondEntry] = starting.history;
+    responses
+      .get(firstEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-no-identity"));
+    responses
+      .get(secondEntry!.clientUserMessageId)!
+      .resolve(startResult("turn-other"));
+    await Promise.all([first, second]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.filter((entry) => entry.status === "running").length,
+      2,
+    );
+    assert.equal(
+      snapshot.rooms[0]?.messages.filter((message) => message.kind === "agent")
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("late unidentifiable duplicate preserves an exact concurrent same-thread candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-late-unidentified-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "exact", [], betaEntry.clientUserMessageId),
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "late without identity"),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const snapshot = triggers.snapshot();
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === betaEntry.id)?.status,
+      "completed",
+    );
+    assert.equal(
+      snapshot.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("concurrent same-thread starts correlate only by exact completion evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-concurrent-correlation-"),
+  );
+  const manager = new ControlledManager();
+  const responses = new Map<
+    string,
+    ReturnType<typeof deferred<ClientRequestResults["turn/start"]>>
+  >();
+  manager.requestHandler = async (params) => {
+    const response = deferred<ClientRequestResults["turn/start"]>();
+    responses.set(params.clientUserMessageId!, response);
+    return await response.promise;
+  };
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Alpha",
+      prompt: "Run alpha.",
+      signalName: "alpha",
+    });
+    await triggers.create({
+      threadId: "shared-thread",
+      kind: "signal",
+      label: "Beta",
+      prompt: "Run beta.",
+      signalName: "beta",
+    });
+    const alpha = triggers.signal("alpha", "one");
+    const beta = triggers.signal("beta", "two");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "starting")
+          .length === 2,
+    );
+    const alphaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run alpha.",
+    )!;
+    const betaEntry = starting.history.find(
+      (entry) => entry.prompt === "Run beta.",
+    )!;
+    await until(() => responses.size === 2);
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-beta", "beta", [], betaEntry.clientUserMessageId),
+    );
+    responses
+      .get(alphaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-alpha"));
+    responses
+      .get(betaEntry.clientUserMessageId)!
+      .resolve(startResult("turn-beta"));
+    await Promise.all([alpha, beta]);
+
+    const correlated = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.find((entry) => entry.id === betaEntry.id)?.status ===
+        "completed",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === betaEntry.id)?.turnId,
+      "turn-beta",
+    );
+    assert.equal(
+      correlated.history.find((entry) => entry.id === alphaEntry.id)?.status,
+      "running",
+    );
+    manager.complete(
+      "shared-thread",
+      completedTurn("turn-alpha", "alpha", [], alphaEntry.clientUserMessageId),
+    );
+    await snapshotWhen(triggers, (snapshot) =>
+      snapshot.history.every((entry) => entry.status === "completed"),
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("timer expiry creates one explicit App Server turn and auditable history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-"));
@@ -388,6 +1937,195 @@ test("failed relay is terminal and is not hidden, queued, or retried", async () 
   }
 });
 
+test("failed start evicts early candidates and ignores late unrelated completion", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-failed-start-cleanup-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "candidate-turn",
+        "candidate",
+        [],
+        starting.history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    response.reject(new Error("App Server connection closed"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(
+      triggers.snapshot().history[0]?.error,
+      "App Server connection closed",
+    );
+
+    manager.complete(
+      "unrelated-thread",
+      completedTurn("candidate-turn", "late duplicate"),
+    );
+    manager.complete(
+      "thread-target",
+      completedTurn("unknown-turn", "unrelated"),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "failed");
+    assert.equal(manager.requests.length, 1);
+  } finally {
+    await triggers.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ambiguous early completions are bounded and require the returned turn id", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-early-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    for (let index = 0; index < 65; index += 1) {
+      manager.completeItem("thread-target", `ambiguous-${String(index)}`, {
+        type: "agentMessage",
+        id: `agent-${String(index)}`,
+        text: `candidate ${String(index)}`,
+        phase: "final_answer",
+        memoryCitation: null,
+      });
+      manager.complete(
+        "thread-target",
+        completedTurn(`ambiguous-${String(index)}`, "no client identity"),
+      );
+    }
+    await settle();
+    response.resolve(startResult("ambiguous-0"));
+    await firing;
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "ambiguous-0",
+        "exact late completion",
+        [],
+        triggers.snapshot().history[0]?.clientUserMessageId ?? null,
+      ),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+  } finally {
+    await triggers.close();
+    assert.equal(manager.activeListeners, 0);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("completed item buffers retain only the latest bounded generation-owned evidence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bounded-completed-items-"),
+  );
+  const manager = new ControlledManager();
+  const response = deferred<ClientRequestResults["turn/start"]>();
+  manager.requestHandler = async () => await response.promise;
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "thread-target",
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect once.",
+      signalName: "deploy",
+    });
+    const firing = triggers.signal("deploy", "ready");
+    const starting = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "starting",
+    );
+    const clientId = starting.history[0]!.clientUserMessageId;
+    manager.completeItem(
+      "thread-target",
+      "bounded-item-turn",
+      canonicalUserMessage("oldest-exact-user", clientId),
+    );
+    for (let index = 0; index < 64; index += 1) {
+      manager.completeItem("thread-target", "bounded-item-turn", {
+        type: "agentMessage",
+        id: `bounded-agent-${String(index)}`,
+        text: `candidate ${String(index)}`,
+        phase: "final_answer",
+        memoryCitation: null,
+      });
+    }
+    manager.complete(
+      "thread-target",
+      completedTurn("bounded-item-turn", "no retained exact identity"),
+    );
+    response.resolve(startResult("bounded-item-turn"));
+    await firing;
+
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    manager.complete(
+      "thread-target",
+      completedTurn(
+        "bounded-item-turn",
+        "ordinary late completion",
+        [],
+        clientId,
+      ),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+  } finally {
+    await triggers.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("long timers reschedule at the clamp boundary instead of firing early", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-long-timer-"));
   const manager = new ControlledManager();
@@ -470,12 +2208,35 @@ test("completed Turn projection is bounded and includes commands/results", () =>
 class ControlledManager implements ZenXTriggerAppServerPort {
   readonly requests: ClientRequestParams["turn/start"][] = [];
   requestError: Error | null = null;
-  #listener:
+  disposeError: Error | null = null;
+  requestHandler:
+    | ((
+        params: ClientRequestParams["turn/start"],
+      ) => Promise<ClientRequestResults["turn/start"]>)
+    | undefined;
+  disposeCount = 0;
+  readonly #listeners = new Set<
+    (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void
+  >();
+  readonly #retainedListeners: Array<
+    (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void
+  > = [];
+  #lastListener:
     | ((
         method: ServerNotificationMethod,
         params: ServerNotificationParams[ServerNotificationMethod],
       ) => void)
     | undefined;
+
+  get activeListeners(): number {
+    return this.#listeners.size;
+  }
 
   async request(
     _method: "turn/start",
@@ -483,18 +2244,9 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   ): Promise<ClientRequestResults["turn/start"]> {
     this.requests.push(params);
     if (this.requestError !== null) throw this.requestError;
-    return {
-      turn: {
-        id: `wakeup-turn-${this.requests.length}`,
-        items: [],
-        itemsView: "full",
-        status: "inProgress",
-        error: null,
-        startedAt: Date.now(),
-        completedAt: null,
-        durationMs: null,
-      },
-    };
+    return this.requestHandler === undefined
+      ? startResult(`wakeup-turn-${this.requests.length}`)
+      : await this.requestHandler(params);
   }
 
   onNotification(
@@ -503,21 +2255,132 @@ class ControlledManager implements ZenXTriggerAppServerPort {
       params: ServerNotificationParams[ServerNotificationMethod],
     ) => void,
   ): () => void {
-    this.#listener = listener;
+    this.#listeners.add(listener);
+    this.#retainedListeners.push(listener);
+    this.#lastListener = listener;
     return () => {
-      if (this.#listener === listener) this.#listener = undefined;
+      if (this.#listeners.delete(listener)) {
+        this.disposeCount += 1;
+        const error = this.disposeError;
+        this.disposeError = null;
+        if (error !== null) throw error;
+      }
     };
   }
 
   complete(threadId: string, turn: Turn): void {
-    this.#listener?.("turn/completed", { threadId, turn });
+    for (const listener of this.#listeners) {
+      listener("turn/completed", { threadId, turn });
+    }
   }
+
+  completeItem(threadId: string, turnId: string, item: ThreadItem): void {
+    for (const listener of this.#listeners) {
+      listener("item/completed", {
+        threadId,
+        turnId,
+        item,
+        completedAtMs: Date.now(),
+      });
+    }
+  }
+
+  completeStale(threadId: string, turn: Turn): void {
+    this.#lastListener?.("turn/completed", { threadId, turn });
+  }
+
+  completeRetained(index: number, threadId: string, turn: Turn): void {
+    this.#retainedListeners[index]?.("turn/completed", { threadId, turn });
+  }
+}
+
+class HeldTitleInference implements ThreadTitleInference {
+  calls = 0;
+  readonly #pending: Array<ReturnType<typeof deferred<string>>> = [];
+
+  async generate(): Promise<string> {
+    this.calls += 1;
+    const pending = deferred<string>();
+    this.#pending.push(pending);
+    return await pending.promise;
+  }
+
+  resolveAt(index: number, title: string): void {
+    this.#pending[index]?.resolve(title);
+  }
+
+  resolveAll(title: string): void {
+    for (const pending of this.#pending) pending.resolve(title);
+  }
+}
+
+class CountingTriggerStore extends ZenXTriggerStore {
+  writes = 0;
+  override async write(snapshot: Parameters<ZenXTriggerStore["write"]>[0]) {
+    this.writes += 1;
+    await super.write(snapshot);
+  }
+}
+
+class BlockingTriggerStore extends ZenXTriggerStore {
+  #entered: ReturnType<typeof deferred<void>> | undefined;
+  #release: ReturnType<typeof deferred<void>> | undefined;
+
+  blockNextWrite(): Promise<void> {
+    this.#entered = deferred<void>();
+    this.#release = deferred<void>();
+    return this.#entered.promise;
+  }
+
+  releaseWrite(): void {
+    this.#release?.resolve();
+    this.#release = undefined;
+  }
+
+  override async write(snapshot: Parameters<ZenXTriggerStore["write"]>[0]) {
+    const entered = this.#entered;
+    const release = this.#release;
+    this.#entered = undefined;
+    if (entered !== undefined && release !== undefined) {
+      entered.resolve();
+      await release.promise;
+    }
+    await super.write(snapshot);
+  }
+}
+
+class FailOnceReadTriggerStore extends ZenXTriggerStore {
+  #failed = false;
+
+  override async read() {
+    if (!this.#failed) {
+      this.#failed = true;
+      throw new Error("read failed");
+    }
+    return await super.read();
+  }
+}
+
+function startResult(id: string): ClientRequestResults["turn/start"] {
+  return {
+    turn: {
+      id,
+      items: [],
+      itemsView: "full",
+      status: "inProgress",
+      error: null,
+      startedAt: Date.now(),
+      completedAt: null,
+      durationMs: null,
+    },
+  };
 }
 
 function completedTurn(
   id: string,
   userText: string,
   extra: ThreadItem[] = [],
+  clientId: string | null = null,
 ): Turn {
   return {
     id,
@@ -525,7 +2388,7 @@ function completedTurn(
       {
         type: "userMessage",
         id: `${id}-user`,
-        clientId: null,
+        clientId,
         content: [{ type: "text", text: userText, text_elements: [] }],
       },
       ...extra,
@@ -546,6 +2409,25 @@ function completedTurn(
   };
 }
 
+function canonicalUserMessage(id: string, clientId: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id,
+    clientId,
+    content: [{ type: "text", text: id, text_elements: [] }],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 function userInputForClientId(
   turns: readonly Turn[],
   clientId: string | null | undefined,
@@ -564,6 +2446,27 @@ function userInputForClientId(
 
 async function settle(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 20));
+}
+
+async function settlesWithin<T>(operation: Promise<T>, timeoutMs: number) {
+  return await Promise.race([
+    operation,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`Operation exceeded ${String(timeoutMs)}ms`)),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 10_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await settle();
+  }
 }
 
 function managerFor(directory: string): AppServerManager {
@@ -593,7 +2496,11 @@ async function snapshotWhen(
     (resolve, reject) => {
       const timeout = setTimeout(() => {
         dispose();
-        reject(new Error("Timed out waiting for trigger"));
+        reject(
+          new Error(
+            `Timed out waiting for trigger: ${JSON.stringify(service.snapshot())}`,
+          ),
+        );
       }, 10_000);
       const dispose = service.onChange((snapshot) => {
         if (predicate(snapshot)) {

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -53,6 +53,8 @@ test("migrates fully validated version 1 history to nullable source metadata", a
       sourceTurnId: _sourceTurnId,
       sourceRoomId: _sourceRoomId,
       sourceRoomMessageId: _sourceRoomMessageId,
+      replyRoomId: _replyRoomId,
+      replyAuthor: _replyAuthor,
       ...entry
     }) => entry,
   );
@@ -66,16 +68,39 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     const migrated = await store.read();
     assert.equal(migrated.history[0]?.sourceThreadId, null);
     assert.equal(migrated.history[0]?.sourceTurnId, null);
+    assert.equal(migrated.history[0]?.replyRoomId, null);
     await store.write(migrated);
-    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 2);
+    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 3);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });
 
-function validState(): TriggerSnapshot & { version: 2 } {
+test("migrates version 2 history to nullable immutable reply routing", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-store-v2-"));
+  const file = path.join(directory, "triggers.json");
+  const state = validState();
+  const history = state.history.map(
+    ({ replyRoomId: _replyRoomId, replyAuthor: _replyAuthor, ...entry }) =>
+      entry,
+  );
+  try {
+    await writeFile(
+      file,
+      JSON.stringify({ ...state, version: 2, history }),
+      "utf8",
+    );
+    const migrated = await new ZenXTriggerStore(file).read();
+    assert.equal(migrated.history[0]?.replyRoomId, null);
+    assert.equal(migrated.history[0]?.replyAuthor, null);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function validState(): TriggerSnapshot & { version: 3 } {
   return {
-    version: 2,
+    version: 3,
     triggers: [
       {
         id: "trigger-a",
@@ -106,6 +131,8 @@ function validState(): TriggerSnapshot & { version: 2 } {
         sourceTurnId: "turn-b",
         sourceRoomId: null,
         sourceRoomMessageId: null,
+        replyRoomId: null,
+        replyAuthor: null,
       },
     ],
     rooms: [


### PR DESCRIPTION
## Motivation  Issue #65 identifies one missing transient boundary shared by Trigger shutdown and thread-title ownership: title inference or native mirroring that ignores cancellation must not keep stop, restart, or quit pending forever, and one generation must not accumulate unbounded wakeups.  ## What changed  - Add the documented `ZenXTriggerGenerationQuiescence` deep module. Retirement synchronously aborts and fences the owner, runs cleanup hooks, waits at most the documented 250ms default, then detaches unresolved work while preserving explicit cleanup failures. - Make title inference, title-store publication, native mirror dispatch, and post-await handling owner-fenced. Expected native mirror records are owner-scoped and globally bounded; retired dispatched mirrors move to a bounded quarantine, and capacity fails closed without evicting stale evidence, so late notifications cannot overwrite or suppress a newer authoritative title. - Keep native mirror dispatch outside the title mutation lock. A retired never-settling mirror no longer blocks a successor owner, while late outcomes remain classified without publishing stale projection state. - Cap admitted in-flight wakeups at 64 per Trigger generation. The 65th and later held wakeup receives one durable failed audit record with its stable canonical client ID and issues no additional `turn/start` request. - Preserve the Issue #62 generation-owned notification, timer, completion-correlation, rejected tombstone, thread-affinity, immutable Room routing, and v1/v2→v3 migration behavior. - Await bounded Trigger close before App Server shutdown on quit and smoke cleanup, while still attempting every cleanup boundary and reporting failures.  No durable scheduler, queue, retry engine, transcript, Runtime, protocol method, new Core Item, or self-healing state machine was added.  ## Deterministic TDD  - Reproduced a real `ZenXThreadTitleCoordinator` inference Promise that never resolves and ignores `AbortSignal`; stop, restart, and close now settle within the injected deadline. - Released stale inference after bounded retirement and proved no store publication, in-memory projection, native mirror, or successor-owner mutation. - Held `setNativeName` after dispatch, retired its owner, started a same-title successor, released the stale call, delivered its late notification, and proved the newer authoritative native rename remains visible. - Covered throwing mirrors, cleanup hooks, deadline scheduling/cancellation, notification disposer, Trigger timer cancellation, and entered store-write boundaries. - Held 65 concurrent wakeups and proved exactly 64 ordinary `turn/start` attempts, 65 unique durable correlations, and one deterministic capacity failure.  ## Validation  Passed locally on Windows:  - `npx tsx --test test/trigger-generation-quiescence.test.ts test/thread-title-coordinator.test.ts test/trigger-service.test.ts test/trigger-store.test.ts` — 55/55 - `npm --workspace apps/zenx run typecheck` - `npm --workspace apps/zenx run build` - root `npm run typecheck` - root `npm run build` - root `npm run lint` - changed-file Prettier checks and `git diff --check`  Honest platform-only baseline limitations:  - Full ZenX: 163/168; five existing Windows-host failures require POSIX `printf`, POSIX `/tmp` path expectations, or Unix executable spawning. - Root Node: 86/93 with six Windows permission/POSIX-shell failures and one platform skip. - IMZen: 37/38; the remaining test relies on POSIX chmod semantics. - Repository-wide Prettier baseline still reports 131 pre-existing files; every changed file passes Prettier.  GitHub Linux CI on the exact pushed head is the authoritative full-platform gate.  Closes #65 