### PR TITLE
ZenX title ownership root retirement and canonical projection identity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -97,8 +97,13 @@
 - **ZenXThreadTitleOwnershipRoot** — 每个标题 ownership domain 的瞬时 root closure 在任何 nested
   transaction 可能拒绝前同步登记其 retirement outcome，并按 transaction/发生顺序有界聚合 abort、hook、
   scheduler 与 cleanup 失败；`stop`、successor claim 与 fresh read 都对 predecessor 的任一 nested retirement
-  failure fail closed，且 poison 只留在该 domain。退休的 quiescence deadline 为 250ms，timeout 只终止等待而
-  所有迟到 promise 仍已注册 rejection observer；它不引入 durable retry、scheduler 或 queue。
+  failure fail closed，且 poison 只留在该 domain。为同时容纳 64 个 mirror reservation 与有界 overflow/
+  successor probe，root 最多登记 128 个 descendant transaction、129 个含 root 的
+  retirement outcome 与 64 条 failure evidence；超限只保留一个确定性的 saturation failure 并拒绝继续登记，
+  hook/failure-listener 各自硬限 64、tracked-work 硬限 128。parent retirement 已结束后才出现的合法 child 仍立即登记到
+  同一 root failure closure；store 从第一次 claim 起订阅该 closure，cached retire 曾成功也必须重新检查 late
+  poison。退休的 quiescence deadline 为 250ms，timeout 只终止等待而所有迟到 promise 仍已注册 rejection
+  observer；它不引入 durable retry、scheduler 或 queue。
 - **ZenXThreadTitleProjectionIdentity** — 默认文件 backend 以“最近存在祖先的 native realpath + 尚不存在的规范化
   suffix”形成 process-local projection key，Windows 上再按不区分大小写的 pathname 语义折叠，因此 relative、
   absolute、symlink/canonical 与文件尚不存在时的 case aliases 共享 identity；不同 key 不共享。注入 backend

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,8 +102,12 @@
   retirement outcome 与 64 条 failure evidence；超限只保留一个确定性的 saturation failure 并拒绝继续登记，
   hook/failure-listener 各自硬限 64、tracked-work 硬限 128。parent retirement 已结束后才出现的合法 child 仍立即登记到
   同一 root failure closure；store 从第一次 claim 起订阅该 closure，cached retire 曾成功也必须重新检查 late
-  poison。退休的 quiescence deadline 为 250ms，timeout 只终止等待而所有迟到 promise 仍已注册 rejection
-  observer；它不引入 durable retry、scheduler 或 queue。
+  poison；store domain 再以最多 128 个 transient listener（容纳同一 accepted coordinator handoff 上限）将 poison
+  同步投给当前 successor，使其 root、snapshot、
+  transaction 创建与 native mirror authority 一并 fenced。每条 failure 在进入 closure 时即复制为无 cause/对象图、
+  message 最多 160 字符的确定性 Error，`AggregateError.errors` 不保留原始 throw value。退休的 quiescence deadline
+  为 250ms，timeout 只终止等待而所有迟到 promise 仍已注册 rejection observer；它不引入 durable retry、scheduler
+  或 queue。
 - **ZenXThreadTitleProjectionIdentity** — 默认文件 backend 以“最近存在祖先的 native realpath + 尚不存在的规范化
   suffix”形成 process-local projection key，Windows 上再按不区分大小写的 pathname 语义折叠，因此 relative、
   absolute、symlink/canonical 与文件尚不存在时的 case aliases 共享 identity；不同 key 不共享。注入 backend

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,7 +91,26 @@
 - **ZenXTitleInference** — ZenX 主进程使用独立配置的标题模型执行一次不写 journal、
   不创建 Turn 的辅助推理；credential 仍只在主进程内存中按当前 Provider 解析。
 - **ZenXThreadTitleCoordinator** — ZenX 主进程从首条有意义的来源标注输入立即建立
-  provisional 投影，并异步协调生成、显式重试与 authoritative manual rename。
+  provisional 投影，并异步协调生成、显式重试与 authoritative manual rename；同一 durable
+  projection 在一个进程内只能有一个 root ownership domain，coordinator、store 与 native mirror
+  queue 都复用该 domain，不创建第二套 runtime 或 coordinator。
+- **ZenXThreadTitleOwnershipRoot** — 每个标题 ownership domain 的瞬时 root closure 在任何 nested
+  transaction 可能拒绝前同步登记其 retirement outcome，并按 transaction/发生顺序有界聚合 abort、hook、
+  scheduler 与 cleanup 失败；`stop`、successor claim 与 fresh read 都对 predecessor 的任一 nested retirement
+  failure fail closed，且 poison 只留在该 domain。退休的 quiescence deadline 为 250ms，timeout 只终止等待而
+  所有迟到 promise 仍已注册 rejection observer；它不引入 durable retry、scheduler 或 queue。
+- **ZenXThreadTitleProjectionIdentity** — 默认文件 backend 以“最近存在祖先的 native realpath + 尚不存在的规范化
+  suffix”形成 process-local projection key，Windows 上再按不区分大小写的 pathname 语义折叠，因此 relative、
+  absolute、symlink/canonical 与文件尚不存在时的 case aliases 共享 identity；不同 key 不共享。注入 backend
+  必须提供显式稳定的 backend identity，domain key 是 backend identity 与 projection key 的二元组，pathname
+  文本绝不跨 backend 合并。每个 backend 的 process-local registry 只持有最多 64 个 stable domain entry，
+  容量用尽时明确失败；backend registry 本身以 identity 为弱键，不持久化、也不成为第二个协调层。
+- **ZenXThreadTitleOwnershipStore** — ownership-aware store 在共享 domain 内同步 claim owner、串行 read/stage/
+  atomic replace/compensation/cleanup，并禁止 retired owner 发布；任何无法确认或补偿的结果 poison 该 domain，
+  successor 不得通过别名重新取得一份健康状态。custom store 必须显式提供同等稳定的 `ownershipDomain`。
+- **ZenXThreadTitleNativeMirrorQueue** — generated/manual 标题才进入与 ownership domain 完全同 identity 的瞬时镜像
+  queue；每个 native notification 都是 authoritative，迟到 retired resolve/reject 只合并修复当前 successor，
+  active/queued/quarantined/reservation/diagnostic 状态合计硬限 64 且 exactly-once release。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,32 +94,39 @@
   provisional 投影，并异步协调生成、显式重试与 authoritative manual rename；同一 durable
   projection 在一个进程内只能有一个 root ownership domain，coordinator、store 与 native mirror
   queue 都复用该 domain，不创建第二套 runtime 或 coordinator。
+- **ZenXThreadTitleFailureClosure** — 标题 ownership 模块用一个 total、不会抛出的有界 normalizer
+  在任意 retirement、abort、hook、scheduler、observation、tracked-work、store stage/write/rename/replace、
+  cleanup 或 compensation 失败被丢弃前复制其证据，并同步 poison 精确 ownership domain；复制后的
+  `Error` message 最多 160 字符且不保留 cause、proxy、getter 或对象图，按 transaction/occurrence 稳定排序，
+  64 条后以一条确定性 saturation evidence 收口，normalization 自身失败也只生成同样有界的 fallback evidence。
 - **ZenXThreadTitleOwnershipRoot** — 每个标题 ownership domain 的瞬时 root closure 在任何 nested
-  transaction 可能拒绝前同步登记其 retirement outcome，并按 transaction/发生顺序有界聚合 abort、hook、
-  scheduler 与 cleanup 失败；`stop`、successor claim 与 fresh read 都对 predecessor 的任一 nested retirement
-  failure fail closed，且 poison 只留在该 domain。为同时容纳 64 个 mirror reservation 与有界 overflow/
-  successor probe，root 最多登记 128 个 descendant transaction、129 个含 root 的
-  retirement outcome 与 64 条 failure evidence；超限只保留一个确定性的 saturation failure 并拒绝继续登记，
-  hook/failure-listener 各自硬限 64、tracked-work 硬限 128。parent retirement 已结束后才出现的合法 child 仍立即登记到
-  同一 root failure closure；store 从第一次 claim 起订阅该 closure，cached retire 曾成功也必须重新检查 late
-  poison；store domain 再以最多 128 个 transient listener（容纳同一 accepted coordinator handoff 上限）将 poison
-  同步投给当前 successor，使其 root、snapshot、
-  transaction 创建与 native mirror authority 一并 fenced。每条 failure 在进入 closure 时即复制为无 cause/对象图、
-  message 最多 160 字符的确定性 Error，`AggregateError.errors` 不保留原始 throw value。退休的 quiescence deadline
-  为 250ms，timeout 只终止等待而所有迟到 promise 仍已注册 rejection observer；它不引入 durable retry、scheduler
-  或 queue。
+  transaction 可能拒绝前同步登记其 retirement outcome，并通过模块自有、逐 listener 捕获异常的 safe abort
+  notification boundary 通知，而不依赖原生 `AbortSignal` 对 throwing listener 的 process-level 行为；hook、
+  scheduler、abort、child、cleanup、observation、normalization 与 listener fault 都 fence 该 root，`stop`、
+  successor claim 与 fresh read fail closed，且 poison 只留在该 domain。root 最多登记 128 个 descendant、
+  129 个含 root 的 outcome、64 条 evidence、64 个 hook、64 个 failure listener、64 个 safe abort listener 与
+  128 个 tracked operation；store domain 最多持有 128 个 transient failure listener，coordinator 最多持有 64 个
+  transient change listener，超限或 listener fault 都有界且 fail closed。parent retirement 已结束后出现的合法 child
+  仍加入同一 closure，250ms deadline 只结束等待，所有迟到 promise 仍保留 rejection observer，不引入 durable
+  retry、scheduler 或 queue。
 - **ZenXThreadTitleProjectionIdentity** — 默认文件 backend 以“最近存在祖先的 native realpath + 尚不存在的规范化
-  suffix”形成 process-local projection key，Windows 上再按不区分大小写的 pathname 语义折叠，因此 relative、
-  absolute、symlink/canonical 与文件尚不存在时的 case aliases 共享 identity；不同 key 不共享。注入 backend
-  必须提供显式稳定的 backend identity，domain key 是 backend identity 与 projection key 的二元组，pathname
-  文本绝不跨 backend 合并。每个 backend 的 process-local registry 只持有最多 64 个 stable domain entry，
-  容量用尽时明确失败；backend registry 本身以 identity 为弱键，不持久化、也不成为第二个协调层。
+  suffix”形成 process-local projection key，Windows 上按不区分大小写的 pathname 语义折叠，因此 relative、
+  absolute、symlink/canonical 与尚不存在文件的 case aliases 共享 identity；注入 backend 必须提供显式稳定
+  identity，domain key 是 backend identity 与 projection key 的二元组。每个 backend registry 最多 64 个
+  stable domain entry，容量用尽时明确失败；registry 以 identity 为弱键、不会持久化或成为第二个协调层。
 - **ZenXThreadTitleOwnershipStore** — ownership-aware store 在共享 domain 内同步 claim owner、串行 read/stage/
-  atomic replace/compensation/cleanup，并禁止 retired owner 发布；任何无法确认或补偿的结果 poison 该 domain，
-  successor 不得通过别名重新取得一份健康状态。custom store 必须显式提供同等稳定的 `ownershipDomain`。
+  atomic replace/compensation/cleanup，并在任何 store boundary failure 上先以同一 failure closure 规范化、再同步
+  poison domain 与当前 initialized coordinator/root 及 canonical aliases；future/in-flight claim/read/commit、
+  snapshot、transaction 创建、native authority、stop/restart/fresh coordinator 都 fail closed，post-replace
+  compensation failure 也不能把旧 durable projection 暴露给 successor，custom store 必须显式提供稳定
+  `ownershipDomain`。
 - **ZenXThreadTitleNativeMirrorQueue** — generated/manual 标题才进入与 ownership domain 完全同 identity 的瞬时镜像
   queue；每个 native notification 都是 authoritative，迟到 retired resolve/reject 只合并修复当前 successor，
-  active/queued/quarantined/reservation/diagnostic 状态合计硬限 64 且 exactly-once release。
+  active/queued/quarantined/reservation/diagnostic 状态合计硬限 64 且 exactly-once release，domain poison 后不再取得
+  authority 或派发额外 mirror。
+- **ZenXThreadTitleLifecycle** — `stop`、`close`、`restart` 与 quit 在 250ms owner retirement 边界内尝试全部 cleanup，
+  但任一 poison 都必须被报告；`restart` 只有在新 owner 完成 claim、恢复写入、native authority 激活并再次确认
+  domain/root 健康后才可成功，不能返回一个其 `snapshot` 已不可用的 coordinator。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
 

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -23,6 +23,7 @@ import { zenXProviderTransport } from "./system-proxy.js";
 import { ZenXTriggerService } from "./trigger-service.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
 import { ZenXThreadTitleCoordinator } from "./thread-title-coordinator.js";
+import { normalizeTitleOwnershipFailure } from "./thread-title-failure.js";
 import { ZenXThreadTitleStore } from "./thread-title-store.js";
 import { observeCompletedUserMessageTitle } from "./thread-title-notification.js";
 import { ZenXConfiguredTitleInference } from "./title-inference.js";
@@ -176,12 +177,24 @@ app.whenReady().then(async () => {
       await appServerManager.start();
     } else {
       selfControlPort.attach(appServerManager, hostConfig.cwd);
-      await titleCoordinator?.stop();
+      const restartErrors: Error[] = [];
+      try {
+        await titleCoordinator?.stop();
+      } catch (error) {
+        restartErrors.push(normalizeTitleOwnershipFailure(error));
+      }
       try {
         await appServerManager.restart(hostConfig);
-      } finally {
-        await titleCoordinator?.restart();
+      } catch (error) {
+        restartErrors.push(normalizeTitleOwnershipFailure(error));
       }
+      try {
+        await titleCoordinator?.restart();
+      } catch (error) {
+        restartErrors.push(normalizeTitleOwnershipFailure(error));
+      }
+      if (restartErrors.length > 0)
+        throw new AggregateError(restartErrors, "Could not fully restart ZenX");
     }
   });
   createWindow();
@@ -201,18 +214,18 @@ app.on("before-quit", (event) => {
     try {
       await titleCoordinator?.close();
     } catch (error) {
-      errors.push(error);
+      errors.push(normalizeTitleOwnershipFailure(error));
     }
     try {
       await appServerManager!.stop();
     } catch (error) {
-      errors.push(error);
+      errors.push(normalizeTitleOwnershipFailure(error));
     }
     try {
       selfControlPort.detach();
       await capabilityService?.close();
     } catch (error) {
-      errors.push(error);
+      errors.push(normalizeTitleOwnershipFailure(error));
     }
     if (errors.length > 0)
       console.error(

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -176,7 +176,12 @@ app.whenReady().then(async () => {
       await appServerManager.start();
     } else {
       selfControlPort.attach(appServerManager, hostConfig.cwd);
-      await appServerManager.restart(hostConfig);
+      await titleCoordinator?.stop();
+      try {
+        await appServerManager.restart(hostConfig);
+      } finally {
+        await titleCoordinator?.restart();
+      }
     }
   });
   createWindow();
@@ -191,13 +196,30 @@ app.on("before-quit", (event) => {
   event.preventDefault();
   quitting = true;
   triggerService?.stop();
-  void appServerManager
-    .stop()
-    .then(async () => {
+  void (async () => {
+    const errors: unknown[] = [];
+    try {
+      await titleCoordinator?.close();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await appServerManager!.stop();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
       selfControlPort.detach();
       await capabilityService?.close();
-    })
-    .finally(() => app.quit());
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length > 0)
+      console.error(
+        "Could not fully stop ZenX before quit",
+        new AggregateError(errors),
+      );
+  })().finally(() => app.quit());
 });
 
 app.on("window-all-closed", () => {

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -1,61 +1,95 @@
+import {
+  ZenXThreadTitleOwnershipTransaction,
+  type ZenXThreadTitleOwnershipTransactionOptions,
+} from "./thread-title-ownership-transaction.js";
+import type { ZenXThreadTitleOwnershipStore } from "./thread-title-store.js";
 import type {
   ThreadTitleInference,
   ThreadTitleProjection,
   ThreadTitleSnapshot,
 } from "./thread-title-types.js";
-import { ZenXThreadTitleStore } from "./thread-title-store.js";
 
 const MAX_TITLE_LENGTH = 64;
+const MAX_NATIVE_MIRROR_STATE = 64;
+const nativeMirrorQueues = new WeakMap<object, NativeMirrorQueue>();
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
 
+interface GenerationOwner {
+  readonly version: number;
+  readonly owner: ZenXThreadTitleOwnershipTransaction;
+}
+
 export class ZenXThreadTitleCoordinator {
-  readonly #store: ZenXThreadTitleStore;
+  readonly #store: ZenXThreadTitleOwnershipStore;
   readonly #inference: ThreadTitleInference;
   readonly #titleModel: () => string;
-  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
   readonly #listeners = new Set<(snapshot: ThreadTitleSnapshot) => void>();
-  readonly #expectedNativeMirrors = new Map<string, string[]>();
-  readonly #nativeAuthorityVersions = new Map<string, number>();
+  readonly #ownershipOptions: ZenXThreadTitleOwnershipTransactionOptions;
+  readonly #nativeMirrors: NativeMirrorQueue;
+  readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
+  readonly #generationOwners = new Map<string, GenerationOwner>();
+  #owner: ZenXThreadTitleOwnershipTransaction;
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
+  #initialized = false;
 
   constructor(options: {
-    store: ZenXThreadTitleStore;
+    store: ZenXThreadTitleOwnershipStore;
     inference: ThreadTitleInference;
     titleModel(): string;
     setNativeName(threadId: string, title: string): Promise<void>;
+    ownership?: ZenXThreadTitleOwnershipTransactionOptions;
   }) {
     this.#store = options.store;
     this.#inference = options.inference;
     this.#titleModel = options.titleModel;
+    this.#ownershipOptions = options.ownership ?? {};
     this.#setNativeName = options.setNativeName;
+    this.#owner = new ZenXThreadTitleOwnershipTransaction(
+      this.#ownershipOptions,
+    );
+    this.#nativeMirrors = nativeMirrorQueue(options.store.ownershipDomain);
   }
 
   async initialize(): Promise<void> {
+    await this.#initializeAndActivateOwner(this.#owner);
+  }
+
+  async restart(): Promise<void> {
+    await this.stop();
+    this.#owner = new ZenXThreadTitleOwnershipTransaction(
+      this.#ownershipOptions,
+    );
+    this.#mutation = Promise.resolve();
+    this.#initializationError = undefined;
+    this.#initialized = false;
+    await this.#initializeAndActivateOwner(this.#owner);
+  }
+
+  async stop(): Promise<void> {
     try {
-      const restored = await this.#store.read();
-      let changed = false;
-      for (const [threadId, projection] of Object.entries(restored)) {
-        if (projection.status !== "generating") continue;
-        restored[threadId] = {
-          ...projection,
-          status: "failed",
-          version: projection.version + 1,
-          error:
-            "Title generation stopped when ZenX restarted. Retry explicitly.",
-        };
-        changed = true;
-      }
-      this.#snapshot = restored;
-      if (changed) await this.#store.write(restored);
+      await this.#owner.retire();
     } catch (error) {
       this.#initializationError = asError(error);
-      console.error(
-        `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
-      );
+      throw error;
     }
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.stop();
+    } finally {
+      this.#listeners.clear();
+    }
+  }
+
+  createOwnershipTransaction(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+  ): ZenXThreadTitleOwnershipTransaction {
+    this.#assertAvailable();
+    return this.#owner.fork(options);
   }
 
   snapshot(): ThreadTitleSnapshot {
@@ -71,14 +105,36 @@ export class ZenXThreadTitleCoordinator {
   async observe(
     threadId: string,
     input: string,
+    ownership?: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleProjection | undefined> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner(ownership);
     const source = meaningfulTitleSource(input);
     if (source === null) return undefined;
-    const result = await this.#serial(async () => {
+    const result = await this.#serial(owner, async () => {
       const existing = this.#snapshot[threadId];
-      if (existing !== undefined)
-        return { projection: existing, created: false };
+      if (existing !== undefined) {
+        if (
+          !["provisional", "generating"].includes(existing.status) ||
+          this.#hasCurrentGenerationOwner(existing)
+        ) {
+          return { projection: existing, created: false };
+        }
+        const generating = {
+          ...existing,
+          status: "generating" as const,
+          version:
+            existing.status === "provisional"
+              ? existing.version + 1
+              : existing.version,
+        };
+        if (
+          existing.status === "provisional" &&
+          !(await this.#commit(generating, owner))
+        ) {
+          return undefined;
+        }
+        return { projection: generating, created: true };
+      }
       const provisional: ThreadTitleProjection = {
         threadId,
         title: normalizeThreadTitle(source),
@@ -86,57 +142,59 @@ export class ZenXThreadTitleCoordinator {
         version: 1,
         source,
       };
-      await this.#commit(provisional);
-      await this.#mirror(threadId, provisional.title);
+      if (!(await this.#commit(provisional, owner))) return undefined;
       const generating = {
         ...provisional,
         status: "generating" as const,
         version: 2,
       };
-      await this.#commit(generating);
+      if (!(await this.#commit(generating, owner))) return undefined;
       return { projection: generating, created: true };
     });
-    if (result.created) this.#startGeneration(result.projection);
-    return result.projection;
+    if (result?.created === true)
+      this.#startGeneration(result.projection, owner);
+    return result?.projection;
   }
 
   async rename(
     threadId: string,
     title: string,
+    ownership?: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner(ownership);
     const normalized = normalizeManualTitle(title);
-    return await this.#serial(async () => {
+    const projection = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
-      const projection: ThreadTitleProjection = {
+      const next: ThreadTitleProjection = {
         threadId,
         title: normalized,
         status: "manual",
         version: (current?.version ?? 0) + 1,
         source: current?.source ?? normalized,
       };
-      await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
-      return projection;
+      if (!(await this.#commit(next, owner)))
+        throw new Error("Title ownership changed during rename");
+      return next;
     });
+    this.#nativeMirrors.enqueue(threadId, normalized, owner);
+    return projection;
   }
 
   async synchronizeNativeName(
     threadId: string,
     title: string,
   ): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
+    const owner = this.#operationOwner();
     const normalized = normalizeManualTitle(title);
-    if (this.#consumeExpectedNativeMirror(threadId, normalized)) {
+    // App Server exposes no dispatch correlation token. Title equality is not
+    // provenance, so every notification is conservatively authoritative. A
+    // successful authority commit cancels any older queued repair before the
+    // current active dispatch is reconciled. A same-title echo is still
+    // authoritative but cannot enqueue a recursive repair.
+    const nativeAuthorityVersion = this.#nativeAuthorityVersion(threadId) + 1;
+    this.#nativeAuthorityVersions.set(threadId, nativeAuthorityVersion);
+    const projection = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
-      if (current !== undefined) return current;
-    }
-    this.#recordNativeAuthority(threadId);
-    return await this.#serial(async () => {
-      const current = this.#snapshot[threadId];
-      if (current?.status === "manual" && current.title === normalized) {
-        return current;
-      }
       const projection: ThreadTitleProjection = {
         threadId,
         title: normalized,
@@ -144,15 +202,19 @@ export class ZenXThreadTitleCoordinator {
         version: (current?.version ?? 0) + 1,
         source: current?.source ?? normalized,
       };
-      await this.#commit(projection);
-      await this.#mirror(threadId, normalized);
+      if (!(await this.#commit(projection, owner)))
+        throw new Error("Title ownership changed during native rename");
       return projection;
     });
+    this.#nativeMirrors.reconcileAuthoritative(threadId, normalized, owner);
+    return projection;
   }
 
+  readonly #nativeAuthorityVersions = new Map<string, number>();
+
   async retry(threadId: string): Promise<ThreadTitleProjection> {
-    this.#assertAvailable();
-    const generating = await this.#serial(async () => {
+    const owner = this.#operationOwner();
+    const generating = await this.#serial(owner, async () => {
       const current = this.#snapshot[threadId];
       if (current === undefined)
         throw new Error("Thread has no title input to retry");
@@ -164,23 +226,74 @@ export class ZenXThreadTitleCoordinator {
         version: current.version + 1,
       };
       delete next.error;
-      await this.#commit(next);
+      if (!(await this.#commit(next, owner)))
+        throw new Error("Title ownership changed during retry");
       return next;
     });
-    this.#startGeneration(generating);
+    this.#startGeneration(generating, owner);
     return generating;
   }
 
-  async #generate(started: ThreadTitleProjection): Promise<void> {
+  async #initializeOwner(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    try {
+      const restored = await this.#store.claim(owner);
+      if (!owner.isCurrent()) return;
+      let changed = false;
+      for (const [threadId, projection] of Object.entries(restored)) {
+        if (projection.status !== "generating") continue;
+        restored[threadId] = {
+          ...projection,
+          status: "failed",
+          version: projection.version + 1,
+          error:
+            "Title generation stopped when ZenX restarted. Retry explicitly.",
+        };
+        changed = true;
+      }
+      if (changed && !(await this.#store.commit(restored, owner))) return;
+      if (!owner.isCurrent()) return;
+      this.#snapshot = restored;
+      this.#initialized = true;
+    } catch (error) {
+      this.#initializationError = asError(error);
+      console.error(
+        `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
+      );
+    }
+  }
+
+  async #initializeAndActivateOwner(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    const initialization = this.#initializeOwner(owner);
+    this.#nativeMirrors.activate(
+      owner,
+      this.#setNativeName,
+      async (threadId) => {
+        await initialization;
+        if (!owner.isCurrent() || !this.#initialized) return undefined;
+        return this.#snapshot[threadId]?.title;
+      },
+    );
+    await initialization;
+  }
+
+  async #generate(
+    started: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
     try {
       const generated = normalizeGeneratedTitle(
         await this.#inference.generate(
           started.source,
           this.#titleModel(),
-          new AbortController().signal,
+          owner.signal,
         ),
       );
-      await this.#serial(async () => {
+      if (!owner.isCurrent()) return;
+      await this.#serial(owner, async () => {
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
@@ -196,70 +309,81 @@ export class ZenXThreadTitleCoordinator {
         const nativeAuthorityVersion = this.#nativeAuthorityVersion(
           started.threadId,
         );
-        await this.#commit(projection);
+        if (!(await this.#commit(projection, owner))) return;
         if (
+          owner.isCurrent() &&
           this.#nativeAuthorityVersion(started.threadId) ===
-          nativeAuthorityVersion
+            nativeAuthorityVersion
         ) {
-          await this.#mirror(started.threadId, generated);
+          this.#nativeMirrors.enqueue(started.threadId, generated, owner);
         }
       });
     } catch (error) {
-      await this.#serial(async () => {
+      if (!owner.isCurrent()) return;
+      await this.#serial(owner, async () => {
         const current = this.#snapshot[started.threadId];
         if (
           current?.status !== "generating" ||
           current.version !== started.version
         )
           return;
-        await this.#commit({
-          ...current,
-          status: "failed",
-          version: current.version + 1,
-          error: describeError(error),
-        });
+        await this.#commit(
+          {
+            ...current,
+            status: "failed",
+            version: current.version + 1,
+            error: describeError(error),
+          },
+          owner,
+        );
       });
     }
   }
 
-  async #commit(projection: ThreadTitleProjection): Promise<void> {
+  async #commit(
+    projection: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    if (!owner.isCurrent()) return false;
     const next = { ...this.#snapshot, [projection.threadId]: projection };
-    await this.#store.write(next);
+    if (!(await this.#store.commit(next, owner)) || !owner.isCurrent())
+      return false;
     this.#snapshot = next;
-    for (const listener of this.#listeners) listener(this.snapshot());
-  }
-
-  async #mirror(threadId: string, title: string): Promise<void> {
-    const expected = this.#expectedNativeMirrors.get(threadId) ?? [];
-    expected.push(title);
-    this.#expectedNativeMirrors.set(threadId, expected);
-    try {
-      await this.#setNativeName(threadId, title);
-    } catch (error) {
-      this.#removeExpectedNativeMirror(threadId, title);
-      console.warn(
-        `Could not mirror ZenX thread title: ${describeError(error)}`,
-      );
-    }
-  }
-
-  #consumeExpectedNativeMirror(threadId: string, title: string): boolean {
-    const expected = this.#expectedNativeMirrors.get(threadId);
-    const index = expected?.indexOf(title) ?? -1;
-    if (expected === undefined || index < 0) return false;
-    expected.splice(index, 1);
-    if (expected.length === 0) this.#expectedNativeMirrors.delete(threadId);
+    for (const listener of this.#listeners)
+      listener(structuredClone(this.#snapshot));
     return true;
   }
 
-  #removeExpectedNativeMirror(threadId: string, title: string): void {
-    this.#consumeExpectedNativeMirror(threadId, title);
+  #startGeneration(
+    projection: ThreadTitleProjection,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    if (!owner.isCurrent()) return;
+    const generation = { version: projection.version, owner };
+    this.#generationOwners.set(projection.threadId, generation);
+    const disposeRetirement = owner.onRetire(() => {
+      if (this.#generationOwners.get(projection.threadId) === generation)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    const operation = this.#generate(projection, owner).finally(() => {
+      disposeRetirement();
+      if (this.#generationOwners.get(projection.threadId) === generation)
+        this.#generationOwners.delete(projection.threadId);
+    });
+    owner.track(operation);
+    void operation.catch((error: unknown) => {
+      if (owner.isCurrent()) {
+        console.error(
+          `Could not persist title generation result: ${asError(error).message}`,
+        );
+      }
+    });
   }
 
-  #recordNativeAuthority(threadId: string): void {
-    this.#nativeAuthorityVersions.set(
-      threadId,
-      this.#nativeAuthorityVersion(threadId) + 1,
+  #hasCurrentGenerationOwner(projection: ThreadTitleProjection): boolean {
+    const generation = this.#generationOwners.get(projection.threadId);
+    return (
+      generation?.version === projection.version && generation.owner.isCurrent()
     );
   }
 
@@ -267,30 +391,430 @@ export class ZenXThreadTitleCoordinator {
     return this.#nativeAuthorityVersions.get(threadId) ?? 0;
   }
 
-  #startGeneration(projection: ThreadTitleProjection): void {
-    void this.#generate(projection).catch((error: unknown) => {
-      console.error(
-        `Could not persist title generation result: ${asError(error).message}`,
-      );
-    });
+  #operationOwner(
+    ownership?: ZenXThreadTitleOwnershipTransaction,
+  ): ZenXThreadTitleOwnershipTransaction {
+    this.#assertAvailable();
+    const owner = ownership ?? this.#owner;
+    if (owner.root !== this.#owner || !owner.isCurrent())
+      throw new Error("ZenX thread-title ownership transaction is retired");
+    return owner;
   }
 
   #assertAvailable(): void {
+    const retirementFailure = this.#owner.retirementFailure();
+    if (retirementFailure !== undefined) {
+      throw new Error(
+        `ZenX thread titles are unavailable: ${retirementFailure.message}`,
+        { cause: retirementFailure },
+      );
+    }
     if (this.#initializationError !== undefined) {
       throw new Error(
         `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
       );
     }
+    if (!this.#initialized)
+      throw new Error("ZenX thread titles are not initialized");
   }
 
-  async #serial<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.#mutation.then(operation, operation);
+  async #serial<T>(
+    owner: ZenXThreadTitleOwnershipTransaction,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const guarded = async (): Promise<T> => {
+      if (!owner.isCurrent())
+        throw new Error("ZenX thread-title ownership transaction is retired");
+      return await operation();
+    };
+    const result = this.#mutation.then(guarded, guarded);
     this.#mutation = result.then(
       () => undefined,
       () => undefined,
     );
-    return await result;
+    return await owner.track(result);
   }
+}
+
+type NativeMirrorJobState = "queued" | "active" | "retired" | "settled";
+
+interface NativeMirrorDiagnostic {
+  readonly threadId: string;
+  readonly title: string;
+  readonly ownerId: string;
+}
+
+interface NativeMirrorAuthority {
+  readonly owner: ZenXThreadTitleOwnershipTransaction;
+  readonly setNativeName: (threadId: string, title: string) => Promise<void>;
+  readonly desiredTitle: (threadId: string) => Promise<string | undefined>;
+}
+
+class NativeMirrorReservation {
+  #released = false;
+
+  constructor(readonly releaseCapacity: () => void) {}
+
+  release(): void {
+    if (this.#released) return;
+    this.#released = true;
+    this.releaseCapacity();
+  }
+}
+
+class NativeMirrorJob {
+  state: NativeMirrorJobState = "queued";
+  disposeRetirement: (() => void) | undefined;
+  repairAfterSettlement = false;
+
+  constructor(
+    readonly threadId: string,
+    readonly title: string,
+    readonly owner: ZenXThreadTitleOwnershipTransaction,
+    readonly reservation: NativeMirrorReservation,
+    readonly setNativeName: (threadId: string, title: string) => Promise<void>,
+  ) {}
+}
+
+class NativeMirrorRepair {
+  disposeRetirement: (() => void) | undefined;
+
+  constructor(
+    readonly threadId: string,
+    readonly authority: NativeMirrorAuthority,
+    readonly reservation: NativeMirrorReservation,
+  ) {}
+}
+
+class NativeMirrorQueue {
+  readonly #active = new Map<string, NativeMirrorJob>();
+  readonly #queued = new Map<string, NativeMirrorJob>();
+  readonly #repairs = new Map<string, NativeMirrorRepair>();
+  readonly #quarantined: NativeMirrorDiagnostic[] = [];
+  #authority: NativeMirrorAuthority | undefined;
+  #reservations = 0;
+  #capacityWarned = false;
+
+  activate(
+    owner: ZenXThreadTitleOwnershipTransaction,
+    setNativeName: (threadId: string, title: string) => Promise<void>,
+    desiredTitle: (threadId: string) => Promise<string | undefined>,
+  ): void {
+    this.#authority = { owner, setNativeName, desiredTitle };
+  }
+
+  reconcileAuthoritative(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    this.#retireRepair(threadId, true);
+    const queued = this.#queued.get(threadId);
+    if (queued !== undefined) this.#retireJob(queued, true);
+    const active = this.#active.get(threadId);
+    if (active !== undefined && active.title !== title)
+      this.enqueue(threadId, title, owner);
+  }
+
+  enqueue(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): void {
+    const authority = this.#authorityFor(owner);
+    if (authority === undefined) return;
+    this.#retireRepair(threadId, true);
+    const queued = this.#queued.get(threadId);
+    if (
+      queued !== undefined &&
+      queued.title === title &&
+      queued.owner === owner
+    )
+      return;
+    if (queued !== undefined) this.#retireJob(queued, true);
+    const reservation = this.#reserve();
+    if (reservation === undefined) return;
+    this.#queueReserved(
+      threadId,
+      title,
+      owner,
+      authority.setNativeName,
+      reservation,
+    );
+  }
+
+  #queueReserved(
+    threadId: string,
+    title: string,
+    owner: ZenXThreadTitleOwnershipTransaction,
+    setNativeName: (threadId: string, title: string) => Promise<void>,
+    reservation: NativeMirrorReservation,
+  ): void {
+    const queued = this.#queued.get(threadId);
+    if (
+      queued !== undefined &&
+      queued.title === title &&
+      queued.owner === owner
+    ) {
+      reservation.release();
+      return;
+    }
+    if (queued !== undefined) this.#retireJob(queued, true);
+    if (!owner.isCurrent()) {
+      reservation.release();
+      return;
+    }
+    const job = new NativeMirrorJob(
+      threadId,
+      title,
+      owner,
+      reservation,
+      setNativeName,
+    );
+    job.disposeRetirement = owner.onRetire(() => this.#retireJob(job, true));
+    this.#queued.set(threadId, job);
+    this.#pump(threadId);
+  }
+
+  #pump(threadId: string): void {
+    if (this.#active.has(threadId)) return;
+    const job = this.#queued.get(threadId);
+    if (job === undefined) return;
+    this.#queued.delete(threadId);
+    if (!job.owner.isCurrent()) {
+      this.#retireJob(job, true);
+      return;
+    }
+    job.state = "active";
+    this.#active.set(threadId, job);
+    const operation = Promise.resolve().then(async () => {
+      await job.setNativeName(job.threadId, job.title);
+    });
+    job.owner.track(operation);
+    void operation.then(
+      () => this.#settleJob(job),
+      (error: unknown) => {
+        if (job.state === "active" && job.owner.isCurrent()) {
+          console.warn(
+            `Could not mirror ZenX thread title: ${describeError(error)}`,
+          );
+        }
+        this.#settleJob(job);
+      },
+    );
+  }
+
+  #settleJob(job: NativeMirrorJob): void {
+    if (job.state === "retired") {
+      this.#repairAfterRetiredCompletion(job);
+      return;
+    }
+    if (job.state !== "active") return;
+    const repairAfterSettlement = job.repairAfterSettlement;
+    job.state = "settled";
+    job.disposeRetirement?.();
+    job.disposeRetirement = undefined;
+    if (this.#active.get(job.threadId) === job)
+      this.#active.delete(job.threadId);
+    job.reservation.release();
+    if (repairAfterSettlement) this.#scheduleRepair(job.threadId);
+    this.#pump(job.threadId);
+  }
+
+  #retireJob(job: NativeMirrorJob, diagnose: boolean): void {
+    if (job.state === "retired" || job.state === "settled") return;
+    const wasActive = job.state === "active";
+    job.state = "retired";
+    job.disposeRetirement?.();
+    job.disposeRetirement = undefined;
+    if (this.#queued.get(job.threadId) === job)
+      this.#queued.delete(job.threadId);
+    if (this.#active.get(job.threadId) === job)
+      this.#active.delete(job.threadId);
+    job.reservation.release();
+    if (diagnose) this.#appendDiagnostic(job);
+    if (wasActive || !this.#active.has(job.threadId)) this.#pump(job.threadId);
+  }
+
+  #repairAfterRetiredCompletion(job: NativeMirrorJob): void {
+    const authority = this.#authority;
+    if (authority === undefined || !authority.owner.isCurrent()) return;
+    const queued = this.#queued.get(job.threadId);
+    if (
+      queued !== undefined &&
+      queued.owner.root === authority.owner.root &&
+      queued.owner.isCurrent()
+    )
+      return;
+    const active = this.#active.get(job.threadId);
+    if (
+      active !== undefined &&
+      active.owner.root === authority.owner.root &&
+      active.owner.isCurrent()
+    ) {
+      active.repairAfterSettlement = true;
+      return;
+    }
+    this.#scheduleRepair(job.threadId);
+  }
+
+  #scheduleRepair(threadId: string): void {
+    const authority = this.#authority;
+    if (authority === undefined || !authority.owner.isCurrent()) return;
+    const queued = this.#queued.get(threadId);
+    if (
+      queued !== undefined &&
+      queued.owner.root === authority.owner.root &&
+      queued.owner.isCurrent()
+    )
+      return;
+    const existing = this.#repairs.get(threadId);
+    if (existing?.authority === authority) return;
+    if (existing !== undefined) this.#retireRepair(threadId, true);
+    const reservation = this.#reserve();
+    if (reservation === undefined) return;
+    const repair = new NativeMirrorRepair(threadId, authority, reservation);
+    repair.disposeRetirement = authority.owner.onRetire(() =>
+      this.#retireRepair(threadId, true, repair),
+    );
+    this.#repairs.set(threadId, repair);
+    const resolution = Promise.resolve().then(async () =>
+      authority.desiredTitle(threadId),
+    );
+    authority.owner.track(resolution);
+    void resolution.then(
+      (title) => this.#resolveRepair(repair, title),
+      (error: unknown) => {
+        if (this.#repairs.get(threadId) !== repair) return;
+        this.#retireRepair(threadId, true, repair);
+        if (authority.owner.isCurrent())
+          console.warn(
+            `Could not reconcile a late ZenX native title mirror: ${describeError(error)}`,
+          );
+      },
+    );
+  }
+
+  #resolveRepair(repair: NativeMirrorRepair, title: string | undefined): void {
+    if (this.#repairs.get(repair.threadId) !== repair) return;
+    this.#repairs.delete(repair.threadId);
+    repair.disposeRetirement?.();
+    repair.disposeRetirement = undefined;
+    if (
+      title === undefined ||
+      this.#authority !== repair.authority ||
+      !repair.authority.owner.isCurrent()
+    ) {
+      repair.reservation.release();
+      if (this.#authority !== repair.authority)
+        this.#scheduleRepair(repair.threadId);
+      return;
+    }
+    this.#queueReserved(
+      repair.threadId,
+      title,
+      repair.authority.owner,
+      repair.authority.setNativeName,
+      repair.reservation,
+    );
+  }
+
+  #retireRepair(
+    threadId: string,
+    diagnose: boolean,
+    expected?: NativeMirrorRepair,
+  ): void {
+    const repair = this.#repairs.get(threadId);
+    if (repair === undefined || (expected !== undefined && repair !== expected))
+      return;
+    this.#repairs.delete(threadId);
+    repair.disposeRetirement?.();
+    repair.disposeRetirement = undefined;
+    repair.reservation.release();
+    if (diagnose)
+      this.#appendDiagnostic({
+        threadId,
+        title: "<latest-authority-repair>",
+        ownerId: repair.authority.owner.id,
+      });
+  }
+
+  #appendDiagnostic(job: NativeMirrorJob | NativeMirrorDiagnostic): void {
+    while (
+      this.#reservations + this.#quarantined.length >=
+      MAX_NATIVE_MIRROR_STATE
+    ) {
+      if (this.#quarantined.length === 0) return;
+      this.#quarantined.shift();
+    }
+    this.#quarantined.push(
+      "ownerId" in job
+        ? job
+        : {
+            threadId: job.threadId,
+            title: job.title,
+            ownerId: job.owner.id,
+          },
+    );
+  }
+
+  #makeRoomFromDiagnostics(): void {
+    while (
+      this.#quarantined.length > 0 &&
+      this.#reservations + this.#quarantined.length >= MAX_NATIVE_MIRROR_STATE
+    ) {
+      this.#quarantined.shift();
+    }
+  }
+
+  #warnCapacity(): void {
+    if (this.#capacityWarned) return;
+    this.#capacityWarned = true;
+    console.warn(
+      `Could not mirror ZenX thread title: ${String(MAX_NATIVE_MIRROR_STATE)} live or queued native mirror operations already occupy the bounded transaction`,
+    );
+  }
+
+  #authorityFor(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): NativeMirrorAuthority | undefined {
+    const authority = this.#authority;
+    return authority !== undefined &&
+      authority.owner.root === owner.root &&
+      authority.owner.isCurrent() &&
+      owner.isCurrent()
+      ? authority
+      : undefined;
+  }
+
+  #reserve(): NativeMirrorReservation | undefined {
+    this.#makeRoomFromDiagnostics();
+    if (
+      this.#reservations + this.#quarantined.length >=
+      MAX_NATIVE_MIRROR_STATE
+    ) {
+      this.#warnCapacity();
+      return undefined;
+    }
+    this.#reservations += 1;
+    this.#capacityWarned = false;
+    return new NativeMirrorReservation(() => {
+      this.#reservations -= 1;
+      if (
+        this.#reservations + this.#quarantined.length <
+        MAX_NATIVE_MIRROR_STATE
+      )
+        this.#capacityWarned = false;
+    });
+  }
+}
+
+function nativeMirrorQueue(ownershipDomain: object): NativeMirrorQueue {
+  const existing = nativeMirrorQueues.get(ownershipDomain);
+  if (existing !== undefined) return existing;
+  const queue = new NativeMirrorQueue();
+  nativeMirrorQueues.set(ownershipDomain, queue);
+  return queue;
 }
 
 export function meaningfulTitleSource(input: string): string | null {

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -28,11 +28,13 @@ export class ZenXThreadTitleCoordinator {
   readonly #ownershipOptions: ZenXThreadTitleOwnershipTransactionOptions;
   readonly #nativeMirrors: NativeMirrorQueue;
   readonly #setNativeName: (threadId: string, title: string) => Promise<void>;
+  readonly #disposeDomainFailure: () => void;
   readonly #generationOwners = new Map<string, GenerationOwner>();
   #owner: ZenXThreadTitleOwnershipTransaction;
   #snapshot: ThreadTitleSnapshot = {};
   #mutation = Promise.resolve();
   #initializationError: Error | undefined;
+  #domainFailure: Error | undefined;
   #initialized = false;
 
   constructor(options: {
@@ -51,6 +53,12 @@ export class ZenXThreadTitleCoordinator {
       this.#ownershipOptions,
     );
     this.#nativeMirrors = nativeMirrorQueue(options.store.ownershipDomain);
+    this.#disposeDomainFailure = options.store.ownershipDomain.onFailure(
+      (failure) => {
+        this.#domainFailure ??= failure;
+        void this.#owner.retire().catch(() => undefined);
+      },
+    );
   }
 
   async initialize(): Promise<void> {
@@ -80,6 +88,7 @@ export class ZenXThreadTitleCoordinator {
       this.#initializationError = lateFailure;
       throw lateFailure;
     }
+    if (this.#domainFailure !== undefined) throw this.#domainFailure;
   }
 
   async close(): Promise<void> {
@@ -87,6 +96,7 @@ export class ZenXThreadTitleCoordinator {
       await this.stop();
     } finally {
       this.#listeners.clear();
+      this.#disposeDomainFailure();
     }
   }
 
@@ -407,6 +417,12 @@ export class ZenXThreadTitleCoordinator {
   }
 
   #assertAvailable(): void {
+    if (this.#domainFailure !== undefined) {
+      throw new Error(
+        `ZenX thread titles are unavailable: ${this.#domainFailure.message}`,
+        { cause: this.#domainFailure },
+      );
+    }
     const retirementFailure = this.#owner.retirementFailure();
     if (retirementFailure !== undefined) {
       throw new Error(

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -2,6 +2,7 @@ import {
   ZenXThreadTitleOwnershipTransaction,
   type ZenXThreadTitleOwnershipTransactionOptions,
 } from "./thread-title-ownership-transaction.js";
+import { normalizeTitleOwnershipFailure } from "./thread-title-failure.js";
 import type { ZenXThreadTitleOwnershipStore } from "./thread-title-store.js";
 import type {
   ThreadTitleInference,
@@ -11,6 +12,7 @@ import type {
 
 const MAX_TITLE_LENGTH = 64;
 const MAX_NATIVE_MIRROR_STATE = 64;
+const MAX_COORDINATOR_CHANGE_LISTENERS = 64;
 const nativeMirrorQueues = new WeakMap<object, NativeMirrorQueue>();
 const identifierNoise =
   /\b(?:zenx-wakeup:[^\s]+|[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b/giu;
@@ -55,7 +57,7 @@ export class ZenXThreadTitleCoordinator {
     this.#nativeMirrors = nativeMirrorQueue(options.store.ownershipDomain);
     this.#disposeDomainFailure = options.store.ownershipDomain.onFailure(
       (failure) => {
-        this.#domainFailure ??= failure;
+        this.#domainFailure = normalizeTitleOwnershipFailure(failure);
         void this.#owner.retire().catch(() => undefined);
       },
     );
@@ -74,13 +76,14 @@ export class ZenXThreadTitleCoordinator {
     this.#initializationError = undefined;
     this.#initialized = false;
     await this.#initializeAndActivateOwner(this.#owner);
+    this.#assertAvailable();
   }
 
   async stop(): Promise<void> {
     try {
       await this.#owner.retire();
     } catch (error) {
-      this.#initializationError = asError(error);
+      this.#initializationError = normalizeTitleOwnershipFailure(error);
       throw error;
     }
     const lateFailure = this.#owner.retirementFailure();
@@ -113,6 +116,16 @@ export class ZenXThreadTitleCoordinator {
   }
 
   onChange(listener: (snapshot: ThreadTitleSnapshot) => void): () => void {
+    if (this.#listeners.size >= MAX_COORDINATOR_CHANGE_LISTENERS) {
+      this.#owner.poison(
+        new Error(
+          `Title coordinator reached its bounded capacity of ${String(
+            MAX_COORDINATOR_CHANGE_LISTENERS,
+          )} change listeners`,
+        ),
+      );
+      return () => undefined;
+    }
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
   }
@@ -272,7 +285,7 @@ export class ZenXThreadTitleCoordinator {
       this.#snapshot = restored;
       this.#initialized = true;
     } catch (error) {
-      this.#initializationError = asError(error);
+      this.#initializationError = normalizeTitleOwnershipFailure(error);
       console.error(
         `ZenX thread titles are unavailable: ${this.#initializationError.message}`,
       );
@@ -364,8 +377,20 @@ export class ZenXThreadTitleCoordinator {
     if (!(await this.#store.commit(next, owner)) || !owner.isCurrent())
       return false;
     this.#snapshot = next;
-    for (const listener of this.#listeners)
-      listener(structuredClone(this.#snapshot));
+    for (const listener of this.#listeners) {
+      try {
+        const result = (listener as (snapshot: ThreadTitleSnapshot) => unknown)(
+          structuredClone(this.#snapshot),
+        );
+        void Promise.resolve(result).then(undefined, (error: unknown) => {
+          this.#listeners.delete(listener);
+          owner.poison(error);
+        });
+      } catch (error) {
+        this.#listeners.delete(listener);
+        owner.poison(error);
+      }
+    }
     return true;
   }
 
@@ -389,7 +414,7 @@ export class ZenXThreadTitleCoordinator {
     void operation.catch((error: unknown) => {
       if (owner.isCurrent()) {
         console.error(
-          `Could not persist title generation result: ${asError(error).message}`,
+          `Could not persist title generation result: ${describeError(error)}`,
         );
       }
     });
@@ -420,14 +445,12 @@ export class ZenXThreadTitleCoordinator {
     if (this.#domainFailure !== undefined) {
       throw new Error(
         `ZenX thread titles are unavailable: ${this.#domainFailure.message}`,
-        { cause: this.#domainFailure },
       );
     }
     const retirementFailure = this.#owner.retirementFailure();
     if (retirementFailure !== undefined) {
       throw new Error(
         `ZenX thread titles are unavailable: ${retirementFailure.message}`,
-        { cause: retirementFailure },
       );
     }
     if (this.#initializationError !== undefined) {
@@ -890,9 +913,5 @@ function normalizeManualTitle(input: string): string {
 }
 
 function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function asError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
+  return normalizeTitleOwnershipFailure(error).message;
 }

--- a/apps/zenx/src/main/thread-title-coordinator.ts
+++ b/apps/zenx/src/main/thread-title-coordinator.ts
@@ -75,6 +75,11 @@ export class ZenXThreadTitleCoordinator {
       this.#initializationError = asError(error);
       throw error;
     }
+    const lateFailure = this.#owner.retirementFailure();
+    if (lateFailure !== undefined) {
+      this.#initializationError = lateFailure;
+      throw lateFailure;
+    }
   }
 
   async close(): Promise<void> {

--- a/apps/zenx/src/main/thread-title-failure.ts
+++ b/apps/zenx/src/main/thread-title-failure.ts
@@ -1,0 +1,120 @@
+export const MAX_TITLE_OWNERSHIP_FAILURE_EVIDENCE = 64;
+export const MAX_TITLE_OWNERSHIP_ERROR_MESSAGE_LENGTH = 160;
+
+const MAX_TITLE_OWNERSHIP_AGGREGATE_MESSAGE_LENGTH = 2_048;
+const NORMALIZATION_FALLBACK =
+  "Unprintable title ownership failure (normalization failed)";
+
+/**
+ * Copies an arbitrary thrown value without retaining or trusting its object
+ * graph. Every reflective/coercion operation is guarded, so this function is
+ * total even for hostile proxies, getters, symbols, cycles, and toString.
+ */
+export function normalizeTitleOwnershipFailure(value: unknown): Error {
+  let description: string | undefined;
+  try {
+    description = primitiveDescription(value);
+  } catch {
+    description = undefined;
+  }
+
+  if (
+    description === undefined &&
+    (typeof value === "object" || typeof value === "function") &&
+    value !== null
+  ) {
+    try {
+      description = primitiveDescription(Reflect.get(value, "message"));
+    } catch {
+      description = undefined;
+    }
+    if (description === undefined) {
+      try {
+        description = String(value);
+      } catch {
+        description = undefined;
+      }
+    }
+  }
+
+  const message = boundedTitleOwnershipMessage(
+    description === undefined || description.length === 0
+      ? NORMALIZATION_FALLBACK
+      : description,
+  );
+  return new Error(message);
+}
+
+export function aggregateTitleOwnershipFailures(
+  failures: readonly unknown[],
+  summary: string,
+): AggregateError {
+  const diagnostics = failures.map(normalizeTitleOwnershipFailure);
+  const details = diagnostics.map((failure) => failure.message).join("; ");
+  return new AggregateError(
+    diagnostics,
+    boundedAggregateMessage(
+      details.length === 0 ? summary : `${summary}: ${details}`,
+    ),
+  );
+}
+
+export class BoundedTitleOwnershipFailures {
+  readonly #failures: Error[] = [];
+  #saturated = false;
+
+  record(value: unknown): void {
+    if (this.#saturated) return;
+    if (this.#failures.length < MAX_TITLE_OWNERSHIP_FAILURE_EVIDENCE - 1) {
+      this.#failures.push(normalizeTitleOwnershipFailure(value));
+      return;
+    }
+    this.#saturated = true;
+    this.#failures.push(
+      new Error(
+        boundedTitleOwnershipMessage(
+          `Title ownership failure evidence reached its bounded capacity of ${String(
+            MAX_TITLE_OWNERSHIP_FAILURE_EVIDENCE,
+          )}; additional failures were omitted`,
+        ),
+      ),
+    );
+  }
+
+  get healthy(): boolean {
+    return this.#failures.length === 0;
+  }
+
+  aggregate(summary: string): AggregateError | undefined {
+    return this.#failures.length === 0
+      ? undefined
+      : aggregateTitleOwnershipFailures(this.#failures, summary);
+  }
+}
+
+function primitiveDescription(value: unknown): string | undefined {
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+    case "bigint":
+    case "boolean":
+    case "undefined":
+    case "symbol":
+      return String(value);
+    default:
+      return value === null ? "null" : undefined;
+  }
+}
+
+function boundedTitleOwnershipMessage(message: string): string {
+  return message.length <= MAX_TITLE_OWNERSHIP_ERROR_MESSAGE_LENGTH
+    ? message
+    : `${message.slice(0, MAX_TITLE_OWNERSHIP_ERROR_MESSAGE_LENGTH - 1)}…`;
+}
+
+function boundedAggregateMessage(message: string): string {
+  return message.length <= MAX_TITLE_OWNERSHIP_AGGREGATE_MESSAGE_LENGTH
+    ? message
+    : `${message.slice(0, MAX_TITLE_OWNERSHIP_AGGREGATE_MESSAGE_LENGTH - 1)}…`;
+}

--- a/apps/zenx/src/main/thread-title-ownership-transaction.ts
+++ b/apps/zenx/src/main/thread-title-ownership-transaction.ts
@@ -1,4 +1,11 @@
 const DEFAULT_QUIESCENCE_DEADLINE_MS = 250;
+const MAX_NESTED_RETIREMENT_TRANSACTIONS = 128;
+const MAX_RETIREMENT_OUTCOMES = MAX_NESTED_RETIREMENT_TRANSACTIONS + 1;
+const MAX_RETIREMENT_FAILURE_EVIDENCE = 64;
+const MAX_RETIREMENT_FAILURE_LISTENERS = 64;
+const MAX_RETIREMENT_HOOKS = 64;
+const MAX_TRACKED_RETIREMENT_WORK = 128;
+const MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH = 160;
 
 export interface ZenXThreadTitleOwnershipTransactionOptions {
   deadlineMs?: number;
@@ -17,12 +24,34 @@ type RetirementOutcome =
   { readonly ok: true } | { readonly ok: false; readonly error: unknown };
 
 class RootRetirementClosure {
+  readonly #rootOrder: number;
   readonly #failures: RetirementFailure[] = [];
   readonly #observations = new Map<number, Promise<RetirementOutcome>>();
+  readonly #failureListeners = new Set<(failure: AggregateError) => void>();
+  #nestedTransactions = 0;
+  #failureEvidenceSaturated = false;
   #nextOccurrence = 0;
+
+  constructor(rootOrder: number) {
+    this.#rootOrder = rootOrder;
+  }
+
+  registerChild(transactionOrder: number, ancestry: readonly number[]): void {
+    if (this.#nestedTransactions >= MAX_NESTED_RETIREMENT_TRANSACTIONS) {
+      const failure = new Error(
+        `Title ownership retirement reached its bounded capacity of ${String(
+          MAX_NESTED_RETIREMENT_TRANSACTIONS,
+        )} nested transactions`,
+      );
+      this.record(transactionOrder, ancestry, failure);
+      throw failure;
+    }
+    this.#nestedTransactions += 1;
+  }
 
   observe(
     transactionOrder: number,
+    ancestry: readonly number[],
     retirement: Promise<void>,
   ): Promise<RetirementOutcome> {
     const existing = this.#observations.get(transactionOrder);
@@ -31,6 +60,18 @@ class RootRetirementClosure {
       () => ({ ok: true }),
       (error: unknown) => ({ ok: false, error }),
     );
+    if (this.#observations.size >= MAX_RETIREMENT_OUTCOMES) {
+      this.record(
+        transactionOrder,
+        ancestry,
+        new Error(
+          `Title ownership retirement reached its bounded capacity of ${String(
+            MAX_RETIREMENT_OUTCOMES,
+          )} observed outcomes`,
+        ),
+      );
+      return outcome;
+    }
     this.#observations.set(transactionOrder, outcome);
     return outcome;
   }
@@ -40,27 +81,88 @@ class RootRetirementClosure {
     ancestry: readonly number[],
     error: unknown,
   ): void {
-    this.#failures.push({
-      transactionOrder,
-      ancestry,
-      occurrence: this.#nextOccurrence++,
-      error,
-    });
+    if (this.#failureEvidenceSaturated) return;
+    const occurrence = this.#nextOccurrence++;
+    if (this.#failures.length < MAX_RETIREMENT_FAILURE_EVIDENCE - 1) {
+      this.#failures.push({
+        transactionOrder,
+        ancestry,
+        occurrence,
+        error,
+      });
+    } else {
+      this.#failureEvidenceSaturated = true;
+      this.#failures.push({
+        transactionOrder,
+        ancestry,
+        occurrence,
+        error: new Error(
+          `Title ownership retirement reached its bounded capacity of ${String(
+            MAX_RETIREMENT_FAILURE_EVIDENCE,
+          )} failure evidence records; additional failures were omitted`,
+        ),
+      });
+    }
+    this.#notifyFailureListeners();
   }
 
   failuresFor(transactionOrder: number): unknown[] {
+    return this.#failureRecordsFor(transactionOrder).map(
+      (failure) => failure.error,
+    );
+  }
+
+  addFailureListener(
+    transactionOrder: number,
+    ancestry: readonly number[],
+    listener: (failure: AggregateError) => void,
+  ): () => void {
+    if (this.#failureListeners.size >= MAX_RETIREMENT_FAILURE_LISTENERS) {
+      this.record(
+        transactionOrder,
+        ancestry,
+        new Error(
+          `Title ownership retirement reached its bounded capacity of ${String(
+            MAX_RETIREMENT_FAILURE_LISTENERS,
+          )} failure listeners`,
+        ),
+      );
+      this.#notifyListener(listener);
+      return () => undefined;
+    }
+    this.#failureListeners.add(listener);
+    if (!this.healthy) this.#notifyListener(listener);
+    return () => this.#failureListeners.delete(listener);
+  }
+
+  get healthy(): boolean {
+    return this.#failures.length === 0;
+  }
+
+  #failureRecordsFor(transactionOrder: number): RetirementFailure[] {
     return this.#failures
       .filter((failure) => failure.ancestry.includes(transactionOrder))
       .sort(
         (left, right) =>
           left.transactionOrder - right.transactionOrder ||
           left.occurrence - right.occurrence,
-      )
-      .map((failure) => failure.error);
+      );
   }
 
-  get healthy(): boolean {
-    return this.#failures.length === 0;
+  #notifyFailureListeners(): void {
+    for (const listener of this.#failureListeners)
+      this.#notifyListener(listener);
+  }
+
+  #notifyListener(listener: (failure: AggregateError) => void): void {
+    const failures = this.failuresFor(this.#rootOrder);
+    if (failures.length === 0) return;
+    try {
+      listener(aggregateRetirementFailures(failures));
+    } catch {
+      // Failure observers are best-effort notifications. The root remains
+      // poisoned even if an observer itself is unavailable.
+    }
   }
 }
 
@@ -100,12 +202,15 @@ export class ZenXThreadTitleOwnershipTransaction {
       ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
     this.#parent = parent;
     if (parent === undefined) {
-      this.#closure = new RootRetirementClosure();
+      this.#closure = new RootRetirementClosure(this.#order);
       this.#ancestry = [this.#order];
     } else {
+      const parentAlreadyFenced = !parent.isCurrent();
       this.#closure = parent.#closure;
       this.#ancestry = [...parent.#ancestry, this.#order];
+      this.#closure.registerChild(this.#order, this.#ancestry);
       parent.#children.push(this);
+      if (parentAlreadyFenced) void this.retire();
     }
   }
 
@@ -132,6 +237,15 @@ export class ZenXThreadTitleOwnershipTransaction {
     return aggregateRetirementFailures(failures);
   }
 
+  onRetirementFailure(listener: (failure: AggregateError) => void): () => void {
+    const root = this.root;
+    return this.#closure.addFailureListener(
+      root.#order,
+      root.#ancestry,
+      listener,
+    );
+  }
+
   fork(
     options: ZenXThreadTitleOwnershipTransactionOptions = {},
   ): ZenXThreadTitleOwnershipTransaction {
@@ -146,8 +260,18 @@ export class ZenXThreadTitleOwnershipTransaction {
       () => undefined,
     );
     if (this.#active) {
-      this.#tracked.add(settled);
-      void settled.finally(() => this.#tracked.delete(settled));
+      if (this.#tracked.size >= MAX_TRACKED_RETIREMENT_WORK) {
+        this.#record(
+          new Error(
+            `Title ownership retirement reached its bounded capacity of ${String(
+              MAX_TRACKED_RETIREMENT_WORK,
+            )} tracked operations`,
+          ),
+        );
+      } else {
+        this.#tracked.add(settled);
+        void settled.finally(() => this.#tracked.delete(settled));
+      }
     }
     if (this.root !== this) this.root.track(operation);
     return operation;
@@ -156,6 +280,16 @@ export class ZenXThreadTitleOwnershipTransaction {
   onRetire(callback: () => void): () => void {
     if (!this.isCurrent()) {
       callback();
+      return () => undefined;
+    }
+    if (this.#retirementHooks.size >= MAX_RETIREMENT_HOOKS) {
+      this.#record(
+        new Error(
+          `Title ownership retirement reached its bounded capacity of ${String(
+            MAX_RETIREMENT_HOOKS,
+          )} hooks`,
+        ),
+      );
       return () => undefined;
     }
     this.#retirementHooks.add(callback);
@@ -175,7 +309,7 @@ export class ZenXThreadTitleOwnershipTransaction {
     this.#retirement = retirement;
 
     // Registration and a rejection observer exist before retirement work runs.
-    this.#closure.observe(this.#order, retirement);
+    this.#closure.observe(this.#order, this.#ancestry, retirement);
     void this.#retireNow().then(resolveRetirement, rejectRetirement);
     return retirement;
   }
@@ -183,7 +317,7 @@ export class ZenXThreadTitleOwnershipTransaction {
   async #retireNow(): Promise<void> {
     const childOutcomes = this.#children.map((child) => {
       const retirement = child.retire();
-      return this.#closure.observe(child.#order, retirement);
+      return this.#closure.observe(child.#order, child.#ancestry, retirement);
     });
 
     try {
@@ -251,7 +385,9 @@ function validDeadline(value: number): number {
 }
 
 function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.length <= MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH) return message;
+  return `${message.slice(0, MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH - 1)}…`;
 }
 
 function aggregateRetirementFailures(failures: unknown[]): AggregateError {

--- a/apps/zenx/src/main/thread-title-ownership-transaction.ts
+++ b/apps/zenx/src/main/thread-title-ownership-transaction.ts
@@ -1,11 +1,17 @@
+import {
+  aggregateTitleOwnershipFailures,
+  MAX_TITLE_OWNERSHIP_FAILURE_EVIDENCE,
+  normalizeTitleOwnershipFailure,
+} from "./thread-title-failure.js";
+
 const DEFAULT_QUIESCENCE_DEADLINE_MS = 250;
 const MAX_NESTED_RETIREMENT_TRANSACTIONS = 128;
 const MAX_RETIREMENT_OUTCOMES = MAX_NESTED_RETIREMENT_TRANSACTIONS + 1;
-const MAX_RETIREMENT_FAILURE_EVIDENCE = 64;
+const MAX_RETIREMENT_FAILURE_EVIDENCE = MAX_TITLE_OWNERSHIP_FAILURE_EVIDENCE;
 const MAX_RETIREMENT_FAILURE_LISTENERS = 64;
 const MAX_RETIREMENT_HOOKS = 64;
+const MAX_SAFE_ABORT_LISTENERS = 64;
 const MAX_TRACKED_RETIREMENT_WORK = 128;
-const MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH = 160;
 
 export interface ZenXThreadTitleOwnershipTransactionOptions {
   deadlineMs?: number;
@@ -57,7 +63,11 @@ class RootRetirementClosure {
     if (existing !== undefined) return existing;
     const outcome = retirement.then<RetirementOutcome, RetirementOutcome>(
       () => ({ ok: true }),
-      () => ({ ok: false }),
+      (reason: unknown) => {
+        if (this.#failureRecordsFor(transactionOrder).length === 0)
+          this.record(transactionOrder, ancestry, reason);
+        return { ok: false };
+      },
     );
     if (this.#observations.size >= MAX_RETIREMENT_OUTCOMES) {
       this.record(
@@ -87,7 +97,7 @@ class RootRetirementClosure {
         transactionOrder,
         ancestry,
         occurrence,
-        error: normalizeRetirementFailure(error),
+        error: normalizeTitleOwnershipFailure(error),
       });
     } else {
       this.#failureEvidenceSaturated = true;
@@ -157,10 +167,16 @@ class RootRetirementClosure {
     const failures = this.failuresFor(this.#rootOrder);
     if (failures.length === 0) return;
     try {
-      listener(aggregateRetirementFailures(failures));
-    } catch {
-      // Failure observers are best-effort notifications. The root remains
-      // poisoned even if an observer itself is unavailable.
+      const result = (listener as (failure: AggregateError) => unknown)(
+        aggregateRetirementFailures(failures),
+      );
+      observeAuxiliaryFailure(result, (error) => {
+        this.#failureListeners.delete(listener);
+        this.record(this.#rootOrder, [this.#rootOrder], error);
+      });
+    } catch (error) {
+      this.#failureListeners.delete(listener);
+      this.record(this.#rootOrder, [this.#rootOrder], error);
     }
   }
 }
@@ -175,7 +191,7 @@ let nextTransactionOrder = 0;
 export class ZenXThreadTitleOwnershipTransaction {
   readonly #order = ++nextTransactionOrder;
   readonly id = `title-owner-${String(this.#order)}`;
-  readonly #abort = new AbortController();
+  readonly #abort: OwnedSafeAbortController;
   readonly #deadlineMs: number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
@@ -199,6 +215,7 @@ export class ZenXThreadTitleOwnershipTransaction {
     this.#cancelScheduled =
       options.cancelScheduled ??
       ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+    this.#abort = new OwnedSafeAbortController((error) => this.#record(error));
     this.#parent = parent;
     if (parent === undefined) {
       this.#closure = new RootRetirementClosure(this.#order);
@@ -234,6 +251,10 @@ export class ZenXThreadTitleOwnershipTransaction {
     const failures = this.#closure.failuresFor(this.#order);
     if (failures.length === 0) return undefined;
     return aggregateRetirementFailures(failures);
+  }
+
+  poison(error: unknown): void {
+    this.#record(error);
   }
 
   onRetirementFailure(listener: (failure: AggregateError) => void): () => void {
@@ -278,7 +299,12 @@ export class ZenXThreadTitleOwnershipTransaction {
 
   onRetire(callback: () => void): () => void {
     if (!this.isCurrent()) {
-      callback();
+      try {
+        const result = (callback as () => unknown)();
+        this.#observeRetirementAuxiliary(result);
+      } catch (error) {
+        this.#record(error);
+      }
       return () => undefined;
     }
     if (this.#retirementHooks.size >= MAX_RETIREMENT_HOOKS) {
@@ -309,7 +335,13 @@ export class ZenXThreadTitleOwnershipTransaction {
 
     // Registration and a rejection observer exist before retirement work runs.
     this.#closure.observe(this.#order, this.#ancestry, retirement);
-    void this.#retireNow().then(resolveRetirement, rejectRetirement);
+    void this.#retireNow().then(resolveRetirement, (error: unknown) => {
+      if (this.#closure.failuresFor(this.#order).length === 0)
+        this.#record(error);
+      rejectRetirement(
+        this.retirementFailure() ?? normalizeTitleOwnershipFailure(error),
+      );
+    });
     return retirement;
   }
 
@@ -324,9 +356,11 @@ export class ZenXThreadTitleOwnershipTransaction {
     } catch (error) {
       this.#record(error);
     }
+    await Promise.resolve();
     for (const hook of this.#retirementHooks) {
       try {
-        hook();
+        const result = (hook as () => unknown)();
+        this.#observeRetirementAuxiliary(result);
       } catch (error) {
         this.#record(error);
       }
@@ -360,7 +394,10 @@ export class ZenXThreadTitleOwnershipTransaction {
     ]);
     if (outcome === "settled" && deadlineHandle !== undefined) {
       try {
-        this.#cancelScheduled(deadlineHandle);
+        const result = (this.#cancelScheduled as (handle: unknown) => unknown)(
+          deadlineHandle,
+        );
+        void observeAuxiliaryFailure(result, (error) => this.#record(error));
       } catch (error) {
         errors.push(error);
       }
@@ -371,6 +408,207 @@ export class ZenXThreadTitleOwnershipTransaction {
 
   #record(error: unknown): void {
     this.#closure.record(this.#order, this.#ancestry, error);
+  }
+
+  #observeRetirementAuxiliary(result: unknown): void {
+    const observation = observeAuxiliaryFailure(result, (error) =>
+      this.#record(error),
+    );
+    if (this.#tracked.size >= MAX_TRACKED_RETIREMENT_WORK) {
+      this.#record(
+        new Error(
+          `Title ownership retirement reached its bounded capacity of ${String(
+            MAX_TRACKED_RETIREMENT_WORK,
+          )} tracked operations`,
+        ),
+      );
+      return;
+    }
+    this.#tracked.add(observation);
+    void observation.finally(() => this.#tracked.delete(observation));
+  }
+}
+
+type SafeAbortListener = EventListenerOrEventListenerObject;
+
+interface SafeAbortRegistration {
+  readonly type: string;
+  readonly listener: SafeAbortListener;
+  readonly capture: boolean;
+  readonly wrapped: EventListener;
+}
+
+/** Keeps a native-branded signal for model/fetch adapters while ensuring that
+ * every listener registered through this owned signal surface is isolated. */
+class OwnedSafeAbortController {
+  readonly #controller = new AbortController();
+  readonly #registrations: SafeAbortRegistration[] = [];
+  readonly #record: (error: unknown) => void;
+  #onabort: EventHandler | null = null;
+
+  readonly signal: AbortSignal;
+
+  constructor(record: (error: unknown) => void) {
+    this.#record = record;
+    const signal = this.#controller.signal;
+    const add = signal.addEventListener.bind(signal);
+    const remove = signal.removeEventListener.bind(signal);
+    Object.defineProperties(signal, {
+      addEventListener: {
+        configurable: false,
+        value: (
+          type: string,
+          listener: SafeAbortListener | null,
+          options?: boolean | AddEventListenerOptions,
+        ) => {
+          if (listener === null) return;
+          const capture = safeEventOption(options, "capture", this.#record);
+          const once = safeEventOption(options, "once", this.#record);
+          if (
+            this.#registrations.some(
+              (entry) =>
+                entry.type === type &&
+                entry.listener === listener &&
+                entry.capture === capture,
+            )
+          )
+            return;
+          if (this.#registrations.length >= MAX_SAFE_ABORT_LISTENERS) {
+            this.#record(
+              new Error(
+                `Title ownership abort notification reached its bounded capacity of ${String(
+                  MAX_SAFE_ABORT_LISTENERS,
+                )} listeners`,
+              ),
+            );
+            return;
+          }
+          const wrapped: EventListener = (event) => {
+            if (once) this.#forget(type, listener, capture, remove);
+            this.#invoke(listener, event);
+          };
+          this.#registrations.push({ type, listener, capture, wrapped });
+          try {
+            add(type, wrapped, { capture, once: false });
+          } catch (error) {
+            this.#forget(type, listener, capture, remove);
+            this.#record(error);
+          }
+        },
+      },
+      removeEventListener: {
+        configurable: false,
+        value: (
+          type: string,
+          listener: SafeAbortListener | null,
+          options?: boolean | EventListenerOptions,
+        ) => {
+          if (listener === null) return;
+          const capture = safeEventOption(options, "capture", this.#record);
+          const registration = this.#registrations.find(
+            (entry) =>
+              entry.type === type &&
+              entry.listener === listener &&
+              entry.capture === capture,
+          );
+          if (registration === undefined) return;
+          const index = this.#registrations.indexOf(registration);
+          this.#registrations.splice(index, 1);
+          try {
+            remove(type, registration.wrapped, capture);
+          } catch (error) {
+            this.#record(error);
+          }
+        },
+      },
+      onabort: {
+        configurable: false,
+        get: () => this.#onabort,
+        set: (listener: EventHandler | null) => {
+          if (this.#onabort !== null)
+            signal.removeEventListener("abort", this.#onabort);
+          this.#onabort = listener;
+          if (listener !== null) signal.addEventListener("abort", listener);
+        },
+      },
+    });
+    this.signal = signal;
+  }
+
+  abort(): void {
+    this.#controller.abort(
+      normalizeTitleOwnershipFailure("Title ownership transaction retired"),
+    );
+  }
+
+  #invoke(listener: SafeAbortListener, event: Event): void {
+    try {
+      let result: unknown;
+      if (typeof listener === "function") {
+        result = Reflect.apply(listener, this.signal, [event]);
+      } else {
+        const handleEvent = Reflect.get(listener, "handleEvent");
+        if (typeof handleEvent !== "function") return;
+        result = Reflect.apply(handleEvent, listener, [event]);
+      }
+      void observeAuxiliaryFailure(result, this.#record);
+    } catch (error) {
+      this.#record(error);
+    }
+  }
+
+  #forget(
+    type: string,
+    listener: SafeAbortListener,
+    capture: boolean,
+    remove: AbortSignal["removeEventListener"],
+  ): void {
+    const registration = this.#registrations.find(
+      (entry) =>
+        entry.type === type &&
+        entry.listener === listener &&
+        entry.capture === capture,
+    );
+    if (registration === undefined) return;
+    this.#registrations.splice(this.#registrations.indexOf(registration), 1);
+    try {
+      remove(type, registration.wrapped, capture);
+    } catch (error) {
+      this.#record(error);
+    }
+  }
+}
+
+type EventHandler = (this: AbortSignal, event: Event) => unknown;
+
+function safeEventOption(
+  options: boolean | EventListenerOptions | AddEventListenerOptions | undefined,
+  key: "capture" | "once",
+  record: (error: unknown) => void,
+): boolean {
+  if (typeof options === "boolean") return key === "capture" && options;
+  if (options === undefined) return false;
+  try {
+    return Boolean(Reflect.get(options, key));
+  } catch (error) {
+    record(error);
+    return false;
+  }
+}
+
+async function observeAuxiliaryFailure(
+  result: unknown,
+  record: (error: unknown) => void,
+): Promise<void> {
+  try {
+    await result;
+  } catch (error) {
+    try {
+      record(error);
+    } catch {
+      // The normalizer/closure record path is designed to be total. This last
+      // guard prevents an observation boundary from creating a process escape.
+    }
   }
 }
 
@@ -383,24 +621,11 @@ function validDeadline(value: number): number {
   return value;
 }
 
-function describeError(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error);
-  if (message.length <= MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH) return message;
-  return `${message.slice(0, MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH - 1)}…`;
-}
-
-function normalizeRetirementFailure(error: unknown): Error {
-  return new Error(describeError(error));
-}
-
 function aggregateRetirementFailures(
   failures: readonly Error[],
 ): AggregateError {
-  const diagnostics = failures.map(normalizeRetirementFailure);
-  return new AggregateError(
-    diagnostics,
-    `Could not fully retire title ownership transaction: ${diagnostics
-      .map(describeError)
-      .join("; ")}`,
+  return aggregateTitleOwnershipFailures(
+    failures,
+    "Could not fully retire title ownership transaction",
   );
 }

--- a/apps/zenx/src/main/thread-title-ownership-transaction.ts
+++ b/apps/zenx/src/main/thread-title-ownership-transaction.ts
@@ -1,0 +1,264 @@
+const DEFAULT_QUIESCENCE_DEADLINE_MS = 250;
+
+export interface ZenXThreadTitleOwnershipTransactionOptions {
+  deadlineMs?: number;
+  schedule?: (callback: () => void, delayMs: number) => unknown;
+  cancelScheduled?: (handle: unknown) => void;
+}
+
+interface RetirementFailure {
+  readonly transactionOrder: number;
+  readonly ancestry: readonly number[];
+  readonly occurrence: number;
+  readonly error: unknown;
+}
+
+type RetirementOutcome =
+  { readonly ok: true } | { readonly ok: false; readonly error: unknown };
+
+class RootRetirementClosure {
+  readonly #failures: RetirementFailure[] = [];
+  readonly #observations = new Map<number, Promise<RetirementOutcome>>();
+  #nextOccurrence = 0;
+
+  observe(
+    transactionOrder: number,
+    retirement: Promise<void>,
+  ): Promise<RetirementOutcome> {
+    const existing = this.#observations.get(transactionOrder);
+    if (existing !== undefined) return existing;
+    const outcome = retirement.then<RetirementOutcome, RetirementOutcome>(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+    this.#observations.set(transactionOrder, outcome);
+    return outcome;
+  }
+
+  record(
+    transactionOrder: number,
+    ancestry: readonly number[],
+    error: unknown,
+  ): void {
+    this.#failures.push({
+      transactionOrder,
+      ancestry,
+      occurrence: this.#nextOccurrence++,
+      error,
+    });
+  }
+
+  failuresFor(transactionOrder: number): unknown[] {
+    return this.#failures
+      .filter((failure) => failure.ancestry.includes(transactionOrder))
+      .sort(
+        (left, right) =>
+          left.transactionOrder - right.transactionOrder ||
+          left.occurrence - right.occurrence,
+      )
+      .map((failure) => failure.error);
+  }
+
+  get healthy(): boolean {
+    return this.#failures.length === 0;
+  }
+}
+
+let nextTransactionOrder = 0;
+
+/**
+ * A transient title-work owner. Every transaction belongs to one root-owned
+ * retirement closure. Child retirement is synchronously registered there
+ * before abort, hooks, scheduling, or cleanup can reject.
+ */
+export class ZenXThreadTitleOwnershipTransaction {
+  readonly #order = ++nextTransactionOrder;
+  readonly id = `title-owner-${String(this.#order)}`;
+  readonly #abort = new AbortController();
+  readonly #deadlineMs: number;
+  readonly #schedule: (callback: () => void, delayMs: number) => unknown;
+  readonly #cancelScheduled: (handle: unknown) => void;
+  readonly #tracked = new Set<Promise<void>>();
+  readonly #retirementHooks = new Set<() => void>();
+  readonly #children: ZenXThreadTitleOwnershipTransaction[] = [];
+  readonly #parent: ZenXThreadTitleOwnershipTransaction | undefined;
+  readonly #closure: RootRetirementClosure;
+  readonly #ancestry: readonly number[];
+  #active = true;
+  #retirement: Promise<void> | undefined;
+
+  constructor(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+    parent?: ZenXThreadTitleOwnershipTransaction,
+  ) {
+    this.#deadlineMs = validDeadline(
+      options.deadlineMs ?? DEFAULT_QUIESCENCE_DEADLINE_MS,
+    );
+    this.#schedule = options.schedule ?? setTimeout;
+    this.#cancelScheduled =
+      options.cancelScheduled ??
+      ((handle) => clearTimeout(handle as ReturnType<typeof setTimeout>));
+    this.#parent = parent;
+    if (parent === undefined) {
+      this.#closure = new RootRetirementClosure();
+      this.#ancestry = [this.#order];
+    } else {
+      this.#closure = parent.#closure;
+      this.#ancestry = [...parent.#ancestry, this.#order];
+      parent.#children.push(this);
+    }
+  }
+
+  get signal(): AbortSignal {
+    return this.#abort.signal;
+  }
+
+  get root(): ZenXThreadTitleOwnershipTransaction {
+    return this.#parent?.root ?? this;
+  }
+
+  isCurrent(): boolean {
+    return (
+      this.#active &&
+      !this.#abort.signal.aborted &&
+      this.#closure.healthy &&
+      (this.#parent?.isCurrent() ?? true)
+    );
+  }
+
+  retirementFailure(): AggregateError | undefined {
+    const failures = this.#closure.failuresFor(this.#order);
+    if (failures.length === 0) return undefined;
+    return aggregateRetirementFailures(failures);
+  }
+
+  fork(
+    options: ZenXThreadTitleOwnershipTransactionOptions = {},
+  ): ZenXThreadTitleOwnershipTransaction {
+    if (!this.isCurrent())
+      throw new Error("Cannot fork retired title ownership");
+    return new ZenXThreadTitleOwnershipTransaction(options, this);
+  }
+
+  track<T>(operation: Promise<T>): Promise<T> {
+    const settled = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    if (this.#active) {
+      this.#tracked.add(settled);
+      void settled.finally(() => this.#tracked.delete(settled));
+    }
+    if (this.root !== this) this.root.track(operation);
+    return operation;
+  }
+
+  onRetire(callback: () => void): () => void {
+    if (!this.isCurrent()) {
+      callback();
+      return () => undefined;
+    }
+    this.#retirementHooks.add(callback);
+    return () => this.#retirementHooks.delete(callback);
+  }
+
+  retire(): Promise<void> {
+    if (this.#retirement !== undefined) return this.#retirement;
+    this.#active = false;
+
+    let resolveRetirement!: () => void;
+    let rejectRetirement!: (error: unknown) => void;
+    const retirement = new Promise<void>((resolve, reject) => {
+      resolveRetirement = resolve;
+      rejectRetirement = reject;
+    });
+    this.#retirement = retirement;
+
+    // Registration and a rejection observer exist before retirement work runs.
+    this.#closure.observe(this.#order, retirement);
+    void this.#retireNow().then(resolveRetirement, rejectRetirement);
+    return retirement;
+  }
+
+  async #retireNow(): Promise<void> {
+    const childOutcomes = this.#children.map((child) => {
+      const retirement = child.retire();
+      return this.#closure.observe(child.#order, retirement);
+    });
+
+    try {
+      this.#abort.abort();
+    } catch (error) {
+      this.#record(error);
+    }
+    for (const hook of this.#retirementHooks) {
+      try {
+        hook();
+      } catch (error) {
+        this.#record(error);
+      }
+    }
+    this.#retirementHooks.clear();
+
+    for (const error of await this.#finishQuiescence()) this.#record(error);
+    await Promise.all(childOutcomes);
+
+    const failures = this.#closure.failuresFor(this.#order);
+    if (failures.length > 0) throw aggregateRetirementFailures(failures);
+  }
+
+  async #finishQuiescence(): Promise<unknown[]> {
+    const errors: unknown[] = [];
+    const work = Promise.all([...this.#tracked]).then(() => undefined);
+    let deadlineHandle: unknown;
+    let resolveDeadline!: () => void;
+    const deadline = new Promise<void>((resolve) => {
+      resolveDeadline = resolve;
+    });
+    try {
+      deadlineHandle = this.#schedule(resolveDeadline, this.#deadlineMs);
+    } catch (error) {
+      errors.push(error);
+      resolveDeadline();
+    }
+    const outcome = await Promise.race([
+      work.then(() => "settled" as const),
+      deadline.then(() => "deadline" as const),
+    ]);
+    if (outcome === "settled" && deadlineHandle !== undefined) {
+      try {
+        this.#cancelScheduled(deadlineHandle);
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    this.#tracked.clear();
+    return errors;
+  }
+
+  #record(error: unknown): void {
+    this.#closure.record(this.#order, this.#ancestry, error);
+  }
+}
+
+function validDeadline(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(
+      "Title ownership quiescence deadline must be a finite non-negative number",
+    );
+  }
+  return value;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function aggregateRetirementFailures(failures: unknown[]): AggregateError {
+  return new AggregateError(
+    failures,
+    `Could not fully retire title ownership transaction: ${failures
+      .map(describeError)
+      .join("; ")}`,
+  );
+}

--- a/apps/zenx/src/main/thread-title-ownership-transaction.ts
+++ b/apps/zenx/src/main/thread-title-ownership-transaction.ts
@@ -17,11 +17,10 @@ interface RetirementFailure {
   readonly transactionOrder: number;
   readonly ancestry: readonly number[];
   readonly occurrence: number;
-  readonly error: unknown;
+  readonly error: Error;
 }
 
-type RetirementOutcome =
-  { readonly ok: true } | { readonly ok: false; readonly error: unknown };
+type RetirementOutcome = { readonly ok: true } | { readonly ok: false };
 
 class RootRetirementClosure {
   readonly #rootOrder: number;
@@ -58,7 +57,7 @@ class RootRetirementClosure {
     if (existing !== undefined) return existing;
     const outcome = retirement.then<RetirementOutcome, RetirementOutcome>(
       () => ({ ok: true }),
-      (error: unknown) => ({ ok: false, error }),
+      () => ({ ok: false }),
     );
     if (this.#observations.size >= MAX_RETIREMENT_OUTCOMES) {
       this.record(
@@ -88,7 +87,7 @@ class RootRetirementClosure {
         transactionOrder,
         ancestry,
         occurrence,
-        error,
+        error: normalizeRetirementFailure(error),
       });
     } else {
       this.#failureEvidenceSaturated = true;
@@ -106,7 +105,7 @@ class RootRetirementClosure {
     this.#notifyFailureListeners();
   }
 
-  failuresFor(transactionOrder: number): unknown[] {
+  failuresFor(transactionOrder: number): Error[] {
     return this.#failureRecordsFor(transactionOrder).map(
       (failure) => failure.error,
     );
@@ -390,10 +389,17 @@ function describeError(error: unknown): string {
   return `${message.slice(0, MAX_RETIREMENT_ERROR_DESCRIPTION_LENGTH - 1)}…`;
 }
 
-function aggregateRetirementFailures(failures: unknown[]): AggregateError {
+function normalizeRetirementFailure(error: unknown): Error {
+  return new Error(describeError(error));
+}
+
+function aggregateRetirementFailures(
+  failures: readonly Error[],
+): AggregateError {
+  const diagnostics = failures.map(normalizeRetirementFailure);
   return new AggregateError(
-    failures,
-    `Could not fully retire title ownership transaction: ${failures
+    diagnostics,
+    `Could not fully retire title ownership transaction: ${diagnostics
       .map(describeError)
       .join("; ")}`,
   );

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -1,28 +1,332 @@
-import { mkdir, open, rename, writeFile } from "node:fs/promises";
+import { realpathSync } from "node:fs";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import { ZenXThreadTitleOwnershipTransaction } from "./thread-title-ownership-transaction.js";
 import type {
   ThreadTitleProjection,
   ThreadTitleSnapshot,
 } from "./thread-title-types.js";
 
-export class ZenXThreadTitleStore {
-  readonly #filePath: string;
+export interface ZenXThreadTitleStoreFileSystem {
+  mkdir(
+    directory: string,
+    options: { recursive: true; mode: number },
+  ): Promise<unknown>;
+  readFile(file: string, encoding: "utf8"): Promise<string>;
+  writeFile(
+    file: string,
+    data: string,
+    options: { encoding: "utf8"; mode: number },
+  ): Promise<void>;
+  rename(source: string, destination: string): Promise<void>;
+  rm(file: string, options: { force: true }): Promise<void>;
+}
 
-  constructor(filePath: string) {
-    this.#filePath = path.resolve(filePath);
+/**
+ * Custom title stores must implement this ownership-aware contract. `claim`
+ * synchronously supersedes the prior root owner before its serialized read;
+ * every instance for the same durable projection shares that serialized
+ * ownership domain and stable `ownershipDomain` identity, predecessor
+ * retirement rejection is observed before the read, and `commit` never
+ * publishes a non-current owner.
+ */
+export interface ZenXThreadTitleOwnershipStore {
+  readonly ownershipDomain: object;
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot>;
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean>;
+}
+
+const nodeFileSystem: ZenXThreadTitleStoreFileSystem = {
+  mkdir,
+  readFile,
+  writeFile,
+  rename,
+  rm,
+};
+
+const MAX_OWNERSHIP_DOMAINS_PER_BACKEND = 64;
+const nodeFileSystemBackendIdentity = {};
+const protocolRegistries = new WeakMap<
+  object,
+  Map<string, ZenXThreadTitleStoreProtocol>
+>();
+
+export interface CanonicalTitleProjectionKeyOptions {
+  platform?: NodeJS.Platform;
+  cwd?: string;
+  realpath?: (candidate: string) => string;
+}
+
+/**
+ * Resolves aliases through the nearest existing ancestor so the key is stable
+ * even before the projection file itself exists.
+ */
+export function canonicalTitleProjectionKey(
+  filePath: string,
+  options: CanonicalTitleProjectionKeyOptions = {},
+): string {
+  return canonicalProjectionPath(filePath, options).key;
+}
+
+export class ZenXThreadTitleStore implements ZenXThreadTitleOwnershipStore {
+  readonly #protocol: ZenXThreadTitleStoreProtocol;
+
+  get ownershipDomain(): object {
+    return this.#protocol;
   }
 
-  async read(): Promise<ThreadTitleSnapshot> {
-    let handle;
-    try {
-      handle = await open(this.#filePath, "r");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
-      throw error;
+  constructor(
+    filePath: string,
+    options: {
+      fileSystem?: ZenXThreadTitleStoreFileSystem;
+      backendIdentity?: object;
+    } = {},
+  ) {
+    if (
+      options.fileSystem !== undefined &&
+      options.backendIdentity === undefined
+    ) {
+      throw new Error(
+        "Injected title-store fileSystem requires an explicit stable backendIdentity",
+      );
     }
+    if (
+      options.fileSystem === undefined &&
+      options.backendIdentity !== undefined
+    ) {
+      throw new Error(
+        "backendIdentity is only valid with an injected title-store fileSystem",
+      );
+    }
+    const backendIdentity =
+      options.backendIdentity ?? nodeFileSystemBackendIdentity;
+    const canonical = canonicalProjectionPath(filePath);
+    this.#protocol = protocolFor(
+      backendIdentity,
+      canonical.key,
+      () =>
+        new ZenXThreadTitleStoreProtocol(
+          canonical.filePath,
+          options.fileSystem ?? nodeFileSystem,
+        ),
+    );
+  }
+
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot> {
+    return this.#protocol.claim(owner);
+  }
+
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    return this.#protocol.commit(snapshot, owner);
+  }
+}
+
+function protocolFor(
+  backendIdentity: object,
+  projectionKey: string,
+  create: () => ZenXThreadTitleStoreProtocol,
+): ZenXThreadTitleStoreProtocol {
+  let registry = protocolRegistries.get(backendIdentity);
+  if (registry === undefined) {
+    registry = new Map();
+    protocolRegistries.set(backendIdentity, registry);
+  }
+  const existing = registry.get(projectionKey);
+  if (existing !== undefined) return existing;
+  if (registry.size >= MAX_OWNERSHIP_DOMAINS_PER_BACKEND) {
+    throw new Error(
+      `Title ownership-domain registry reached its bounded capacity of ${String(
+        MAX_OWNERSHIP_DOMAINS_PER_BACKEND,
+      )}`,
+    );
+  }
+  const protocol = create();
+  registry.set(projectionKey, protocol);
+  return protocol;
+}
+
+function canonicalProjectionPath(
+  filePath: string,
+  options: CanonicalTitleProjectionKeyOptions = {},
+): { readonly filePath: string; readonly key: string } {
+  const platform = options.platform ?? process.platform;
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const cwd = options.cwd ?? process.cwd();
+  const resolveRealpath = options.realpath ?? realpathSync.native;
+  const unresolved: string[] = [];
+  let cursor = pathApi.resolve(cwd, filePath);
+  let canonical: string | undefined;
+
+  while (canonical === undefined) {
     try {
-      const value: unknown = JSON.parse(await handle.readFile("utf8"));
+      canonical = resolveRealpath(cursor);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+      const parent = pathApi.dirname(cursor);
+      if (parent === cursor) {
+        canonical = cursor;
+        break;
+      }
+      unresolved.unshift(pathApi.basename(cursor));
+      cursor = parent;
+    }
+  }
+  const physicalPath = pathApi.normalize(
+    pathApi.join(canonical, ...unresolved),
+  );
+  return {
+    filePath: physicalPath,
+    key: platform === "win32" ? physicalPath.toLowerCase() : physicalPath,
+  };
+}
+
+class ZenXThreadTitleStoreProtocol {
+  readonly #filePath: string;
+  readonly #fileSystem: ZenXThreadTitleStoreFileSystem;
+  #currentRoot: ZenXThreadTitleOwnershipTransaction | undefined;
+  #tail = Promise.resolve();
+  #failure: Error | undefined;
+  #temporarySequence = 0;
+
+  constructor(filePath: string, fileSystem: ZenXThreadTitleStoreFileSystem) {
+    this.#filePath = filePath;
+    this.#fileSystem = fileSystem;
+  }
+
+  claim(
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<ThreadTitleSnapshot> {
+    const root = owner.root;
+    let retirement: Promise<RetirementOutcome> | undefined;
+    if (this.#currentRoot !== root) {
+      const previous = this.#currentRoot;
+      this.#currentRoot = root;
+      if (previous !== undefined) retirement = observeRetirement(previous);
+    }
+    const operation = this.#serial(async () => {
+      if (retirement !== undefined) {
+        const outcome = await retirement;
+        if (!outcome.ok) {
+          const failure = new Error(
+            `ZenX title-store ownership retirement failed: ${describeError(outcome.error)}`,
+            { cause: outcome.error },
+          );
+          this.#failure = failure;
+          throw failure;
+        }
+      }
+      this.#assertHealthy();
+      if (!this.#owns(owner))
+        throw new Error("Title ownership changed before the store read");
+      return await this.#readSnapshot();
+    });
+    return owner.track(operation);
+  }
+
+  commit(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    const operation = this.#serial(async () => {
+      this.#assertHealthy();
+      if (!this.#owns(owner)) return false;
+      return await this.#commitSnapshot(snapshot, owner);
+    });
+    return owner.track(operation);
+  }
+
+  async #commitSnapshot(
+    snapshot: ThreadTitleSnapshot,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<boolean> {
+    const directory = path.dirname(this.#filePath);
+    const temporary = this.#temporaryPath(owner, "stage");
+    let staged = false;
+    let primaryError: unknown;
+    try {
+      await this.#fileSystem.mkdir(directory, { recursive: true, mode: 0o700 });
+      if (!this.#owns(owner)) return false;
+      const previous = await this.#readRaw();
+      if (!this.#owns(owner)) return false;
+      staged = true;
+      await this.#fileSystem.writeFile(
+        temporary,
+        `${JSON.stringify(snapshot, null, 2)}\n`,
+        { encoding: "utf8", mode: 0o600 },
+      );
+      if (!this.#owns(owner)) return false;
+      await this.#fileSystem.rename(temporary, this.#filePath);
+      staged = false;
+      if (this.#owns(owner)) return true;
+      try {
+        await this.#restore(previous, owner);
+      } catch (error) {
+        const failure = new Error(
+          `ZenX title-store ownership compensation failed: ${describeError(error)}`,
+          { cause: error },
+        );
+        this.#failure = failure;
+        throw failure;
+      }
+      return false;
+    } catch (error) {
+      primaryError = error;
+      throw error;
+    } finally {
+      if (staged) {
+        try {
+          await this.#fileSystem.rm(temporary, { force: true });
+        } catch (cleanupError) {
+          if (primaryError === undefined) throw cleanupError;
+          this.#failure = new AggregateError(
+            [primaryError, cleanupError],
+            "ZenX title-store write and staged-file cleanup failed",
+          );
+        }
+      }
+    }
+  }
+
+  async #restore(
+    previous: string | undefined,
+    owner: ZenXThreadTitleOwnershipTransaction,
+  ): Promise<void> {
+    if (previous === undefined) {
+      await this.#fileSystem.rm(this.#filePath, { force: true });
+      return;
+    }
+    const temporary = this.#temporaryPath(owner, "compensate");
+    let staged = false;
+    try {
+      staged = true;
+      await this.#fileSystem.writeFile(temporary, previous, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await this.#fileSystem.rename(temporary, this.#filePath);
+      staged = false;
+    } finally {
+      if (staged) await this.#fileSystem.rm(temporary, { force: true });
+    }
+  }
+
+  async #readSnapshot(): Promise<ThreadTitleSnapshot> {
+    const raw = await this.#readRaw();
+    if (raw === undefined) return {};
+    try {
+      const value: unknown = JSON.parse(raw);
       if (!isRecord(value))
         throw new Error("ZenX thread title store is invalid");
       return Object.fromEntries(
@@ -35,20 +339,59 @@ export class ZenXThreadTitleStore {
       if (error instanceof SyntaxError)
         throw new Error("ZenX thread title store contains invalid JSON");
       throw error;
-    } finally {
-      await handle.close();
     }
   }
 
-  async write(snapshot: ThreadTitleSnapshot): Promise<void> {
-    const directory = path.dirname(this.#filePath);
-    await mkdir(directory, { recursive: true, mode: 0o700 });
-    const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(snapshot, null, 2)}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    await rename(temporary, this.#filePath);
+  async #readRaw(): Promise<string | undefined> {
+    try {
+      return await this.#fileSystem.readFile(this.#filePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw error;
+    }
+  }
+
+  #owns(owner: ZenXThreadTitleOwnershipTransaction): boolean {
+    return this.#currentRoot === owner.root && owner.isCurrent();
+  }
+
+  #temporaryPath(
+    owner: ZenXThreadTitleOwnershipTransaction,
+    phase: string,
+  ): string {
+    this.#temporarySequence += 1;
+    return `${this.#filePath}.${process.pid}.${owner.id}.${String(
+      this.#temporarySequence,
+    )}.${phase}.tmp`;
+  }
+
+  #assertHealthy(): void {
+    if (this.#failure !== undefined) throw this.#failure;
+  }
+
+  #serial<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#tail.then(operation, operation);
+    this.#tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}
+
+type RetirementOutcome =
+  { readonly ok: true } | { readonly ok: false; readonly error: unknown };
+
+function observeRetirement(
+  owner: ZenXThreadTitleOwnershipTransaction,
+): Promise<RetirementOutcome> {
+  try {
+    return owner.retire().then(
+      () => ({ ok: true }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+  } catch (error) {
+    return Promise.resolve({ ok: false, error });
   }
 }
 
@@ -77,4 +420,8 @@ function validateProjection(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -32,7 +32,7 @@ export interface ZenXThreadTitleStoreFileSystem {
  * publishes a non-current owner.
  */
 export interface ZenXThreadTitleOwnershipStore {
-  readonly ownershipDomain: object;
+  readonly ownershipDomain: ZenXThreadTitleOwnershipDomain;
   claim(
     owner: ZenXThreadTitleOwnershipTransaction,
   ): Promise<ThreadTitleSnapshot>;
@@ -40,6 +40,11 @@ export interface ZenXThreadTitleOwnershipStore {
     snapshot: ThreadTitleSnapshot,
     owner: ZenXThreadTitleOwnershipTransaction,
   ): Promise<boolean>;
+}
+
+export interface ZenXThreadTitleOwnershipDomain {
+  failure(): Error | undefined;
+  onFailure(listener: (failure: Error) => void): () => void;
 }
 
 const nodeFileSystem: ZenXThreadTitleStoreFileSystem = {
@@ -51,6 +56,7 @@ const nodeFileSystem: ZenXThreadTitleStoreFileSystem = {
 };
 
 const MAX_OWNERSHIP_DOMAINS_PER_BACKEND = 64;
+const MAX_OWNERSHIP_DOMAIN_FAILURE_LISTENERS = 128;
 const nodeFileSystemBackendIdentity = {};
 const protocolRegistries = new WeakMap<
   object,
@@ -77,7 +83,7 @@ export function canonicalTitleProjectionKey(
 export class ZenXThreadTitleStore implements ZenXThreadTitleOwnershipStore {
   readonly #protocol: ZenXThreadTitleStoreProtocol;
 
-  get ownershipDomain(): object {
+  get ownershipDomain(): ZenXThreadTitleOwnershipDomain {
     return this.#protocol;
   }
 
@@ -195,6 +201,7 @@ function canonicalProjectionPath(
 class ZenXThreadTitleStoreProtocol {
   readonly #filePath: string;
   readonly #fileSystem: ZenXThreadTitleStoreFileSystem;
+  readonly #failureListeners = new Set<(failure: Error) => void>();
   #currentRoot: ZenXThreadTitleOwnershipTransaction | undefined;
   #tail = Promise.resolve();
   #failure: Error | undefined;
@@ -203,6 +210,28 @@ class ZenXThreadTitleStoreProtocol {
   constructor(filePath: string, fileSystem: ZenXThreadTitleStoreFileSystem) {
     this.#filePath = filePath;
     this.#fileSystem = fileSystem;
+  }
+
+  failure(): Error | undefined {
+    return this.#failure;
+  }
+
+  onFailure(listener: (failure: Error) => void): () => void {
+    if (this.#failureListeners.size >= MAX_OWNERSHIP_DOMAIN_FAILURE_LISTENERS) {
+      const failure = this.#poisonRetirement(
+        new Error(
+          `Title ownership domain reached its bounded capacity of ${String(
+            MAX_OWNERSHIP_DOMAIN_FAILURE_LISTENERS,
+          )} failure listeners`,
+        ),
+      );
+      this.#notifyFailureListener(listener, failure);
+      return () => undefined;
+    }
+    this.#failureListeners.add(listener);
+    if (this.#failure !== undefined)
+      this.#notifyFailureListener(listener, this.#failure);
+    return () => this.#failureListeners.delete(listener);
   }
 
   claim(
@@ -378,7 +407,20 @@ class ZenXThreadTitleStoreProtocol {
       `ZenX title-store ownership retirement failed: ${describeError(error)}`,
       { cause: error },
     );
+    for (const listener of this.#failureListeners)
+      this.#notifyFailureListener(listener, this.#failure);
     return this.#failure;
+  }
+
+  #notifyFailureListener(
+    listener: (failure: Error) => void,
+    failure: Error,
+  ): void {
+    try {
+      listener(failure);
+    } catch {
+      // The domain remains poisoned even if a transient observer is gone.
+    }
   }
 
   #serial<T>(operation: () => Promise<T>): Promise<T> {

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -213,24 +213,24 @@ class ZenXThreadTitleStoreProtocol {
     if (this.#currentRoot !== root) {
       const previous = this.#currentRoot;
       this.#currentRoot = root;
+      root.onRetirementFailure((error) => this.#poisonRetirement(error));
       if (previous !== undefined) retirement = observeRetirement(previous);
     }
     const operation = this.#serial(async () => {
       if (retirement !== undefined) {
         const outcome = await retirement;
         if (!outcome.ok) {
-          const failure = new Error(
-            `ZenX title-store ownership retirement failed: ${describeError(outcome.error)}`,
-            { cause: outcome.error },
-          );
-          this.#failure = failure;
-          throw failure;
+          throw this.#poisonRetirement(outcome.error);
         }
       }
       this.#assertHealthy();
       if (!this.#owns(owner))
         throw new Error("Title ownership changed before the store read");
-      return await this.#readSnapshot();
+      const snapshot = await this.#readSnapshot();
+      this.#assertHealthy();
+      if (!this.#owns(owner))
+        throw new Error("Title ownership changed during the store read");
+      return snapshot;
     });
     return owner.track(operation);
   }
@@ -352,7 +352,11 @@ class ZenXThreadTitleStoreProtocol {
   }
 
   #owns(owner: ZenXThreadTitleOwnershipTransaction): boolean {
-    return this.#currentRoot === owner.root && owner.isCurrent();
+    return (
+      this.#failure === undefined &&
+      this.#currentRoot === owner.root &&
+      owner.isCurrent()
+    );
   }
 
   #temporaryPath(
@@ -367,6 +371,14 @@ class ZenXThreadTitleStoreProtocol {
 
   #assertHealthy(): void {
     if (this.#failure !== undefined) throw this.#failure;
+  }
+
+  #poisonRetirement(error: unknown): Error {
+    this.#failure ??= new Error(
+      `ZenX title-store ownership retirement failed: ${describeError(error)}`,
+      { cause: error },
+    );
+    return this.#failure;
   }
 
   #serial<T>(operation: () => Promise<T>): Promise<T> {
@@ -387,7 +399,12 @@ function observeRetirement(
 ): Promise<RetirementOutcome> {
   try {
     return owner.retire().then(
-      () => ({ ok: true }),
+      () => {
+        const lateFailure = owner.retirementFailure();
+        return lateFailure === undefined
+          ? { ok: true }
+          : { ok: false, error: lateFailure };
+      },
       (error: unknown) => ({ ok: false, error }),
     );
   } catch (error) {

--- a/apps/zenx/src/main/thread-title-store.ts
+++ b/apps/zenx/src/main/thread-title-store.ts
@@ -2,6 +2,10 @@ import { realpathSync } from "node:fs";
 import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 
+import {
+  BoundedTitleOwnershipFailures,
+  normalizeTitleOwnershipFailure,
+} from "./thread-title-failure.js";
 import { ZenXThreadTitleOwnershipTransaction } from "./thread-title-ownership-transaction.js";
 import type {
   ThreadTitleProjection,
@@ -178,7 +182,7 @@ function canonicalProjectionPath(
     try {
       canonical = resolveRealpath(cursor);
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
+      const code = safeStringProperty(error, "code");
       if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
       const parent = pathApi.dirname(cursor);
       if (parent === cursor) {
@@ -202,10 +206,11 @@ class ZenXThreadTitleStoreProtocol {
   readonly #filePath: string;
   readonly #fileSystem: ZenXThreadTitleStoreFileSystem;
   readonly #failureListeners = new Set<(failure: Error) => void>();
+  readonly #failures = new BoundedTitleOwnershipFailures();
   #currentRoot: ZenXThreadTitleOwnershipTransaction | undefined;
   #tail = Promise.resolve();
-  #failure: Error | undefined;
   #temporarySequence = 0;
+  #failureSummary = "ZenX title-store ownership failed";
 
   constructor(filePath: string, fileSystem: ZenXThreadTitleStoreFileSystem) {
     this.#filePath = filePath;
@@ -213,7 +218,7 @@ class ZenXThreadTitleStoreProtocol {
   }
 
   failure(): Error | undefined {
-    return this.#failure;
+    return this.#domainFailure();
   }
 
   onFailure(listener: (failure: Error) => void): () => void {
@@ -229,8 +234,8 @@ class ZenXThreadTitleStoreProtocol {
       return () => undefined;
     }
     this.#failureListeners.add(listener);
-    if (this.#failure !== undefined)
-      this.#notifyFailureListener(listener, this.#failure);
+    const failure = this.#domainFailure();
+    if (failure !== undefined) this.#notifyFailureListener(listener, failure);
     return () => this.#failureListeners.delete(listener);
   }
 
@@ -242,7 +247,9 @@ class ZenXThreadTitleStoreProtocol {
     if (this.#currentRoot !== root) {
       const previous = this.#currentRoot;
       this.#currentRoot = root;
-      root.onRetirementFailure((error) => this.#poisonRetirement(error));
+      root.onRetirementFailure((error) => this.#poisonRetirement(error, root));
+      const existingFailure = this.#domainFailure();
+      if (existingFailure !== undefined) root.poison(existingFailure);
       if (previous !== undefined) retirement = observeRetirement(previous);
     }
     const operation = this.#serial(async () => {
@@ -255,7 +262,12 @@ class ZenXThreadTitleStoreProtocol {
       this.#assertHealthy();
       if (!this.#owns(owner))
         throw new Error("Title ownership changed before the store read");
-      const snapshot = await this.#readSnapshot();
+      let snapshot: ThreadTitleSnapshot;
+      try {
+        snapshot = await this.#readSnapshot();
+      } catch (error) {
+        throw this.#poison(error);
+      }
       this.#assertHealthy();
       if (!this.#owns(owner))
         throw new Error("Title ownership changed during the store read");
@@ -283,7 +295,7 @@ class ZenXThreadTitleStoreProtocol {
     const directory = path.dirname(this.#filePath);
     const temporary = this.#temporaryPath(owner, "stage");
     let staged = false;
-    let primaryError: unknown;
+    let primaryFailed = false;
     try {
       await this.#fileSystem.mkdir(directory, { recursive: true, mode: 0o700 });
       if (!this.#owns(owner)) return false;
@@ -302,29 +314,24 @@ class ZenXThreadTitleStoreProtocol {
       try {
         await this.#restore(previous, owner);
       } catch (error) {
-        const failure = new Error(
-          `ZenX title-store ownership compensation failed: ${describeError(error)}`,
-          { cause: error },
-        );
-        this.#failure = failure;
-        throw failure;
+        if (this.#failures.healthy) this.#poison(error);
+        throw this.#requireDomainFailure();
       }
       return false;
     } catch (error) {
-      primaryError = error;
-      throw error;
+      primaryFailed = true;
+      if (this.#failures.healthy) this.#poison(error);
+      throw this.#requireDomainFailure();
     } finally {
       if (staged) {
         try {
           await this.#fileSystem.rm(temporary, { force: true });
         } catch (cleanupError) {
-          if (primaryError === undefined) throw cleanupError;
-          this.#failure = new AggregateError(
-            [primaryError, cleanupError],
-            "ZenX title-store write and staged-file cleanup failed",
-          );
+          this.#poison(cleanupError);
+          throw this.#requireDomainFailure();
         }
       }
+      if (primaryFailed) this.#assertHealthy();
     }
   }
 
@@ -346,8 +353,24 @@ class ZenXThreadTitleStoreProtocol {
       });
       await this.#fileSystem.rename(temporary, this.#filePath);
       staged = false;
+    } catch (error) {
+      this.#poisonWithContext(
+        error,
+        "ZenX title-store ownership compensation failed",
+      );
+      throw this.#requireDomainFailure();
     } finally {
-      if (staged) await this.#fileSystem.rm(temporary, { force: true });
+      if (staged) {
+        try {
+          await this.#fileSystem.rm(temporary, { force: true });
+        } catch (cleanupError) {
+          this.#poisonWithContext(
+            cleanupError,
+            "ZenX title-store ownership compensation cleanup failed",
+          );
+          throw this.#requireDomainFailure();
+        }
+      }
     }
   }
 
@@ -375,14 +398,14 @@ class ZenXThreadTitleStoreProtocol {
     try {
       return await this.#fileSystem.readFile(this.#filePath, "utf8");
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      if (safeStringProperty(error, "code") === "ENOENT") return undefined;
       throw error;
     }
   }
 
   #owns(owner: ZenXThreadTitleOwnershipTransaction): boolean {
     return (
-      this.#failure === undefined &&
+      this.#failures.healthy &&
       this.#currentRoot === owner.root &&
       owner.isCurrent()
     );
@@ -399,17 +422,54 @@ class ZenXThreadTitleStoreProtocol {
   }
 
   #assertHealthy(): void {
-    if (this.#failure !== undefined) throw this.#failure;
+    const failure = this.#domainFailure();
+    if (failure !== undefined) throw failure;
   }
 
-  #poisonRetirement(error: unknown): Error {
-    this.#failure ??= new Error(
-      `ZenX title-store ownership retirement failed: ${describeError(error)}`,
-      { cause: error },
-    );
+  #poisonRetirement(
+    error: unknown,
+    failedRoot?: ZenXThreadTitleOwnershipTransaction,
+  ): Error {
+    return this.#failures.healthy
+      ? this.#poison(
+          error,
+          "ZenX title-store ownership retirement failed",
+          failedRoot !== this.#currentRoot,
+        )
+      : this.#requireDomainFailure();
+  }
+
+  #poison(
+    error: unknown,
+    summary = "ZenX title-store ownership failed",
+    fenceCurrent = true,
+  ): Error {
+    if (this.#failures.healthy) this.#failureSummary = summary;
+    this.#failures.record(error);
+    const failure = this.#requireDomainFailure();
+    if (fenceCurrent) this.#currentRoot?.poison(failure);
     for (const listener of this.#failureListeners)
-      this.#notifyFailureListener(listener, this.#failure);
-    return this.#failure;
+      this.#notifyFailureListener(listener, failure);
+    return failure;
+  }
+
+  #domainFailure(): AggregateError | undefined {
+    return this.#failures.aggregate(this.#failureSummary);
+  }
+
+  #poisonWithContext(error: unknown, context: string): Error {
+    const normalized = normalizeTitleOwnershipFailure(error);
+    return this.#poison(`${context}: ${normalized.message}`);
+  }
+
+  #requireDomainFailure(): AggregateError {
+    return (
+      this.#domainFailure() ??
+      new AggregateError(
+        [normalizeTitleOwnershipFailure("Unknown title-store failure")],
+        "ZenX title-store ownership failed",
+      )
+    );
   }
 
   #notifyFailureListener(
@@ -417,9 +477,14 @@ class ZenXThreadTitleStoreProtocol {
     failure: Error,
   ): void {
     try {
-      listener(failure);
-    } catch {
-      // The domain remains poisoned even if a transient observer is gone.
+      const result = (listener as (failure: Error) => unknown)(failure);
+      void Promise.resolve(result).then(undefined, (error: unknown) => {
+        this.#failureListeners.delete(listener);
+        this.#poison(error);
+      });
+    } catch (error) {
+      this.#failureListeners.delete(listener);
+      this.#poison(error);
     }
   }
 
@@ -481,6 +546,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function describeError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function safeStringProperty(value: unknown, key: string): string | undefined {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  )
+    return undefined;
+  try {
+    const property = Reflect.get(value, key);
+    return typeof property === "string" ? property : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/apps/zenx/test/thread-title-native-mirror.test.ts
+++ b/apps/zenx/test/thread-title-native-mirror.test.ts
@@ -1,0 +1,486 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleStore } from "../src/main/thread-title-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
+
+test("same-title and distinct native notifications always advance authority", async () => {
+  await withDirectory(async (file) => {
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async () => undefined,
+    );
+    await instance.initialize();
+    const renamed = await instance.rename("thread-a", "Same title");
+    const same = await instance.synchronizeNativeName("thread-a", "Same title");
+    assert.equal(same.status, "manual");
+    assert.equal(same.version, renamed.version + 1);
+    const distinct = await instance.synchronizeNativeName(
+      "thread-a",
+      "Distinct native title",
+    );
+    assert.equal(distinct.status, "manual");
+    assert.equal(distinct.version, same.version + 1);
+    await instance.close();
+  });
+});
+
+test("newer same-title authority cancels an older queued conflict repair", async () => {
+  await withDirectory(async (file) => {
+    const active = deferred<void>();
+    const dispatches: string[] = [];
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        dispatches.push(title);
+        if (dispatches.length === 1) await active.promise;
+      },
+    );
+    await instance.initialize();
+    await instance.rename("thread-a", "A");
+    await until(() => dispatches.length === 1);
+
+    const conflict = await instance.synchronizeNativeName("thread-a", "C");
+    const newer = await instance.synchronizeNativeName("thread-a", "A");
+    assert.equal(conflict.version + 1, newer.version);
+    assert.equal(newer.title, "A");
+
+    active.resolve();
+    await tick();
+    await tick();
+    assert.deepEqual(dispatches, ["A"]);
+    assert.deepEqual(instance.snapshot()["thread-a"], newer);
+    await instance.close();
+  });
+});
+
+test("retired same-title evidence cannot consume a successor mirror or native authority", async () => {
+  await withDirectory(async (file) => {
+    const firstInference = new ControlledInference();
+    const firstMirror = deferred<void>();
+    const secondMirror = deferred<void>();
+    const mirrorCalls: string[] = [];
+    const first = coordinator(
+      file,
+      firstInference,
+      async (_threadId, title) => {
+        mirrorCalls.push(`A:${title}`);
+        await firstMirror.promise;
+      },
+    );
+    await first.initialize();
+    await first.observe("thread-a", "Same title");
+    firstInference.resolve("Same title");
+    await until(() => mirrorCalls.length === 1);
+
+    const observedBeforeRetire = await first.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(observedBeforeRetire.status, "manual");
+    await settlesWithin(first.stop(), 100);
+
+    const successor = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        mirrorCalls.push(`B:${title}`);
+        await secondMirror.promise;
+      },
+    );
+    await successor.initialize();
+    const successorRename = await successor.rename("thread-a", "Same title");
+    await until(() => mirrorCalls.length === 2);
+
+    const lateA = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(lateA.version, successorRename.version + 1);
+    const liveB = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(liveB.version, lateA.version + 1);
+
+    firstMirror.resolve();
+    await tick();
+    const laterA = await successor.synchronizeNativeName(
+      "thread-a",
+      "Same title",
+    );
+    assert.equal(laterA.version, liveB.version + 1);
+    secondMirror.resolve();
+    await successor.close();
+  });
+});
+
+for (const outcome of ["resolve", "reject"] as const) {
+  test(`late ${outcome} from a retired owner repairs the current successor title`, async () => {
+    await withDirectory(async (file) => {
+      const late = deferred<void>();
+      const calls: string[] = [];
+      let nativeName: string | undefined;
+      const first = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(`A:${title}`);
+          await late.promise;
+          nativeName = title;
+          if (outcome === "reject") throw new Error("late retired rejection");
+        },
+      );
+      await first.initialize();
+      await first.rename("thread-a", "A");
+      await until(() => calls.length === 1);
+
+      const successor = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(`B:${title}`);
+          nativeName = title;
+        },
+      );
+      await successor.initialize();
+      const renamed = await successor.rename("thread-a", "B");
+      await until(() => nativeName === "B");
+
+      late.resolve();
+      await until(() => calls.length === 3, 200);
+      assert.deepEqual(calls, ["A:A", "B:B", "B:B"]);
+      assert.equal(nativeName, "B");
+      assert.deepEqual(successor.snapshot()["thread-a"], renamed);
+
+      await first.close();
+      await successor.close();
+    });
+  });
+}
+
+test("more than 64 late retired completions stay bounded and preserve successor capacity", async () => {
+  await withDirectory(async (file) => {
+    const calls: string[] = [];
+    const coordinators: ZenXThreadTitleCoordinator[] = [];
+    const late: Array<ReturnType<typeof deferred<void>>> = [];
+    let nativeName: string | undefined;
+
+    for (let index = 0; index < 65; index += 1) {
+      const completion = deferred<void>();
+      late.push(completion);
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        async (_threadId, title) => {
+          calls.push(title);
+          await completion.promise;
+          nativeName = title;
+        },
+        0,
+      );
+      coordinators.push(instance);
+      await instance.initialize();
+      await instance.rename("thread-a", `Retired ${String(index)}`);
+      await until(() => calls.length === index + 1);
+    }
+
+    const successor = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        calls.push(title);
+        nativeName = title;
+      },
+      0,
+    );
+    coordinators.push(successor);
+    await successor.initialize();
+    await successor.rename("thread-a", "Final successor");
+    await until(() => nativeName === "Final successor");
+    assert.equal(calls.length, 66);
+
+    for (let index = 0; index < late.length; index += 1) {
+      late[index]!.resolve();
+      await until(
+        () => calls.length === 67 + index && nativeName === "Final successor",
+      );
+    }
+    assert.equal(calls.length, 131);
+    assert.equal(nativeName, "Final successor");
+
+    for (const instance of coordinators) await instance.close();
+  });
+});
+
+test("retirement releases mirror reservations exactly once and restores capacity", async () => {
+  await withDirectory(async (file) => {
+    const calls: Array<ReturnType<typeof deferred<void>>> = [];
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...arguments_: unknown[]) => {
+      warnings.push(arguments_.map(String).join(" "));
+    };
+    try {
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        async () => {
+          const call = deferred<void>();
+          calls.push(call);
+          await call.promise;
+        },
+      );
+      await instance.initialize();
+      const owners = Array.from({ length: 70 }, () =>
+        instance.createOwnershipTransaction({ deadlineMs: 0 }),
+      );
+      for (let index = 0; index < 64; index += 1) {
+        await instance.rename(
+          `thread-${String(index)}`,
+          `Title ${String(index)}`,
+          owners[index],
+        );
+      }
+      await until(() => calls.length === 64);
+
+      for (let index = 64; index < 67; index += 1) {
+        await instance.rename(
+          `overflow-${String(index)}`,
+          `Overflow ${String(index)}`,
+          owners[index],
+        );
+      }
+      await tick();
+      assert.equal(calls.length, 64);
+      assert.equal(capacityWarnings(warnings), 1);
+
+      await owners[0]!.retire();
+      await instance.rename("successor-a", "Successor A", owners[67]);
+      await until(() => calls.length === 65);
+
+      calls[0]!.resolve();
+      await tick();
+      await instance.rename("still-full", "Still full", owners[68]);
+      await tick();
+      assert.equal(calls.length, 65);
+
+      await owners[1]!.retire();
+      await instance.rename("successor-b", "Successor B", owners[69]);
+      await until(() => calls.length === 66);
+      assert.equal(capacityWarnings(warnings), 2);
+
+      for (const call of calls) call.resolve();
+      await instance.close();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+test("retired queued work detaches from a never-settling predecessor for its successor", async () => {
+  await withDirectory(async (file) => {
+    const calls: Array<{
+      title: string;
+      completion: ReturnType<typeof deferred<void>>;
+    }> = [];
+    const instance = coordinator(
+      file,
+      new ControlledInference(),
+      async (_threadId, title) => {
+        const completion = deferred<void>();
+        calls.push({ title, completion });
+        await completion.promise;
+      },
+    );
+    await instance.initialize();
+    const predecessor = instance.createOwnershipTransaction({ deadlineMs: 0 });
+    const staleQueued = instance.createOwnershipTransaction({ deadlineMs: 0 });
+    const successor = instance.createOwnershipTransaction({ deadlineMs: 0 });
+
+    await instance.rename("thread-a", "Never settles", predecessor);
+    await until(() => calls.length === 1);
+    await instance.rename("thread-a", "Retired while queued", staleQueued);
+    await staleQueued.retire();
+    await instance.rename("thread-a", "Successor dispatch", successor);
+    await predecessor.retire();
+
+    await until(() => calls.length === 2);
+    assert.deepEqual(
+      calls.map((call) => call.title),
+      ["Never settles", "Successor dispatch"],
+    );
+    calls[0]!.completion.resolve();
+    calls[1]!.completion.resolve();
+    await instance.close();
+  });
+});
+
+test("throwing and rejected mirrors release their reservations", async () => {
+  await withDirectory(async (file) => {
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...arguments_: unknown[]) => {
+      warnings.push(arguments_.map(String).join(" "));
+    };
+    try {
+      let calls = 0;
+      const instance = coordinator(
+        file,
+        new ControlledInference(),
+        (_threadId, _title) => {
+          calls += 1;
+          if (calls === 1) throw new Error("synchronous mirror throw");
+          return Promise.reject(new Error("asynchronous mirror rejection"));
+        },
+      );
+      await instance.initialize();
+      await instance.rename("thread-a", "Throwing mirror");
+      await until(() => calls === 1);
+      await instance.rename("thread-b", "Rejected mirror");
+      await until(() => calls === 2);
+      await until(
+        () =>
+          warnings.filter((warning) => warning.includes("mirror")).length === 2,
+      );
+      assert.equal(
+        warnings.filter((warning) => warning.includes("mirror")).length,
+        2,
+      );
+      await instance.close();
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+test("stop, restart, and close detach never-settling title work within the deadline", async () => {
+  await withDirectory(async (file) => {
+    const inference = new ControlledInference();
+    const mirrors: Array<ReturnType<typeof deferred<void>>> = [];
+    const instance = coordinator(
+      file,
+      inference,
+      async () => {
+        const mirror = deferred<void>();
+        mirrors.push(mirror);
+        await mirror.promise;
+      },
+      10,
+    );
+    await instance.initialize();
+    await instance.observe("thread-generation", "Never settling generation");
+    await instance.rename("thread-mirror", "Never settling mirror");
+    await until(() => mirrors.length === 1);
+
+    await settlesWithin(instance.stop(), 100);
+    inference.resolve("Late generated title");
+    mirrors[0]!.resolve();
+    await tick();
+    assert.equal(
+      instance.snapshot()["thread-generation"]?.status,
+      "generating",
+    );
+
+    await settlesWithin(instance.restart(), 100);
+    assert.equal(instance.snapshot()["thread-generation"]?.status, "failed");
+    await instance.rename("thread-successor", "Successor mirror");
+    await until(() => mirrors.length === 2);
+    await settlesWithin(instance.close(), 100);
+    mirrors[1]!.resolve();
+  });
+});
+
+function coordinator(
+  file: string,
+  inference: ThreadTitleInference,
+  setNativeName: (threadId: string, title: string) => Promise<void>,
+  deadlineMs = 10,
+): ZenXThreadTitleCoordinator {
+  return new ZenXThreadTitleCoordinator({
+    store: new ZenXThreadTitleStore(file),
+    inference,
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName,
+    ownership: { deadlineMs },
+  });
+}
+
+class ControlledInference implements ThreadTitleInference {
+  readonly #pending: Array<ReturnType<typeof deferred<string>>> = [];
+
+  async generate(): Promise<string> {
+    const pending = deferred<string>();
+    this.#pending.push(pending);
+    return await pending.promise;
+  }
+
+  resolve(title: string): void {
+    this.#pending.shift()?.resolve(title);
+  }
+}
+
+async function withDirectory(
+  run: (file: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-native-mirror-"),
+  );
+  try {
+    await run(path.join(directory, "titles.json"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function capacityWarnings(warnings: string[]): number {
+  return warnings.filter((warning) => warning.includes("bounded transaction"))
+    .length;
+}
+
+async function until(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await tick();
+  }
+}
+
+async function settlesWithin<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return await Promise.race([
+    operation,
+    new Promise<never>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`Operation exceeded ${String(timeoutMs)}ms`)),
+        timeoutMs,
+      ),
+    ),
+  ]);
+}
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -85,7 +85,7 @@ test("an App Server rename between generated commit and mirror restores native a
   await assertRenameWinsGenerationRace("after-generated-commit");
 });
 
-test("an App Server rename while generated mirror is in flight restores native authority", async () => {
+test("a later dispatch notification supersedes authority observed while that dispatch was in flight", async () => {
   await assertRenameWinsGenerationRace("during-generated-mirror");
 });
 
@@ -158,6 +158,7 @@ async function assertRenameWinsGenerationRace(
     const inference = new ControlledInference();
     let nativeName = "";
     let synchronization: Promise<unknown> | undefined;
+    const synchronizations: Promise<unknown>[] = [];
     let injected = false;
     let titles!: ZenXThreadTitleCoordinator;
     titles = new ZenXThreadTitleCoordinator({
@@ -176,10 +177,16 @@ async function assertRenameWinsGenerationRace(
             "thread-race",
             "Agent authority",
           );
-          await tick();
+          synchronizations.push(synchronization);
+          await synchronization;
         }
         nativeName = title;
-        void titles.synchronizeNativeName("thread-race", title);
+        const mirrorNotification = titles.synchronizeNativeName(
+          "thread-race",
+          title,
+        );
+        synchronizations.push(mirrorNotification);
+        await mirrorNotification;
       },
     });
     if (phase === "after-generated-commit") {
@@ -191,6 +198,7 @@ async function assertRenameWinsGenerationRace(
           "thread-race",
           "Agent authority",
         );
+        synchronizations.push(synchronization);
       });
     }
     await titles.initialize();
@@ -205,14 +213,27 @@ async function assertRenameWinsGenerationRace(
     }
     assert.notEqual(synchronization, undefined);
     await synchronization;
+    if (phase === "during-generated-mirror")
+      await until(() => synchronizations.length === 2);
+    for (let index = 0; index < synchronizations.length; index += 1)
+      await synchronizations[index];
     assert.deepEqual(titles.snapshot()["thread-race"], {
       threadId: "thread-race",
-      title: "Agent authority",
+      title:
+        phase === "during-generated-mirror"
+          ? "Late generated"
+          : "Agent authority",
       status: "manual",
-      version: 4,
+      version: phase === "during-generated-mirror" ? 5 : 4,
       source: "Original title source",
     });
-    assert.equal(nativeName, "Agent authority");
+    assert.equal(
+      nativeName,
+      phase === "during-generated-mirror"
+        ? "Late generated"
+        : "Agent authority",
+    );
+    await titles.stop();
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -245,6 +266,14 @@ async function waitForStatus(
     await tick();
   }
   assert.fail(`Timed out waiting for title status ${status}`);
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 5_000; attempt += 1) {
+    if (predicate()) return;
+    await tick();
+  }
+  assert.fail("Timed out waiting for condition");
 }
 
 async function tick(): Promise<void> {

--- a/apps/zenx/test/thread-title-ownership-root.test.ts
+++ b/apps/zenx/test/thread-title-ownership-root.test.ts
@@ -295,6 +295,88 @@ test("late predecessor poison closes a successor read already in flight", async 
   });
 });
 
+test("late predecessor poison fences an already initialized successor domain", async () => {
+  await withDirectory(async (directory) => {
+    const unhandled: unknown[] = [];
+    const listener = (error: unknown) => unhandled.push(error);
+    process.on("unhandledRejection", listener);
+    try {
+      const file = path.join(directory, "titles.json");
+      const mirrors: Array<ReturnType<typeof deferred<void>>> = [];
+      const store = new ZenXThreadTitleStore(file);
+      const predecessor = coordinator(store, undefined, 0);
+      await predecessor.initialize();
+      const oldRoot = predecessor.createOwnershipTransaction({
+        deadlineMs: 0,
+      }).root;
+      await predecessor.stop();
+
+      const successor = coordinator(
+        new ZenXThreadTitleStore(path.relative(process.cwd(), file)),
+        async () => {
+          const mirror = deferred<void>();
+          mirrors.push(mirror);
+          await mirror.promise;
+        },
+        0,
+      );
+      await successor.initialize();
+      await successor.rename("thread-a", "successor before poison");
+      await until(() => mirrors.length === 1);
+
+      const late = new ZenXThreadTitleOwnershipTransaction(
+        {
+          deadlineMs: 0,
+          schedule: () => {
+            throw new Error("late predecessor poison");
+          },
+        },
+        oldRoot,
+      );
+      void late.retire();
+      await tick();
+
+      assert.match(
+        oldRoot.retirementFailure()?.message ?? "",
+        /late predecessor poison/u,
+      );
+      assert.throws(() => successor.snapshot(), /late predecessor poison/u);
+      assert.throws(
+        () => successor.createOwnershipTransaction(),
+        /late predecessor poison/u,
+      );
+      await assert.rejects(
+        successor.rename("thread-b", "must not commit or mirror"),
+        /late predecessor poison/u,
+      );
+      await assert.rejects(
+        successor.synchronizeNativeName("thread-a", "native authority"),
+        /late predecessor poison/u,
+      );
+      await assert.rejects(successor.stop(), /late predecessor poison/u);
+      assert.equal(mirrors.length, 1);
+
+      const aliased = coordinator(new ZenXThreadTitleStore(file));
+      await aliased.initialize();
+      assert.throws(() => aliased.snapshot(), /late predecessor poison/u);
+
+      const unrelated = coordinator(
+        new ZenXThreadTitleStore(path.join(directory, "unrelated.json")),
+      );
+      await unrelated.initialize();
+      assert.deepEqual(unrelated.snapshot(), {});
+      await unrelated.close();
+
+      mirrors[0]?.resolve();
+      await tick();
+      assert.equal(mirrors.length, 1);
+      assert.deepEqual(unhandled, []);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+});
+
 test("retirement registration and failure evidence stay hard-bounded", async () => {
   const unhandled: unknown[] = [];
   const listener = (error: unknown) => unhandled.push(error);
@@ -332,6 +414,56 @@ test("retirement registration and failure evidence stay hard-bounded", async () 
       assert.ok(error.message.length <= 12_000);
       return true;
     });
+    await tick();
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+});
+
+test("stored and exposed retirement failures are deterministic bounded copies", async () => {
+  const unhandled: unknown[] = [];
+  const listener = (error: unknown) => unhandled.push(error);
+  process.on("unhandledRejection", listener);
+  try {
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+    for (let index = 0; index < 64; index += 1) {
+      const child = root.fork({ deadlineMs: 0 });
+      child.onRetire(() => {
+        if (index === 0) {
+          throw {
+            message: "object-" + "x".repeat(1_000),
+            cause: { secretGraph: "must not be retained" },
+          };
+        }
+        throw new Error(`failure-${String(index)}-${"y".repeat(1_000)}`, {
+          cause: { secretGraph: "must not be retained" },
+        });
+      });
+    }
+
+    await assert.rejects(root.retire(), (error: unknown) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.errors.length, 64);
+      for (const entry of error.errors) {
+        assert.ok(entry instanceof Error);
+        assert.ok(entry.message.length <= 160);
+        assert.equal(entry.cause, undefined);
+      }
+      assert.equal(error.errors[0]?.message, "[object Object]");
+      assert.match(error.errors[1]?.message ?? "", /^failure-1-y+…$/u);
+      assert.ok(error.message.length <= 12_000);
+      return true;
+    });
+
+    const repeated = root.retirementFailure();
+    assert.ok(repeated instanceof AggregateError);
+    assert.deepEqual(
+      repeated.errors.map((entry) => entry.message),
+      (await rejectedAggregate(root.retire())).errors.map(
+        (entry) => entry.message,
+      ),
+    );
     await tick();
     assert.deepEqual(unhandled, []);
   } finally {
@@ -630,4 +762,16 @@ async function tick(): Promise<void> {
 
 async function delay(milliseconds: number): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function rejectedAggregate(
+  operation: Promise<void>,
+): Promise<AggregateError> {
+  try {
+    await operation;
+  } catch (error) {
+    assert.ok(error instanceof AggregateError);
+    return error;
+  }
+  assert.fail("Expected AggregateError rejection");
 }

--- a/apps/zenx/test/thread-title-ownership-root.test.ts
+++ b/apps/zenx/test/thread-title-ownership-root.test.ts
@@ -185,6 +185,160 @@ test("a nested quiescence timeout observes late rejection", async () => {
   }
 });
 
+test("late child failure after cached root retirement poisons stop and successor reads", async () => {
+  await withDirectory(async (directory) => {
+    const unhandled: unknown[] = [];
+    const listener = (error: unknown) => unhandled.push(error);
+    process.on("unhandledRejection", listener);
+    try {
+      const file = path.join(directory, "titles.json");
+      const store = new ZenXThreadTitleStore(file);
+      const titles = coordinator(store, undefined, 0);
+      await titles.initialize();
+      const root = titles.createOwnershipTransaction({ deadlineMs: 0 }).root;
+      root.onRetire(() => {
+        setTimeout(() => {
+          const lateChild = new ZenXThreadTitleOwnershipTransaction(
+            {
+              deadlineMs: 0,
+              schedule: () => {
+                throw new Error("late child scheduler");
+              },
+            },
+            root,
+          );
+          void lateChild.retire();
+        }, 20);
+      });
+
+      await titles.stop();
+      await delay(60);
+      assert.match(
+        root.retirementFailure()?.message ?? "",
+        /late child scheduler/u,
+      );
+      await assert.rejects(titles.stop(), /late child scheduler/u);
+      assert.throws(() => titles.snapshot(), /late child scheduler/u);
+
+      await assert.rejects(
+        store.claim(new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 })),
+        /late child scheduler/u,
+      );
+
+      const successor = coordinator(
+        new ZenXThreadTitleStore(path.relative(process.cwd(), file)),
+      );
+      await successor.initialize();
+      assert.throws(() => successor.snapshot(), /late child scheduler/u);
+
+      const fresh = coordinator(new ZenXThreadTitleStore(file));
+      await fresh.initialize();
+      assert.throws(() => fresh.snapshot(), /retirement failed/u);
+      await tick();
+      assert.deepEqual(unhandled, []);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+});
+
+test("late predecessor poison closes a successor read already in flight", async () => {
+  await withDirectory(async (directory) => {
+    const file = path.join(directory, "titles.json");
+    await writeFile(file, "{}\n", "utf8");
+    const readEntered = deferred<void>();
+    const releaseRead = deferred<void>();
+    let blockRead = false;
+    const fileSystem: ZenXThreadTitleStoreFileSystem = {
+      ...injectedFileSystem(),
+      readFile: async (candidate, encoding) => {
+        if (blockRead) {
+          readEntered.resolve();
+          await releaseRead.promise;
+        }
+        return await readFile(candidate, encoding);
+      },
+    };
+    const backendIdentity = {};
+    const store = new ZenXThreadTitleStore(file, {
+      fileSystem,
+      backendIdentity,
+    });
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+    await store.claim(root);
+    await root.retire();
+
+    blockRead = true;
+    const successor = new ZenXThreadTitleOwnershipTransaction({
+      deadlineMs: 0,
+    });
+    const claim = store.claim(successor);
+    await readEntered.promise;
+    const lateChild = new ZenXThreadTitleOwnershipTransaction(
+      {
+        deadlineMs: 0,
+        schedule: () => {
+          throw new Error("late failure during read");
+        },
+      },
+      root,
+    );
+    void lateChild.retire();
+    await tick();
+    releaseRead.resolve();
+
+    await assert.rejects(claim, /late failure during read/u);
+    await assert.rejects(
+      store.claim(new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 })),
+      /retirement failed/u,
+    );
+  });
+});
+
+test("retirement registration and failure evidence stay hard-bounded", async () => {
+  const unhandled: unknown[] = [];
+  const listener = (error: unknown) => unhandled.push(error);
+  process.on("unhandledRejection", listener);
+  try {
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+    for (let index = 0; index < 128; index += 1) {
+      const child = root.fork({ deadlineMs: 0 });
+      child.onRetire(() => {
+        throw new Error(`failure-${String(index)}`);
+      });
+    }
+    assert.throws(
+      () => root.fork({ deadlineMs: 0 }),
+      /bounded capacity of 128 nested transactions/u,
+    );
+    for (let index = 0; index < 1_000; index += 1) {
+      assert.throws(
+        () => root.fork({ deadlineMs: 0 }),
+        /retired title ownership/u,
+      );
+    }
+
+    await assert.rejects(root.retire(), (error: unknown) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(error.errors.length, 64);
+      assert.equal(
+        (error.errors[0] as Error | undefined)?.message,
+        "failure-0",
+      );
+      assert.match(
+        (error.errors.at(-1) as Error | undefined)?.message ?? "",
+        /bounded capacity of 128 nested transactions/u,
+      );
+      assert.ok(error.message.length <= 12_000);
+      return true;
+    });
+    await tick();
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+});
+
 test("a failed ownership domain does not poison another projection", async () => {
   await withDirectory(async (directory) => {
     const failed = new ZenXThreadTitleStore(path.join(directory, "a.json"));
@@ -472,4 +626,8 @@ async function withDirectory(
 
 async function tick(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 }

--- a/apps/zenx/test/thread-title-ownership-root.test.ts
+++ b/apps/zenx/test/thread-title-ownership-root.test.ts
@@ -1,0 +1,475 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleOwnershipTransaction } from "../src/main/thread-title-ownership-transaction.js";
+import {
+  canonicalTitleProjectionKey,
+  ZenXThreadTitleStore,
+  type ZenXThreadTitleStoreFileSystem,
+} from "../src/main/thread-title-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
+
+test("root observes a throwing nested child hook before it can reject", async () => {
+  const unhandled: unknown[] = [];
+  const listener = (error: unknown) => unhandled.push(error);
+  process.on("unhandledRejection", listener);
+  try {
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+    const child = root.fork({ deadlineMs: 5 });
+    const grandchild = child.fork({ deadlineMs: 5 });
+    grandchild.onRetire(() => {
+      throw new Error("nested retirement hook failed");
+    });
+
+    await assert.rejects(root.retire(), /nested retirement hook failed/u);
+    await tick();
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+});
+
+test("nested scheduler failure closes stop, successor claim, and fresh read", async () => {
+  await withDirectory(async (directory) => {
+    const file = path.join(directory, "titles.json");
+    const store = new ZenXThreadTitleStore(file);
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+    root.fork({
+      deadlineMs: 5,
+      schedule: () => {
+        throw new Error("nested scheduler failed");
+      },
+    });
+    await store.claim(root);
+
+    await assert.rejects(root.retire(), /nested scheduler failed/u);
+    const successor = new ZenXThreadTitleOwnershipTransaction({
+      deadlineMs: 5,
+    });
+    await assert.rejects(store.claim(successor), /nested scheduler failed/u);
+
+    const freshAlias = new ZenXThreadTitleStore(
+      path.relative(process.cwd(), file),
+    );
+    const fresh = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+    await assert.rejects(freshAlias.claim(fresh), /retirement failed/u);
+    await successor.retire();
+    await fresh.retire();
+  });
+});
+
+for (const failure of ["hook", "scheduler"] as const) {
+  test(`coordinator stop and aliased successor read fail closed over nested ${failure}`, async () => {
+    await withDirectory(async (directory) => {
+      const file = path.join(directory, "titles.json");
+      const first = coordinator(new ZenXThreadTitleStore(file));
+      await first.initialize();
+      const child = first.createOwnershipTransaction(
+        failure === "scheduler"
+          ? {
+              deadlineMs: 5,
+              schedule: () => {
+                throw new Error("coordinator nested scheduler");
+              },
+            }
+          : { deadlineMs: 5 },
+      );
+      if (failure === "hook")
+        child.onRetire(() => {
+          throw new Error("coordinator nested hook");
+        });
+
+      await assert.rejects(first.stop(), new RegExp(failure, "u"));
+      assert.throws(() => first.snapshot(), /titles are unavailable/u);
+
+      const successor = coordinator(
+        new ZenXThreadTitleStore(path.relative(process.cwd(), file)),
+      );
+      await successor.initialize();
+      assert.throws(() => successor.snapshot(), new RegExp(failure, "u"));
+
+      const fresh = coordinator(new ZenXThreadTitleStore(file));
+      await fresh.initialize();
+      assert.throws(() => fresh.snapshot(), /retirement failed/u);
+    });
+  });
+}
+
+test("an independently failed child immediately fences its coordinator domain", async () => {
+  await withDirectory(async (directory) => {
+    const titles = coordinator(
+      new ZenXThreadTitleStore(path.join(directory, "titles.json")),
+    );
+    await titles.initialize();
+    const child = titles.createOwnershipTransaction({ deadlineMs: 5 });
+    child.onRetire(() => {
+      throw new Error("independent nested failure");
+    });
+
+    await assert.rejects(child.retire(), /independent nested failure/u);
+    assert.throws(() => titles.snapshot(), /independent nested failure/u);
+    await assert.rejects(
+      titles.rename("thread-a", "must not publish"),
+      /independent nested failure/u,
+    );
+    await assert.rejects(titles.stop(), /independent nested failure/u);
+  });
+});
+
+test("multiple nested retirement failures aggregate in stable bounded order", async () => {
+  const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+  const first = root.fork({ deadlineMs: 5 });
+  const second = root.fork({
+    deadlineMs: 5,
+    schedule: () => {
+      throw new Error("second scheduler");
+    },
+  });
+  const third = second.fork({ deadlineMs: 5 });
+  root.fork({
+    deadlineMs: 5,
+    schedule: () => ({}),
+    cancelScheduled: () => {
+      throw new Error("fourth cleanup");
+    },
+  });
+  first.onRetire(() => {
+    throw new Error("first hook");
+  });
+  third.onRetire(() => {
+    throw new Error("third hook");
+  });
+
+  const started = Date.now();
+  await assert.rejects(root.retire(), (error: unknown) => {
+    assert.ok(error instanceof AggregateError);
+    assert.deepEqual(
+      error.errors.map((entry: unknown) =>
+        entry instanceof Error ? entry.message : String(entry),
+      ),
+      ["first hook", "second scheduler", "third hook", "fourth cleanup"],
+    );
+    return true;
+  });
+  assert.ok(Date.now() - started < 200);
+});
+
+test("a nested quiescence timeout observes late rejection", async () => {
+  const unhandled: unknown[] = [];
+  const listener = (error: unknown) => unhandled.push(error);
+  process.on("unhandledRejection", listener);
+  try {
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+    const child = root.fork({ deadlineMs: 0 });
+    const late = deferred<void>();
+    child.track(late.promise);
+    await root.retire();
+    late.reject(new Error("late after quiescence"));
+    await tick();
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.off("unhandledRejection", listener);
+  }
+});
+
+test("a failed ownership domain does not poison another projection", async () => {
+  await withDirectory(async (directory) => {
+    const failed = new ZenXThreadTitleStore(path.join(directory, "a.json"));
+    const healthy = new ZenXThreadTitleStore(path.join(directory, "b.json"));
+    const failedRoot = new ZenXThreadTitleOwnershipTransaction({
+      deadlineMs: 5,
+      schedule: () => {
+        throw new Error("domain A scheduler");
+      },
+    });
+    await failed.claim(failedRoot);
+    await assert.rejects(failedRoot.retire(), /domain A scheduler/u);
+    await assert.rejects(
+      failed.claim(new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 })),
+      /domain A scheduler/u,
+    );
+
+    const healthyOwner = new ZenXThreadTitleOwnershipTransaction({
+      deadlineMs: 5,
+    });
+    assert.deepEqual(await healthy.claim(healthyOwner), {});
+    await healthyOwner.retire();
+  });
+});
+
+test("Windows case aliases have one canonical projection key before creation", () => {
+  const options = {
+    platform: "win32" as const,
+    cwd: "C:\\Users\\Zen\\Project",
+    realpath: (candidate: string) => {
+      if (candidate.toLowerCase() === "c:\\users\\zen") return "C:\\Users\\Zen";
+      const error = Object.assign(new Error("missing"), { code: "ENOENT" });
+      throw error;
+    },
+  };
+  assert.equal(
+    canonicalTitleProjectionKey("C:\\Users\\Zen\\Future\\Titles.JSON", options),
+    canonicalTitleProjectionKey("c:\\users\\zen\\future\\titles.json", options),
+  );
+});
+
+test("relative, absolute, and canonical aliases share one default domain", async () => {
+  await withDirectory(async (directory) => {
+    const physical = path.join(directory, "physical");
+    const alias = path.join(directory, "alias");
+    await mkdir(physical);
+    await symlink(
+      physical,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const absolute = path.join(physical, "titles.json");
+    const relative = path.relative(process.cwd(), absolute);
+    const canonicalAlias = path.join(alias, "titles.json");
+
+    const first = new ZenXThreadTitleStore(relative);
+    const second = new ZenXThreadTitleStore(absolute);
+    const third = new ZenXThreadTitleStore(canonicalAlias);
+    assert.equal(first.ownershipDomain, second.ownershipDomain);
+    assert.equal(second.ownershipDomain, third.ownershipDomain);
+    assert.notEqual(
+      first.ownershipDomain,
+      new ZenXThreadTitleStore(path.join(physical, "other.json"))
+        .ownershipDomain,
+    );
+  });
+});
+
+test(
+  "Windows case aliases share a store domain",
+  { skip: process.platform !== "win32" },
+  async () => {
+    await withDirectory(async (directory) => {
+      const file = path.join(directory, "Future", "Titles.json");
+      const caseAlias = file.toUpperCase();
+      assert.equal(
+        new ZenXThreadTitleStore(file).ownershipDomain,
+        new ZenXThreadTitleStore(caseAlias).ownershipDomain,
+      );
+    });
+  },
+);
+
+test("aliased coordinators share one native mirror queue", async () => {
+  await withDirectory(async (directory) => {
+    const physical = path.join(directory, "physical");
+    const alias = path.join(directory, "alias");
+    await mkdir(physical);
+    await symlink(
+      physical,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const late = deferred<void>();
+    const calls: string[] = [];
+    let nativeName: string | undefined;
+    const first = coordinator(
+      new ZenXThreadTitleStore(path.join(alias, "titles.json")),
+      async (_threadId, title) => {
+        calls.push(`A:${title}`);
+        await late.promise;
+        nativeName = title;
+      },
+      0,
+    );
+    await first.initialize();
+    await first.rename("thread-a", "A");
+    await until(() => calls.length === 1);
+
+    const successor = coordinator(
+      new ZenXThreadTitleStore(path.join(physical, "titles.json")),
+      async (_threadId, title) => {
+        calls.push(`B:${title}`);
+        nativeName = title;
+      },
+      0,
+    );
+    await successor.initialize();
+    await successor.rename("thread-a", "B");
+    await until(() => nativeName === "B");
+
+    late.resolve();
+    await until(() => calls.length === 3 && nativeName === "B");
+    assert.deepEqual(calls, ["A:A", "B:B", "B:B"]);
+    await first.close();
+    await successor.close();
+  });
+});
+
+test("backend identity participates in ownership-domain identity", async () => {
+  await withDirectory(async (directory) => {
+    const file = path.join(directory, "titles.json");
+    const backendA = {};
+    const backendB = {};
+    const fileSystem = injectedFileSystem();
+    const first = new ZenXThreadTitleStore(file, {
+      fileSystem,
+      backendIdentity: backendA,
+    });
+    const sameBackend = new ZenXThreadTitleStore(
+      path.relative(process.cwd(), file),
+      { fileSystem, backendIdentity: backendA },
+    );
+    const differentBackend = new ZenXThreadTitleStore(file, {
+      fileSystem,
+      backendIdentity: backendB,
+    });
+
+    assert.equal(first.ownershipDomain, sameBackend.ownershipDomain);
+    assert.notEqual(first.ownershipDomain, differentBackend.ownershipDomain);
+    assert.throws(
+      () => new ZenXThreadTitleStore(file, { fileSystem }),
+      /backendIdentity/u,
+    );
+  });
+});
+
+test("ownership-domain identity registry fails closed at its bound", async () => {
+  await withDirectory(async (directory) => {
+    const backendIdentity = {};
+    const fileSystem = injectedFileSystem();
+    const stores = Array.from(
+      { length: 64 },
+      (_, index) =>
+        new ZenXThreadTitleStore(
+          path.join(directory, `titles-${String(index)}.json`),
+          { fileSystem, backendIdentity },
+        ),
+    );
+    assert.equal(stores.length, 64);
+    assert.throws(
+      () =>
+        new ZenXThreadTitleStore(path.join(directory, "overflow.json"), {
+          fileSystem,
+          backendIdentity,
+        }),
+      /bounded capacity of 64/u,
+    );
+  });
+});
+
+test("poisoned predecessor cannot be bypassed through a canonical alias", async () => {
+  await withDirectory(async (directory) => {
+    const physical = path.join(directory, "physical");
+    const alias = path.join(directory, "alias");
+    await mkdir(physical);
+    await symlink(
+      physical,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const firstStore = new ZenXThreadTitleStore(
+      path.join(alias, "titles.json"),
+    );
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+    root.fork({
+      deadlineMs: 5,
+      schedule: () => {
+        throw new Error("aliased predecessor failed");
+      },
+    });
+    await firstStore.claim(root);
+    await assert.rejects(root.retire(), /aliased predecessor failed/u);
+
+    const canonicalStore = new ZenXThreadTitleStore(
+      path.join(await realpath(physical), "titles.json"),
+    );
+    await assert.rejects(
+      canonicalStore.claim(
+        new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 }),
+      ),
+      /aliased predecessor failed/u,
+    );
+  });
+});
+
+function injectedFileSystem(): ZenXThreadTitleStoreFileSystem {
+  return {
+    mkdir,
+    readFile,
+    writeFile: async (file, data, options) => {
+      await writeFile(file, data, options);
+    },
+    rename,
+    rm: async (file, options) => {
+      await rm(file, options);
+    },
+  };
+}
+
+function coordinator(
+  store: ZenXThreadTitleStore,
+  setNativeName: (
+    threadId: string,
+    title: string,
+  ) => Promise<void> = async () => undefined,
+  deadlineMs = 5,
+): ZenXThreadTitleCoordinator {
+  return new ZenXThreadTitleCoordinator({
+    store,
+    inference: new NeverInference(),
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName,
+    ownership: { deadlineMs },
+  });
+}
+
+class NeverInference implements ThreadTitleInference {
+  async generate(): Promise<string> {
+    return await new Promise<string>(() => undefined);
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function until(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for condition");
+    await tick();
+  }
+}
+
+async function withDirectory(
+  run: (directory: string) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-ownership-root-"),
+  );
+  try {
+    await run(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}

--- a/apps/zenx/test/thread-title-ownership-root.test.ts
+++ b/apps/zenx/test/thread-title-ownership-root.test.ts
@@ -42,6 +42,98 @@ test("root observes a throwing nested child hook before it can reject", async ()
   }
 });
 
+test("hostile retirement values are total bounded copies before domain poison", async () => {
+  await withDirectory(async (directory) => {
+    const unhandled: unknown[] = [];
+    const listener = (error: unknown) => unhandled.push(error);
+    process.on("unhandledRejection", listener);
+    try {
+      const file = path.join(directory, "titles.json");
+      const first = coordinator(new ZenXThreadTitleStore(file));
+      await first.initialize();
+      const child = first.createOwnershipTransaction({ deadlineMs: 0 });
+      const hostile = new Proxy(
+        { cause: { mustNotEscape: true } },
+        {
+          get() {
+            throw new Error("hostile getter escaped");
+          },
+          getPrototypeOf() {
+            throw new Error("hostile prototype escaped");
+          },
+        },
+      );
+      child.onRetire(() => {
+        throw hostile;
+      });
+
+      await assert.rejects(first.stop(), (error: unknown) => {
+        assertCopiedAggregate(error);
+        assert.match((error as Error).message, /unprintable|normaliz/iu);
+        return true;
+      });
+      assert.throws(() => first.snapshot(), /unprintable|normaliz/iu);
+
+      const successor = coordinator(
+        new ZenXThreadTitleStore(path.relative(process.cwd(), file)),
+      );
+      await successor.initialize();
+      assert.throws(() => successor.snapshot(), /unprintable|normaliz/iu);
+      await tick();
+      assert.deepEqual(unhandled, []);
+    } finally {
+      process.off("unhandledRejection", listener);
+    }
+  });
+});
+
+test("owned abort notification captures throwing and rejecting listeners", async () => {
+  const uncaught: unknown[] = [];
+  const unhandled: unknown[] = [];
+  const onUncaught = (error: unknown) => uncaught.push(error);
+  const onUnhandled = (error: unknown) => unhandled.push(error);
+  process.on("uncaughtException", onUncaught);
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+    root.signal.addEventListener("abort", () => {
+      throw new Error("synchronous abort listener failed");
+    });
+    root.signal.addEventListener("abort", async () => {
+      throw new Error("asynchronous abort listener failed");
+    });
+
+    await assert.rejects(root.retire(), (error: unknown) => {
+      assertCopiedAggregate(error);
+      assert.match((error as Error).message, /abort listener failed/u);
+      return true;
+    });
+    await tick();
+    await tick();
+    assert.deepEqual(uncaught, []);
+    assert.deepEqual(unhandled, []);
+    assert.equal(root.isCurrent(), false);
+  } finally {
+    process.off("uncaughtException", onUncaught);
+    process.off("unhandledRejection", onUnhandled);
+  }
+});
+
+test("owned abort notification keeps listener identity scoped to event type", async () => {
+  const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 0 });
+  let calls = 0;
+  const listener = () => {
+    calls += 1;
+  };
+  root.signal.addEventListener("not-abort", listener);
+  root.signal.addEventListener("abort", listener);
+  root.signal.removeEventListener("not-abort", listener);
+
+  await root.retire();
+
+  assert.equal(calls, 1);
+});
+
 test("nested scheduler failure closes stop, successor claim, and fresh read", async () => {
   await withDirectory(async (directory) => {
     const file = path.join(directory, "titles.json");
@@ -66,8 +158,8 @@ test("nested scheduler failure closes stop, successor claim, and fresh read", as
     );
     const fresh = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
     await assert.rejects(freshAlias.claim(fresh), /retirement failed/u);
-    await successor.retire();
-    await fresh.retire();
+    await assert.rejects(successor.retire(), /retirement failed/u);
+    await assert.rejects(fresh.retire(), /retirement failed/u);
   });
 });
 
@@ -183,6 +275,14 @@ test("a nested quiescence timeout observes late rejection", async () => {
   } finally {
     process.off("unhandledRejection", listener);
   }
+});
+
+test("an asynchronous retirement hook cannot outlive the bounded deadline", async () => {
+  const root = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 5 });
+  root.onRetire(async () => await new Promise<void>(() => undefined));
+  const started = Date.now();
+  await root.retire();
+  assert.ok(Date.now() - started < 200);
 });
 
 test("late child failure after cached root retirement poisons stop and successor reads", async () => {
@@ -450,7 +550,7 @@ test("stored and exposed retirement failures are deterministic bounded copies", 
         assert.ok(entry.message.length <= 160);
         assert.equal(entry.cause, undefined);
       }
-      assert.equal(error.errors[0]?.message, "[object Object]");
+      assert.match(error.errors[0]?.message ?? "", /^object-x+…$/u);
       assert.match(error.errors[1]?.message ?? "", /^failure-1-y+…$/u);
       assert.ok(error.message.length <= 12_000);
       return true;
@@ -774,4 +874,17 @@ async function rejectedAggregate(
     return error;
   }
   assert.fail("Expected AggregateError rejection");
+}
+
+function assertCopiedAggregate(
+  error: unknown,
+): asserts error is AggregateError {
+  assert.ok(error instanceof AggregateError);
+  assert.ok(error.errors.length > 0);
+  assert.ok(error.errors.length <= 64);
+  for (const entry of error.errors) {
+    assert.ok(entry instanceof Error);
+    assert.ok(entry.message.length <= 160);
+    assert.equal(entry.cause, undefined);
+  }
 }

--- a/apps/zenx/test/thread-title-ownership-transaction.test.ts
+++ b/apps/zenx/test/thread-title-ownership-transaction.test.ts
@@ -101,6 +101,12 @@ test("compensation failure poisons serialized reads instead of exposing stale da
     controlled.release();
     await assert.rejects(stale, /compensation failed/u);
     await initialization;
+    assert.throws(() => first.snapshot(), /compensation failed/u);
+    assert.throws(
+      () => first.createOwnershipTransaction(),
+      /compensation failed/u,
+    );
+    await assert.rejects(first.restart(), /compensation failed/u);
     assert.throws(() => successor.snapshot(), /compensation failed/u);
 
     const fresh = coordinator(
@@ -112,6 +118,158 @@ test("compensation failure poisons serialized reads instead of exposing stale da
     await fresh.initialize();
     assert.throws(() => fresh.snapshot(), /compensation failed/u);
     assert.deepEqual(await stagedFiles(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("primary store failure plus hostile cleanup exposes only bounded copies", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-hostile-cleanup-"),
+  );
+  const file = path.join(directory, "titles.json");
+  try {
+    const controlled = new ControlledTitleFileSystem();
+    controlled.failure = "rename";
+    controlled.cleanupFailure = new Proxy(
+      { cause: { mustNotEscape: true } },
+      {
+        get() {
+          throw new Error("hostile cleanup getter escaped");
+        },
+        getPrototypeOf() {
+          throw new Error("hostile cleanup prototype escaped");
+        },
+      },
+    );
+    const instance = coordinator(
+      new ZenXThreadTitleStore(file, {
+        fileSystem: controlled,
+        backendIdentity: controlled,
+      }),
+    );
+    await instance.initialize();
+
+    await assert.rejects(
+      instance.rename("thread-a", "Must not publish"),
+      (error: unknown) => {
+        assertBoundedAggregate(error);
+        assert.equal(error.errors.length, 2);
+        assert.match(error.errors[0]?.message ?? "", /rename failed/u);
+        assert.match(error.errors[1]?.message ?? "", /unprintable|normaliz/iu);
+        return true;
+      },
+    );
+    assert.throws(() => instance.snapshot(), /rename failed/u);
+    await assert.rejects(instance.stop(), /rename failed/u);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("store poison during an entered mutation fences every coordinator surface", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-entered-store-poison-"),
+  );
+  const file = path.join(directory, "titles.json");
+  try {
+    const entered = deferred<void>();
+    const release = deferred<void>();
+    const backendIdentity = {};
+    const fileSystem: ZenXThreadTitleStoreFileSystem = {
+      mkdir,
+      readFile,
+      writeFile: async (candidate, data, options) => {
+        await writeFile(candidate, data, options);
+        entered.resolve();
+        await release.promise;
+        throw new Error("entered staged write failed");
+      },
+      rename,
+      rm: async (candidate, options) => await rm(candidate, options),
+    };
+    let mirrors = 0;
+    const instance = coordinator(
+      new ZenXThreadTitleStore(file, { fileSystem, backendIdentity }),
+      async () => {
+        mirrors += 1;
+      },
+    );
+    await instance.initialize();
+    const mutation = instance.rename("thread-a", "Must not mirror");
+    await entered.promise;
+    release.resolve();
+    await assert.rejects(mutation, /entered staged write failed/u);
+
+    assert.throws(() => instance.snapshot(), /entered staged write failed/u);
+    assert.throws(
+      () => instance.createOwnershipTransaction(),
+      /entered staged write failed/u,
+    );
+    await assert.rejects(
+      instance.synchronizeNativeName("thread-a", "Native must fail"),
+      /entered staged write failed/u,
+    );
+    await assert.rejects(instance.stop(), /entered staged write failed/u);
+    await assert.rejects(instance.restart(), /entered staged write failed/u);
+    assert.equal(mirrors, 0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("poison arriving during restart makes restart reject", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-restart-poison-"),
+  );
+  const file = path.join(directory, "titles.json");
+  try {
+    const readEntered = deferred<void>();
+    const releaseRead = deferred<void>();
+    let blockRead = false;
+    const backendIdentity = {};
+    const fileSystem: ZenXThreadTitleStoreFileSystem = {
+      mkdir,
+      readFile: async (candidate, encoding) => {
+        if (blockRead) {
+          readEntered.resolve();
+          await releaseRead.promise;
+        }
+        return await readFile(candidate, encoding);
+      },
+      writeFile: async (candidate, data, options) =>
+        await writeFile(candidate, data, options),
+      rename,
+      rm: async (candidate, options) => await rm(candidate, options),
+    };
+    const store = new ZenXThreadTitleStore(file, {
+      fileSystem,
+      backendIdentity,
+    });
+    const instance = coordinator(store);
+    await instance.initialize();
+    const predecessorRoot = instance.createOwnershipTransaction({
+      deadlineMs: 0,
+    }).root;
+    blockRead = true;
+    const restarting = instance.restart();
+    await readEntered.promise;
+
+    const late = new ZenXThreadTitleOwnershipTransaction(
+      {
+        deadlineMs: 0,
+        schedule: () => {
+          throw new Error("poison during restart");
+        },
+      },
+      predecessorRoot,
+    );
+    void late.retire();
+    await tick();
+    releaseRead.resolve();
+
+    await assert.rejects(restarting, /poison during restart/u);
+    assert.throws(() => instance.snapshot(), /poison during restart/u);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -149,8 +307,8 @@ for (const failure of ["scheduler", "retirement hook"] as const) {
 
       const fresh = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 10 });
       await assert.rejects(store.claim(fresh), /retirement failed/u);
-      await successor.retire();
-      await fresh.retire();
+      await assert.rejects(successor.retire(), /retirement failed/u);
+      await assert.rejects(fresh.retire(), /retirement failed/u);
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -177,9 +335,15 @@ for (const failure of ["write", "rename"] as const) {
         instance.observe("thread-a", "Failed staged title"),
         new RegExp(`${failure} failed`, "u"),
       );
-      assert.deepEqual(instance.snapshot(), {});
+      assert.throws(
+        () => instance.snapshot(),
+        new RegExp(`${failure} failed`, "u"),
+      );
       assert.deepEqual(await stagedFiles(directory), []);
-      await instance.close();
+      await assert.rejects(
+        instance.close(),
+        new RegExp(`${failure} failed`, "u"),
+      );
     } finally {
       await rm(directory, { recursive: true, force: true });
     }
@@ -192,6 +356,7 @@ type BlockPhase =
 class ControlledTitleFileSystem implements ZenXThreadTitleStoreFileSystem {
   failure: "write" | "rename" | undefined;
   failCompensation = false;
+  cleanupFailure: unknown;
   #phase: BlockPhase | undefined;
   #entered = deferred<void>();
   #release = deferred<void>();
@@ -248,6 +413,11 @@ class ControlledTitleFileSystem implements ZenXThreadTitleStoreFileSystem {
   }
 
   async rm(file: string, options: { force: true }): Promise<void> {
+    if (this.cleanupFailure !== undefined) {
+      const failure = this.cleanupFailure;
+      this.cleanupFailure = undefined;
+      throw failure;
+    }
     await rm(file, options);
   }
 
@@ -260,12 +430,18 @@ class ControlledTitleFileSystem implements ZenXThreadTitleStoreFileSystem {
   }
 }
 
-function coordinator(store: ZenXThreadTitleStore): ZenXThreadTitleCoordinator {
+function coordinator(
+  store: ZenXThreadTitleStore,
+  setNativeName: (
+    threadId: string,
+    title: string,
+  ) => Promise<void> = async () => undefined,
+): ZenXThreadTitleCoordinator {
   return new ZenXThreadTitleCoordinator({
     store,
     inference: new NeverInference(),
     titleModel: () => "gpt-5.6-luna",
-    setNativeName: async () => undefined,
+    setNativeName,
     ownership: { deadlineMs: 10 },
   });
 }
@@ -301,4 +477,17 @@ function deferred<T>() {
 
 async function tick(): Promise<void> {
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+function assertBoundedAggregate(
+  error: unknown,
+): asserts error is AggregateError & { errors: Error[] } {
+  assert.ok(error instanceof AggregateError);
+  assert.ok(error.errors.length > 0);
+  assert.ok(error.errors.length <= 64);
+  for (const entry of error.errors) {
+    assert.ok(entry instanceof Error);
+    assert.ok(entry.message.length <= 160);
+    assert.equal(entry.cause, undefined);
+  }
 }

--- a/apps/zenx/test/thread-title-ownership-transaction.test.ts
+++ b/apps/zenx/test/thread-title-ownership-transaction.test.ts
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { ZenXThreadTitleCoordinator } from "../src/main/thread-title-coordinator.js";
+import { ZenXThreadTitleOwnershipTransaction } from "../src/main/thread-title-ownership-transaction.js";
+import {
+  ZenXThreadTitleStore,
+  type ZenXThreadTitleStoreFileSystem,
+} from "../src/main/thread-title-store.js";
+import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
+
+for (const phase of [
+  "mkdir",
+  "staged-write",
+  "commit-before-replace",
+  "atomic-replace",
+] as const) {
+  test(`successor claim hides a retired owner during ${phase}`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), `zenx-title-${phase}-`),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const controlled = new ControlledTitleFileSystem();
+      const first = coordinator(
+        new ZenXThreadTitleStore(file, {
+          fileSystem: controlled,
+          backendIdentity: controlled,
+        }),
+      );
+      await first.initialize();
+      controlled.block(phase);
+      const stale = first.observe("thread-a", "Retired owner title");
+      await controlled.entered;
+
+      const successor = coordinator(
+        new ZenXThreadTitleStore(file, {
+          fileSystem: controlled,
+          backendIdentity: controlled,
+        }),
+      );
+      let initialized = false;
+      const initialization = successor.initialize().then(() => {
+        initialized = true;
+      });
+      await tick();
+      assert.equal(initialized, false);
+      assert.throws(() => successor.snapshot(), /not initialized/u);
+
+      controlled.release();
+      assert.equal(await stale, undefined);
+      await initialization;
+      assert.deepEqual(successor.snapshot(), {});
+      assert.deepEqual(await readJsonOrEmpty(file), {});
+      assert.deepEqual(await stagedFiles(directory), []);
+      await successor.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+test("compensation failure poisons serialized reads instead of exposing stale data", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-title-compensation-"),
+  );
+  const file = path.join(directory, "titles.json");
+  try {
+    await writeFile(file, "{}\n", "utf8");
+    const controlled = new ControlledTitleFileSystem();
+    controlled.failCompensation = true;
+    const first = coordinator(
+      new ZenXThreadTitleStore(file, {
+        fileSystem: controlled,
+        backendIdentity: controlled,
+      }),
+    );
+    await first.initialize();
+    controlled.block("atomic-replace");
+    const stale = first.observe("thread-a", "Never authoritative");
+    await controlled.entered;
+
+    const successor = coordinator(
+      new ZenXThreadTitleStore(file, {
+        fileSystem: controlled,
+        backendIdentity: controlled,
+      }),
+    );
+    const initialization = successor.initialize();
+    controlled.release();
+    await assert.rejects(stale, /compensation failed/u);
+    await initialization;
+    assert.throws(() => successor.snapshot(), /compensation failed/u);
+
+    const fresh = coordinator(
+      new ZenXThreadTitleStore(file, {
+        fileSystem: controlled,
+        backendIdentity: controlled,
+      }),
+    );
+    await fresh.initialize();
+    assert.throws(() => fresh.snapshot(), /compensation failed/u);
+    assert.deepEqual(await stagedFiles(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+for (const failure of ["scheduler", "retirement hook"] as const) {
+  test(`successor claim handles and propagates ${failure} rejection`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "zenx-title-retirement-failure-"),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const store = new ZenXThreadTitleStore(file);
+      const predecessor = new ZenXThreadTitleOwnershipTransaction(
+        failure === "scheduler"
+          ? {
+              deadlineMs: 10,
+              schedule: () => {
+                throw new Error("scheduler failed");
+              },
+            }
+          : { deadlineMs: 10 },
+      );
+      if (failure === "retirement hook")
+        predecessor.onRetire(() => {
+          throw new Error("retirement hook failed");
+        });
+      await store.claim(predecessor);
+
+      const successor = new ZenXThreadTitleOwnershipTransaction({
+        deadlineMs: 10,
+      });
+      await assert.rejects(store.claim(successor), new RegExp(failure, "u"));
+      await tick();
+
+      const fresh = new ZenXThreadTitleOwnershipTransaction({ deadlineMs: 10 });
+      await assert.rejects(store.claim(fresh), /retirement failed/u);
+      await successor.retire();
+      await fresh.retire();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+for (const failure of ["write", "rename"] as const) {
+  test(`${failure} failure removes every staged title file`, async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), `zenx-title-${failure}-failure-`),
+    );
+    const file = path.join(directory, "titles.json");
+    try {
+      const controlled = new ControlledTitleFileSystem();
+      controlled.failure = failure;
+      const instance = coordinator(
+        new ZenXThreadTitleStore(file, {
+          fileSystem: controlled,
+          backendIdentity: controlled,
+        }),
+      );
+      await instance.initialize();
+      await assert.rejects(
+        instance.observe("thread-a", "Failed staged title"),
+        new RegExp(`${failure} failed`, "u"),
+      );
+      assert.deepEqual(instance.snapshot(), {});
+      assert.deepEqual(await stagedFiles(directory), []);
+      await instance.close();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+}
+
+type BlockPhase =
+  "mkdir" | "staged-write" | "commit-before-replace" | "atomic-replace";
+
+class ControlledTitleFileSystem implements ZenXThreadTitleStoreFileSystem {
+  failure: "write" | "rename" | undefined;
+  failCompensation = false;
+  #phase: BlockPhase | undefined;
+  #entered = deferred<void>();
+  #release = deferred<void>();
+
+  get entered(): Promise<void> {
+    return this.#entered.promise;
+  }
+
+  block(phase: BlockPhase): void {
+    this.#phase = phase;
+    this.#entered = deferred<void>();
+    this.#release = deferred<void>();
+  }
+
+  release(): void {
+    this.#release.resolve();
+  }
+
+  async mkdir(
+    directory: string,
+    options: { recursive: true; mode: number },
+  ): Promise<unknown> {
+    if (this.#phase === "mkdir") await this.#hold();
+    return await mkdir(directory, options);
+  }
+
+  async readFile(file: string, encoding: "utf8"): Promise<string> {
+    return await readFile(file, encoding);
+  }
+
+  async writeFile(
+    file: string,
+    data: string,
+    options: { encoding: "utf8"; mode: number },
+  ): Promise<void> {
+    await writeFile(file, data, options);
+    if (this.failure === "write") {
+      this.failure = undefined;
+      throw new Error("write failed");
+    }
+    if (this.#phase === "staged-write") await this.#hold();
+  }
+
+  async rename(source: string, destination: string): Promise<void> {
+    if (this.failCompensation && source.includes(".compensate.tmp"))
+      throw new Error("compensation rename failed");
+    if (this.failure === "rename") {
+      this.failure = undefined;
+      throw new Error("rename failed");
+    }
+    if (this.#phase === "commit-before-replace") await this.#hold();
+    await rename(source, destination);
+    if (this.#phase === "atomic-replace") await this.#hold();
+  }
+
+  async rm(file: string, options: { force: true }): Promise<void> {
+    await rm(file, options);
+  }
+
+  async #hold(): Promise<void> {
+    const entered = this.#entered;
+    const release = this.#release;
+    this.#phase = undefined;
+    entered.resolve();
+    await release.promise;
+  }
+}
+
+function coordinator(store: ZenXThreadTitleStore): ZenXThreadTitleCoordinator {
+  return new ZenXThreadTitleCoordinator({
+    store,
+    inference: new NeverInference(),
+    titleModel: () => "gpt-5.6-luna",
+    setNativeName: async () => undefined,
+    ownership: { deadlineMs: 10 },
+  });
+}
+
+class NeverInference implements ThreadTitleInference {
+  async generate(): Promise<string> {
+    return await new Promise<string>(() => undefined);
+  }
+}
+
+async function readJsonOrEmpty(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw error;
+  }
+}
+
+async function stagedFiles(directory: string): Promise<string[]> {
+  return (await readdir(directory)).filter((file) => file.endsWith(".tmp"));
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}


### PR DESCRIPTION
## Summary

Implements one root-scoped, failure-closed ZenX title ownership domain and one canonical process-local identity for each supported durable title projection. The terminal repair closes every arbitrary retirement/store failure through the same bounded diagnostic and exact-domain poison boundary.

Closes #73

## Exact scope

- Base: `28977c8f509441f9767b3b99bde0fc50a8dc9bc3`
- Head: `091d0234e2437cd9d1e49c7a614eaf3b994a51e0`
- Branch: `codex/issue-73-title-ownership-root`
- ZenX title failure normalization, ownership transaction, ownership-aware store, coordinator/native mirror lifecycle, main-process stop/restart/quit integration, architecture contract, and deterministic title tests only
- No Trigger, Room, Browser, Computer, Zen Core ItemList, or wire-protocol authority expansion; no second runtime/coordinator or durable scheduler/retry/queue

## Architecture decisions

- One total guarded normalizer copies arbitrary thrown values without retaining their object graph. Primitive coercion, hostile `message`/`toString`, proxies, getters, symbols, cycles, and normalization faults cannot escape. Every copied `Error` message is at most 160 characters and cause-free; aggregate summaries are bounded.
- Root retirement observes and records normalized child/root rejection evidence before it can be dropped. Evidence is deterministic by transaction/occurrence, capped at 64 with saturation; descendants, outcomes, hooks, failure listeners, safe abort listeners, tracked work, coordinator listeners, and store-domain listeners all have documented hard bounds.
- The ownership module retains a native-branded `AbortSignal` but owns the ordinary `addEventListener`/`removeEventListener`/`onabort` notification seam. Throwing and rejected listeners poison the root without `uncaughtException` or `unhandledRejection`; registration identity follows `(event type, listener, capture)` semantics.
- Any mkdir/read/stage/write/rename/replace/temp-cleanup/compensation failure poisons the canonical store domain before further cleanup, appends later bounded evidence, and synchronously fences the current root/coordinator and aliases. Future/in-flight claim/read/commit, snapshot, transaction creation, native authority/mirror, stop/restart/fresh coordinator fail closed; unrelated domains remain usable.
- `restart` succeeds only after claim/recovery/native activation and a final owner/domain availability check. Restart and quit attempt all cleanup boundaries and report normalized aggregate failures. The 250 ms retirement deadline remains a bounded detach boundary.
- Default projection identity remains nearest-existing-ancestor native realpath plus normalized missing suffix with Windows case folding. Injected backend identity remains explicit; each backend registry is process-local/weak/bounded to 64; `NativeMirrorQueue` keys off the exact ownership domain.
- Accepted #68 stage/atomic replace/compensation/temp cleanup, conservative native authority, late retired repair, exactly-once reservations, 64-capacity bounds, and bounded stop/restart/close are preserved.

## Terminal repair dispositions

1. **Total hostile-value normalization:** all retirement, observation, store, cleanup, compensation, and lifecycle failures are bounded copied diagnostics; raw thrown values/cause graphs are not retained or exposed.
2. **Abort-listener containment:** synchronous throws and rejected promises are observed inside the ownership boundary with no process escape; listener state is bounded and EventTarget identity semantics are preserved.
3. **Store-to-current poison:** store failures synchronously poison/fence the current initialized coordinator/root, canonical aliases, in-flight/future persistence and native authority. Primary and hostile cleanup evidence aggregate deterministically.
4. **Honest restart:** poison arriving during new-owner initialization makes `restart()` reject rather than returning an unavailable coordinator.

## Deterministic local evidence

Passed on Windows:

- `npm exec -- tsx --test test/thread-title-*.test.ts` — 60/60
- ownership/transaction/native-mirror/failure-closure subset repeated 15 times — 15/15 runs, 0 failures
- new blocker regressions cover hostile proxy/getter/toString values; bounded copied aggregate evidence; throwing/rejected abort listeners without process escape; event-type-scoped listener identity; primary plus hostile cleanup; entered store poison fencing all coordinator/native surfaces; poison during restart; bounded asynchronous retirement hooks; canonical alias and unrelated-domain behavior
- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- root `npm run typecheck`
- root `npm run lint`
- changed-file Prettier check
- `git diff --check`

Known current Windows/platform baselines, unrelated to this change:

- ZenX full test: 173/178; the same five existing POSIX path/shell/executable assumptions fail.
- Root Node test: 86/93; six existing Windows permission/POSIX-shell failures and one platform skip.
- IMZen: 37/38; one existing chmod-semantics test fails.

## Required exact-head checks

GitHub Actions on exact head `091d0234e2437cd9d1e49c7a614eaf3b994a51e0` must finish with every required job passing before direct-merge handoff. A moving, pending, or failing head is not accepted.

## Residual risks

- Ownership poison and canonical identity remain intentionally process-local; no durable poison journal or retry state exists.
- The owned safe abort surface contains ordinary signal `addEventListener`/`removeEventListener`/`onabort` usage while retaining native brand. Deliberate bypass through `EventTarget.prototype` is outside this module seam.
- Registry/listener/evidence saturation fails closed at documented bounds and does not evict established identity.
- Store-to-root poison is synchronously re-entrant by design; bounded accumulators and listener deletion prevent unbounded recursion, and repeated race suites cover the accepted handoff paths.
- Local full-suite red is limited to the documented Windows/POSIX baselines above; required GitHub Actions are the publication authority.

## Terminal workflow

This is the user-approved final same-branch repair after Review Round 3. There is no Round 4 or additional repair review. Once exact-head required checks are green, Main may merge directly; this worker will not merge or mark the PR ready.
