### PR TITLE
fix(zenx): make title ownership transactional

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,6 +92,14 @@
   不创建 Turn 的辅助推理；credential 仍只在主进程内存中按当前 Provider 解析。
 - **ZenXThreadTitleCoordinator** — ZenX 主进程从首条有意义的来源标注输入立即建立
   provisional 投影，并异步协调生成、显式重试与 authoritative manual rename。
+- **ZenXThreadTitleOwnershipTransaction** — ZenX 标题投影的瞬时单 owner 事务把
+  claim/read/stage/atomic replace/失败补偿、原生名称镜像及 250ms 有界退休收进同一因果边界；
+  successor 先同步撤销旧 owner，再经串行 store contract 读取，未带 App Server correlation token
+  的名称通知始终保留 native authority，因此 provisional 只先在 ZenX 投影可见，generated/manual
+  才镜像到原生名称，且所有 expected/quarantined/queued 镜像证据合计硬限 64。
+- **ZenXThreadTitleOwnershipStore** — 默认文件存储与任何 custom store 都必须在同一 durable projection
+  上实现共享的同步 owner claim、串行 read/commit 与退休后不可发布契约，不能用 coordinator 的事后补偿
+  猜测提交是否仍然有效。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,10 +96,12 @@
   claim/read/stage/atomic replace/失败补偿、原生名称镜像及 250ms 有界退休收进同一因果边界；
   successor 先同步撤销旧 owner，再经串行 store contract 读取，未带 App Server correlation token
   的名称通知始终保留 native authority，因此 provisional 只先在 ZenX 投影可见，generated/manual
-  才镜像到原生名称，且所有 expected/quarantined/queued 镜像证据合计硬限 64。
+  才镜像到原生名称；同一 store ownership domain 共享瞬时镜像 tail，退休 dispatch 的迟到完成只触发
+  当前 successor authority 的有界合并修复而不能消费它，且所有 expected/quarantined/queued 镜像证据合计硬限 64。
 - **ZenXThreadTitleOwnershipStore** — 默认文件存储与任何 custom store 都必须在同一 durable projection
-  上实现共享的同步 owner claim、串行 read/commit 与退休后不可发布契约，不能用 coordinator 的事后补偿
-  猜测提交是否仍然有效。
+  上提供稳定的瞬时 ownership-domain identity，并实现共享的同步 owner claim、可观测且无未处理 rejection
+  的有界 predecessor retirement、串行 read/commit 与退休后不可发布契约，不能用 coordinator 的事后补偿
+  猜测提交是否仍然有效；退休失败会使 successor read fail closed。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
 

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -176,7 +176,12 @@ app.whenReady().then(async () => {
       await appServerManager.start();
     } else {
       selfControlPort.attach(appServerManager, hostConfig.cwd);
-      await appServerManager.restart(hostConfig);
+      await titleCoordinator?.stop();
+      try {
+        await appServerManager.restart(hostConfig);
+      } finally {
+        await titleCoordinator?.restart();
+      }
     }
   });
   createWindow();
@@ -191,13 +196,30 @@ app.on("before-quit", (event) => {
   event.preventDefault();
   quitting = true;
   triggerService?.stop();
-  void appServerManager
-    .stop()
-    .then(async () => {
+  void (async () => {
+    const errors: unknown[] = [];
+    try {
+      await titleCoordinator?.close();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await appServerManager!.stop();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
       selfControlPort.detach();
       await capabilityService?.close();
-    })
-    .finally(() => app.quit());
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0)
+      console.error(
+        "Could not fully stop ZenX before quit",
+        new AggregateError(errors),
+      );
+  })().finally(() => app.quit());
 });
 
 app.on("window-all-closed", () => {

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -1,61 +1,87 @@
+import {
+  ZenXThreadTitleOwnershipTransaction,
+  type ZenXThreadTitleOwnershipTransactionOptions,
+} from "./thread-title-ownership-transaction.js";
+import type { ZenXThreadTitleOwnershipStore } from "./thread-title-store.js";
 import type {
   ThreadTitleInference,
   ThreadTitleProjection,
   ThreadTitleSnapshot,
 } from "./thread-title-types.js";
-import { ZenXThreadTitleStore } from "./thread-title-store.js";
 
 const MAX_TITLE_LENGTH = 64;
+const MAX_NATIVE_MIRROR_STATE = 64;
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
 
+interface GenerationOwner {
+  readonly version: number;
+  readonly owner: ZenXThreadTitleOwnershipTransaction;
+}
+
 export class ZenXThreadTitleCoordinator {
-  readonly #store: ZenXThreadTitleStore;
+  readonly #store: ZenXThreadTitleOwnershipStore;
   readonly #inference: ThreadTitleInference;
   readonly #titleModel: () => string;
-  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
-  readonly #expectedNativeMirrors = new Map<string, string[]>();
-  readonly #nativeAuthorityVersions = new Map<string, number>();
+  readonly #ownershipOptions: ZenXThreadTitleOwnershipTransactionOptions;
+  readonly #nativeMirrors: NativeMirrorQueue;
+  readonly #generationOwners = new Map<string, GenerationOwner>();
+  #owner: ZenXThreadTitleOwnershipTransaction;
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
+  #initialized = false;
 
   constructor(options: {
-    store: ZenXThreadTitleStore;
+    store: ZenXThreadTitleOwnershipStore;
     inference: ThreadTitleInference;
     titleModel(): string;
     setNativeName(threadId: string, title: string): Promise<void>;
+    ownership?: ZenXThreadTitleOwnershipTransactionOptions;
   }) {
     this.#store = options.store;
     this.#inference = options.inference;
     this.#titleModel = options.titleModel;
-    this.#setNativeName = options.setNativeName;
+    this.#ownershipOptions = options.ownership ?? {};
+    this.#owner = new ZenXThreadTitleOwnershipTransaction(
+      this.#ownershipOptions,
+    );
+    this.#nativeMirrors = new NativeMirrorQueue(options.setNativeName);
   }
 
   async initialize(): Promise<void> {
+    await this.#initializeOwner(this.#owner);
+  }
+
+  async restart(): Promise<void> {
+    await this.stop();
+    this.#owner = new ZenXThreadTitleOwnershipTransaction(
+      this.#ownershipOptions,
+    );
+    this.#mutation = Promise.resolve();
+    this.#initializationError = undefined;
+    this.#initialized = false;
+    await this.#initializeOwner(this.#owner);
+  }
+
+  async stop(): Promise<void> {
+    await this.#owner.retire();
+  }
+
+  async close(): Promise<void> {
     try {
-      const restored = await this.#store.read();
-      let changed = false;
-      for (const [threadId, projection] of Object.entries(restored)) {
-        if (projection.status !== "generating") continue;
-        restored[threadId] = {
-          ...projection,
-          status: "failed",
-          version: projection.version + 1,
-          error:
-            "Title generation stopped when ZenX restarted. Retry explicitly.",
-        };
-        changed = true;
-      }
-      this.#snapshot = restored;
-      if (changed) await this.#store.write(restored);
-    } catch (error) {
-      this.#initializationError = asError(error);
-      console.error(
-        `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
-      );
+      await this.stop();
+    } finally {
+      this.#listeners.clear();
     }
+  }
+
+  createOwnershipTransaction(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+  ): ZenXThreadTitleOwnershipTransaction {
+    this.#assertAvailable();
+    return this.#owner.fork(options);
   }
 
   snapshot(): ThreadTitleSnapshot {
@@ -71,14 +97,36 @@ export class ZenXThreadTitleCoordinator {
   async observe(
     threadId: string,
     input: string,
+    ownership?: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleProjection | undefined> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner(ownership);
     const source = meaningfulTitleSource(input);
     if (source === null) return undefined;
-    const result = await this.#serial(async () => {
+    const result = await this.#serial(owner, async () => {
       const existing = this.#snapshot[threadId];
-      if (existing !== undefined)
-        return { projection: existing, created: false };
+      if (existing !== undefined) {
+        if (
+          !["provisional", "generating"].includes(existing.status) ||
+          this.#hasCurrentGenerationOwner(existing)
+        ) {
+          return { projection: existing, created: false };
+        }
+        const generating = {
+          ...existing,
+          status: "generating" as const,
+          version:
+            existing.status === "provisional"
+              ? existing.version + 1
+              : existing.version,
+        };
+        if (
+          existing.status === "provisional" &&
+          !(await this.#commit(generating, owner))
+        ) {
+          return undefined;
+        }
+        return { projection: generating, created: true };
+      }
       const provisional: ThreadTitleProjection = {
         threadId,
         title: normalizeThreadTitle(source),
@@ -86,57 +134,60 @@ export class ZenXThreadTitleCoordinator {
         version: 1,
         source,
       };
-      await this.#commit(provisional);
-      await this.#mirror(threadId, provisional.title);
+      if (!(await this.#commit(provisional, owner))) return undefined;
       const generating = {
         ...provisional,
         status: "generating" as const,
         version: 2,
       };
-      await this.#commit(generating);
+      if (!(await this.#commit(generating, owner))) return undefined;
       return { projection: generating, created: true };
     });
-    if (result.created) this.#startGeneration(result.projection);
-    return result.projection;
+    if (result?.created === true)
+      this.#startGeneration(result.projection, owner);
+    return result?.projection;
   }
 
   async rename(
     threadId: string,
     title: string,
+    ownership?: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner(ownership);
     const normalized = normalizeManualTitle(title);
-    return await this.#serial(async () => {
+    const projection = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
-      const projection: ThreadTitleProjection = {
+      const next: ThreadTitleProjection = {
         threadId,
         title: normalized,
         status: "manual",
         version: (current?.version ?? 0) + 1,
         source: current?.source ?? normalized,
       };
-      await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
-      return projection;
+      if (!(await this.#commit(next, owner)))
+        throw new Error("Title ownership changed during rename");
+      return next;
     });
+    this.#nativeMirrors.enqueue(threadId, normalized, owner);
+    return projection;
   }
 
   async synchronizeNativeName(
     threadId: string,
     title: string,
   ): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner();
     const normalized = normalizeManualTitle(title);
-    if (this.#consumeExpectedNativeMirror(threadId, normalized)) {
+    // App Server exposes no dispatch correlation token. Title equality is not
+    // provenance, so every notification is conservatively authoritative. A
+    // conflicting in-flight dispatch is followed by one queued repair; its
+    // same-title echo is still authoritative but cannot enqueue another repair.
+    const repairAfterConflictingDispatch =
+      this.#nativeMirrors.hasConflictingActive(threadId, normalized);
+    const nativeAuthorityVersion = this.#nativeAuthorityVersion(threadId) + 1;
+    this.#nativeAuthorityVersions.set(threadId, nativeAuthorityVersion);
+    const projection = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
-      if (current !== undefined) return current;
-    }
-    this.#recordNativeAuthority(threadId);
-    return await this.#serial(async () => {
-      const current = this.#snapshot[threadId];
-      if (current?.status === "manual" && current.title === normalized) {
-        return current;
-      }
       const projection: ThreadTitleProjection = {
         threadId,
         title: normalized,
@@ -144,15 +195,20 @@ export class ZenXThreadTitleCoordinator {
         version: (current?.version ?? 0) + 1,
         source: current?.source ?? normalized,
       };
-      await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
+      if (!(await this.#commit(projection, owner)))
+        throw new Error("Title ownership changed during native rename");
       return projection;
     });
+    if (repairAfterConflictingDispatch)
+      this.#nativeMirrors.enqueue(threadId, normalized, owner);
+    return projection;
   }
 
+  readonly #nativeAuthorityVersions = new Map<string, number>();
+
   async retry(threadId: string): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
-    const generating = await this.#serial(async () => {
+    const owner = this.#operationOwner();
+    const generating = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
       if (current === undefined)
         throw new Error("Thread has no title input to retry");
@@ -164,23 +220,58 @@ export class ZenXThreadTitleCoordinator {
         version: current.version + 1,
       };
       delete next.error;
-      await this.#commit(next);
+      if (!(await this.#commit(next, owner)))
+        throw new Error("Title ownership changed during retry");
       return next;
     });
-    this.#startGeneration(generating);
+    this.#startGeneration(generating, owner);
     return generating;
   }
 
-  async #generate(started: ThreadTitleProjection): Promise<void> {
+  async #initializeOwner(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    try {
+      const restored = await this.#store.claim(owner);
+      if (!owner.isCurrent()) return;
+      let changed = false;
+      for (const [threadId, projection] of Object.entries(restored)) {
+        if (projection.status !== "generating") continue;
+        restored[threadId] = {
+          ...projection,
+          status: "failed",
+          version: projection.version + 1,
+          error:
+            "Title generation stopped when ZenX restarted. Retry explicitly.",
+        };
+        changed = true;
+      }
+      if (changed && !(await this.#store.commit(restored, owner))) return;
+      if (!owner.isCurrent()) return;
+      this.#snapshot = restored;
+      this.#initialized = true;
+    } catch (error) {
+      this.#initializationError = asError(error);
+      console.error(
+        `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
+      );
+    }
+  }
+
+  async #generate(
+    started: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
     try {
       const generated = normalizeGeneratedTitle(
         await this.#inference.generate(
           started.source,
           this.#titleModel(),
-          new AbortController().signal,
+          owner.signal,
         ),
       );
-      await this.#serial(async () => {
+      if (!owner.isCurrent()) return;
+      await this.#serial(owner, async () => {
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
@@ -196,70 +287,81 @@ export class ZenXThreadTitleCoordinator {
         const nativeAuthorityVersion = this.#nativeAuthorityVersion(
           started.threadId,
         );
-        await this.#commit(projection);
+        if (!(await this.#commit(projection, owner))) return;
         if (
+          owner.isCurrent() &&
           this.#nativeAuthorityVersion(started.threadId) ===
-          nativeAuthorityVersion
+            nativeAuthorityVersion
         ) {
-          await this.#mirror(started.threadId, generated);
+          this.#nativeMirrors.enqueue(started.threadId, generated, owner);
         }
       });
     } catch (error) {
-      await this.#serial(async () => {
+      if (!owner.isCurrent()) return;
+      await this.#serial(owner, async () => {
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
           current.version !== started.version
         )
           return;
-        await this.#commit({
-          ...current,
-          status: "failed",
-          version: current.version + 1,
-          error: describeError(error),
-        });
+        await this.#commit(
+          {
+            ...current,
+            status: "failed",
+            version: current.version + 1,
+            error: describeError(error),
+          },
+          owner,
+        );
       });
     }
   }
 
-  async #commit(projection: ThreadTitleProjection): Promise<void> {
+  async #commit(
+    projection: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    if (!owner.isCurrent()) return false;
     const next = { ...this.#snapshot, [projection.threadId]: projection };
-    await this.#store.write(next);
+    if (!(await this.#store.commit(next, owner)) || !owner.isCurrent())
+      return false;
     this.#snapshot = next;
-    for (const listener of this.#listeners) listener(this.snapshot());
-  }
-
-  async #mirror(threadId: string, title: string): Promise<void> {
-    const expected = this.#expectedNativeMirrors.get(threadId) ?? [];
-    expected.push(title);
-    this.#expectedNativeMirrors.set(threadId, expected);
-    try {
-      await this.#setNativeName(threadId, title);
-    } catch (error) {
-      this.#removeExpectedNativeMirror(threadId, title);
-      console.warn(
-        `Could not mirror ZenX thread title: ${describeError(error)}`,
-      );
-    }
-  }
-
-  #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
-    const expected = this.#expectedNativeMirrors.get(threadId);
-    const index = expected?.indexOf(title) ?? -1;
-    if (expected === undefined || index < 0) return false;
-    expected.splice(index, 1);
-    if (expected.length === 0) this.#expectedNativeMirrors.delete(threadId);
+    for (const listener of this.#listeners)
+      listener(structuredClone(this.#snapshot));
     return true;
   }
 
-  #removeExpectedNativeMirror(threadId: string, title: string): void {
-    this.#consumeExpectedNativeMirror(threadId, title);
+  #startGeneration(
+    projection: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    if (!owner.isCurrent()) return;
+    const generation = { version: projection.version, owner };
+    this.#generationOwners.set(projection.threadId, generation);
+    const disposeRetirement = owner.onRetire(() => {
+      if (this.#generationOwners.get(projection.threadId) === generation)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    const operation = this.#generate(projection, owner).finally(() => {
+      disposeRetirement();
+      if (this.#generationOwners.get(projection.threadId) === generation)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    owner.track(operation);
+    void operation.catch((error: unknown) => {
+      if (owner.isCurrent()) {
+        console.error(
+          `Could not persist title generation result: ${asError(error).message}`,
+        );
+      }
+    });
   }
 
-  #recordNativeAuthority(threadId: string): void {
-    this.#nativeAuthorityVersions.set(
-      threadId,
-      this.#nativeAuthorityVersion(threadId) + 1,
+  #hasCurrentGenerationOwner(projection: ThreadTitleProjection): boolean {
+    const generation = this.#generationOwners.get(projection.threadId);
+    return (
+      generation?.version === projection.version && generation.owner.isCurrent()
     );
   }
 
@@ -267,12 +369,14 @@ export class ZenXThreadTitleCoordinator {
     return this.#nativeAuthorityVersions.get(threadId) ?? 0;
   }
 
-  #startGeneration(projection: ThreadTitleProjection): void {
-    void this.#generate(projection).catch((error: unknown) => {
-      console.error(
-        `Could not persist title generation result: ${asError(error).message}`,
-      );
-    });
+  #operationOwner(
+    ownership?: ZenXThreadTitleOwnershipTransaction,
+  ): ZenXThreadTitleOwnershipTransaction {
+    this.#assertAvailable();
+    const owner = ownership ?? this.#owner;
+    if (owner.root !== this.#owner || !owner.isCurrent())
+      throw new Error("ZenX thread-title ownership transaction is retired");
+    return owner;
   }
 
   #assertAvailable(): void {
@@ -281,15 +385,201 @@ export class ZenXThreadTitleCoordinator {
         `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
       );
     }
+    if (!this.#initialized)
+      throw new Error("ZenX thread titles are not initialized");
   }
 
-  async #serial<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.#mutation.then(operation, operation);
+  async #serial<T>(
+    owner: ZenXThreadTitleOwnershipTransaction,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const guarded = async (): Promise<T> => {
+      if (!owner.isCurrent())
+        throw new Error("ZenX thread-title ownership transaction is retired");
+      return await operation();
+    };
+    const result = this.#mutation.then(guarded, guarded);
     this.#mutation = result.then(
       () => undefined,
       () => undefined,
     );
-    return await result;
+    return await owner.track(result);
+  }
+}
+
+type NativeMirrorJobState = "queued" | "active" | "retired" | "settled";
+
+interface NativeMirrorDiagnostic {
+  readonly threadId: string;
+  readonly title: string;
+  readonly ownerId: string;
+}
+
+class NativeMirrorReservation {
+  #released = false;
+
+  constructor(readonly releaseCapacity: () => void) {}
+
+  release(): void {
+    if (this.#released) return;
+    this.#released = true;
+    this.releaseCapacity();
+  }
+}
+
+class NativeMirrorJob {
+  state: NativeMirrorJobState = "queued";
+  disposeRetirement: (() => void) | undefined;
+
+  constructor(
+    readonly threadId: string,
+    readonly title: string,
+    readonly owner: ZenXThreadTitleOwnershipTransaction,
+    readonly reservation: NativeMirrorReservation,
+  ) {}
+}
+
+class NativeMirrorQueue {
+  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
+  readonly #active = new Map<string, NativeMirrorJob>();
+  readonly #queued = new Map<string, NativeMirrorJob>();
+  readonly #quarantined: NativeMirrorDiagnostic[] = [];
+  #reservations = 0;
+  #capacityWarned = false;
+
+  constructor(
+    setNativeName: (threadId: string, title: string) => Promise<void>,
+  ) {
+    this.#setNativeName = setNativeName;
+  }
+
+  hasConflictingActive(threadId: string, title: string): boolean {
+    const active = this.#active.get(threadId);
+    return active !== undefined && active.title !== title;
+  }
+
+  enqueue(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    if (!owner.isCurrent()) return;
+    const queued = this.#queued.get(threadId);
+    if (
+      queued !== undefined &&
+      queued.title === title &&
+      queued.owner === owner
+    )
+      return;
+    if (queued !== undefined) this.#retireJob(queued, true);
+    this.#makeRoomFromDiagnostics();
+    if (
+      this.#reservations + this.#quarantined.length >=
+      MAX_NATIVE_MIRROR_STATE
+    ) {
+      this.#warnCapacity();
+      return;
+    }
+    this.#reservations += 1;
+    this.#capacityWarned = false;
+    const reservation = new NativeMirrorReservation(() => {
+      this.#reservations -= 1;
+      if (
+        this.#reservations + this.#quarantined.length <
+        MAX_NATIVE_MIRROR_STATE
+      )
+        this.#capacityWarned = false;
+    });
+    const job = new NativeMirrorJob(threadId, title, owner, reservation);
+    job.disposeRetirement = owner.onRetire(() => this.#retireJob(job, true));
+    this.#queued.set(threadId, job);
+    this.#pump(threadId);
+  }
+
+  #pump(threadId: string): void {
+    if (this.#active.has(threadId)) return;
+    const job = this.#queued.get(threadId);
+    if (job === undefined) return;
+    this.#queued.delete(threadId);
+    if (!job.owner.isCurrent()) {
+      this.#retireJob(job, true);
+      return;
+    }
+    job.state = "active";
+    this.#active.set(threadId, job);
+    const operation = Promise.resolve().then(async () => {
+      await this.#setNativeName(job.threadId, job.title);
+    });
+    job.owner.track(operation);
+    void operation.then(
+      () => this.#settleJob(job),
+      (error: unknown) => {
+        if (job.state === "active" && job.owner.isCurrent()) {
+          console.warn(
+            `Could not mirror ZenX thread title: ${describeError(error)}`,
+          );
+        }
+        this.#settleJob(job);
+      },
+    );
+  }
+
+  #settleJob(job: NativeMirrorJob): void {
+    if (job.state !== "active") return;
+    job.state = "settled";
+    job.disposeRetirement?.();
+    job.disposeRetirement = undefined;
+    if (this.#active.get(job.threadId) === job)
+      this.#active.delete(job.threadId);
+    job.reservation.release();
+    this.#pump(job.threadId);
+  }
+
+  #retireJob(job: NativeMirrorJob, diagnose: boolean): void {
+    if (job.state === "retired" || job.state === "settled") return;
+    const wasActive = job.state === "active";
+    job.state = "retired";
+    job.disposeRetirement?.();
+    job.disposeRetirement = undefined;
+    if (this.#queued.get(job.threadId) === job)
+      this.#queued.delete(job.threadId);
+    if (this.#active.get(job.threadId) === job)
+      this.#active.delete(job.threadId);
+    job.reservation.release();
+    if (diagnose) this.#appendDiagnostic(job);
+    if (wasActive || !this.#active.has(job.threadId)) this.#pump(job.threadId);
+  }
+
+  #appendDiagnostic(job: NativeMirrorJob): void {
+    while (
+      this.#reservations + this.#quarantined.length >=
+      MAX_NATIVE_MIRROR_STATE
+    ) {
+      if (this.#quarantined.length === 0) return;
+      this.#quarantined.shift();
+    }
+    this.#quarantined.push({
+      threadId: job.threadId,
+      title: job.title,
+      ownerId: job.owner.id,
+    });
+  }
+
+  #makeRoomFromDiagnostics(): void {
+    while (
+      this.#quarantined.length > 0 &&
+      this.#reservations + this.#quarantined.length >= MAX_NATIVE_MIRROR_STATE
+    ) {
+      this.#quarantined.shift();
+    }
+  }
+
+  #warnCapacity(): void {
+    if (this.#capacityWarned) return;
+    this.#capacityWarned = true;
+    console.warn(
+      `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_STATE)} live or queued native mirror operations already occupy the bounded transaction`,
+    );
   }
 }
 

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -11,6 +11,7 @@ import type {
 
 const MAX_TITLE_LENGTH = 64;
 const MAX_NATIVE_MIRROR_STATE = 64;
+const nativeMirrorQueues = new WeakMap<object, NativeMirrorQueue>();
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
 
@@ -26,6 +27,7 @@ export class ZenXThreadTitleCoordinator {
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
   readonly #ownershipOptions: ZenXThreadTitleOwnershipTransactionOptions;
   readonly #nativeMirrors: NativeMirrorQueue;
+  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #generationOwners = new Map<string, GenerationOwner>();
   #owner: ZenXThreadTitleOwnershipTransaction;
   #snapshot: ThreadTitleSnapshot = {};
@@ -44,14 +46,15 @@ export class ZenXThreadTitleCoordinator {
     this.#inference = options.inference;
     this.#titleModel = options.titleModel;
     this.#ownershipOptions = options.ownership ?? {};
+    this.#setNativeName = options.setNativeName;
     this.#owner = new ZenXThreadTitleOwnershipTransaction(
       this.#ownershipOptions,
     );
-    this.#nativeMirrors = new NativeMirrorQueue(options.setNativeName);
+    this.#nativeMirrors = nativeMirrorQueue(options.store.ownershipDomain);
   }
 
   async initialize(): Promise<void> {
-    await this.#initializeOwner(this.#owner);
+    await this.#initializeAndActivateOwner(this.#owner);
   }
 
   async restart(): Promise<void> {
@@ -62,7 +65,7 @@ export class ZenXThreadTitleCoordinator {
     this.#mutation = Promise.resolve();
     this.#initializationError = undefined;
     this.#initialized = false;
-    await this.#initializeOwner(this.#owner);
+    await this.#initializeAndActivateOwner(this.#owner);
   }
 
   async stop(): Promise<void> {
@@ -256,6 +259,22 @@ export class ZenXThreadTitleCoordinator {
     }
   }
 
+  async #initializeAndActivateOwner(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    const initialization = this.#initializeOwner(owner);
+    this.#nativeMirrors.activate(
+      owner,
+      this.#setNativeName,
+      async (threadId) => {
+        await initialization;
+        if (!owner.isCurrent() || !this.#initialized) return undefined;
+        return this.#snapshot[threadId]?.title;
+      },
+    );
+    await initialization;
+  }
+
   async #generate(
     started: ThreadTitleProjection,
     owner: ZenXThreadTitleOwnershipTransaction,
@@ -413,6 +432,12 @@ interface NativeMirrorDiagnostic {
   readonly ownerId: string;
 }
 
+interface NativeMirrorAuthority {
+  readonly owner: ZenXThreadTitleOwnershipTransaction;
+  readonly setNativeName: (threadId: string, title: string) => Promise<void>;
+  readonly desiredTitle: (threadId: string) => Promise<string | undefined>;
+}
+
 class NativeMirrorReservation {
   #released = false;
 
@@ -428,27 +453,42 @@ class NativeMirrorReservation {
 class NativeMirrorJob {
   state: NativeMirrorJobState = "queued";
   disposeRetirement: (() => void) | undefined;
+  repairAfterSettlement = false;
 
   constructor(
     readonly threadId: string,
     readonly title: string,
     readonly owner: ZenXThreadTitleOwnershipTransaction,
     readonly reservation: NativeMirrorReservation,
+    readonly setNativeName: (threadId: string, title: string) => Promise<void>,
+  ) {}
+}
+
+class NativeMirrorRepair {
+  disposeRetirement: (() => void) | undefined;
+
+  constructor(
+    readonly threadId: string,
+    readonly authority: NativeMirrorAuthority,
+    readonly reservation: NativeMirrorReservation,
   ) {}
 }
 
 class NativeMirrorQueue {
-  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #active = new Map<string, NativeMirrorJob>();
   readonly #queued = new Map<string, NativeMirrorJob>();
+  readonly #repairs = new Map<string, NativeMirrorRepair>();
   readonly #quarantined: NativeMirrorDiagnostic[] = [];
+  #authority: NativeMirrorAuthority | undefined;
   #reservations = 0;
   #capacityWarned = false;
 
-  constructor(
+  activate(
+    owner: ZenXThreadTitleOwnershipTransaction,
     setNativeName: (threadId: string, title: string) => Promise<void>,
-  ) {
-    this.#setNativeName = setNativeName;
+    desiredTitle: (threadId: string) => Promise<string | undefined>,
+  ): void {
+    this.#authority = { owner, setNativeName, desiredTitle };
   }
 
   reconcileAuthoritative(
@@ -456,6 +496,7 @@ class NativeMirrorQueue {
     title: string,
     owner: ZenXThreadTitleOwnershipTransaction,
   ): void {
+    this.#retireRepair(threadId, true);
     const queued = this.#queued.get(threadId);
     if (queued !== undefined) this.#retireJob(queued, true);
     const active = this.#active.get(threadId);
@@ -468,7 +509,9 @@ class NativeMirrorQueue {
     title: string,
     owner: ZenXThreadTitleOwnershipTransaction,
   ): void {
-    if (!owner.isCurrent()) return;
+    const authority = this.#authorityFor(owner);
+    if (authority === undefined) return;
+    this.#retireRepair(threadId, true);
     const queued = this.#queued.get(threadId);
     if (
       queued !== undefined &&
@@ -477,25 +520,45 @@ class NativeMirrorQueue {
     )
       return;
     if (queued !== undefined) this.#retireJob(queued, true);
-    this.#makeRoomFromDiagnostics();
+    const reservation = this.#reserve();
+    if (reservation === undefined) return;
+    this.#queueReserved(
+      threadId,
+      title,
+      owner,
+      authority.setNativeName,
+      reservation,
+    );
+  }
+
+  #queueReserved(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+    setNativeName: (threadId: string, title: string) => Promise<void>,
+    reservation: NativeMirrorReservation,
+  ): void {
+    const queued = this.#queued.get(threadId);
     if (
-      this.#reservations + this.#quarantined.length >=
-      MAX_NATIVE_MIRROR_STATE
+      queued !== undefined &&
+      queued.title === title &&
+      queued.owner === owner
     ) {
-      this.#warnCapacity();
+      reservation.release();
       return;
     }
-    this.#reservations += 1;
-    this.#capacityWarned = false;
-    const reservation = new NativeMirrorReservation(() => {
-      this.#reservations -= 1;
-      if (
-        this.#reservations + this.#quarantined.length <
-        MAX_NATIVE_MIRROR_STATE
-      )
-        this.#capacityWarned = false;
-    });
-    const job = new NativeMirrorJob(threadId, title, owner, reservation);
+    if (queued !== undefined) this.#retireJob(queued, true);
+    if (!owner.isCurrent()) {
+      reservation.release();
+      return;
+    }
+    const job = new NativeMirrorJob(
+      threadId,
+      title,
+      owner,
+      reservation,
+      setNativeName,
+    );
     job.disposeRetirement = owner.onRetire(() => this.#retireJob(job, true));
     this.#queued.set(threadId, job);
     this.#pump(threadId);
@@ -513,7 +576,7 @@ class NativeMirrorQueue {
     job.state = "active";
     this.#active.set(threadId, job);
     const operation = Promise.resolve().then(async () => {
-      await this.#setNativeName(job.threadId, job.title);
+      await job.setNativeName(job.threadId, job.title);
     });
     job.owner.track(operation);
     void operation.then(
@@ -530,13 +593,19 @@ class NativeMirrorQueue {
   }
 
   #settleJob(job: NativeMirrorJob): void {
+    if (job.state === "retired") {
+      this.#repairAfterRetiredCompletion(job);
+      return;
+    }
     if (job.state !== "active") return;
+    const repairAfterSettlement = job.repairAfterSettlement;
     job.state = "settled";
     job.disposeRetirement?.();
     job.disposeRetirement = undefined;
     if (this.#active.get(job.threadId) === job)
       this.#active.delete(job.threadId);
     job.reservation.release();
+    if (repairAfterSettlement) this.#scheduleRepair(job.threadId);
     this.#pump(job.threadId);
   }
 
@@ -555,7 +624,110 @@ class NativeMirrorQueue {
     if (wasActive || !this.#active.has(job.threadId)) this.#pump(job.threadId);
   }
 
-  #appendDiagnostic(job: NativeMirrorJob): void {
+  #repairAfterRetiredCompletion(job: NativeMirrorJob): void {
+    const authority = this.#authority;
+    if (authority === undefined || !authority.owner.isCurrent()) return;
+    const queued = this.#queued.get(job.threadId);
+    if (
+      queued !== undefined &&
+      queued.owner.root === authority.owner.root &&
+      queued.owner.isCurrent()
+    )
+      return;
+    const active = this.#active.get(job.threadId);
+    if (
+      active !== undefined &&
+      active.owner.root === authority.owner.root &&
+      active.owner.isCurrent()
+    ) {
+      active.repairAfterSettlement = true;
+      return;
+    }
+    this.#scheduleRepair(job.threadId);
+  }
+
+  #scheduleRepair(threadId: string): void {
+    const authority = this.#authority;
+    if (authority === undefined || !authority.owner.isCurrent()) return;
+    const queued = this.#queued.get(threadId);
+    if (
+      queued !== undefined &&
+      queued.owner.root === authority.owner.root &&
+      queued.owner.isCurrent()
+    )
+      return;
+    const existing = this.#repairs.get(threadId);
+    if (existing?.authority === authority) return;
+    if (existing !== undefined) this.#retireRepair(threadId, true);
+    const reservation = this.#reserve();
+    if (reservation === undefined) return;
+    const repair = new NativeMirrorRepair(threadId, authority, reservation);
+    repair.disposeRetirement = authority.owner.onRetire(() =>
+      this.#retireRepair(threadId, true, repair),
+    );
+    this.#repairs.set(threadId, repair);
+    const resolution = Promise.resolve().then(async () =>
+      authority.desiredTitle(threadId),
+    );
+    authority.owner.track(resolution);
+    void resolution.then(
+      (title) => this.#resolveRepair(repair, title),
+      (error: unknown) => {
+        if (this.#repairs.get(threadId) !== repair) return;
+        this.#retireRepair(threadId, true, repair);
+        if (authority.owner.isCurrent())
+          console.warn(
+            `Could not reconcile a late ZenX native title mirror: ${describeError(error)}`,
+          );
+      },
+    );
+  }
+
+  #resolveRepair(repair: NativeMirrorRepair, title: string | undefined): void {
+    if (this.#repairs.get(repair.threadId) !== repair) return;
+    this.#repairs.delete(repair.threadId);
+    repair.disposeRetirement?.();
+    repair.disposeRetirement = undefined;
+    if (
+      title === undefined ||
+      this.#authority !== repair.authority ||
+      !repair.authority.owner.isCurrent()
+    ) {
+      repair.reservation.release();
+      if (this.#authority !== repair.authority)
+        this.#scheduleRepair(repair.threadId);
+      return;
+    }
+    this.#queueReserved(
+      repair.threadId,
+      title,
+      repair.authority.owner,
+      repair.authority.setNativeName,
+      repair.reservation,
+    );
+  }
+
+  #retireRepair(
+    threadId: string,
+    diagnose: boolean,
+    expected?: NativeMirrorRepair,
+  ): void {
+    const repair = this.#repairs.get(threadId);
+    if (repair === undefined || (expected !== undefined && repair !== expected))
+      return;
+    this.#repairs.delete(threadId);
+    repair.disposeRetirement?.();
+    repair.disposeRetirement = undefined;
+    repair.reservation.release();
+    if (diagnose)
+      this.#appendDiagnostic({
+        threadId,
+        title: "<latest-authority-repair>",
+        ownerId: repair.authority.owner.id,
+      });
+  }
+
+  #appendDiagnostic(job: NativeMirrorJob | NativeMirrorDiagnostic): void {
     while (
       this.#reservations + this.#quarantined.length >=
       MAX_NATIVE_MIRROR_STATE
@@ -563,11 +735,15 @@ class NativeMirrorQueue {
       if (this.#quarantined.length === 0) return;
       this.#quarantined.shift();
     }
-    this.#quarantined.push({
-      threadId: job.threadId,
-      title: job.title,
-      ownerId: job.owner.id,
-    });
+    this.#quarantined.push(
+      "ownerId" in job
+        ? job
+        : {
+            threadId: job.threadId,
+            title: job.title,
+            ownerId: job.owner.id,
+          },
+    );
   }
 
   #makeRoomFromDiagnostics(): void {
@@ -586,6 +762,47 @@ class NativeMirrorQueue {
       `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_STATE)} live or queued native mirror operations already occupy the bounded transaction`,
     );
   }
+
+  #authorityFor(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): NativeMirrorAuthority | undefined {
+    const authority = this.#authority;
+    return authority !== undefined &&
+      authority.owner.root === owner.root &&
+      authority.owner.isCurrent() &&
+      owner.isCurrent()
+      ? authority
+      : undefined;
+  }
+
+  #reserve(): NativeMirrorReservation | undefined {
+    this.#makeRoomFromDiagnostics();
+    if (
+      this.#reservations + this.#quarantined.length >=
+      MAX_NATIVE_MIRROR_STATE
+    ) {
+      this.#warnCapacity();
+      return undefined;
+    }
+    this.#reservations += 1;
+    this.#capacityWarned = false;
+    return new NativeMirrorReservation(() => {
+      this.#reservations -= 1;
+      if (
+        this.#reservations + this.#quarantined.length <
+        MAX_NATIVE_MIRROR_STATE
+      )
+        this.#capacityWarned = false;
+    });
+  }
+}
+
+function nativeMirrorQueue(ownershipDomain: object): NativeMirrorQueue {
+  const existing = nativeMirrorQueues.get(ownershipDomain);
+  if (existing !== undefined) return existing;
+  const queue = new NativeMirrorQueue();
+  nativeMirrorQueues.set(ownershipDomain, queue);
+  return queue;
 }
 
 export function meaningfulTitleSource(input: string): string | null {

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -180,10 +180,9 @@ export class ZenXThreadTitleCoordinator {
     const normalized = normalizeManualTitle(title);
     // App Server exposes no dispatch correlation token. Title equality is not
     // provenance, so every notification is conservatively authoritative. A
-    // conflicting in-flight dispatch is followed by one queued repair; its
-    // same-title echo is still authoritative but cannot enqueue another repair.
-    const repairAfterConflictingDispatch =
-      this.#nativeMirrors.hasConflictingActive(threadId, normalized);
+    // successful authority commit cancels any older queued repair before the
+    // current active dispatch is reconciled. A same-title echo is still
+    // authoritative but cannot enqueue a recursive repair.
     const nativeAuthorityVersion = this.#nativeAuthorityVersion(threadId) + 1;
     this.#nativeAuthorityVersions.set(threadId, nativeAuthorityVersion);
     const projection = await this.#serial(owner, async () => {
@@ -199,8 +198,7 @@ export class ZenXThreadTitleCoordinator {
         throw new Error("Title ownership changed during native rename");
       return projection;
     });
-    if (repairAfterConflictingDispatch)
-      this.#nativeMirrors.enqueue(threadId, normalized, owner);
+    this.#nativeMirrors.reconcileAuthoritative(threadId, normalized, owner);
     return projection;
   }
 
@@ -453,9 +451,16 @@ class NativeMirrorQueue {
     this.#setNativeName = setNativeName;
   }
 
-  hasConflictingActive(threadId: string, title: string): boolean {
+  reconcileAuthoritative(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    const queued = this.#queued.get(threadId);
+    if (queued !== undefined) this.#retireJob(queued, true);
     const active = this.#active.get(threadId);
-    return active !== undefined && active.title !== title;
+    if (active !== undefined && active.title !== title)
+      this.enqueue(threadId, title, owner);
   }
 
   enqueue(

--- a/apps/zenx/src/main/thread-title-ownership-transaction.ts
+++ b/apps/zenx/src/main/thread-title-ownership-transaction.ts
@@ -1,0 +1,159 @@
+const DEFAULT_QUIESCENCE_DEADLINE_MS = 250;
+
+export interface ZenXThreadTitleOwnershipTransactionOptions {
+  deadlineMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => unknown;
+  cancelScheduled?: (handle: unknown) => void;
+}
+
+let nextTransactionId = 0;
+
+/**
+ * A transient title-work owner. Store commits, inference, and native mirrors all
+ * capture one instance so retirement is a synchronous authority fence even
+ * when the underlying asynchronous operation cannot be cancelled.
+ */
+export class ZenXThreadTitleOwnershipTransaction {
+  readonly id = `title-owner-${String(++nextTransactionId)}`;
+  readonly #abort = new AbortController();
+  readonly #deadlineMs: number;
+  readonly #schedule: (callback: () => void, delayMs: number) => unknown;
+  readonly #cancelScheduled: (handle: unknown) => void;
+  readonly #tracked = new Set<Promise<void>>();
+  readonly #retirementHooks = new Set<() => void>();
+  readonly #parent: ZenXThreadTitleOwnershipTransaction | undefined;
+  readonly #disposeParentRetirement: (() => void) | undefined;
+  #active = true;
+  #retirement: Promise<void> | undefined;
+
+  constructor(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+    parent?: ZenXThreadTitleOwnershipTransaction,
+  ) {
+    this.#deadlineMs = validDeadline(
+      options.deadlineMs ?? DEFAULT_QUIESCENCE_DEADLINE_MS,
+    );
+    this.#schedule = options.schedule ?? setTimeout;
+    this.#cancelScheduled =
+      options.cancelScheduled ??
+      ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+    this.#parent = parent;
+    this.#disposeParentRetirement = parent?.onRetire(() => {
+      void this.retire();
+    });
+  }
+
+  get signal(): AbortSignal {
+    return this.#abort.signal;
+  }
+
+  get root(): ZenXThreadTitleOwnershipTransaction {
+    return this.#parent?.root ?? this;
+  }
+
+  isCurrent(): boolean {
+    return (
+      this.#active &&
+      !this.#abort.signal.aborted &&
+      (this.#parent?.isCurrent() ?? true)
+    );
+  }
+
+  fork(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+  ): ZenXThreadTitleOwnershipTransaction {
+    return new ZenXThreadTitleOwnershipTransaction(options, this);
+  }
+
+  track<T>(operation: Promise<T>): Promise<T> {
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    if (this.#active) {
+      this.#tracked.add(settled);
+      void settled.finally(() => this.#tracked.delete(settled));
+    }
+    if (this.root !== this) this.root.track(operation);
+    return operation;
+  }
+
+  onRetire(callback: () => void): () => void {
+    if (!this.isCurrent()) {
+      callback();
+      return () => undefined;
+    }
+    this.#retirementHooks.add(callback);
+    return () => this.#retirementHooks.delete(callback);
+  }
+
+  retire(): Promise<void> {
+    if (this.#retirement !== undefined) return this.#retirement;
+    this.#active = false;
+    this.#disposeParentRetirement?.();
+    const errors: unknown[] = [];
+    try {
+      this.#abort.abort();
+    } catch (error) {
+      errors.push(error);
+    }
+    for (const hook of this.#retirementHooks) {
+      try {
+        hook();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.#retirementHooks.clear();
+    this.#retirement = this.#finishRetirement(errors);
+    return this.#retirement;
+  }
+
+  async #finishRetirement(errors: unknown[]): Promise<void> {
+    const work = Promise.all([...this.#tracked]).then(() => undefined);
+    let deadlineHandle: unknown;
+    let resolveDeadline!: () => void;
+    const deadline = new Promise<void>((resolve) => {
+      resolveDeadline = resolve;
+    });
+    try {
+      deadlineHandle = this.#schedule(resolveDeadline, this.#deadlineMs);
+    } catch (error) {
+      errors.push(error);
+      resolveDeadline();
+    }
+    const outcome = await Promise.race([
+      work.then(() => "settled" as const),
+      deadline.then(() => "deadline" as const),
+    ]);
+    if (outcome === "settled" && deadlineHandle !== undefined) {
+      try {
+        this.#cancelScheduled(deadlineHandle);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.#tracked.clear();
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        `Could not fully retire title ownership transaction: ${errors
+          .map(describeError)
+          .join("; ")}`,
+      );
+    }
+  }
+}
+
+function validDeadline(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(
+      "Title ownership quiescence deadline must be a finite non-negative number",
+    );
+  }
+  return value;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -1,28 +1,210 @@
-import { mkdir, open, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { ZenXThreadTitleOwnershipTransaction } from "./thread-title-ownership-transaction.js";
 import type {
   ThreadTitleProjection,
   ThreadTitleSnapshot,
 } from "./thread-title-types.js";
 
-export class ZenXThreadTitleStore {
-  readonly #filePath: string;
+export interface ZenXThreadTitleStoreFileSystem {
+  mkdir(
+    directory: string,
+    options: { recursive: true; mode: number },
+  ): Promise<unknown>;
+  readFile(file: string, encoding: "utf8"): Promise<string>;
+  writeFile(
+    file: string,
+    data: string,
+    options: { encoding: "utf8"; mode: number },
+  ): Promise<void>;
+  rename(source: string, destination: string): Promise<void>;
+  rm(file: string, options: { force: true }): Promise<void>;
+}
 
-  constructor(filePath: string) {
-    this.#filePath = path.resolve(filePath);
+/**
+ * Custom title stores must implement this ownership-aware contract. `claim`
+ * synchronously supersedes the prior root owner before its serialized read;
+ * every instance for the same durable projection shares that serialized
+ * ownership domain, and `commit` never publishes a non-current owner.
+ */
+export interface ZenXThreadTitleOwnershipStore {
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot>;
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean>;
+}
+
+const nodeFileSystem: ZenXThreadTitleStoreFileSystem = {
+  mkdir,
+  readFile,
+  writeFile,
+  rename,
+  rm,
+};
+
+const protocols = new Map<string, ZenXThreadTitleStoreProtocol>();
+
+export class ZenXThreadTitleStore implements ZenXThreadTitleOwnershipStore {
+  readonly #protocol: ZenXThreadTitleStoreProtocol;
+
+  constructor(
+    filePath: string,
+    options: { fileSystem?: ZenXThreadTitleStoreFileSystem } = {},
+  ) {
+    const resolved = path.resolve(filePath);
+    const existing = protocols.get(resolved);
+    if (existing !== undefined) {
+      this.#protocol = existing;
+      return;
+    }
+    this.#protocol = new ZenXThreadTitleStoreProtocol(
+      resolved,
+      options.fileSystem ?? nodeFileSystem,
+    );
+    protocols.set(resolved, this.#protocol);
   }
 
-  async read(): Promise<ThreadTitleSnapshot> {
-    let handle;
-    try {
-      handle = await open(this.#filePath, "r");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
-      throw error;
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot> {
+    return this.#protocol.claim(owner);
+  }
+
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    return this.#protocol.commit(snapshot, owner);
+  }
+}
+
+class ZenXThreadTitleStoreProtocol {
+  readonly #filePath: string;
+  readonly #fileSystem: ZenXThreadTitleStoreFileSystem;
+  #currentRoot: ZenXThreadTitleOwnershipTransaction | undefined;
+  #tail = Promise.resolve();
+  #failure: Error | undefined;
+  #temporarySequence = 0;
+
+  constructor(filePath: string, fileSystem: ZenXThreadTitleStoreFileSystem) {
+    this.#filePath = filePath;
+    this.#fileSystem = fileSystem;
+  }
+
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot> {
+    const root = owner.root;
+    if (this.#currentRoot !== root) {
+      const previous = this.#currentRoot;
+      this.#currentRoot = root;
+      if (previous !== undefined) void previous.retire();
     }
+    const operation = this.#serial(async () => {
+      this.#assertHealthy();
+      if (!this.#owns(owner))
+        throw new Error("Title ownership changed before the store read");
+      return await this.#readSnapshot();
+    });
+    return owner.track(operation);
+  }
+
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    const operation = this.#serial(async () => {
+      this.#assertHealthy();
+      if (!this.#owns(owner)) return false;
+      return await this.#commitSnapshot(snapshot, owner);
+    });
+    return owner.track(operation);
+  }
+
+  async #commitSnapshot(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    const directory = path.dirname(this.#filePath);
+    const temporary = this.#temporaryPath(owner, "stage");
+    let staged = false;
+    let primaryError: unknown;
     try {
-      const value: unknown = JSON.parse(await handle.readFile("utf8"));
+      await this.#fileSystem.mkdir(directory, { recursive: true, mode: 0o700 });
+      if (!this.#owns(owner)) return false;
+      const previous = await this.#readRaw();
+      if (!this.#owns(owner)) return false;
+      staged = true;
+      await this.#fileSystem.writeFile(
+        temporary,
+        `${JSON.stringify(snapshot, null, 2)}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+      if (!this.#owns(owner)) return false;
+      await this.#fileSystem.rename(temporary, this.#filePath);
+      staged = false;
+      if (this.#owns(owner)) return true;
+      try {
+        await this.#restore(previous, owner);
+      } catch (error) {
+        const failure = new Error(
+          `ZenX title-store ownership compensation failed: ${describeError(error)}`,
+          { cause: error },
+        );
+        this.#failure = failure;
+        throw failure;
+      }
+      return false;
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (staged) {
+        try {
+          await this.#fileSystem.rm(temporary, { force: true });
+        } catch (cleanupError) {
+          if (primaryError === undefined) throw cleanupError;
+          this.#failure = new AggregateError(
+            [primaryError, cleanupError],
+            "ZenX title-store write and staged-file cleanup failed",
+          );
+        }
+      }
+    }
+  }
+
+  async #restore(
+    previous: string | undefined,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    if (previous === undefined) {
+      await this.#fileSystem.rm(this.#filePath, { force: true });
+      return;
+    }
+    const temporary = this.#temporaryPath(owner, "compensate");
+    let staged = false;
+    try {
+      staged = true;
+      await this.#fileSystem.writeFile(temporary, previous, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await this.#fileSystem.rename(temporary, this.#filePath);
+      staged = false;
+    } finally {
+      if (staged) await this.#fileSystem.rm(temporary, { force: true });
+    }
+  }
+
+  async #readSnapshot(): Promise<ThreadTitleSnapshot> {
+    const raw = await this.#readRaw();
+    if (raw === undefined) return {};
+    try {
+      const value: unknown = JSON.parse(raw);
       if (!isRecord(value))
         throw new Error("ZenX thread title store is invalid");
       return Object.fromEntries(
@@ -35,20 +217,43 @@ export class ZenXThreadTitleStore {
       if (error instanceof SyntaxError)
         throw new Error("ZenX thread title store contains invalid JSON");
       throw error;
-    } finally {
-      await handle.close();
     }
   }
 
-  async write(snapshot: ThreadTitleSnapshot): Promise<void> {
-    const directory = path.dirname(this.#filePath);
-    await mkdir(directory, { recursive: true, mode: 0o700 });
-    const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    await rename(temporary, this.#filePath);
+  async #readRaw(): Promise<string | undefined> {
+    try {
+      return await this.#fileSystem.readFile(this.#filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  #owns(owner: ZenXThreadTitleOwnershipTransaction): boolean {
+    return this.#currentRoot === owner.root && owner.isCurrent();
+  }
+
+  #temporaryPath(
+    owner: ZenXThreadTitleOwnershipTransaction,
+    phase: string,
+  ): string {
+    this.#temporarySequence += 1;
+    return `${this.#filePath}.${process.pid}.${owner.id}.${String(
+      this.#temporarySequence,
+    )}.${phase}.tmp`;
+  }
+
+  #assertHealthy(): void {
+    if (this.#failure !== undefined) throw this.#failure;
+  }
+
+  #serial<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#tail.then(operation, operation);
+    this.#tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 }
 
@@ -77,4 +282,8 @@ function validateProjection(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -26,9 +26,12 @@ export interface ZenXThreadTitleStoreFileSystem {
  * Custom title stores must implement this ownership-aware contract. `claim`
  * synchronously supersedes the prior root owner before its serialized read;
  * every instance for the same durable projection shares that serialized
- * ownership domain, and `commit` never publishes a non-current owner.
+ * ownership domain and stable `ownershipDomain` identity, predecessor
+ * retirement rejection is observed before the read, and `commit` never
+ * publishes a non-current owner.
  */
 export interface ZenXThreadTitleOwnershipStore {
+  readonly ownershipDomain: object;
   claim(
     owner: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleSnapshot>;
@@ -50,6 +53,10 @@ const protocols = new Map<string, ZenXThreadTitleStoreProtocol>();
 
 export class ZenXThreadTitleStore implements ZenXThreadTitleOwnershipStore {
   readonly #protocol: ZenXThreadTitleStoreProtocol;
+
+  get ownershipDomain(): object {
+    return this.#protocol;
+  }
 
   constructor(
     filePath: string,
@@ -99,12 +106,24 @@ class ZenXThreadTitleStoreProtocol {
     owner: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleSnapshot> {
     const root = owner.root;
+    let retirement: Promise<RetirementOutcome> | undefined;
     if (this.#currentRoot !== root) {
       const previous = this.#currentRoot;
       this.#currentRoot = root;
-      if (previous !== undefined) void previous.retire();
+      if (previous !== undefined) retirement = observeRetirement(previous);
     }
     const operation = this.#serial(async () => {
+      if (retirement !== undefined) {
+        const outcome = await retirement;
+        if (!outcome.ok) {
+          const failure = new Error(
+            `ZenX title-store ownership retirement failed: ${describeError(outcome.error)}`,
+            { cause: outcome.error },
+          );
+          this.#failure = failure;
+          throw failure;
+        }
+      }
       this.#assertHealthy();
       if (!this.#owns(owner))
         throw new Error("Title ownership changed before the store read");
@@ -254,6 +273,22 @@ class ZenXThreadTitleStoreProtocol {
       () => undefined,
     );
     return result;
+  }
+}
+
+type RetirementOutcome =
+  { readonly ok: true } | { readonly ok: false; readonly error: unknown };
+
+function observeRetirement(
+  owner: ZenXThreadTitleOwnershipTransaction,
+): Promise<RetirementOutcome> {
+  try {
+    return owner.retire().then(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+  } catch (error) {
+    return Promise.resolve({ ok: false, error });
   }
 }
 

--- a/apps/zenx/test/thread-title-native-mirror.test.ts
+++ b/apps/zenx/test/thread-title-native-mirror.test.ts
@@ -121,6 +121,104 @@ test("retired same-title evidence cannot consume a successor mirror or native au
   });
 });
 
+for (const outcome of ["resolve", "reject"] as const) {
+  test(`late ${outcome} from a retired owner repairs the current successor title`, async () => {
+    await withDirectory(async (file) => {
+      const late = deferred<void>();
+      const calls: string[] = [];
+      let nativeName: string | undefined;
+      const first = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(`A:${title}`);
+          await late.promise;
+          nativeName = title;
+          if (outcome === "reject") throw new Error("late retired rejection");
+        },
+      );
+      await first.initialize();
+      await first.rename("thread-a", "A");
+      await until(() => calls.length === 1);
+
+      const successor = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(`B:${title}`);
+          nativeName = title;
+        },
+      );
+      await successor.initialize();
+      const renamed = await successor.rename("thread-a", "B");
+      await until(() => nativeName === "B");
+
+      late.resolve();
+      await until(() => calls.length === 3, 200);
+      assert.deepEqual(calls, ["A:A", "B:B", "B:B"]);
+      assert.equal(nativeName, "B");
+      assert.deepEqual(successor.snapshot()["thread-a"], renamed);
+
+      await first.close();
+      await successor.close();
+    });
+  });
+}
+
+test("more than 64 late retired completions stay bounded and preserve successor capacity", async () => {
+  await withDirectory(async (file) => {
+    const calls: string[] = [];
+    const coordinators: ZenXThreadTitleCoordinator[] = [];
+    const late: Array<ReturnType<typeof deferred<void>>> = [];
+    let nativeName: string | undefined;
+
+    for (let index = 0; index < 65; index += 1) {
+      const completion = deferred<void>();
+      late.push(completion);
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(title);
+          await completion.promise;
+          nativeName = title;
+        },
+        0,
+      );
+      coordinators.push(instance);
+      await instance.initialize();
+      await instance.rename("thread-a", `Retired ${String(index)}`);
+      await until(() => calls.length === index + 1);
+    }
+
+    const successor = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        calls.push(title);
+        nativeName = title;
+      },
+      0,
+    );
+    coordinators.push(successor);
+    await successor.initialize();
+    await successor.rename("thread-a", "Final successor");
+    await until(() => nativeName === "Final successor");
+    assert.equal(calls.length, 66);
+
+    for (let index = 0; index < late.length; index += 1) {
+      late[index]!.resolve();
+      await until(
+        () => calls.length === 67 + index && nativeName === "Final successor",
+      );
+    }
+    assert.equal(calls.length, 131);
+    assert.equal(nativeName, "Final successor");
+
+    for (const instance of coordinators) await instance.close();
+  });
+});
+
 test("retirement releases mirror reservations exactly once and restores capacity", async () => {
   await withDirectory(async (file) => {
     const calls: Array<ReturnType<typeof deferred<void>>> = [];
@@ -356,8 +454,11 @@ function capacityWarnings(warnings: string[]): number {
     .length;
 }
 
-async function until(predicate: () => boolean): Promise<void> {
-  const deadline = Date.now() + 5_000;
+async function until(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
   while (!predicate()) {
     if (Date.now() >= deadline)
       throw new Error("Timed out waiting for condition");

--- a/apps/zenx/test/thread-title-native-mirror.test.ts
+++ b/apps/zenx/test/thread-title-native-mirror.test.ts
@@ -30,6 +30,36 @@ test("same-title and distinct native notifications always advance authority", as
   });
 });
 
+test("newer same-title authority cancels an older queued conflict repair", async () => {
+  await withDirectory(async (file) => {
+    const active = deferred<void>();
+    const dispatches: string[] = [];
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        dispatches.push(title);
+        if (dispatches.length === 1) await active.promise;
+      },
+    );
+    await instance.initialize();
+    await instance.rename("thread-a", "A");
+    await until(() => dispatches.length === 1);
+
+    const conflict = await instance.synchronizeNativeName("thread-a", "C");
+    const newer = await instance.synchronizeNativeName("thread-a", "A");
+    assert.equal(conflict.version + 1, newer.version);
+    assert.equal(newer.title, "A");
+
+    active.resolve();
+    await tick();
+    await tick();
+    assert.deepEqual(dispatches, ["A"]);
+    assert.deepEqual(instance.snapshot()["thread-a"], newer);
+    await instance.close();
+  });
+});
+
 test("retired same-title evidence cannot consume a successor mirror or native authority", async () => {
   await withDirectory(async (file) => {
     const firstInference = new ControlledInference();

--- a/apps/zenx/test/thread-title-native-mirror.test.ts
+++ b/apps/zenx/test/thread-title-native-mirror.test.ts
@@ -1,0 +1,355 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleStore } from "../src/main/thread-title-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
+
+test("same-title and distinct native notifications always advance authority", async () => {
+  await withDirectory(async (file) => {
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async () => undefined,
+    );
+    await instance.initialize();
+    const renamed = await instance.rename("thread-a", "Same title");
+    const same = await instance.synchronizeNativeName("thread-a", "Same title");
+    assert.equal(same.status, "manual");
+    assert.equal(same.version, renamed.version + 1);
+    const distinct = await instance.synchronizeNativeName(
+      "thread-a",
+      "Distinct native title",
+    );
+    assert.equal(distinct.status, "manual");
+    assert.equal(distinct.version, same.version + 1);
+    await instance.close();
+  });
+});
+
+test("retired same-title evidence cannot consume a successor mirror or native authority", async () => {
+  await withDirectory(async (file) => {
+    const firstInference = new ControlledInference();
+    const firstMirror = deferred<void>();
+    const secondMirror = deferred<void>();
+    const mirrorCalls: string[] = [];
+    const first = coordinator(
+      file,
+      firstInference,
+      async (_threadId, title) => {
+        mirrorCalls.push(`A:${title}`);
+        await firstMirror.promise;
+      },
+    );
+    await first.initialize();
+    await first.observe("thread-a", "Same title");
+    firstInference.resolve("Same title");
+    await until(() => mirrorCalls.length === 1);
+
+    const observedBeforeRetire = await first.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(observedBeforeRetire.status, "manual");
+    await settlesWithin(first.stop(), 100);
+
+    const successor = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        mirrorCalls.push(`B:${title}`);
+        await secondMirror.promise;
+      },
+    );
+    await successor.initialize();
+    const successorRename = await successor.rename("thread-a", "Same title");
+    await until(() => mirrorCalls.length === 2);
+
+    const lateA = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(lateA.version, successorRename.version + 1);
+    const liveB = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(liveB.version, lateA.version + 1);
+
+    firstMirror.resolve();
+    await tick();
+    const laterA = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(laterA.version, liveB.version + 1);
+    secondMirror.resolve();
+    await successor.close();
+  });
+});
+
+test("retirement releases mirror reservations exactly once and restores capacity", async () => {
+  await withDirectory(async (file) => {
+    const calls: Array<ReturnType<typeof deferred<void>>> = [];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...arguments_: unknown[]) => {
+      warnings.push(arguments_.map(String).join(" "));
+    };
+    try {
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        async () => {
+          const call = deferred<void>();
+          calls.push(call);
+          await call.promise;
+        },
+      );
+      await instance.initialize();
+      const owners = Array.from({ length: 70 }, () =>
+        instance.createOwnershipTransaction({ deadlineMs: 0 }),
+      );
+      for (let index = 0; index < 64; index += 1) {
+        await instance.rename(
+          `thread-${String(index)}`,
+          `Title ${String(index)}`,
+          owners[index],
+        );
+      }
+      await until(() => calls.length === 64);
+
+      for (let index = 64; index < 67; index += 1) {
+        await instance.rename(
+          `overflow-${String(index)}`,
+          `Overflow ${String(index)}`,
+          owners[index],
+        );
+      }
+      await tick();
+      assert.equal(calls.length, 64);
+      assert.equal(capacityWarnings(warnings), 1);
+
+      await owners[0]!.retire();
+      await instance.rename("successor-a", "Successor A", owners[67]);
+      await until(() => calls.length === 65);
+
+      calls[0]!.resolve();
+      await tick();
+      await instance.rename("still-full", "Still full", owners[68]);
+      await tick();
+      assert.equal(calls.length, 65);
+
+      await owners[1]!.retire();
+      await instance.rename("successor-b", "Successor B", owners[69]);
+      await until(() => calls.length === 66);
+      assert.equal(capacityWarnings(warnings), 2);
+
+      for (const call of calls) call.resolve();
+      await instance.close();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+test("retired queued work detaches from a never-settling predecessor for its successor", async () => {
+  await withDirectory(async (file) => {
+    const calls: Array<{
+      title: string;
+      completion: ReturnType<typeof deferred<void>>;
+    }> = [];
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        const completion = deferred<void>();
+        calls.push({ title, completion });
+        await completion.promise;
+      },
+    );
+    await instance.initialize();
+    const predecessor = instance.createOwnershipTransaction({ deadlineMs: 0 });
+    const staleQueued = instance.createOwnershipTransaction({ deadlineMs: 0 });
+    const successor = instance.createOwnershipTransaction({ deadlineMs: 0 });
+
+    await instance.rename("thread-a", "Never settles", predecessor);
+    await until(() => calls.length === 1);
+    await instance.rename("thread-a", "Retired while queued", staleQueued);
+    await staleQueued.retire();
+    await instance.rename("thread-a", "Successor dispatch", successor);
+    await predecessor.retire();
+
+    await until(() => calls.length === 2);
+    assert.deepEqual(
+      calls.map((call) => call.title),
+      ["Never settles", "Successor dispatch"],
+    );
+    calls[0]!.completion.resolve();
+    calls[1]!.completion.resolve();
+    await instance.close();
+  });
+});
+
+test("throwing and rejected mirrors release their reservations", async () => {
+  await withDirectory(async (file) => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...arguments_: unknown[]) => {
+      warnings.push(arguments_.map(String).join(" "));
+    };
+    try {
+      let calls = 0;
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        (_threadId, _title) => {
+          calls += 1;
+          if (calls === 1) throw new Error("synchronous mirror throw");
+          return Promise.reject(new Error("asynchronous mirror rejection"));
+        },
+      );
+      await instance.initialize();
+      await instance.rename("thread-a", "Throwing mirror");
+      await until(() => calls === 1);
+      await instance.rename("thread-b", "Rejected mirror");
+      await until(() => calls === 2);
+      await until(
+        () =>
+          warnings.filter((warning) => warning.includes("mirror")).length === 2,
+      );
+      assert.equal(
+        warnings.filter((warning) => warning.includes("mirror")).length,
+        2,
+      );
+      await instance.close();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+test("stop, restart, and close detach never-settling title work within the deadline", async () => {
+  await withDirectory(async (file) => {
+    const inference = new ControlledInference();
+    const mirrors: Array<ReturnType<typeof deferred<void>>> = [];
+    const instance = coordinator(
+      file,
+      inference,
+      async () => {
+        const mirror = deferred<void>();
+        mirrors.push(mirror);
+        await mirror.promise;
+      },
+      10,
+    );
+    await instance.initialize();
+    await instance.observe("thread-generation", "Never settling generation");
+    await instance.rename("thread-mirror", "Never settling mirror");
+    await until(() => mirrors.length === 1);
+
+    await settlesWithin(instance.stop(), 100);
+    inference.resolve("Late generated title");
+    mirrors[0]!.resolve();
+    await tick();
+    assert.equal(
+      instance.snapshot()["thread-generation"]?.status,
+      "generating",
+    );
+
+    await settlesWithin(instance.restart(), 100);
+    assert.equal(instance.snapshot()["thread-generation"]?.status, "failed");
+    await instance.rename("thread-successor", "Successor mirror");
+    await until(() => mirrors.length === 2);
+    await settlesWithin(instance.close(), 100);
+    mirrors[1]!.resolve();
+  });
+});
+
+function coordinator(
+  file: string,
+  inference: ThreadTitleInference,
+  setNativeName: (threadId: string, title: string) => Promise<void>,
+  deadlineMs = 10,
+): ZenXThreadTitleCoordinator {
+  return new ZenXThreadTitleCoordinator({
+    store: new ZenXThreadTitleStore(file),
+    inference,
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName,
+    ownership: { deadlineMs },
+  });
+}
+
+class ControlledInference implements ThreadTitleInference {
+  readonly #pending: Array<ReturnType<typeof deferred<string>>> = [];
+
+  async generate(): Promise<string> {
+    const pending = deferred<string>();
+    this.#pending.push(pending);
+    return await pending.promise;
+  }
+
+  resolve(title: string): void {
+    this.#pending.shift()?.resolve(title);
+  }
+}
+
+async function withDirectory(
+  run: (file: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-native-mirror-"),
+  );
+  try {
+    await run(path.join(directory, "titles.json"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function capacityWarnings(warnings: string[]): number {
+  return warnings.filter((warning) => warning.includes("bounded transaction"))
+    .length;
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await tick();
+  }
+}
+
+async function settlesWithin<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return await Promise.race([
+    operation,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`Operation exceeded ${String(timeoutMs)}ms`)),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -85,7 +85,7 @@ test("an App Server rename between generated commit and mirror restores native a
   await assertRenameWinsGenerationRace("after-generated-commit");
 });
 
-test("an App Server rename while generated mirror is in flight restores native authority", async () => {
+test("a later dispatch notification supersedes authority observed while that dispatch was in flight", async () => {
   await assertRenameWinsGenerationRace("during-generated-mirror");
 });
 
@@ -178,12 +178,15 @@ async function assertRenameWinsGenerationRace(
             "Agent authority",
           );
           synchronizations.push(synchronization);
-          await tick();
+          await synchronization;
         }
         nativeName = title;
-        synchronizations.push(
-          titles.synchronizeNativeName("thread-race", title),
+        const mirrorNotification = titles.synchronizeNativeName(
+          "thread-race",
+          title,
         );
+        synchronizations.push(mirrorNotification);
+        await mirrorNotification;
       },
     });
     if (phase === "after-generated-commit") {
@@ -210,16 +213,26 @@ async function assertRenameWinsGenerationRace(
     }
     assert.notEqual(synchronization, undefined);
     await synchronization;
-    assert.deepEqual(titles.snapshot()["thread-race"], {
-      threadId: "thread-race",
-      title: "Agent authority",
-      status: "manual",
-      version: 4,
-      source: "Original title source",
-    });
-    assert.equal(nativeName, "Agent authority");
+    if (phase === "during-generated-mirror")
+      await until(() => synchronizations.length === 2);
     for (let index = 0; index < synchronizations.length; index += 1)
       await synchronizations[index];
+    assert.deepEqual(titles.snapshot()["thread-race"], {
+      threadId: "thread-race",
+      title:
+        phase === "during-generated-mirror"
+          ? "Late generated"
+          : "Agent authority",
+      status: "manual",
+      version: phase === "during-generated-mirror" ? 5 : 4,
+      source: "Original title source",
+    });
+    assert.equal(
+      nativeName,
+      phase === "during-generated-mirror"
+        ? "Late generated"
+        : "Agent authority",
+    );
     await titles.stop();
   } finally {
     await rm(directory, { recursive: true, force: true });
@@ -253,6 +266,14 @@ async function waitForStatus(
     await tick();
   }
   assert.fail(`Timed out waiting for title status ${status}`);
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 5_000; attempt += 1) {
+    if (predicate()) return;
+    await tick();
+  }
+  assert.fail("Timed out waiting for condition");
 }
 
 async function tick(): Promise<void> {

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -158,6 +158,7 @@ async function assertRenameWinsGenerationRace(
     const inference = new ControlledInference();
     let nativeName = "";
     let synchronization: Promise<unknown> | undefined;
+    const synchronizations: Promise<unknown>[] = [];
     let injected = false;
     let titles!: ZenXThreadTitleCoordinator;
     titles = new ZenXThreadTitleCoordinator({
@@ -176,10 +177,13 @@ async function assertRenameWinsGenerationRace(
             "thread-race",
             "Agent authority",
           );
+          synchronizations.push(synchronization);
           await tick();
         }
         nativeName = title;
-        void titles.synchronizeNativeName("thread-race", title);
+        synchronizations.push(
+          titles.synchronizeNativeName("thread-race", title),
+        );
       },
     });
     if (phase === "after-generated-commit") {
@@ -191,6 +195,7 @@ async function assertRenameWinsGenerationRace(
           "thread-race",
           "Agent authority",
         );
+        synchronizations.push(synchronization);
       });
     }
     await titles.initialize();
@@ -213,6 +218,9 @@ async function assertRenameWinsGenerationRace(
       source: "Original title source",
     });
     assert.equal(nativeName, "Agent authority");
+    for (let index = 0; index < synchronizations.length; index += 1)
+      await synchronizations[index];
+    await titles.stop();
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/thread-title-ownership-transaction.test.ts
+++ b/apps/zenx/test/thread-title-ownership-transaction.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import test from "node:test";
 
 import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleOwnershipTransaction } from "../src/main/thread-title-ownership-transaction.js";
 import {
   ZenXThreadTitleStore,
   type ZenXThreadTitleStoreFileSystem,
@@ -94,6 +95,46 @@ test("compensation failure poisons serialized reads instead of exposing stale da
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+for (const failure of ["scheduler", "retirement hook"] as const) {
+  test(`successor claim handles and propagates ${failure} rejection`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "zenx-title-retirement-failure-"),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const store = new ZenXThreadTitleStore(file);
+      const predecessor = new ZenXThreadTitleOwnershipTransaction(
+        failure === "scheduler"
+          ? {
+              deadlineMs: 10,
+              schedule: () => {
+                throw new Error("scheduler failed");
+              },
+            }
+          : { deadlineMs: 10 },
+      );
+      if (failure === "retirement hook")
+        predecessor.onRetire(() => {
+          throw new Error("retirement hook failed");
+        });
+      await store.claim(predecessor);
+
+      const successor = new ZenXThreadTitleOwnershipTransaction({
+        deadlineMs: 10,
+      });
+      await assert.rejects(store.claim(successor), new RegExp(failure, "u"));
+      await tick();
+
+      const fresh = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 10 });
+      await assert.rejects(store.claim(fresh), /retirement failed/u);
+      await successor.retire();
+      await fresh.retire();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
 
 for (const failure of ["write", "rename"] as const) {
   test(`${failure} failure removes every staged title file`, async () => {

--- a/apps/zenx/test/thread-title-ownership-transaction.test.ts
+++ b/apps/zenx/test/thread-title-ownership-transaction.test.ts
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import {
+  ZenXThreadTitleStore,
+  type ZenXThreadTitleStoreFileSystem,
+} from "../src/main/thread-title-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
+
+for (const phase of [
+  "mkdir",
+  "staged-write",
+  "commit-before-replace",
+  "atomic-replace",
+] as const) {
+  test(`successor claim hides a retired owner during ${phase}`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), `zenx-title-${phase}-`),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const controlled = new ControlledTitleFileSystem();
+      const first = coordinator(
+        new ZenXThreadTitleStore(file, { fileSystem: controlled }),
+      );
+      await first.initialize();
+      controlled.block(phase);
+      const stale = first.observe("thread-a", "Retired owner title");
+      await controlled.entered;
+
+      const successor = coordinator(new ZenXThreadTitleStore(file));
+      let initialized = false;
+      const initialization = successor.initialize().then(() => {
+        initialized = true;
+      });
+      await tick();
+      assert.equal(initialized, false);
+      assert.throws(() => successor.snapshot(), /not initialized/u);
+
+      controlled.release();
+      assert.equal(await stale, undefined);
+      await initialization;
+      assert.deepEqual(successor.snapshot(), {});
+      assert.deepEqual(await readJsonOrEmpty(file), {});
+      assert.deepEqual(await stagedFiles(directory), []);
+      await successor.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test("compensation failure poisons serialized reads instead of exposing stale data", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-compensation-"),
+  );
+  const file = path.join(directory, "titles.json");
+  try {
+    await writeFile(file, "{}\n", "utf8");
+    const controlled = new ControlledTitleFileSystem();
+    controlled.failCompensation = true;
+    const first = coordinator(
+      new ZenXThreadTitleStore(file, { fileSystem: controlled }),
+    );
+    await first.initialize();
+    controlled.block("atomic-replace");
+    const stale = first.observe("thread-a", "Never authoritative");
+    await controlled.entered;
+
+    const successor = coordinator(new ZenXThreadTitleStore(file));
+    const initialization = successor.initialize();
+    controlled.release();
+    await assert.rejects(stale, /compensation failed/u);
+    await initialization;
+    assert.throws(() => successor.snapshot(), /compensation failed/u);
+
+    const fresh = coordinator(new ZenXThreadTitleStore(file));
+    await fresh.initialize();
+    assert.throws(() => fresh.snapshot(), /compensation failed/u);
+    assert.deepEqual(await stagedFiles(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+for (const failure of ["write", "rename"] as const) {
+  test(`${failure} failure removes every staged title file`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), `zenx-title-${failure}-failure-`),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const controlled = new ControlledTitleFileSystem();
+      controlled.failure = failure;
+      const instance = coordinator(
+        new ZenXThreadTitleStore(file, { fileSystem: controlled }),
+      );
+      await instance.initialize();
+      await assert.rejects(
+        instance.observe("thread-a", "Failed staged title"),
+        new RegExp(`${failure} failed`, "u"),
+      );
+      assert.deepEqual(instance.snapshot(), {});
+      assert.deepEqual(await stagedFiles(directory), []);
+      await instance.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+type BlockPhase =
+  "mkdir" | "staged-write" | "commit-before-replace" | "atomic-replace";
+
+class ControlledTitleFileSystem implements ZenXThreadTitleStoreFileSystem {
+  failure: "write" | "rename" | undefined;
+  failCompensation = false;
+  #phase: BlockPhase | undefined;
+  #entered = deferred<void>();
+  #release = deferred<void>();
+
+  get entered(): Promise<void> {
+    return this.#entered.promise;
+  }
+
+  block(phase: BlockPhase): void {
+    this.#phase = phase;
+    this.#entered = deferred<void>();
+    this.#release = deferred<void>();
+  }
+
+  release(): void {
+    this.#release.resolve();
+  }
+
+  async mkdir(
+    directory: string,
+    options: { recursive: true; mode: number },
+  ): Promise<unknown> {
+    if (this.#phase === "mkdir") await this.#hold();
+    return await mkdir(directory, options);
+  }
+
+  async readFile(file: string, encoding: "utf8"): Promise<string> {
+    return await readFile(file, encoding);
+  }
+
+  async writeFile(
+    file: string,
+    data: string,
+    options: { encoding: "utf8"; mode: number },
+  ): Promise<void> {
+    await writeFile(file, data, options);
+    if (this.failure === "write") {
+      this.failure = undefined;
+      throw new Error("write failed");
+    }
+    if (this.#phase === "staged-write") await this.#hold();
+  }
+
+  async rename(source: string, destination: string): Promise<void> {
+    if (this.failCompensation && source.includes(".compensate.tmp"))
+      throw new Error("compensation rename failed");
+    if (this.failure === "rename") {
+      this.failure = undefined;
+      throw new Error("rename failed");
+    }
+    if (this.#phase === "commit-before-replace") await this.#hold();
+    await rename(source, destination);
+    if (this.#phase === "atomic-replace") await this.#hold();
+  }
+
+  async rm(file: string, options: { force: true }): Promise<void> {
+    await rm(file, options);
+  }
+
+  async #hold(): Promise<void> {
+    const entered = this.#entered;
+    const release = this.#release;
+    this.#phase = undefined;
+    entered.resolve();
+    await release.promise;
+  }
+}
+
+function coordinator(store: ZenXThreadTitleStore): ZenXThreadTitleCoordinator {
+  return new ZenXThreadTitleCoordinator({
+    store,
+    inference: new NeverInference(),
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName: async () => undefined,
+    ownership: { deadlineMs: 10 },
+  });
+}
+
+class NeverInference implements ThreadTitleInference {
+  async generate(): Promise<string> {
+    return await new Promise<string>(() => undefined);
+  }
+}
+
+async function readJsonOrEmpty(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function stagedFiles(directory: string): Promise<string[]> {
+  return (await readdir(directory)).filter((file) => file.endsWith(".tmp"));
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
## Motivation

Issue #68 requires one transient ownership boundary across durable title publication, native-name provenance, retirement, and bounded mirror work. The prior title-only suppression and check-before-replace flow could expose retired-owner state or starve successors.

## What changed

- Add the documented `ZenXThreadTitleOwnershipTransaction` with synchronous retirement fencing, abort propagation, tracked work, and a 250 ms bounded quiescence deadline.
- Replace the title store API with the explicit ownership-aware `claim/commit` contract. Same-path stores share one serialized ownership domain; successor claim retires the prior owner before reading.
- Stage unique files, atomically replace, compensate a replace that completed after retirement, poison subsequent reads if compensation fails, and clean staged files after write/rename failures.
- Treat every App Server name notification as authoritative because the wire protocol has no correlation token. Title equality never authorizes suppression; provisional titles remain ZenX-local until generated/manual.
- Replace Promise-tail admission with owner-scoped cancellable/coalesced jobs and exactly-once reservations. Active/queued/quarantined state is hard-bounded to 64, stale predecessors detach, and saturation warnings are bounded per episode.
- Retire title ownership before App Server restart/quit and restart with a fresh owner.

## Deterministic TDD

- Retirement during mkdir, staged write, pre-replace commit, and post-replace completion.
- Fresh coordinator read blocking and compensation-failure fail-closed behavior.
- Staged-file cleanup after write and rename errors.
- Same-title retired evidence versus successor mirrors, plus same-title/distinct native authority version fences.
- 64-slot saturation, active/queued retirement, successor capacity recovery, throw/rejection release, and late-completion no-double-release.
- Never-settling inference/mirror stop, restart, and close bounded by the injected quiescence deadline.
- Focused title suite: 27/27, plus 15 repeated deterministic race runs.

## Validation

Passed locally on Windows:

- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- root `npm run typecheck`
- root `npm run build`
- root `npm run lint`
- changed-file Prettier checks and `git diff --check`

Known current Windows/platform baselines, unrelated to this change:

- ZenX full test: 139/144; five existing POSIX path/shell/executable assumptions fail.
- Root Node: 86/93; six existing Windows permission/POSIX-shell failures and one platform skip.
- IMZen: 37/38; one chmod-semantics test fails on Windows.
- Repository-wide `npm run check` stops at the existing 136-file Prettier baseline; every changed file passes Prettier.

GitHub Linux CI on the exact pushed head is the authoritative full-platform gate.

Closes #68