### PR TITLE
Add user-browser document execution fence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,19 @@ jobs:
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:windows-computer
 
+  zenx-windows-user-browser-smoke:
+    name: ZenX Windows attached user-browser smoke
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace apps/zenx run smoke:windows-user-browser
+
   zenx-playwright-provider-smoke:
     name: ZenX real Playwright provider smoke
     runs-on: macos-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,6 +77,14 @@
   协商实际影响且禁止静默降级。
 - **ZenXCapabilityObservation** — ZenX provider 用短时、目标域绑定的 opaque ID 连接 observe→act，执行前按语义指纹
   重验且在导航、关闭、新观察或动作后失效；它是产品侧瞬时状态，不进入 Zen Core 或 durable journal。
+- **ZenXUserBrowserAttachmentEpoch** — ZenX user-browser provider 用实际 CDP sessionId、target、逻辑 session owner 与
+  attach attempt/incarnation 关联一次瞬时 attachment ownership，并在移除任何映射前把无法证明闭合的生命周期证据
+  单调提升为有界 session taint；target 只在发布点原子授予一个逻辑 session/incarnation，且每次操作与清理都重验该
+  owner；它不进入 Zen Core、durable journal，也绝不取得关闭用户 target 或 profile 的权限。
+- **ZenXUserBrowserDocumentExecutionFence** — ZenX user-browser provider 把 target、精确 attachment epoch/session、逻辑
+  session owner/incarnation、main-frame loader/url/revision、isolated execution context 与 provider revision 绑定为一次
+  瞬时且 fail-closed 的 acquire→dispatch fence，并在每个 awaited setup 步骤后及发送 page code 前按有序 CDP 事件流
+  原子重验；它不进入 Zen Core 或 durable journal，且 mutation 已发送后的失效继续使用 outcome-unknown/taint 与 lease 语义。
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,8 +83,9 @@
   owner；它不进入 Zen Core、durable journal，也绝不取得关闭用户 target 或 profile 的权限。
 - **ZenXUserBrowserDocumentExecutionFence** — ZenX user-browser provider 把 target、精确 attachment epoch/session、逻辑
   session owner/incarnation、main-frame loader/url/revision、isolated execution context 与 provider revision 绑定为一次
-  瞬时且 fail-closed 的 acquire→dispatch fence，并在每个 awaited setup 步骤后及发送 page code 前按有序 CDP 事件流
-  原子重验；它不进入 Zen Core 或 durable journal，且 mutation 已发送后的失效继续使用 outcome-unknown/taint 与 lease 语义。
+  瞬时且 fail-closed 的 acquire→dispatch fence，先把 Page/Runtime domain enable 作为精确 attachment setup barrier，
+  再在每个 awaited setup 步骤后及发送 page code 前按有序 CDP 事件流原子重验；它不进入 Zen Core 或 durable journal，
+  且 mutation 已发送后的失效继续使用 outcome-unknown/taint 与 lease 语义。
 - **ZenXWinAppCliComputerProvider** — ZenX Windows 产品层把 Microsoft WinApp CLI 的 HWND/UIA/WGC JSON
   投影为既有的有界 opaque observation 与 background-safe computer tools；外部 CLI 的安装、版本和进程生命周期
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -19,8 +19,10 @@ stub App Server 记录真实调用，在不污染 Zen Core 的前提下扩展协
 host、Thread 列表与恢复、流式 Item、审批、模型切换、soft steer、interrupt 与
 Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / Room，
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
-首批 browser provider 优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
-回落到 bundled Electron/CDP 临时 profile；两者都只暴露有界 DOM 操作。computer
+首批 browser provider 默认优先复用 Playwright CLI 的跨平台 headless 隔离 session，缺失或不兼容时
+回落到 bundled Electron/CDP 临时 profile；用户也可显式选择 loopback CDP user-session
+provider 附着到自己预先开启的 Chrome/Edge/Chromium，原位使用认证状态而不导出 cookie、
+storage 或 auth header，连接失败时绝不回落到隔离登录态；三者都只暴露有界 DOM 操作。computer
 公共 contract 暴露语义动作、平台能力与 background-safe/foreground-required 影响协商；
 当前 macOS provider 优先复用 Peekaboo 3.x 的 background-first 操作，缺失或不兼容时以 bundled
 AX/窗口定向截图和明确提示、可取消的前台输入形成基线；

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -83,18 +83,67 @@ moving the OS pointer or activating a browser window. Inspection returns bounded
 visible text plus opaque IDs bound to the latest tab/document observation, never
 raw CSS selectors, cookies, storage, headers, or unrelated tabs. Actions
 revalidate visibility, supported action, and semantic identity, then invalidate
-the observation; navigation and close do likewise. Password values are omitted
-and secure controls reject typing. `browser_type` is deliberately non-secret-only
-because its text argument is part of the canonical tool call. Sessions have hard
+the observation; navigation and close do likewise. Existing input values are
+omitted, while text arguments dispatch normally regardless of password or
+autocomplete metadata and remain ordinary canonical tool-call arguments. Sessions have hard
 per-session/global tab caps plus explicit tab/session close tools.
 `browser_close_session` destroys all session windows, awaits storage/cache/auth
 cleanup, and advances the partition generation; reopening the same `sessionId`
 therefore starts without the prior cookies or session storage. Generation state
 exists only for active/pending sessions, so logical session bookkeeping is bounded.
-Attaching the user's existing Chrome profile or tabs is not implemented; it
-would be a separate explicit opt-in mode with different privacy and interaction
-impact. This implementation does not claim parity with any proprietary browser
-automation product.
+User-browser attachment is a separate explicit opt-in mode. Start a supported
+Chrome, Edge, or Chromium 100+ yourself with a loopback remote-debugging port,
+open or sign into the pages you want ZenX to use, then start ZenX with:
+
+```powershell
+$env:ZENX_BROWSER_MODE = "user-session"
+$env:ZENX_USER_BROWSER_CDP_ENDPOINT = "http://127.0.0.1:9222"
+npm --workspace apps/zenx run dev
+```
+
+Modern Chromium releases may require the user to choose an explicit non-default
+`--user-data-dir` when enabling `--remote-debugging-port=9222`; ZenX never starts
+the browser, copies cookie databases, or attempts to unlock a profile directory.
+The endpoint must be unauthenticated loopback HTTP and must identify Chrome,
+Edge, or Chromium. Unavailable or incompatible endpoints remain terminal
+`user-browser-cdp` diagnostics and never fall back to Playwright/Electron.
+Inspection and action reuse authenticated page state in place, but only bounded
+visible text and opaque target IDs reach the Agent; cookies, storage state, auth
+headers, and credentials are never requested or returned. Closing a tab/session
+in this mode only detaches ZenX state, and closing ZenX only disconnects CDP; the
+user's tabs, browser process, storage, and profile remain intact. Settings labels
+browser provider diagnostics as `user-session` or `isolated-session`.
+One transient provider-local attachment-epoch boundary serializes every public
+request, including tab/session/backend close, and preserves bounded create/
+attach/enable/mutation/detach outcome evidence until closure is known. Inspect/
+action dispatch is bound to a provider-owned CDP execution document and mutations
+retain their tab lease through post-confirmation. The actual CDP send boundary
+classifies known setup/protocol failures separately from dispatched outcome
+uncertainty. Each attachment epoch binds the actual CDP `sessionId`, target, logical-session
+owner/incarnation, and attach attempt. Lifecycle events reap only that exact
+epoch; the deprecated detach-event `targetId` is used solely to correlate a
+pending attach before its response and can never select a current successor.
+Any unrecognized lifecycle or detach uncertainty is deduplicated, bounded, and
+promoted to session taint before target/session maps are removed, so every later
+normal operation fails closed while cleanup can still detach known ownership.
+Active logical sessions have a fixed fail-closed admission bound and are removed
+only by explicit session/backend closure. Target discovery is enabled before relying
+on created/destroyed events. Logical close sends `Target.detachFromTarget` only
+for ZenX-owned attachments, compensates late attachment outcomes when possible,
+never reports success over remaining taint, and never sends `Target.closeTarget`.
+Outcome-unknown evidence is monotonic even when compensation, target lifecycle
+events, or a later detach safely close resource ownership; reconnect or logical
+session reuse cannot adopt a quarantined stale attachment mapping.
+Provider-created tabs start with a unique transient marker in background,
+non-focused mode and are then navigated to the requested URL; the marker lets a
+lost `Target.createTarget` reply be reconciled against the operation's
+pre-create target snapshot without mistaking a user tab for ZenX-owned work.
+CDP commands have bounded outcomes, and HTTP reconciliation plus the browser
+WebSocket are restricted to the same numeric loopback authority.
+
+The default `ZENX_BROWSER_MODE=isolated` continues to select Playwright CLI or
+the bundled ephemeral Electron/CDP provider. This implementation does not claim
+parity with any proprietary browser automation product.
 
 The computer contract is platform-neutral: tools describe semantic observation,
 press/value/capture operations and their interaction impact, while a platform
@@ -168,8 +217,8 @@ mature external implementations while retaining a runnable bundled baseline:
   role/name/type/security/visibility/action fingerprint. Missing or incompatible
   CLI installations remain explicit in provider diagnostics and use the existing
   bundled Chromium CDP ephemeral-partition provider. Install `@playwright/cli`
-  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; attaching a user
-  profile is still unsupported. See <https://playwright.dev/agent-cli/introduction>
+  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; user-session attachment
+  remains a separate explicit CDP provider. See <https://playwright.dev/agent-cli/introduction>
   and <https://playwright.dev/docs/api/class-browsercontext>.
 - A future `isolated` interaction mode/provider can place arbitrary control in a
   VM, cloud desktop, or remote host. OSWorld's provider separation across
@@ -233,6 +282,7 @@ npm run check
 npm --workspace apps/zenx run smoke:capabilities
 # Windows only, after installing Microsoft WinApp CLI:
 npm --workspace apps/zenx run smoke:windows-computer
+npm --workspace apps/zenx run smoke:windows-user-browser
 npm --workspace apps/zenx run smoke:providers
 ```
 
@@ -245,8 +295,8 @@ the child-host capability bridge, derived projects, Thread create/list/read/stat
 active `start | steer | replace`, follow-up delivery, bounded redaction, canonical
 command audit, and the real OpenAI subscription tool serialization boundary.
 The packaged capability smoke covers a real hidden dedicated browser
-open/inspect/navigate/click/type/close, including forged/stale/changed/hidden and
-password target rejection. It also seeds a cookie and session storage, closes
+open/inspect/navigate/click/type/close, including forged/stale/changed/hidden
+rejection and ordinary password-field input dispatch. It also seeds a cookie and session storage, closes
 the session, reopens the same ID, and verifies both are absent. It asserts those
 background-safe browser operations
 leave the real pointer position and foreground application unchanged. The macOS
@@ -273,6 +323,14 @@ provider/version/permission diagnostics. CI installs the pinned official
 `@playwright/cli` and requires that provider to be selected; a local run may
 exercise the Electron fallback when the CLI is absent. The smoke only probes
 Peekaboo availability and permissions; it never sends desktop input.
+The Windows user-browser smoke launches a real installed Chrome/Edge process
+with an explicit temporary profile and CDP port, establishes authenticated state
+inside that browser, attaches ZenX, lists/inspects/acts in the existing tab, and
+opens a provider-created background tab while checking the foreground HWND and
+both tabs' document visibility. It records the actual visible target ID before
+open, after open, and after close; verifies the original target survives and the
+provider-created target remains hidden; then verifies ZenX detach leaves the
+browser process and tabs alive without projecting cookie material.
 It does
 not run foreground takeover against the user's desktop; foreground execution
 and immediate pre-input cancellation are covered by provider/bridge tests. The

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -12,6 +12,7 @@
     "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
+    "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",
     "smoke:providers": "npm run build && electron ./out/main/provider-smoke.js",
     "check": "npm run typecheck && npm test && npm run build"
   },

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -153,7 +153,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_inspect",
       description:
-        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Password/secure values are never returned and secure controls cannot be typed.",
+        "Create the latest bounded observation for one ZenX browser tab and return opaque target IDs for visible controls. Existing input values are not returned.",
       inputSchema: browserTargetSchema(),
       permissions: ["browser.tabs.read"],
       interactionMode: "background_safe",
@@ -175,7 +175,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "browser_type",
       description:
-        "Replace a non-secret value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Password/secure controls and secret text are unsupported because tool arguments are journaled.",
+        "Replace the value in one visible, typeable opaque target from the latest browser_inspect observation, optionally submitting its form. Text is dispatched as an ordinary tool argument regardless of field metadata.",
       inputSchema: browserTargetSchema(
         {
           observationId: stringSchema(),
@@ -216,7 +216,7 @@ export const browserCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Instructions for targeted, inspect-before-act browser automation.",
       content:
-        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Typing is for non-secret text only because tool arguments are journaled, and password/secure controls are rejected. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
+        "Choose a stable sessionId for the task. List or open tabs, then inspect the exact tab before clicking or typing. Act only with the observationId and opaque targetId from the latest inspect; re-inspect after navigation or every action. Text is dispatched as an ordinary tool argument regardless of field metadata. Close tabs or the session when done; close_session clears the current partition so a later same-ID session starts clean. Never ask for cookies, storage state, auth headers, or hidden page content.",
     },
     {
       id: "browser-research",
@@ -440,7 +440,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     const inspected = await evaluateInTab<{
       visibleText: string;
       targets: BrowserTargetFingerprint[];
-    }>(tab, INSPECT_SCRIPT);
+    }>(tab, browserInspectScript);
     const observationId = randomUUID();
     const targets = new Map<string, BrowserTargetFingerprint>();
     const projectedTargets = inspected.targets.slice(0, 80).map((target) => {
@@ -485,7 +485,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "click"),
+      browserActionScript(target, "click"),
     );
     if (!result.ok) {
       throw new Error(
@@ -511,15 +511,10 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
       targetId,
       "type",
     );
-    if (target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     tab.observation = undefined;
     const result = await evaluateInTab<{ ok: boolean; reason?: string }>(
       tab,
-      actionScript(target, "type", text, submit),
+      browserActionScript(target, "type", text, submit),
     );
     if (!result.ok) {
       throw new Error(
@@ -681,17 +676,12 @@ export function resolveBrowserObservedTarget(
     throw new Error("Browser target ID is forged, stale, or unknown");
   }
   if (!target.actions.includes(action)) {
-    if (action === "type" && target.secure) {
-      throw new Error(
-        "Browser typing into password or secure controls is unsupported; browser_type is non-secret-only because tool arguments are journaled",
-      );
-    }
     throw new Error(`Browser target does not support ${action}`);
   }
   return target;
 }
 
-const INSPECT_SCRIPT = `(() => {
+export const browserInspectScript = `(() => {
   const visible = (element) => {
     const style = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
@@ -703,7 +693,7 @@ const INSPECT_SCRIPT = `(() => {
     ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
   );
   const typeable = (element) => {
-    if (secure(element) || element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
+    if (element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
     if (element instanceof HTMLTextAreaElement) return true;
     if (!(element instanceof HTMLInputElement)) return false;
     return !["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase());
@@ -747,13 +737,12 @@ const INSPECT_SCRIPT = `(() => {
         href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
         secure: isSecure,
         actions,
-        ...(!isSecure && (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) ? { value: element.value.slice(0, 160) } : {}),
       };
     }),
   };
 })()`;
 
-function actionScript(
+export function browserActionScript(
   target: BrowserTargetFingerprint,
   action: "click" | "type",
   text = "",
@@ -804,7 +793,6 @@ function actionScript(
       element.click();
       return { ok: true };
     }
-    if (secure) return { ok: false, reason: "secure-control" };
     if (!(element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) || element.disabled || element.readOnly) return { ok: false, reason: "not-typeable" };
     if (element instanceof HTMLInputElement && ["button", "checkbox", "file", "hidden", "image", "radio", "reset", "submit"].includes(element.type.toLowerCase())) return { ok: false, reason: "not-typeable" };
     const prototype = element instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
@@ -850,7 +838,7 @@ function summarizeTab(tab: BrowserTab): BrowserTabSummary {
     sessionId: tab.sessionId,
     tabId: tab.tabId,
     title: tab.window.getTitle().slice(0, 256),
-    url: redactUrl(tab.window.webContents.getURL()),
+    url: redactBrowserUrl(tab.window.webContents.getURL()),
     loading: tab.window.webContents.isLoading(),
   };
 }
@@ -875,7 +863,7 @@ function safeBrowserUrl(raw: string): string {
   return url.toString();
 }
 
-function redactUrl(raw: string): string {
+export function redactBrowserUrl(raw: string): string {
   if (raw.length === 0) return "";
   const url = new URL(raw);
   url.username = "";

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -653,14 +653,13 @@ function playwrightTargetFingerprint(
     autocomplete: dom.autocomplete,
     href: dom.href || node.url || "",
     secure,
-    actions: playwrightNodeActions(node, dom, secure),
+    actions: playwrightNodeActions(node, dom),
   };
 }
 
 function playwrightNodeActions(
   node: PlaywrightAriaNode,
   dom: PlaywrightDomMetadata,
-  secure: boolean,
 ): Array<"click" | "type"> {
   if (node.disabled === true) return [];
   const clickRoles = new Set([
@@ -691,8 +690,7 @@ function playwrightNodeActions(
     ...(clickRoles.has(node.role) || node.cursor === "pointer"
       ? (["click"] as const)
       : []),
-    ...(!secure &&
-    typeRoles.has(node.role) &&
+    ...(typeRoles.has(node.role) &&
     !(dom.tag === "input" && nonTypeableInput.has(dom.type.toLowerCase()))
       ? (["type"] as const)
       : []),
@@ -759,11 +757,6 @@ function requireObservedTarget(
   }
   if (target.disabled || !target.actions.includes(action)) {
     throw new Error(`Browser target does not support ${action}`);
-  }
-  if (action === "type" && target.secure) {
-    throw new Error(
-      "browser_type rejects password or secure controls because supplied text is journaled",
-    );
   }
   return target;
 }

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -19,6 +19,8 @@ import {
 } from "./external-provider.js";
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
+import { connectUserBrowserCdp } from "./user-browser-provider.js";
+import type { UserBrowserConnection } from "./user-browser-provider.js";
 import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
@@ -45,6 +47,10 @@ export interface ZenXCapabilityProviderCatalogOptions {
   environment?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   runner?: ExternalProviderProcessRunner;
+  userBrowserConnector?: (
+    endpoint: string,
+    signal?: AbortSignal,
+  ) => Promise<UserBrowserConnection>;
 }
 
 // @playwright/cli has its own 0.1.x package version. It embeds Playwright
@@ -57,10 +63,92 @@ const MAX_PEEKABOO_EXCLUSIVE = [4, 0, 0] as const;
 
 export async function selectBrowserProvider(
   options: ZenXCapabilityProviderCatalogOptions,
-): Promise<ZenXCapabilityProviderSelection<ZenXBrowserBackend>> {
+): Promise<ZenXOptionalCapabilityProviderSelection<ZenXBrowserBackend>> {
   const runner = options.runner ?? new SystemExternalProviderProcessRunner();
   const environment = options.environment ?? process.env;
   const platform = options.platform ?? process.platform;
+  const browserMode = environment.ZENX_BROWSER_MODE ?? "isolated";
+  if (browserMode === "user-session") {
+    const endpoint = environment.ZENX_USER_BROWSER_CDP_ENDPOINT;
+    if (endpoint === undefined || endpoint.trim().length === 0) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              "User-session browser mode requires an explicit ZENX_USER_BROWSER_CDP_ENDPOINT",
+            ),
+            sessionMode: "user-session",
+          },
+        ],
+      };
+    }
+    try {
+      const connection = await (
+        options.userBrowserConnector ?? connectUserBrowserCdp
+      )(endpoint);
+      return {
+        backend: connection.backend,
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          {
+            capabilityId: "browser",
+            providerId: "user-browser-cdp",
+            status: "selected",
+            interactionModes: ["background_safe"],
+            capabilities: [
+              "user_session",
+              "authenticated_state_in_place",
+              "cdp",
+              "dom.inspect",
+              "dom.interact",
+            ],
+            version: connection.product,
+            permissionSummary:
+              "Explicit loopback CDP attachment; uses authenticated page state in place and never exports cookies, storage, headers, or credentials",
+            sessionMode: "user-session",
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        manifest: userBrowserManifest(),
+        diagnostics: [
+          {
+            ...unavailableDiagnostic(
+              "browser",
+              "user-browser-cdp",
+              ["background_safe"],
+              ["user_session", "authenticated_state_in_place", "cdp"],
+              describeError(error),
+            ),
+            sessionMode: "user-session",
+          },
+        ],
+      };
+    }
+  }
+  if (browserMode !== "isolated") {
+    return {
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "browser-mode",
+            ["isolated", "background_safe"],
+            ["explicit_mode_selection"],
+            `Unsupported ZENX_BROWSER_MODE ${browserMode}; expected isolated or user-session`,
+          ),
+          sessionMode: "invalid",
+        },
+      ],
+    };
+  }
   const configured = environment.ZENX_PLAYWRIGHT_CLI;
   const executable = await discoverExecutable(configured ?? "playwright-cli", {
     environment,
@@ -74,15 +162,18 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          configured === undefined
-            ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
-            : `Configured Playwright CLI is not executable: ${configured}`,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            configured === undefined
+              ? "playwright-cli is not installed; install @playwright/cli and its browser, or set ZENX_PLAYWRIGHT_CLI"
+              : `Configured Playwright CLI is not executable: ${configured}`,
+          ),
+          sessionMode: "isolated-session",
+        },
         fallbackDiagnostic,
       ],
     };
@@ -118,6 +209,7 @@ export async function selectBrowserProvider(
           version,
           permissionSummary:
             "Isolated in-memory Playwright session; no foreground desktop input",
+          sessionMode: "isolated-session",
         },
         fallbackDiagnostic,
       ],
@@ -127,18 +219,71 @@ export async function selectBrowserProvider(
       backend: new ElectronBrowserBackend(),
       manifest: browserCapabilityManifest,
       diagnostics: [
-        unavailableDiagnostic(
-          "browser",
-          "playwright-cli",
-          ["isolated"],
-          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
-          describeError(error),
-          executable,
-        ),
+        {
+          ...unavailableDiagnostic(
+            "browser",
+            "playwright-cli",
+            ["isolated"],
+            ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+            describeError(error),
+            executable,
+          ),
+          sessionMode: "isolated-session",
+        },
         electronBrowserDiagnostic("fallback"),
       ],
     };
   }
+}
+
+function userBrowserManifest(): ZenXCapabilityManifest {
+  const manifest = structuredClone(browserCapabilityManifest);
+  return {
+    ...manifest,
+    description:
+      "An explicit attachment to a user-opened Chrome, Edge, or Chromium CDP session that uses authenticated page state in place without exporting session material.",
+    provider: {
+      id: "user-browser-cdp",
+      platforms: ["darwin", "win32", "linux"],
+      interactionModes: ["background_safe"],
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        "cdp",
+        "dom.inspect",
+        "dom.navigate",
+        "dom.interact",
+      ],
+    },
+    tools: manifest.tools.map((tool) => ({
+      ...tool,
+      description:
+        tool.name === "browser_close_session"
+          ? "Detach ZenX capability state from one user-browser session without closing tabs, clearing storage, or changing the user profile."
+          : tool.name === "browser_close"
+            ? "Detach one explicit user-browser tab from this ZenX session without closing the user's tab."
+            : tool.description
+                .replaceAll("dedicated ZenX", "attached user")
+                .replaceAll("hidden tab", "user browser tab")
+                .replaceAll("ephemeral ZenX", "attached user"),
+      capabilities: [
+        "user_session",
+        "authenticated_state_in_place",
+        ...tool.capabilities.filter(
+          (capability) => capability !== "dedicated_profile",
+        ),
+      ],
+    })),
+    resources: manifest.resources.map((resource) =>
+      resource.id === "safe-browser-use"
+        ? {
+            ...resource,
+            content:
+              "This provider is attached to a user-opened browser and may use authenticated page state in place. List tabs, inspect the exact tab, and act only with the latest opaque observation and target IDs. Text is dispatched as an ordinary tool argument regardless of field metadata. Never request or return browser session internals such as cookies, storage state, or auth headers. Closing a tab/session detaches ZenX state only and must not close or clear the user's browser/profile.",
+          }
+        : resource,
+    ),
+  };
 }
 
 export async function selectComputerProvider(
@@ -447,6 +592,7 @@ function electronBrowserDiagnostic(
     interactionModes: ["background_safe"],
     capabilities: ["dedicated_profile", "cdp", "dom.inspect", "dom.interact"],
     permissionSummary: "Bundled hidden ephemeral Electron partition",
+    sessionMode: "isolated-session",
   };
 }
 

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -89,6 +89,7 @@ export interface ZenXCapabilityProviderDiagnostic {
   version?: string;
   permissionSummary?: string;
   reason?: string;
+  sessionMode?: "isolated-session" | "user-session" | "invalid";
 }
 
 export interface ZenXCapabilitySummary {

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -39,8 +39,11 @@ interface UserBrowserAttachmentEpoch extends UserBrowserAttachmentOwner {
   attachAttempt: number;
   attach: UserBrowserCdpOutcome;
   enable: UserBrowserCdpOutcome;
+  runtimeEnable: UserBrowserCdpOutcome;
   detach: UserBrowserCdpOutcome;
-  unknownEvidence: Partial<Record<"attach" | "enable" | "detach", string>>;
+  unknownEvidence: Partial<
+    Record<"attach" | "enable" | "runtimeEnable" | "detach", string>
+  >;
   lifecycleEvidence: string[];
   taint?: string;
   unsettledMutation?: string;
@@ -2073,28 +2076,19 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         invalidExecutionContextIds: new Set(),
         pendingIsolatedContexts: new Map(),
       });
-      try {
-        await this.#send("Page.enable", {}, response.sessionId, signal);
-        attachmentClosure.enable = "known-success";
-        return response.sessionId;
-      } catch (error) {
-        attachmentClosure.enable =
-          error instanceof UserBrowserCdpOutcomeUnknownError
-            ? "outcome-unknown"
-            : "known-failure";
-        if (attachmentClosure.enable === "outcome-unknown") {
-          attachmentClosure.unknownEvidence.enable = describeError(error);
-        }
-        try {
-          await this.#compensateAttachment(
-            attachmentClosure,
-            response.sessionId,
-          );
-        } catch (compensationError) {
-          attachmentClosure.taint = `Page.enable closure failed (${describeError(error)}; ${describeError(compensationError)})`;
-        }
-        throw error;
-      }
+      await this.#enableAttachmentDomain(
+        attachmentClosure,
+        response.sessionId,
+        "Page.enable",
+        signal,
+      );
+      await this.#enableAttachmentDomain(
+        attachmentClosure,
+        response.sessionId,
+        "Runtime.enable",
+        signal,
+      );
+      return response.sessionId;
     })();
     attachment.promise = attaching;
     this.#targetAttachments.set(targetId, attachment);
@@ -2104,6 +2098,58 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       if (this.#targetAttachments.get(targetId) === attachment) {
         this.#targetAttachments.delete(targetId);
       }
+    }
+  }
+
+  async #enableAttachmentDomain(
+    epoch: UserBrowserAttachmentEpoch,
+    sessionId: string,
+    method: "Page.enable" | "Runtime.enable",
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const outcome = method === "Page.enable" ? "enable" : "runtimeEnable";
+    try {
+      await this.#send(method, {}, sessionId, signal);
+      epoch[outcome] = "known-success";
+      this.#assertAttachmentSetupCurrent(epoch, sessionId, method);
+    } catch (error) {
+      if (epoch[outcome] !== "known-success") {
+        epoch[outcome] =
+          error instanceof UserBrowserCdpOutcomeUnknownError
+            ? "outcome-unknown"
+            : "known-failure";
+        if (epoch[outcome] === "outcome-unknown") {
+          epoch.unknownEvidence[outcome] = describeError(error);
+        }
+      }
+      try {
+        await this.#compensateAttachment(epoch, sessionId);
+      } catch (compensationError) {
+        epoch.taint = `${method} closure failed (${describeError(error)}; ${describeError(compensationError)})`;
+      }
+      throw error;
+    }
+  }
+
+  #assertAttachmentSetupCurrent(
+    epoch: UserBrowserAttachmentEpoch,
+    sessionId: string,
+    method: string,
+  ): void {
+    const attachment = this.#targetAttachments.get(epoch.targetId);
+    const document = this.#targetDocuments.get(epoch.targetId);
+    if (
+      this.#closed ||
+      this.#attachmentClosures.get(epoch.targetId) !== epoch ||
+      this.#targetSessions.get(epoch.targetId) !== sessionId ||
+      this.#sessionTargets.get(sessionId) !== epoch.targetId ||
+      this.#sessionEpochs.get(sessionId) !== epoch ||
+      attachment?.epoch !== epoch ||
+      attachment.invalidated ||
+      document === undefined ||
+      document.alive === false
+    ) {
+      throw new Error(`User browser target changed during ${method} setup`);
     }
   }
 
@@ -2126,6 +2172,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       attachAttempt: this.#nextAttachAttempt++,
       attach: "known-failure",
       enable: "known-failure",
+      runtimeEnable: "known-failure",
       detach: "known-failure",
       unknownEvidence: {},
       lifecycleEvidence: [],

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -23,6 +23,7 @@ const USER_BROWSER_MAX_BACKEND_TAINT = 64;
 const USER_BROWSER_MAX_PENDING_CDP_REQUESTS = 128;
 const USER_BROWSER_MAX_ACTIVE_SESSIONS = 32;
 const USER_BROWSER_LATE_RESPONSE_RETENTION_MS = 5_000;
+const USER_BROWSER_DOCUMENT_WORLD_NAME = "__zenx_user_browser_document__";
 
 type UserBrowserCdpOutcome =
   "known-success" | "known-failure" | "outcome-unknown";
@@ -42,6 +43,7 @@ interface UserBrowserAttachmentEpoch extends UserBrowserAttachmentOwner {
   unknownEvidence: Partial<Record<"attach" | "enable" | "detach", string>>;
   lifecycleEvidence: string[];
   taint?: string;
+  unsettledMutation?: string;
 }
 
 interface ZenXUserBrowserDocumentExecutionFence extends UserBrowserAttachmentOwner {
@@ -859,11 +861,30 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       (candidate) => this.#tabs.get(candidate) === tab,
     );
     if (targetId === undefined) throw new Error("User browser tab was closed");
-    const result = this.#startSessionOperation(session, async () => {
-      this.#assertTabCurrent(session, targetId, tab);
-      return await run();
+    const outward = promiseCapability<T>();
+    let operationStarted = false;
+    const retained = this.#startSessionOperation(session, async () => {
+      operationStarted = true;
+      try {
+        this.#assertTabCurrent(session, targetId, tab);
+        const value = await run();
+        outward.resolve(value);
+        return value;
+      } catch (error) {
+        outward.reject(error);
+        if (
+          error instanceof UserBrowserMutationOutcomeUnknownError &&
+          error.settlement !== undefined
+        ) {
+          await error.settlement;
+        }
+        throw error;
+      }
     });
-    const settled = result.then(
+    void retained.catch((error: unknown) => {
+      if (!operationStarted) outward.reject(error);
+    });
+    const settled = retained.then(
       () => undefined,
       () => undefined,
     );
@@ -871,7 +892,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     void settled.then(() => {
       if (tab.operation === settled) tab.operation = undefined;
     });
-    return result;
+    return outward.promise;
   }
 
   #startSessionOperation<T>(
@@ -1323,6 +1344,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     number,
     {
       receive(message: Record<string, unknown>): Promise<void>;
+      expire(): void;
       expires: NodeJS.Timeout;
     }
   >();
@@ -1336,6 +1358,9 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       url: string;
       alive: boolean;
       pendingFrameInvalidations: Set<string>;
+      invalidExecutionContextIds: Set<number>;
+      pendingIsolatedContexts: Map<number, string>;
+      isolatedExecutionContextId?: number;
     }
   >();
   #nextId = 1;
@@ -1538,7 +1563,8 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     let mutationResponseKnown = false;
     try {
       response = asRecord(
-        await this.#send(
+        await this.#sendDocumentRuntimeEvaluate(
+          before,
           "Runtime.evaluate",
           {
             expression,
@@ -1546,12 +1572,8 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
             returnByValue: true,
             contextId: before.executionContextId,
           },
-          before.sessionId,
           signal,
-          USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
-          undefined,
           onDispatched,
-          () => this.#assertDocumentFence(before, true),
         ),
       );
       mutationResponseKnown = true;
@@ -1559,7 +1581,8 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         throw new Error("User browser CDP evaluation failed");
       }
       const confirmation = asRecord(
-        await this.#send(
+        await this.#sendDocumentRuntimeEvaluate(
+          before,
           "Runtime.evaluate",
           {
             expression: "void 0",
@@ -1567,12 +1590,8 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
             returnByValue: true,
             contextId: before.executionContextId,
           },
-          before.sessionId,
           signal,
-          USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
           undefined,
-          undefined,
-          () => this.#assertDocumentFence(before, true),
         ),
       );
       if (confirmation?.exceptionDetails !== undefined) {
@@ -1601,8 +1620,51 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         throw new UserBrowserMutationOutcomeUnknownError(
           "Runtime.evaluate",
           describeError(error),
+          error instanceof UserBrowserCdpOutcomeUnknownError
+            ? error.settlement
+            : undefined,
         );
       }
+      throw error;
+    }
+  }
+
+  async #sendDocumentRuntimeEvaluate(
+    fence: ZenXUserBrowserDocumentExecutionFence & {
+      executionContextId: number;
+    },
+    method: "Runtime.evaluate",
+    params: Record<string, unknown>,
+    signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<unknown> {
+    const settlement = promiseCapability<void>();
+    try {
+      const result = await this.#send(
+        method,
+        params,
+        fence.sessionId,
+        signal,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+        async () => settlement.resolve(),
+        onDispatched,
+        () => this.#assertDocumentFence(fence, true),
+        () => {
+          fence.attachmentEpoch.unsettledMutation ??= `${method} late settlement was not observed`;
+          settlement.resolve();
+        },
+      );
+      settlement.resolve();
+      return result;
+    } catch (error) {
+      if (error instanceof UserBrowserCdpOutcomeUnknownError) {
+        throw new UserBrowserCdpOutcomeUnknownError(
+          method,
+          describeError(error),
+          settlement.promise,
+        );
+      }
+      settlement.resolve();
       throw error;
     }
   }
@@ -1693,6 +1755,9 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       url: frame.url,
       alive: true,
       pendingFrameInvalidations: state.pendingFrameInvalidations,
+      invalidExecutionContextIds: state.invalidExecutionContextIds,
+      pendingIsolatedContexts: state.pendingIsolatedContexts,
+      isolatedExecutionContextId: state.isolatedExecutionContextId,
     });
     await this.#documentBarrier(fence, signal);
     this.#assertDocumentFence(fence, false);
@@ -1701,7 +1766,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         "Page.createIsolatedWorld",
         {
           frameId: frame.id,
-          worldName: "__zenx_user_browser_document__",
+          worldName: USER_BROWSER_DOCUMENT_WORLD_NAME,
           grantUniveralAccess: false,
         },
         sessionId,
@@ -1713,6 +1778,26 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       throw new Error("User browser CDP execution context is invalid");
     }
     fence.executionContextId = world.executionContextId;
+    const contextState = this.#targetDocuments.get(targetId);
+    if (contextState === undefined || contextState.alive === false) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    const replacement = [...contextState.pendingIsolatedContexts].some(
+      ([contextId, frameId]) =>
+        frameId === fence.frameId && contextId !== world.executionContextId,
+    );
+    contextState.pendingIsolatedContexts.clear();
+    contextState.isolatedExecutionContextId = world.executionContextId;
+    if (
+      replacement ||
+      contextState.invalidExecutionContextIds.has(world.executionContextId)
+    ) {
+      this.#invalidateTarget(targetId, false);
+      throw new UserBrowserDocumentChangedBeforeDispatchError(
+        "isolated execution context invalidated",
+      );
+    }
+    contextState.invalidExecutionContextIds.clear();
     await this.#documentBarrier(fence, signal);
     this.#assertDocumentFence(fence, true);
     const identity = JSON.stringify({
@@ -1781,7 +1866,10 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       (fence.url.length > 0 &&
         state.url.length > 0 &&
         state.url !== fence.url) ||
-      (requireContext && fence.executionContextId === undefined)
+      (requireContext &&
+        (fence.executionContextId === undefined ||
+          state.isolatedExecutionContextId !== fence.executionContextId ||
+          state.invalidExecutionContextIds.has(fence.executionContextId)))
     ) {
       throw new UserBrowserDocumentChangedBeforeDispatchError();
     }
@@ -1811,6 +1899,12 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       throw new UserBrowserCdpOutcomeUnknownError(
         "Target.attachToTarget",
         closure.unknownEvidence.attach,
+      );
+    }
+    if (closure?.unsettledMutation !== undefined) {
+      throw new UserBrowserCdpOutcomeUnknownError(
+        "Target.detachFromTarget",
+        closure.unsettledMutation,
       );
     }
     const sessionId = this.#targetSessions.get(targetId);
@@ -1976,6 +2070,8 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         url: "",
         alive: true,
         pendingFrameInvalidations: new Set(),
+        invalidExecutionContextIds: new Set(),
+        pendingIsolatedContexts: new Map(),
       });
       try {
         await this.#send("Page.enable", {}, response.sessionId, signal);
@@ -2119,6 +2215,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     onLateResponse?: (message: Record<string, unknown>) => Promise<void>,
     onDispatched?: () => void,
     beforeDispatch?: () => void,
+    onLateExpiration?: () => void,
   ): Promise<unknown> {
     if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
       throw new Error("User browser CDP connection is unavailable");
@@ -2143,7 +2240,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         this.#pending.delete(id);
         finish();
         if (dispatched && onLateResponse !== undefined) {
-          this.#retainLateResponse(id, onLateResponse);
+          this.#retainLateResponse(id, onLateResponse, onLateExpiration);
         }
         const reason =
           signal?.reason instanceof Error
@@ -2169,6 +2266,12 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         },
         reject: (error) => {
           finish();
+          if (
+            dispatched &&
+            error instanceof UserBrowserCdpOutcomeUnknownError
+          ) {
+            onLateExpiration?.();
+          }
           reject(error);
         },
       };
@@ -2183,7 +2286,7 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
           ),
         );
         if (onLateResponse !== undefined) {
-          this.#retainLateResponse(id, onLateResponse);
+          this.#retainLateResponse(id, onLateResponse, onLateExpiration);
         }
       }, outcomeTimeoutMs);
       signal?.addEventListener("abort", abort, { once: true });
@@ -2215,21 +2318,26 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
   #retainLateResponse(
     id: number,
     receive: (message: Record<string, unknown>) => Promise<void>,
+    expire: () => void = () => undefined,
   ): void {
     if (this.#lateResponses.size >= USER_BROWSER_MAX_OPERATION_EVIDENCE) {
       const oldest = this.#lateResponses.keys().next().value as
         number | undefined;
       if (oldest !== undefined) {
         const evicted = this.#lateResponses.get(oldest);
-        if (evicted !== undefined) clearTimeout(evicted.expires);
+        if (evicted !== undefined) {
+          clearTimeout(evicted.expires);
+          evicted.expire();
+        }
         this.#lateResponses.delete(oldest);
       }
       this.#recordConnectionTaint("late-response cleanup exceeded its bound");
     }
     const expires = setTimeout(() => {
       this.#lateResponses.delete(id);
+      expire();
     }, USER_BROWSER_LATE_RESPONSE_RETENTION_MS);
-    this.#lateResponses.set(id, { receive, expires });
+    this.#lateResponses.set(id, { receive, expire, expires });
   }
 
   #receive(raw: string): void {
@@ -2345,10 +2453,67 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     const document = this.#targetDocuments.get(targetId);
     if (
       document !== undefined &&
+      method === "Runtime.executionContextDestroyed" &&
+      typeof params.executionContextId === "number"
+    ) {
+      if (
+        document.invalidExecutionContextIds.size <
+          USER_BROWSER_MAX_OPERATION_EVIDENCE ||
+        document.invalidExecutionContextIds.has(params.executionContextId)
+      ) {
+        document.invalidExecutionContextIds.add(params.executionContextId);
+      } else {
+        this.#invalidateTarget(targetId, false);
+      }
+      return;
+    }
+    if (
+      document !== undefined &&
+      method === "Runtime.executionContextsCleared"
+    ) {
+      this.#invalidateTarget(targetId, false);
+      return;
+    }
+    if (
+      document !== undefined &&
+      method === "Runtime.executionContextCreated"
+    ) {
+      const context = asRecord(params.context);
+      const auxData = asRecord(context?.auxData);
+      if (
+        typeof context?.id === "number" &&
+        context.name === USER_BROWSER_DOCUMENT_WORLD_NAME &&
+        typeof auxData?.frameId === "string"
+      ) {
+        if (
+          document.pendingIsolatedContexts.size <
+            USER_BROWSER_MAX_OPERATION_EVIDENCE ||
+          document.pendingIsolatedContexts.has(context.id)
+        ) {
+          document.pendingIsolatedContexts.set(context.id, auxData.frameId);
+        } else {
+          this.#invalidateTarget(targetId, false);
+          return;
+        }
+        if (
+          document.frameId === auxData.frameId &&
+          document.isolatedExecutionContextId !== undefined &&
+          document.isolatedExecutionContextId !== context.id
+        ) {
+          document.invalidExecutionContextIds.add(
+            document.isolatedExecutionContextId,
+          );
+        }
+      }
+      return;
+    }
+    if (
+      document !== undefined &&
       document.frameId.length === 0 &&
       typeof params.frameId === "string" &&
       (method === "Page.navigatedWithinDocument" ||
         method === "Page.frameStartedNavigating" ||
+        method === "Page.frameStartedLoading" ||
         method === "Page.backForwardCacheNotUsed")
     ) {
       if (
@@ -2385,9 +2550,14 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       url: "",
       alive: true,
       pendingFrameInvalidations: new Set<string>(),
+      invalidExecutionContextIds: new Set<number>(),
+      pendingIsolatedContexts: new Map<number, string>(),
     };
     state.revision += 1;
     state.alive = !disappeared;
+    state.isolatedExecutionContextId = undefined;
+    state.invalidExecutionContextIds.clear();
+    state.pendingIsolatedContexts.clear();
     this.#targetDocuments.set(targetId, state);
   }
 
@@ -2495,6 +2665,9 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       ...unknown,
       ...closure.lifecycleEvidence,
       ...(closure.taint === undefined ? [] : [closure.taint]),
+      ...(closure.unsettledMutation === undefined
+        ? []
+        : [closure.unsettledMutation]),
     ];
     return evidence.length === 0 ? undefined : evidence.join("; ");
   }
@@ -2508,6 +2681,11 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     this.#targetSessions.clear();
     this.#sessionTargets.clear();
     this.#targetDocuments.clear();
+    for (const late of this.#lateResponses.values()) {
+      clearTimeout(late.expires);
+      late.expire();
+    }
+    this.#lateResponses.clear();
     for (const pending of this.#pending.values()) {
       pending.reject(
         pending.dispatched
@@ -2614,17 +2792,39 @@ export class UserBrowserDocumentChangedAfterDispatchError extends Error {
 }
 
 export class UserBrowserMutationOutcomeUnknownError extends Error {
-  constructor(operation: string, detail: string) {
+  constructor(
+    operation: string,
+    detail: string,
+    readonly settlement?: Promise<void>,
+  ) {
     super(`${operation} outcome is unknown (${detail})`);
   }
 }
 
 export class UserBrowserCdpOutcomeUnknownError extends Error {
-  constructor(method: string, detail: string) {
+  constructor(
+    method: string,
+    detail: string,
+    readonly settlement?: Promise<void>,
+  ) {
     super(`User browser CDP ${method} outcome is unknown (${detail})`);
   }
 }
 class ActionRejectedError extends Error {}
+
+function promiseCapability<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 async function raceAbort<T>(
   operation: Promise<T>,

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1673,10 +1673,17 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     const state = this.#targetDocuments.get(targetId);
     if (state === undefined || state.alive === false)
       throw new UserBrowserDocumentChangedBeforeDispatchError();
-    if (state.pendingFrameInvalidations.has(frame.id)) {
+    const pendingMainFrameInvalidations = [
+      ...state.pendingFrameInvalidations,
+    ].filter((event) => event.endsWith(`\u0000${frame.id}`));
+    if (pendingMainFrameInvalidations.length > 0) {
       state.pendingFrameInvalidations.clear();
       this.#invalidateTarget(targetId, false);
-      throw new UserBrowserDocumentChangedBeforeDispatchError();
+      throw new UserBrowserDocumentChangedBeforeDispatchError(
+        `pending lifecycle ${pendingMainFrameInvalidations
+          .map((event) => event.slice(0, event.indexOf("\u0000")))
+          .join(", ")}`,
+      );
     }
     state.pendingFrameInvalidations.clear();
     this.#targetDocuments.set(targetId, {
@@ -2342,15 +2349,18 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       typeof params.frameId === "string" &&
       (method === "Page.navigatedWithinDocument" ||
         method === "Page.frameStartedNavigating" ||
-        method === "Page.frameStartedLoading" ||
         method === "Page.backForwardCacheNotUsed")
     ) {
       if (
         document.pendingFrameInvalidations.size <
           USER_BROWSER_MAX_OPERATION_EVIDENCE ||
-        document.pendingFrameInvalidations.has(params.frameId)
+        [...document.pendingFrameInvalidations].some((event) =>
+          event.endsWith(`\u0000${params.frameId}`),
+        )
       ) {
-        document.pendingFrameInvalidations.add(params.frameId);
+        document.pendingFrameInvalidations.add(
+          `${method}\u0000${params.frameId}`,
+        );
       } else {
         document.revision += 1;
       }
@@ -2590,8 +2600,10 @@ function sameAttachmentOwner(
 }
 
 export class UserBrowserDocumentChangedBeforeDispatchError extends Error {
-  constructor() {
-    super("User browser document changed before action dispatch");
+  constructor(detail?: string) {
+    super(
+      `User browser document changed before action dispatch${detail === undefined ? "" : ` (${detail})`}`,
+    );
   }
 }
 

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1,0 +1,2730 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+
+import WebSocket from "ws";
+
+import {
+  browserActionScript,
+  browserInspectScript,
+  redactBrowserUrl,
+  resolveBrowserObservedTarget,
+  type BrowserInspection,
+  type BrowserObservation,
+  type BrowserTabSummary,
+  type BrowserTargetFingerprint,
+  type ZenXBrowserBackend,
+} from "./browser-provider.js";
+
+const USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS = 2_000;
+const USER_BROWSER_MAX_TARGET_EVIDENCE = 128;
+const USER_BROWSER_MAX_DISCOVERED_TARGETS = 512;
+const USER_BROWSER_MAX_OPERATION_EVIDENCE = 32;
+const USER_BROWSER_MAX_BACKEND_TAINT = 64;
+const USER_BROWSER_MAX_PENDING_CDP_REQUESTS = 128;
+const USER_BROWSER_MAX_ACTIVE_SESSIONS = 32;
+const USER_BROWSER_LATE_RESPONSE_RETENTION_MS = 5_000;
+
+type UserBrowserCdpOutcome =
+  "known-success" | "known-failure" | "outcome-unknown";
+
+interface UserBrowserAttachmentOwner {
+  logicalSessionId: string;
+  logicalSessionIncarnation: number;
+}
+
+interface UserBrowserAttachmentEpoch extends UserBrowserAttachmentOwner {
+  targetId: string;
+  cdpSessionId?: string;
+  attachAttempt: number;
+  attach: UserBrowserCdpOutcome;
+  enable: UserBrowserCdpOutcome;
+  detach: UserBrowserCdpOutcome;
+  unknownEvidence: Partial<Record<"attach" | "enable" | "detach", string>>;
+  lifecycleEvidence: string[];
+  taint?: string;
+}
+
+interface ZenXUserBrowserDocumentExecutionFence extends UserBrowserAttachmentOwner {
+  targetId: string;
+  sessionId: string;
+  attachmentEpoch: UserBrowserAttachmentEpoch;
+  providerRevision: number;
+  documentRevision: number;
+  frameId: string;
+  loaderId: string;
+  url: string;
+  executionContextId?: number;
+}
+
+export interface UserBrowserCdpTarget {
+  targetId: string;
+  type: string;
+  title: string;
+  url: string;
+}
+
+export interface UserBrowserCdpClient {
+  listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]>;
+  createTarget(url: string, signal?: AbortSignal): Promise<string>;
+  findTargetsByUrl(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<UserBrowserCdpTarget[]>;
+  navigate(
+    targetId: string,
+    url: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<void>;
+  evaluateDocument(
+    targetId: string,
+    expression: string,
+    owner: UserBrowserAttachmentOwner,
+    expectedDocumentIdentity?: string,
+    signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<{ value: unknown; documentIdentity: string }>;
+  detachTarget(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+  ): Promise<void>;
+  closureProblem(
+    targetIds: readonly string[],
+    owner: UserBrowserAttachmentOwner,
+  ): string | undefined;
+  close(): Promise<void> | void;
+}
+
+interface UserBrowserSession {
+  id: string;
+  incarnation: number;
+  targetIds: Set<string>;
+  uncertainTargetIds: Set<string>;
+  ignoredTargetIds: Set<string>;
+  operationTail: Promise<void>;
+  unresolvedCreates: Map<string, Set<string>>;
+  detachFailures: string[];
+  taints: string[];
+  closeQueued: boolean;
+  detaching: boolean;
+}
+
+interface UserBrowserTabState {
+  ownerSessionId: string;
+  ownerSessionIncarnation: number;
+  documentVersion: number;
+  url: string;
+  documentIdentity?: string;
+  observation?: BrowserObservation;
+  operation?: Promise<void>;
+  detaching: boolean;
+  tainted?: string;
+}
+
+class ZenXUserBrowserAttachmentEpochBoundary {
+  readonly backendTaints: string[] = [];
+
+  enqueue<T>(
+    session: UserBrowserSession,
+    assertCurrent: () => void,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    assertCurrent();
+    const previous = session.operationTail;
+    const result = (async () => {
+      await previous;
+      assertCurrent();
+      return await run();
+    })();
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    session.operationTail = settled;
+    return result;
+  }
+
+  recordSessionEvidence(
+    session: UserBrowserSession,
+    collection: string[],
+    detail: string,
+    overflowDetail: string,
+  ): void {
+    if (collection.length < USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      collection.push(detail);
+      return;
+    }
+    this.taintSession(session, overflowDetail);
+  }
+
+  taintSession(session: UserBrowserSession, detail: string): void {
+    if (session.taints.includes(detail)) return;
+    if (session.taints.length < USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      session.taints.push(detail);
+      return;
+    }
+    const overflow = "session taint diagnostics exceeded their bound";
+    if (!session.taints.includes(overflow)) {
+      session.taints[session.taints.length - 1] = overflow;
+    }
+  }
+
+  taintBackend(owner: string, detail: string): void {
+    const evidence = `${owner}: ${detail}`;
+    if (this.backendTaints.includes(evidence)) return;
+    if (this.backendTaints.length < USER_BROWSER_MAX_BACKEND_TAINT) {
+      this.backendTaints.push(evidence);
+      return;
+    }
+    this.backendTaints[this.backendTaints.length - 1] =
+      "backend taint diagnostics exceeded their bound";
+  }
+
+  throwIfSessionTainted(session: UserBrowserSession, operation: string): void {
+    if (session.taints.length === 0) return;
+    throw new Error(
+      `User browser ${operation} outcome is unknown; provider session is tainted (${session.taints.join("; ")})`,
+    );
+  }
+
+  throwIfBackendOwnerTainted(owner: string, operation: string): void {
+    const evidence = this.backendTaints.filter((detail) =>
+      detail.startsWith(`${owner}: `),
+    );
+    if (evidence.length === 0) return;
+    throw new Error(
+      `User browser ${operation} outcome is unknown; provider session is tainted (${evidence.join("; ")})`,
+    );
+  }
+}
+
+export class UserBrowserCdpBackend implements ZenXBrowserBackend {
+  readonly #client: UserBrowserCdpClient;
+  readonly #sessions = new Map<string, UserBrowserSession>();
+  readonly #tabs = new Map<string, UserBrowserTabState>();
+  readonly #detachOperations = new Map<string, Promise<void>>();
+  readonly #sessionCloseOperations = new Map<string, Promise<number>>();
+  readonly #closure = new ZenXUserBrowserAttachmentEpochBoundary();
+  #closeOperation?: Promise<void>;
+  #backendCloseQueued = false;
+  #closing = false;
+  #nextSessionIncarnation = 1;
+
+  constructor(client: UserBrowserCdpClient) {
+    this.#client = client;
+  }
+
+  async listTabs(
+    sessionId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary[]> {
+    throwIfAborted(signal);
+    const session = this.#session(sessionId);
+    const operation = this.#startSessionOperation(session, async () => {
+      const listed = await this.#client.listTargets();
+      const targets = listed.filter(
+        (target) =>
+          target.type === "page" &&
+          isInspectableUrl(target.url) &&
+          !session.ignoredTargetIds.has(target.targetId) &&
+          (this.#tabs.get(target.targetId) === undefined ||
+            (this.#tabs.get(target.targetId)?.ownerSessionId === session.id &&
+              this.#tabs.get(target.targetId)?.ownerSessionIncarnation ===
+                session.incarnation)),
+      );
+      this.#assertSessionCurrent(session);
+      const live = new Set(targets.map((target) => target.targetId));
+      const disappeared: string[] = [];
+      for (const targetId of session.targetIds) {
+        if (!live.has(targetId)) {
+          disappeared.push(targetId);
+        }
+      }
+      for (const targetId of disappeared) {
+        this.#assertTargetCleanupOwner(session, targetId);
+      }
+      const detached = await Promise.allSettled(
+        disappeared.map((targetId) => this.#detachTarget(session, targetId)),
+      );
+      for (const [index, targetId] of disappeared.entries()) {
+        const tab = this.#tabs.get(targetId);
+        if (tab?.tainted !== undefined) {
+          this.#taintSession(session, `target ${targetId}: ${tab.tainted}`);
+        }
+        const result = detached[index];
+        if (result?.status === "rejected") {
+          this.#recordSessionEvidence(
+            session,
+            session.detachFailures,
+            describeError(result.reason),
+            "detach diagnostics exceeded their bound",
+          );
+          this.#taintSession(
+            session,
+            `detach outcome is unknown (${describeError(result.reason)})`,
+          );
+        }
+      }
+      this.#transferClientClosureProblem(session, disappeared);
+      for (const targetId of disappeared) {
+        session.targetIds.delete(targetId);
+        const tab = this.#tabs.get(targetId);
+        if (tab === undefined || this.#tabBelongsToSession(tab, session)) {
+          this.#tabs.delete(targetId);
+        }
+      }
+      const detachFailure = detached.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (detachFailure !== undefined) throw detachFailure.reason;
+      this.#assertSessionIdle(session);
+      this.#throwIfSessionTainted(session, "target reconciliation");
+      this.#assertSessionCurrent(session);
+      const published: UserBrowserCdpTarget[] = [];
+      for (const target of targets) {
+        const tab = this.#tabs.get(target.targetId);
+        if (tab === undefined) {
+          this.#tabs.set(target.targetId, {
+            ownerSessionId: session.id,
+            ownerSessionIncarnation: session.incarnation,
+            documentVersion: 1,
+            url: target.url,
+            detaching: false,
+          });
+        } else if (!this.#tabBelongsToSession(tab, session)) {
+          continue;
+        } else if (tab.url !== target.url) {
+          tab.url = target.url;
+          tab.documentVersion += 1;
+          tab.documentIdentity = undefined;
+          tab.observation = undefined;
+        }
+        session.targetIds.add(target.targetId);
+        published.push(target);
+      }
+      this.#assertSessionCurrent(session);
+      return published
+        .slice(0, 24)
+        .map((target) => summarizeTarget(sessionId, target));
+    });
+    return await raceAbort(operation, signal);
+  }
+
+  async open(
+    sessionId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
+    const session = this.#session(sessionId);
+    const operation = this.#startSessionOperation(session, async () => {
+      const pendingUrl = `about:blank#zenx-pending-${randomUUID()}`;
+      const beforeTargets = await this.#client.listTargets();
+      const beforeTargetIds = new Set(
+        beforeTargets.map((target) => target.targetId),
+      );
+      if (beforeTargets.some((target) => target.url === pendingUrl)) {
+        throw new Error("User browser create marker already exists");
+      }
+      let targetId: string;
+      try {
+        targetId = await this.#client.createTarget(pendingUrl);
+      } catch (error) {
+        this.#recordUnresolvedCreate(session, pendingUrl, beforeTargetIds);
+        const recovered = await this.#reconcileCreate(
+          session,
+          pendingUrl,
+          beforeTargetIds,
+        );
+        if (recovered === undefined) {
+          throw new Error(
+            `User browser create outcome is unknown (${describeError(error)})`,
+          );
+        }
+        throw new Error(
+          `User browser create outcome is unknown; recovered provider target ${recovered.targetId} for cleanup (${describeError(error)})`,
+        );
+      }
+      if (beforeTargetIds.has(targetId)) {
+        this.#recordUnresolvedCreate(session, pendingUrl, beforeTargetIds);
+        throw new Error("User browser create returned a pre-existing target");
+      }
+      // Account for the target before observing the session fence. A concurrent
+      // close can then deterministically detach it instead of orphaning it.
+      const existingTab = this.#tabs.get(targetId);
+      if (
+        existingTab !== undefined &&
+        (existingTab.ownerSessionId !== session.id ||
+          existingTab.ownerSessionIncarnation !== session.incarnation)
+      ) {
+        this.#recordUnresolvedCreate(session, pendingUrl, beforeTargetIds);
+        this.#taintSession(session, "create target crossed session ownership");
+        throw new Error(
+          "User browser create marker reconciliation is ambiguous",
+        );
+      }
+      this.#accountTarget(session, targetId, pendingUrl, false);
+      const matches = await this.#client
+        .findTargetsByUrl(pendingUrl)
+        .catch(() => []);
+      const createdMatches = matches.filter(
+        (target) => !beforeTargetIds.has(target.targetId),
+      );
+      if (
+        createdMatches.length !== 1 ||
+        createdMatches[0]?.type !== "page" ||
+        !this.#tabBelongsToOrIsUnowned(
+          createdMatches[0]?.targetId ?? "",
+          session,
+        ) ||
+        createdMatches[0]?.targetId !== targetId
+      ) {
+        const tab = this.#tabs.get(targetId);
+        if (tab !== undefined) tab.tainted = "create marker was ambiguous";
+        if (createdMatches.some((target) => target.targetId !== targetId)) {
+          this.#recordUnresolvedCreate(session, pendingUrl, beforeTargetIds);
+        }
+        throw new Error(
+          "User browser create marker reconciliation is ambiguous",
+        );
+      }
+      this.#assertSessionCurrent(session);
+      const tab = this.#tabs.get(targetId);
+      let dispatched = false;
+      try {
+        await this.#client.navigate(
+          targetId,
+          url,
+          this.#attachmentOwner(session),
+          undefined,
+          () => (dispatched = true),
+        );
+        if (tab !== undefined) tab.url = url;
+        this.#assertSessionCurrent(session);
+        const summary = await this.#summary(sessionId, targetId);
+        this.#assertSessionCurrent(session);
+        return summary;
+      } catch (error) {
+        if (
+          tab !== undefined &&
+          (error instanceof UserBrowserMutationOutcomeUnknownError ||
+            error instanceof UserBrowserDocumentChangedAfterDispatchError)
+        ) {
+          tab.tainted = describeError(error);
+        }
+        throw error;
+      }
+    });
+    return await raceAbort(operation, signal);
+  }
+
+  async navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
+    let dispatched = false;
+    const operation = this.#startOperation(session, tab, async () => {
+      try {
+        await this.#client.navigate(
+          tabId,
+          url,
+          this.#attachmentOwner(session),
+          signal,
+          () => (dispatched = true),
+        );
+        tab.documentVersion += 1;
+        tab.url = url;
+        tab.documentIdentity = undefined;
+        tab.observation = undefined;
+        return await this.#summary(sessionId, tabId);
+      } catch (error) {
+        if (
+          error instanceof UserBrowserMutationOutcomeUnknownError ||
+          error instanceof UserBrowserDocumentChangedAfterDispatchError
+        ) {
+          tab.tainted = describeError(error);
+        }
+        throw error;
+      }
+    });
+    try {
+      return await raceAbort(operation, signal);
+    } catch (error) {
+      if (
+        error instanceof UserBrowserMutationOutcomeUnknownError ||
+        error instanceof UserBrowserDocumentChangedAfterDispatchError ||
+        (dispatched && signal?.aborted === true)
+      ) {
+        tab.tainted ??= describeError(error);
+        throw new Error(
+          `User browser navigation outcome is unknown after cancellation or connection failure (${describeError(error)})`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  async inspect(
+    sessionId: string,
+    tabId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserInspection> {
+    throwIfAborted(signal);
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
+    const operation = this.#startOperation(session, tab, async () => {
+      let evaluation: { value: unknown; documentIdentity: string };
+      try {
+        evaluation = await this.#client.evaluateDocument(
+          tabId,
+          browserInspectScript,
+          this.#attachmentOwner(session),
+          undefined,
+          signal,
+        );
+      } catch (error) {
+        if (error instanceof UserBrowserDocumentChangedAfterDispatchError) {
+          throw new Error("User browser document changed during inspection");
+        }
+        throw error;
+      }
+      const raw = asRecord(evaluation.value);
+      if (
+        raw === undefined ||
+        typeof raw.visibleText !== "string" ||
+        !Array.isArray(raw.targets)
+      ) {
+        throw new Error(
+          "User browser CDP inspection returned an unsupported shape",
+        );
+      }
+      const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
+      const targets = new Map<string, BrowserTargetFingerprint>();
+      const projected = fingerprints.map((fingerprint) => {
+        const targetId = randomUUID();
+        targets.set(targetId, fingerprint);
+        return {
+          targetId,
+          role: fingerprint.role,
+          name: fingerprint.name,
+          actions: [...fingerprint.actions],
+          ...(fingerprint.secure ? { secure: true as const } : {}),
+          ...(fingerprint.value === undefined
+            ? {}
+            : { value: fingerprint.value }),
+        };
+      });
+      const observationId = randomUUID();
+      const summary = await this.#summary(sessionId, tabId);
+      this.#assertSessionCurrent(session);
+      tab.documentIdentity = evaluation.documentIdentity;
+      tab.observation = {
+        id: observationId,
+        documentVersion: tab.documentVersion,
+        targets,
+      };
+      return {
+        ...summary,
+        observationId,
+        documentVersion: tab.documentVersion,
+        visibleText: raw.visibleText.slice(0, 8_000),
+        targets: projected,
+      };
+    });
+    return await raceAbort(operation, signal);
+  }
+
+  async click(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "click",
+      "",
+      false,
+      signal,
+    );
+  }
+
+  async type(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    return await this.#act(
+      sessionId,
+      tabId,
+      observationId,
+      targetId,
+      "type",
+      text,
+      submit,
+      signal,
+    );
+  }
+
+  async closeTab(sessionId: string, tabId: string): Promise<void> {
+    const session = this.#requireSession(sessionId);
+    this.#transferClientClosureProblem(session, [...session.targetIds]);
+    this.#throwIfSessionTainted(session, "tab close");
+    if (!session.targetIds.has(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    const operation = this.#startSessionOperation(
+      session,
+      async () => {
+        this.#assertTabCurrent(session, tabId, tab, true);
+        tab.detaching = true;
+        let detached = false;
+        try {
+          await this.#detachTarget(session, tabId);
+          detached = true;
+        } catch (error) {
+          this.#recordSessionEvidence(
+            session,
+            session.detachFailures,
+            describeError(error),
+            "detach diagnostics exceeded their bound",
+          );
+          this.#transferClientClosureProblem(session, [tabId]);
+          this.#taintSession(
+            session,
+            `detach outcome is unknown (${describeError(error)})`,
+          );
+          if (
+            session.uncertainTargetIds.size < USER_BROWSER_MAX_TARGET_EVIDENCE
+          ) {
+            session.uncertainTargetIds.add(tabId);
+          } else {
+            this.#taintSession(
+              session,
+              "uncertain detach ownership exceeded its bound",
+            );
+          }
+          throw error;
+        } finally {
+          if (tab.tainted !== undefined) {
+            this.#taintSession(session, `target ${tabId}: ${tab.tainted}`);
+          }
+          session.targetIds.delete(tabId);
+          this.#ignoreTarget(session, tabId);
+          if (
+            this.#tabs.get(tabId) === tab &&
+            this.#tabBelongsToSession(tab, session)
+          ) {
+            this.#tabs.delete(tabId);
+          }
+        }
+        this.#throwIfSessionTainted(session, "tab close");
+      },
+      true,
+    );
+    await operation;
+  }
+
+  async closeSession(sessionId: string): Promise<number> {
+    const existing = this.#sessionCloseOperations.get(sessionId);
+    if (existing !== undefined) return await existing;
+    const session = this.#requireSession(sessionId);
+    session.closeQueued = true;
+    const closing = this.#startSessionOperation(
+      session,
+      async () => {
+        session.detaching = true;
+        for (const targetId of session.targetIds) {
+          const tab = this.#tabs.get(targetId);
+          if (tab !== undefined) {
+            this.#assertTargetCleanupOwner(session, targetId);
+            tab.detaching = true;
+          }
+        }
+        await this.#reconcileUnresolvedCreates(session);
+        const targetIds = [
+          ...new Set([...session.targetIds, ...session.uncertainTargetIds]),
+        ];
+        const count = targetIds.length;
+        for (const targetId of targetIds) {
+          this.#assertTargetCleanupOwner(session, targetId);
+        }
+        this.#transferClientClosureProblem(session, targetIds);
+        const detached = await Promise.allSettled(
+          targetIds.map((targetId) => this.#detachTarget(session, targetId)),
+        );
+        this.#transferClientClosureProblem(session, targetIds);
+        const failure = detached.find(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        );
+        if (failure !== undefined) {
+          this.#recordSessionEvidence(
+            session,
+            session.detachFailures,
+            describeError(failure.reason),
+            "detach diagnostics exceeded their bound",
+          );
+          this.#taintSession(
+            session,
+            `detach outcome is unknown (${describeError(failure.reason)})`,
+          );
+        }
+        for (const targetId of targetIds) {
+          const tab = this.#tabs.get(targetId);
+          if (tab?.tainted !== undefined) {
+            this.#taintSession(session, `target ${targetId}: ${tab.tainted}`);
+          }
+          if (tab === undefined || this.#tabBelongsToSession(tab, session)) {
+            this.#tabs.delete(targetId);
+          }
+        }
+        if (session.detachFailures[0] !== undefined) {
+          this.#taintSession(
+            session,
+            `detach outcome is unknown (${session.detachFailures[0]})`,
+          );
+        }
+        if (session.unresolvedCreates.size > 0) {
+          this.#taintSession(session, "create outcome is unknown");
+        }
+        if (session.taints.length > 0) {
+          for (const taint of session.taints)
+            this.#taintBackend(session.id, taint);
+        }
+        this.#sessions.delete(sessionId);
+        this.#throwIfSessionTainted(session, "session close");
+        return count;
+      },
+      true,
+    );
+    this.#sessionCloseOperations.set(sessionId, closing);
+    void closing
+      .finally(() => {
+        if (this.#sessionCloseOperations.get(sessionId) === closing)
+          this.#sessionCloseOperations.delete(sessionId);
+      })
+      .catch(() => undefined);
+    return await closing;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closeOperation !== undefined) return await this.#closeOperation;
+    this.#backendCloseQueued = true;
+    const requestedSessionClosures = [...this.#sessions.keys()].map(
+      (sessionId) => this.closeSession(sessionId),
+    );
+    const closing = (async () => {
+      const sessionClosures = await Promise.allSettled(
+        requestedSessionClosures,
+      );
+      this.#closing = true;
+      let closeFailure: unknown;
+      try {
+        await this.#client.close();
+      } catch (error) {
+        closeFailure = error;
+      }
+      this.#sessions.clear();
+      this.#tabs.clear();
+      const operationFailure = sessionClosures.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (
+        operationFailure !== undefined &&
+        this.#closure.backendTaints.length === 0
+      )
+        this.#taintBackend(
+          "backend-close",
+          describeError(operationFailure.reason),
+        );
+      if (this.#closure.backendTaints.length > 0) {
+        throw new Error(
+          `User browser backend close outcome is unknown; provider is tainted (${this.#closure.backendTaints.join("; ")})`,
+        );
+      }
+      if (closeFailure !== undefined) throw closeFailure;
+    })();
+    this.#closeOperation = closing;
+    return await closing;
+  }
+
+  async #act(
+    sessionId: string,
+    tabId: string,
+    observationId: string,
+    targetId: string,
+    action: "click" | "type",
+    text: string,
+    submit: boolean,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    throwIfAborted(signal);
+    const { session, tab } = this.#sessionTab(sessionId, tabId);
+    const target = resolveBrowserObservedTarget(
+      tab.observation,
+      tab.documentVersion,
+      observationId,
+      targetId,
+      action,
+    );
+    const expectedDocumentIdentity = tab.documentIdentity;
+    tab.observation = undefined;
+    tab.documentIdentity = undefined;
+    let dispatched = false;
+    const operation = this.#startOperation(session, tab, async () => {
+      let evaluation: { value: unknown; documentIdentity: string };
+      try {
+        evaluation = await this.#client.evaluateDocument(
+          tabId,
+          browserActionScript(target, action, text, submit),
+          this.#attachmentOwner(session),
+          expectedDocumentIdentity,
+          signal,
+          () => (dispatched = true),
+        );
+      } catch (error) {
+        if (error instanceof UserBrowserDocumentChangedBeforeDispatchError)
+          throw error;
+        if (
+          error instanceof UserBrowserMutationOutcomeUnknownError ||
+          error instanceof UserBrowserDocumentChangedAfterDispatchError
+        ) {
+          tab.tainted = describeError(error);
+        }
+        throw error;
+      }
+      const response = asRecord(evaluation.value);
+      if (response?.ok !== true) {
+        throw new ActionRejectedError(String(response?.reason ?? "unknown"));
+      }
+      tab.documentVersion += 1;
+      try {
+        return await this.#summary(sessionId, tabId);
+      } catch (error) {
+        tab.tainted = describeError(error);
+        throw error;
+      }
+    });
+    try {
+      return await raceAbort(operation, signal);
+    } catch (error) {
+      if (error instanceof UserBrowserDocumentChangedBeforeDispatchError) {
+        throw new Error("User browser document changed; inspect again");
+      }
+      if (error instanceof ActionRejectedError) {
+        throw new Error(
+          `User browser target changed or action was rejected (${error.message}); inspect again`,
+        );
+      }
+      if (
+        error instanceof UserBrowserMutationOutcomeUnknownError ||
+        error instanceof UserBrowserDocumentChangedAfterDispatchError ||
+        (dispatched && signal?.aborted === true)
+      ) {
+        tab.tainted ??= describeError(error);
+        throw new Error(
+          `User browser action outcome is unknown after cancellation or connection failure; inspect the current tab before another action (${describeError(error)})`,
+        );
+      }
+      throw error;
+    }
+  }
+
+  #startOperation<T>(
+    session: UserBrowserSession,
+    tab: UserBrowserTabState,
+    run: () => Promise<T>,
+  ): Promise<T> {
+    if (tab.tainted !== undefined) {
+      throw new Error(`User browser tab is tainted (${tab.tainted})`);
+    }
+    const targetId = [...session.targetIds].find(
+      (candidate) => this.#tabs.get(candidate) === tab,
+    );
+    if (targetId === undefined) throw new Error("User browser tab was closed");
+    const result = this.#startSessionOperation(session, async () => {
+      this.#assertTabCurrent(session, targetId, tab);
+      return await run();
+    });
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    tab.operation = settled;
+    void settled.then(() => {
+      if (tab.operation === settled) tab.operation = undefined;
+    });
+    return result;
+  }
+
+  #startSessionOperation<T>(
+    session: UserBrowserSession,
+    run: () => Promise<T>,
+    allowTainted = false,
+  ): Promise<T> {
+    return this.#closure.enqueue(
+      session,
+      () => {
+        this.#assertSessionCurrent(session);
+        if (!allowTainted) {
+          this.#transferClientClosureProblem(session, [...session.targetIds]);
+          this.#closure.throwIfSessionTainted(session, "operation");
+        }
+      },
+      run,
+    );
+  }
+
+  #assertSessionCurrent(session: UserBrowserSession): void {
+    if (
+      this.#closing ||
+      session.detaching ||
+      this.#sessions.get(session.id) !== session
+    ) {
+      throw new Error("User browser session is detaching");
+    }
+  }
+
+  #assertSessionIdle(session: UserBrowserSession): void {
+    for (const targetId of session.targetIds) {
+      const tab = this.#tabs.get(targetId);
+      if (tab?.detaching === true)
+        throw new Error("User browser tab is detaching");
+      if (tab?.tainted !== undefined)
+        throw new Error(`User browser tab is tainted (${tab.tainted})`);
+      if (tab?.operation !== undefined) {
+        throw new Error("User browser tab operation is already in flight");
+      }
+    }
+  }
+
+  #session(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
+    this.#closure.throwIfBackendOwnerTainted(sessionId, "operation");
+    let session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      if (this.#backendCloseQueued) {
+        throw new Error("User browser backend is closing");
+      }
+      if (this.#sessions.size >= USER_BROWSER_MAX_ACTIVE_SESSIONS) {
+        throw new Error(
+          "User browser active session capacity exceeded its bound",
+        );
+      }
+      session = {
+        id: sessionId,
+        incarnation: this.#nextSessionIncarnation++,
+        targetIds: new Set(),
+        uncertainTargetIds: new Set(),
+        ignoredTargetIds: new Set(),
+        operationTail: Promise.resolve(),
+        unresolvedCreates: new Map(),
+        detachFailures: [],
+        taints: [],
+        closeQueued: false,
+        detaching: false,
+      };
+      this.#sessions.set(sessionId, session);
+    }
+    if (session.detaching) throw new Error("User browser session is detaching");
+    return session;
+  }
+
+  #requireSession(sessionId: string): UserBrowserSession {
+    if (this.#closing) throw new Error("User browser backend is closing");
+    this.#closure.throwIfBackendOwnerTainted(sessionId, "close");
+    const session = this.#sessions.get(sessionId);
+    if (session === undefined) {
+      throw new Error(`Unknown user browser session: ${sessionId}`);
+    }
+    if (session.detaching) throw new Error("User browser session is detaching");
+    return session;
+  }
+
+  #sessionTab(
+    sessionId: string,
+    tabId: string,
+  ): { session: UserBrowserSession; tab: UserBrowserTabState } {
+    const session = this.#requireSession(sessionId);
+    this.#transferClientClosureProblem(session, [...session.targetIds]);
+    this.#throwIfSessionTainted(session, "operation");
+    if (!session.targetIds.has(tabId)) {
+      throw new Error(`Unknown user browser tab: ${tabId}`);
+    }
+    const tab = this.#tabs.get(tabId);
+    if (tab === undefined) throw new Error("User browser tab was closed");
+    this.#assertTabOwner(session, tabId, tab);
+    if (tab.tainted !== undefined) {
+      throw new Error(`User browser tab is tainted (${tab.tainted})`);
+    }
+    return { session, tab };
+  }
+
+  async #summary(
+    sessionId: string,
+    targetId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const target = (await this.#client.listTargets(signal)).find(
+      (candidate) =>
+        candidate.targetId === targetId && candidate.type === "page",
+    );
+    if (target === undefined) throw new Error("User browser tab was closed");
+    return summarizeTarget(sessionId, target);
+  }
+
+  #accountTarget(
+    session: UserBrowserSession,
+    targetId: string,
+    url: string,
+    tainted: boolean,
+  ): void {
+    const existing = this.#tabs.get(targetId);
+    if (
+      existing !== undefined &&
+      !this.#tabBelongsToSession(existing, session)
+    ) {
+      this.#taintSession(session, `target ${targetId}: ownership changed`);
+      throw new Error("User browser target belongs to another logical session");
+    }
+    if (
+      !session.targetIds.has(targetId) &&
+      session.targetIds.size >= USER_BROWSER_MAX_TARGET_EVIDENCE
+    ) {
+      this.#taintSession(session, "target ownership exceeded its bound");
+      throw new Error("User browser target ownership exceeded its bound");
+    }
+    session.targetIds.add(targetId);
+    this.#tabs.set(targetId, {
+      ownerSessionId: session.id,
+      ownerSessionIncarnation: session.incarnation,
+      documentVersion: 1,
+      url,
+      detaching: session.detaching,
+      ...(tainted ? { tainted: "create outcome requires cleanup" } : {}),
+    });
+    if (tainted) {
+      this.#taintSession(
+        session,
+        `target ${targetId}: create outcome requires cleanup`,
+      );
+    }
+  }
+
+  #assertTabCurrent(
+    session: UserBrowserSession,
+    targetId: string,
+    tab: UserBrowserTabState,
+    allowTainted = false,
+  ): void {
+    this.#assertSessionCurrent(session);
+    this.#assertTabOwner(session, targetId, tab);
+    if (
+      !session.targetIds.has(targetId) ||
+      this.#tabs.get(targetId) !== tab ||
+      tab.detaching
+    ) {
+      throw new Error("User browser tab is detaching or was closed");
+    }
+    if (!allowTainted && tab.tainted !== undefined) {
+      throw new Error(`User browser tab is tainted (${tab.tainted})`);
+    }
+  }
+
+  #ignoreTarget(session: UserBrowserSession, targetId: string): void {
+    if (session.ignoredTargetIds.has(targetId)) return;
+    if (session.ignoredTargetIds.size >= USER_BROWSER_MAX_TARGET_EVIDENCE) {
+      this.#taintSession(session, "ignored-target evidence exceeded its bound");
+      return;
+    }
+    session.ignoredTargetIds.add(targetId);
+  }
+
+  #recordUnresolvedCreate(
+    session: UserBrowserSession,
+    markerUrl: string,
+    beforeTargetIds: Set<string>,
+  ): void {
+    if (session.unresolvedCreates.has(markerUrl)) return;
+    if (session.unresolvedCreates.size >= USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      this.#taintSession(session, "create-marker evidence exceeded its bound");
+      return;
+    }
+    session.unresolvedCreates.set(markerUrl, beforeTargetIds);
+  }
+
+  #recordSessionEvidence(
+    session: UserBrowserSession,
+    collection: string[],
+    detail: string,
+    overflowDetail: string,
+  ): void {
+    this.#closure.recordSessionEvidence(
+      session,
+      collection,
+      detail,
+      overflowDetail,
+    );
+  }
+
+  #taintSession(session: UserBrowserSession, detail: string): void {
+    this.#closure.taintSession(session, detail);
+  }
+
+  #taintBackend(owner: string, detail: string): void {
+    this.#closure.taintBackend(owner, detail);
+  }
+
+  #transferClientClosureProblem(
+    session: UserBrowserSession,
+    targetIds: readonly string[],
+  ): void {
+    const problem = this.#client.closureProblem(
+      targetIds,
+      this.#attachmentOwner(session),
+    );
+    if (problem !== undefined) {
+      this.#taintSession(
+        session,
+        `client closure outcome is unknown (${problem})`,
+      );
+    }
+  }
+
+  #throwIfSessionTainted(session: UserBrowserSession, operation: string): void {
+    this.#closure.throwIfSessionTainted(session, operation);
+  }
+
+  #detachTarget(session: UserBrowserSession, targetId: string): Promise<void> {
+    this.#assertTargetCleanupOwner(session, targetId);
+    const existing = this.#detachOperations.get(targetId);
+    if (existing !== undefined) return existing;
+    const operation = Promise.resolve().then(() =>
+      this.#client.detachTarget(targetId, this.#attachmentOwner(session)),
+    );
+    this.#detachOperations.set(targetId, operation);
+    void operation
+      .finally(() => {
+        if (this.#detachOperations.get(targetId) === operation)
+          this.#detachOperations.delete(targetId);
+      })
+      .catch(() => undefined);
+    return operation;
+  }
+
+  #attachmentOwner(session: UserBrowserSession): UserBrowserAttachmentOwner {
+    return {
+      logicalSessionId: session.id,
+      logicalSessionIncarnation: session.incarnation,
+    };
+  }
+
+  #tabBelongsToOrIsUnowned(
+    targetId: string,
+    session: UserBrowserSession,
+  ): boolean {
+    const tab = this.#tabs.get(targetId);
+    return tab === undefined || this.#tabBelongsToSession(tab, session);
+  }
+
+  #tabBelongsToSession(
+    tab: UserBrowserTabState,
+    session: UserBrowserSession,
+  ): boolean {
+    return (
+      tab.ownerSessionId === session.id &&
+      tab.ownerSessionIncarnation === session.incarnation
+    );
+  }
+
+  #assertTabOwner(
+    session: UserBrowserSession,
+    targetId: string,
+    tab: UserBrowserTabState,
+  ): void {
+    if (this.#tabBelongsToSession(tab, session)) return;
+    this.#taintSession(session, `target ${targetId}: ownership changed`);
+    throw new Error("User browser target belongs to another logical session");
+  }
+
+  #assertTargetCleanupOwner(
+    session: UserBrowserSession,
+    targetId: string,
+  ): void {
+    const tab = this.#tabs.get(targetId);
+    if (tab !== undefined) this.#assertTabOwner(session, targetId, tab);
+  }
+
+  async #reconcileCreate(
+    session: UserBrowserSession,
+    markerUrl: string,
+    beforeTargetIds: Set<string>,
+  ): Promise<UserBrowserCdpTarget | undefined> {
+    const matches = await this.#client
+      .findTargetsByUrl(markerUrl)
+      .catch(() => []);
+    const candidates = matches.filter(
+      (target) => !beforeTargetIds.has(target.targetId),
+    );
+    if (
+      candidates.length !== 1 ||
+      candidates[0]?.type !== "page" ||
+      !this.#tabBelongsToOrIsUnowned(candidates[0]?.targetId ?? "", session)
+    ) {
+      this.#taintSession(session, "create marker reconciliation is ambiguous");
+      return undefined;
+    }
+    const recovered = candidates[0];
+    if (recovered === undefined) return undefined;
+    session.unresolvedCreates.delete(markerUrl);
+    if (!session.targetIds.has(recovered.targetId)) {
+      this.#accountTarget(session, recovered.targetId, recovered.url, true);
+    }
+    return recovered;
+  }
+
+  async #reconcileUnresolvedCreates(
+    session: UserBrowserSession,
+  ): Promise<void> {
+    for (const [markerUrl, beforeTargetIds] of session.unresolvedCreates) {
+      await this.#reconcileCreate(session, markerUrl, beforeTargetIds);
+    }
+  }
+}
+
+export interface UserBrowserConnection {
+  backend: ZenXBrowserBackend;
+  product: string;
+}
+
+export async function connectUserBrowserCdp(
+  endpoint: string,
+  signal?: AbortSignal,
+): Promise<UserBrowserConnection> {
+  const base = validateCdpEndpoint(endpoint);
+  const timeout = AbortSignal.timeout(5_000);
+  const probeSignal =
+    signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+  const response = await fetch(new URL("/json/version", base), {
+    signal: probeSignal,
+    headers: { accept: "application/json" },
+    redirect: "error",
+  });
+  const finalUrl = validateCdpEndpoint(response.url);
+  if (finalUrl.pathname !== "/json/version") {
+    throw new Error("User browser CDP version response URL is invalid");
+  }
+  if (!response.ok) {
+    throw new Error(
+      `User browser CDP version probe failed with HTTP ${String(response.status)}`,
+    );
+  }
+  const version = asRecord(await response.json());
+  if (version === undefined) {
+    throw new Error("User browser CDP version response is invalid");
+  }
+  const product = validateUserBrowserVersion(version);
+  const webSocketDebuggerUrl = version.webSocketDebuggerUrl;
+  if (typeof webSocketDebuggerUrl !== "string") {
+    throw new Error(
+      "User browser CDP version response is missing webSocketDebuggerUrl",
+    );
+  }
+  const socketUrl = new URL(webSocketDebuggerUrl);
+  if (
+    socketUrl.protocol !== "ws:" ||
+    !isLoopbackHostname(socketUrl.hostname) ||
+    socketUrl.hostname !== base.hostname ||
+    effectivePort(socketUrl) !== effectivePort(base) ||
+    !/^\/devtools\/browser\/[^/]+$/u.test(socketUrl.pathname) ||
+    socketUrl.username.length > 0 ||
+    socketUrl.password.length > 0 ||
+    socketUrl.search.length > 0 ||
+    socketUrl.hash.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP WebSocket must use the same loopback authority as the HTTP endpoint",
+    );
+  }
+  const client = await JsonRpcUserBrowserCdpClient.connect(
+    socketUrl.toString(),
+    base,
+    probeSignal,
+  );
+  return { backend: new UserBrowserCdpBackend(client), product };
+}
+
+export function validateUserBrowserVersion(
+  value: Record<string, unknown>,
+): string {
+  const product = value.Browser;
+  const match =
+    typeof product === "string"
+      ? /^(?:Chrome|Chromium|Edg)\/(\d+)(?:\.\d+){1,3}(?:[-+].*)?$/u.exec(
+          product,
+        )
+      : null;
+  if (
+    typeof product !== "string" ||
+    match === null ||
+    Number.parseInt(match[1] ?? "0", 10) < 100
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must report a supported Chrome, Edge, or Chromium product",
+    );
+  }
+  return product;
+}
+
+class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
+  readonly #socket: WebSocket;
+  readonly #httpBase: URL;
+  readonly #pending = new Map<
+    number,
+    {
+      method: string;
+      dispatched: boolean;
+      resolve(value: unknown): void;
+      reject(error: Error): void;
+    }
+  >();
+  readonly #targetSessions = new Map<string, string>();
+  readonly #sessionTargets = new Map<string, string>();
+  readonly #targetAttachments = new Map<
+    string,
+    {
+      promise: Promise<string>;
+      epoch: UserBrowserAttachmentEpoch;
+      invalidated: boolean;
+      pendingDetachSessionIds: Set<string>;
+    }
+  >();
+  readonly #attachmentClosures = new Map<string, UserBrowserAttachmentEpoch>();
+  readonly #sessionEpochs = new Map<string, UserBrowserAttachmentEpoch>();
+  readonly #retiredSessionIds = new Set<string>();
+  readonly #lateResponses = new Map<
+    number,
+    {
+      receive(message: Record<string, unknown>): Promise<void>;
+      expires: NodeJS.Timeout;
+    }
+  >();
+  readonly #connectionTaints: string[] = [];
+  readonly #targetDocuments = new Map<
+    string,
+    {
+      revision: number;
+      frameId: string;
+      loaderId: string;
+      url: string;
+      alive: boolean;
+      pendingFrameInvalidations: Set<string>;
+    }
+  >();
+  #nextId = 1;
+  #nextAttachAttempt = 1;
+  #providerRevision = 0;
+  #closed = false;
+  #closing = false;
+
+  private constructor(socket: WebSocket, httpBase: URL) {
+    this.#socket = socket;
+    this.#httpBase = httpBase;
+    socket.on("message", (data) => this.#receive(data.toString()));
+    socket.on("close", () =>
+      this.#failAll(new Error("User browser CDP connection closed")),
+    );
+    socket.on("error", (error) => this.#failAll(error));
+  }
+
+  static async connect(
+    url: string,
+    httpBase: URL,
+    signal?: AbortSignal,
+  ): Promise<JsonRpcUserBrowserCdpClient> {
+    const socket = new WebSocket(url, { handshakeTimeout: 5_000 });
+    await new Promise<void>((resolve, reject) => {
+      const abort = () => {
+        socket.close();
+        reject(
+          signal?.reason instanceof Error
+            ? signal.reason
+            : new Error("User browser CDP connection aborted"),
+        );
+      };
+      socket.once("open", () => {
+        signal?.removeEventListener("abort", abort);
+        resolve();
+      });
+      socket.once("error", (error) => {
+        signal?.removeEventListener("abort", abort);
+        reject(error);
+      });
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) abort();
+    });
+    const client = new JsonRpcUserBrowserCdpClient(socket, httpBase);
+    try {
+      await client.#send("Target.setDiscoverTargets", { discover: true });
+    } catch (error) {
+      client.#closing = true;
+      socket.close();
+      throw error;
+    }
+    return client;
+  }
+
+  async listTargets(signal?: AbortSignal): Promise<UserBrowserCdpTarget[]> {
+    const response = asRecord(
+      await this.#send("Target.getTargets", {}, undefined, signal),
+    );
+    const infos = response?.targetInfos;
+    if (!Array.isArray(infos))
+      throw new Error("User browser CDP Target.getTargets response is invalid");
+    if (infos.length > USER_BROWSER_MAX_DISCOVERED_TARGETS) {
+      throw new Error("User browser CDP target list exceeded its bound");
+    }
+    return infos.map((value) => {
+      const target = asRecord(value);
+      if (
+        target === undefined ||
+        typeof target.targetId !== "string" ||
+        typeof target.type !== "string" ||
+        typeof target.title !== "string" ||
+        typeof target.url !== "string"
+      ) {
+        throw new Error("User browser CDP target metadata is invalid");
+      }
+      return {
+        targetId: target.targetId,
+        type: target.type,
+        title: target.title,
+        url: target.url,
+      };
+    });
+  }
+
+  async createTarget(url: string, signal?: AbortSignal): Promise<string> {
+    const response = asRecord(
+      await this.#send(
+        "Target.createTarget",
+        { url, background: true, focus: false },
+        undefined,
+        signal,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+      ),
+    );
+    if (typeof response?.targetId !== "string")
+      throw new Error("User browser CDP createTarget response is invalid");
+    return response.targetId;
+  }
+
+  async findTargetsByUrl(
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<UserBrowserCdpTarget[]> {
+    const timeout = AbortSignal.timeout(5_000);
+    const requestSignal =
+      signal === undefined ? timeout : AbortSignal.any([signal, timeout]);
+    const response = await fetch(new URL("/json/list", this.#httpBase), {
+      signal: requestSignal,
+      headers: { accept: "application/json" },
+      redirect: "error",
+    });
+    const finalUrl = validateCdpEndpoint(response.url);
+    if (finalUrl.pathname !== "/json/list" || !response.ok) {
+      throw new Error("User browser CDP target reconciliation failed");
+    }
+    const value: unknown = await response.json();
+    if (!Array.isArray(value)) {
+      throw new Error(
+        "User browser CDP target reconciliation response is invalid",
+      );
+    }
+    if (value.length > USER_BROWSER_MAX_DISCOVERED_TARGETS) {
+      throw new Error(
+        "User browser CDP target reconciliation exceeded its bound",
+      );
+    }
+    const matches: UserBrowserCdpTarget[] = [];
+    for (const item of value) {
+      const target = asRecord(item);
+      const targetId = target?.id ?? target?.targetId;
+      if (
+        typeof targetId === "string" &&
+        typeof target?.type === "string" &&
+        typeof target?.url === "string" &&
+        target.url === url
+      ) {
+        matches.push({
+          targetId,
+          type: target.type,
+          title: typeof target.title === "string" ? target.title : "",
+          url: target.url,
+        });
+      }
+    }
+    return matches;
+  }
+
+  async navigate(
+    targetId: string,
+    url: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<void> {
+    const sessionId = await this.#attach(targetId, owner, signal);
+    try {
+      await this.#send(
+        "Page.navigate",
+        { url },
+        sessionId,
+        signal,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+        undefined,
+        onDispatched,
+      );
+      this.#assertAttachmentClosedForOperation(
+        targetId,
+        owner,
+        "Page.navigate",
+      );
+    } catch (error) {
+      if (error instanceof UserBrowserCdpOutcomeUnknownError) {
+        throw new UserBrowserMutationOutcomeUnknownError(
+          "Page.navigate",
+          describeError(error),
+        );
+      }
+      throw error;
+    }
+  }
+
+  async evaluateDocument(
+    targetId: string,
+    expression: string,
+    owner: UserBrowserAttachmentOwner,
+    expectedDocumentIdentity?: string,
+    signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<{ value: unknown; documentIdentity: string }> {
+    throwIfAborted(signal);
+    const before = await this.#executionDocument(targetId, owner, signal);
+    if (
+      expectedDocumentIdentity !== undefined &&
+      before.identity !== expectedDocumentIdentity
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    let response: Record<string, unknown> | undefined;
+    let mutationResponseKnown = false;
+    try {
+      response = asRecord(
+        await this.#send(
+          "Runtime.evaluate",
+          {
+            expression,
+            awaitPromise: true,
+            returnByValue: true,
+            contextId: before.executionContextId,
+          },
+          before.sessionId,
+          signal,
+          USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+          undefined,
+          onDispatched,
+          () => this.#assertDocumentFence(before, true),
+        ),
+      );
+      mutationResponseKnown = true;
+      if (response?.exceptionDetails !== undefined) {
+        throw new Error("User browser CDP evaluation failed");
+      }
+      const confirmation = asRecord(
+        await this.#send(
+          "Runtime.evaluate",
+          {
+            expression: "void 0",
+            awaitPromise: true,
+            returnByValue: true,
+            contextId: before.executionContextId,
+          },
+          before.sessionId,
+          signal,
+          USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+          undefined,
+          undefined,
+          () => this.#assertDocumentFence(before, true),
+        ),
+      );
+      if (confirmation?.exceptionDetails !== undefined) {
+        throw new Error("User browser CDP post-confirmation failed");
+      }
+      const after = await this.#executionDocument(targetId, owner, signal);
+      if (after.identity !== before.identity) {
+        throw new UserBrowserDocumentChangedAfterDispatchError();
+      }
+      this.#assertAttachmentClosedForOperation(
+        targetId,
+        owner,
+        "Runtime.evaluate",
+      );
+      return {
+        value: asRecord(response?.result)?.value,
+        documentIdentity: after.identity,
+      };
+    } catch (error) {
+      if (error instanceof UserBrowserDocumentChangedAfterDispatchError)
+        throw error;
+      if (
+        error instanceof UserBrowserCdpOutcomeUnknownError ||
+        mutationResponseKnown
+      ) {
+        throw new UserBrowserMutationOutcomeUnknownError(
+          "Runtime.evaluate",
+          describeError(error),
+        );
+      }
+      throw error;
+    }
+  }
+
+  closureProblem(
+    targetIds: readonly string[],
+    owner: UserBrowserAttachmentOwner,
+  ): string | undefined {
+    const evidence = [...this.#connectionTaints];
+    for (const targetId of targetIds) {
+      const epoch = this.#attachmentClosures.get(targetId);
+      if (epoch !== undefined && !sameAttachmentOwner(epoch, owner)) continue;
+      const problem = this.#attachmentProblem(epoch);
+      if (problem !== undefined) evidence.push(`${targetId}: ${problem}`);
+    }
+    return evidence.length === 0 ? undefined : evidence.join("; ");
+  }
+
+  async #executionDocument(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+  ): Promise<
+    ZenXUserBrowserDocumentExecutionFence & {
+      identity: string;
+      executionContextId: number;
+    }
+  > {
+    const sessionId = await this.#attach(targetId, owner, signal);
+    const epoch = this.#attachmentClosures.get(targetId);
+    const initial = this.#targetDocuments.get(targetId);
+    if (
+      epoch === undefined ||
+      initial === undefined ||
+      !sameAttachmentOwner(epoch, owner) ||
+      epoch.cdpSessionId !== sessionId ||
+      initial.alive === false
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    const fence: ZenXUserBrowserDocumentExecutionFence = {
+      targetId,
+      sessionId,
+      attachmentEpoch: epoch,
+      ...owner,
+      providerRevision: this.#providerRevision,
+      documentRevision: initial.revision,
+      frameId: "",
+      loaderId: "",
+      url: "",
+    };
+    const response = asRecord(
+      await this.#send("Page.getFrameTree", {}, sessionId, signal),
+    );
+    this.#assertDocumentFence(fence, false);
+    const frame = asRecord(asRecord(response?.frameTree)?.frame);
+    if (
+      frame === undefined ||
+      typeof frame.id !== "string" ||
+      typeof frame.loaderId !== "string" ||
+      typeof frame.url !== "string"
+    ) {
+      throw new Error("User browser CDP document identity is invalid");
+    }
+    fence.frameId = frame.id;
+    fence.loaderId = frame.loaderId;
+    fence.url = frame.url;
+    const state = this.#targetDocuments.get(targetId);
+    if (state === undefined || state.alive === false)
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    if (state.pendingFrameInvalidations.has(frame.id)) {
+      state.pendingFrameInvalidations.clear();
+      this.#invalidateTarget(targetId, false);
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    state.pendingFrameInvalidations.clear();
+    this.#targetDocuments.set(targetId, {
+      revision: state.revision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+      alive: true,
+      pendingFrameInvalidations: state.pendingFrameInvalidations,
+    });
+    await this.#documentBarrier(fence, signal);
+    this.#assertDocumentFence(fence, false);
+    const world = asRecord(
+      await this.#send(
+        "Page.createIsolatedWorld",
+        {
+          frameId: frame.id,
+          worldName: "__zenx_user_browser_document__",
+          grantUniveralAccess: false,
+        },
+        sessionId,
+        signal,
+      ),
+    );
+    this.#assertDocumentFence(fence, false);
+    if (typeof world?.executionContextId !== "number") {
+      throw new Error("User browser CDP execution context is invalid");
+    }
+    fence.executionContextId = world.executionContextId;
+    await this.#documentBarrier(fence, signal);
+    this.#assertDocumentFence(fence, true);
+    const identity = JSON.stringify({
+      targetId,
+      sessionId,
+      attachAttempt: fence.attachmentEpoch.attachAttempt,
+      logicalSessionId: fence.logicalSessionId,
+      logicalSessionIncarnation: fence.logicalSessionIncarnation,
+      providerRevision: fence.providerRevision,
+      revision: fence.documentRevision,
+      frameId: frame.id,
+      loaderId: frame.loaderId,
+      url: frame.url,
+      executionContextId: world.executionContextId,
+    });
+    return {
+      identity,
+      ...fence,
+      executionContextId: world.executionContextId,
+    };
+  }
+
+  async #documentBarrier(
+    fence: ZenXUserBrowserDocumentExecutionFence,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    const response = asRecord(
+      await this.#send("Page.getFrameTree", {}, fence.sessionId, signal),
+    );
+    this.#assertDocumentFence(fence, false);
+    const frame = asRecord(asRecord(response?.frameTree)?.frame);
+    if (
+      frame === undefined ||
+      frame.id !== fence.frameId ||
+      frame.loaderId !== fence.loaderId ||
+      frame.url !== fence.url
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+  }
+
+  #assertDocumentFence(
+    fence: ZenXUserBrowserDocumentExecutionFence,
+    requireContext: boolean,
+  ): void {
+    const epoch = this.#attachmentClosures.get(fence.targetId);
+    const state = this.#targetDocuments.get(fence.targetId);
+    if (
+      this.#closed ||
+      this.#providerRevision !== fence.providerRevision ||
+      epoch !== fence.attachmentEpoch ||
+      epoch === undefined ||
+      !sameAttachmentOwner(epoch, fence) ||
+      epoch.cdpSessionId !== fence.sessionId ||
+      this.#targetSessions.get(fence.targetId) !== fence.sessionId ||
+      this.#sessionEpochs.get(fence.sessionId) !== epoch ||
+      state === undefined ||
+      state.alive === false ||
+      state.revision !== fence.documentRevision ||
+      (fence.frameId.length > 0 &&
+        state.frameId.length > 0 &&
+        state.frameId !== fence.frameId) ||
+      (fence.loaderId.length > 0 &&
+        state.loaderId.length > 0 &&
+        state.loaderId !== fence.loaderId) ||
+      (fence.url.length > 0 &&
+        state.url.length > 0 &&
+        state.url !== fence.url) ||
+      (requireContext && fence.executionContextId === undefined)
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+  }
+
+  async detachTarget(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+  ): Promise<void> {
+    const attaching = this.#targetAttachments.get(targetId);
+    if (attaching !== undefined) {
+      if (!sameAttachmentOwner(attaching.epoch, owner)) {
+        throw new Error("User browser attachment ownership changed");
+      }
+      try {
+        await attaching.promise;
+      } catch {
+        // The terminal closure below, not the rejected attach promise, decides
+        // whether known ownership can be retried or uncertainty must surface.
+      }
+    }
+    const closure = this.#attachmentClosures.get(targetId);
+    if (closure !== undefined && !sameAttachmentOwner(closure, owner)) {
+      throw new Error("User browser attachment ownership changed");
+    }
+    if (closure?.unknownEvidence.attach !== undefined) {
+      throw new UserBrowserCdpOutcomeUnknownError(
+        "Target.attachToTarget",
+        closure.unknownEvidence.attach,
+      );
+    }
+    const sessionId = this.#targetSessions.get(targetId);
+    if (sessionId === undefined) {
+      const problem = this.#attachmentProblem(closure);
+      if (problem !== undefined) {
+        throw new UserBrowserCdpOutcomeUnknownError(
+          "Target.detachFromTarget",
+          problem,
+        );
+      }
+      this.#reapTarget(targetId, true);
+      return;
+    }
+    try {
+      await this.#send(
+        "Target.detachFromTarget",
+        { sessionId },
+        undefined,
+        undefined,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+      );
+      if (closure !== undefined) {
+        closure.detach = "known-success";
+        closure.taint = undefined;
+      }
+    } catch (error) {
+      if (closure !== undefined) {
+        if (error instanceof UserBrowserCdpOutcomeUnknownError) {
+          closure.detach = "outcome-unknown";
+          closure.unknownEvidence.detach ??= describeError(error);
+        } else {
+          closure.detach = "known-failure";
+          closure.taint = describeError(error);
+        }
+      }
+      throw error;
+    }
+    this.#reapEpoch(closure, true);
+    const problem = this.#attachmentProblem(closure);
+    if (problem !== undefined) {
+      throw new UserBrowserCdpOutcomeUnknownError(
+        "Target.detachFromTarget",
+        problem,
+      );
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closing) {
+      this.#throwIfAttachmentTainted();
+      return;
+    }
+    this.#closing = true;
+    if (!this.#closed) this.#socket.close();
+    this.#closed = true;
+    this.#failAll(new Error("User browser CDP connection closed"));
+    this.#throwIfAttachmentTainted();
+  }
+
+  async #attach(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    const closure = this.#attachmentClosures.get(targetId);
+    const problem = this.#attachmentProblem(closure);
+    if (problem !== undefined) {
+      throw new UserBrowserCdpOutcomeUnknownError(
+        "Target.attachToTarget",
+        problem,
+      );
+    }
+    const existing = this.#targetSessions.get(targetId);
+    if (existing !== undefined) {
+      if (closure === undefined || !sameAttachmentOwner(closure, owner)) {
+        throw new Error("User browser attachment ownership changed");
+      }
+      return existing;
+    }
+    const pending = this.#targetAttachments.get(targetId);
+    if (pending !== undefined) {
+      if (!sameAttachmentOwner(pending.epoch, owner)) {
+        throw new Error("User browser attachment ownership changed");
+      }
+      return await pending.promise;
+    }
+    const attachmentClosure = this.#attachmentEpoch(targetId, owner);
+    const attachment = {
+      promise: Promise.resolve(""),
+      epoch: attachmentClosure,
+      invalidated: false,
+      pendingDetachSessionIds: new Set<string>(),
+    };
+    const attaching = (async () => {
+      let response: Record<string, unknown> | undefined;
+      try {
+        response = asRecord(
+          await this.#send(
+            "Target.attachToTarget",
+            { targetId, flatten: true },
+            undefined,
+            signal,
+            USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+            async (late) =>
+              await this.#compensateLateAttach(attachmentClosure, late),
+          ),
+        );
+        attachmentClosure.attach = "known-success";
+      } catch (error) {
+        attachmentClosure.attach =
+          error instanceof UserBrowserCdpOutcomeUnknownError
+            ? "outcome-unknown"
+            : "known-failure";
+        if (attachmentClosure.attach === "outcome-unknown") {
+          attachmentClosure.unknownEvidence.attach = describeError(error);
+        }
+        throw error;
+      }
+      if (typeof response?.sessionId !== "string")
+        throw new Error("User browser CDP attach response is invalid");
+      attachmentClosure.cdpSessionId = response.sessionId;
+      if (attachment.pendingDetachSessionIds.has(response.sessionId)) {
+        attachmentClosure.detach = "known-success";
+        this.#retireEpoch(attachmentClosure);
+        throw new Error("User browser target detached during attachment");
+      }
+      for (const staleSessionId of attachment.pendingDetachSessionIds) {
+        this.#recordLifecycleEvidence(
+          attachmentClosure,
+          `unrecognized pending detach ${staleSessionId}`,
+        );
+      }
+      if (attachmentClosure.lifecycleEvidence.length > 0) {
+        await this.#compensateAttachment(
+          attachmentClosure,
+          response.sessionId,
+        ).catch(() => undefined);
+        throw new UserBrowserCdpOutcomeUnknownError(
+          "Target.attachToTarget",
+          attachmentClosure.lifecycleEvidence.join("; "),
+        );
+      }
+      if (attachment.invalidated) {
+        try {
+          await this.#compensateAttachment(
+            attachmentClosure,
+            response.sessionId,
+          );
+        } catch {
+          attachmentClosure.taint =
+            "attachment invalidation compensation failed";
+        }
+        throw new Error("User browser target detached during attachment");
+      }
+      this.#targetSessions.set(targetId, response.sessionId);
+      this.#sessionTargets.set(response.sessionId, targetId);
+      this.#sessionEpochs.set(response.sessionId, attachmentClosure);
+      this.#targetDocuments.set(targetId, {
+        revision: 0,
+        frameId: "",
+        loaderId: "",
+        url: "",
+        alive: true,
+        pendingFrameInvalidations: new Set(),
+      });
+      try {
+        await this.#send("Page.enable", {}, response.sessionId, signal);
+        attachmentClosure.enable = "known-success";
+        return response.sessionId;
+      } catch (error) {
+        attachmentClosure.enable =
+          error instanceof UserBrowserCdpOutcomeUnknownError
+            ? "outcome-unknown"
+            : "known-failure";
+        if (attachmentClosure.enable === "outcome-unknown") {
+          attachmentClosure.unknownEvidence.enable = describeError(error);
+        }
+        try {
+          await this.#compensateAttachment(
+            attachmentClosure,
+            response.sessionId,
+          );
+        } catch (compensationError) {
+          attachmentClosure.taint = `Page.enable closure failed (${describeError(error)}; ${describeError(compensationError)})`;
+        }
+        throw error;
+      }
+    })();
+    attachment.promise = attaching;
+    this.#targetAttachments.set(targetId, attachment);
+    try {
+      return await attaching;
+    } finally {
+      if (this.#targetAttachments.get(targetId) === attachment) {
+        this.#targetAttachments.delete(targetId);
+      }
+    }
+  }
+
+  #attachmentEpoch(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+  ): UserBrowserAttachmentEpoch {
+    if (this.#attachmentClosures.size >= USER_BROWSER_MAX_TARGET_EVIDENCE) {
+      this.#recordConnectionTaint(
+        "attachment closure evidence exceeded its bound",
+      );
+      throw new UserBrowserCdpOutcomeUnknownError(
+        "Target.attachToTarget",
+        "attachment closure evidence exceeded its bound",
+      );
+    }
+    const epoch: UserBrowserAttachmentEpoch = {
+      targetId,
+      ...owner,
+      attachAttempt: this.#nextAttachAttempt++,
+      attach: "known-failure",
+      enable: "known-failure",
+      detach: "known-failure",
+      unknownEvidence: {},
+      lifecycleEvidence: [],
+    };
+    this.#attachmentClosures.set(targetId, epoch);
+    return epoch;
+  }
+
+  async #compensateAttachment(
+    epoch: UserBrowserAttachmentEpoch,
+    sessionId: string,
+  ): Promise<void> {
+    epoch.cdpSessionId = sessionId;
+    this.#sessionEpochs.set(sessionId, epoch);
+    try {
+      await this.#send(
+        "Target.detachFromTarget",
+        { sessionId },
+        undefined,
+        undefined,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+      );
+      epoch.detach = "known-success";
+      epoch.taint = undefined;
+      this.#reapEpoch(epoch, true);
+    } catch (error) {
+      if (error instanceof UserBrowserCdpOutcomeUnknownError) {
+        epoch.detach = "outcome-unknown";
+        epoch.unknownEvidence.detach ??= describeError(error);
+      } else {
+        epoch.detach = "known-failure";
+        epoch.taint = describeError(error);
+      }
+      throw error;
+    }
+  }
+
+  async #compensateLateAttach(
+    epoch: UserBrowserAttachmentEpoch,
+    message: Record<string, unknown>,
+  ): Promise<void> {
+    const protocolError = asRecord(message.error);
+    if (protocolError !== undefined) {
+      epoch.attach = "known-failure";
+      return;
+    }
+    const sessionId = asRecord(message.result)?.sessionId;
+    if (typeof sessionId !== "string") {
+      epoch.taint = "late attach response was invalid";
+      return;
+    }
+    epoch.attach = "known-success";
+    epoch.cdpSessionId = sessionId;
+    await this.#compensateAttachment(epoch, sessionId);
+  }
+
+  #recordConnectionTaint(detail: string): void {
+    if (this.#connectionTaints.includes(detail)) return;
+    if (this.#connectionTaints.length < USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      this.#connectionTaints.push(detail);
+      return;
+    }
+    this.#connectionTaints[this.#connectionTaints.length - 1] =
+      "connection taint diagnostics exceeded their bound";
+  }
+
+  #throwIfAttachmentTainted(): void {
+    const taints = [
+      ...this.#connectionTaints,
+      ...[...this.#attachmentClosures.values()]
+        .map((closure) => this.#attachmentProblem(closure))
+        .filter((detail): detail is string => detail !== undefined),
+    ];
+    if (taints.length > 0) {
+      throw new Error(
+        `User browser CDP attachment outcome is unknown (${taints.join("; ")})`,
+      );
+    }
+  }
+
+  async #send(
+    method: string,
+    params: Record<string, unknown>,
+    sessionId?: string,
+    signal?: AbortSignal,
+    outcomeTimeoutMs = USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+    onLateResponse?: (message: Record<string, unknown>) => Promise<void>,
+    onDispatched?: () => void,
+    beforeDispatch?: () => void,
+  ): Promise<unknown> {
+    if (this.#closed || this.#socket.readyState !== WebSocket.OPEN) {
+      throw new Error("User browser CDP connection is unavailable");
+    }
+    if (this.#pending.size >= USER_BROWSER_MAX_PENDING_CDP_REQUESTS) {
+      this.#recordConnectionTaint("pending CDP requests exceeded their bound");
+      throw new Error("User browser CDP pending request bound exceeded");
+    }
+    if (this.#nextId >= Number.MAX_SAFE_INTEGER) {
+      this.#recordConnectionTaint("CDP request id space was exhausted");
+      throw new Error("User browser CDP request id space was exhausted");
+    }
+    const id = this.#nextId++;
+    return await new Promise((resolve, reject) => {
+      let timeout: NodeJS.Timeout | undefined;
+      let dispatched = false;
+      const finish = () => {
+        signal?.removeEventListener("abort", abort);
+        if (timeout !== undefined) clearTimeout(timeout);
+      };
+      const abort = () => {
+        this.#pending.delete(id);
+        finish();
+        if (dispatched && onLateResponse !== undefined) {
+          this.#retainLateResponse(id, onLateResponse);
+        }
+        const reason =
+          signal?.reason instanceof Error
+            ? signal.reason.message
+            : "command aborted";
+        reject(
+          dispatched
+            ? new UserBrowserCdpOutcomeUnknownError(method, reason)
+            : abortReason(signal ?? AbortSignal.abort()),
+        );
+      };
+      const pending: {
+        method: string;
+        dispatched: boolean;
+        resolve(value: unknown): void;
+        reject(error: Error): void;
+      } = {
+        method,
+        dispatched: false,
+        resolve: (value) => {
+          finish();
+          resolve(value);
+        },
+        reject: (error) => {
+          finish();
+          reject(error);
+        },
+      };
+      this.#pending.set(id, pending);
+      timeout = setTimeout(() => {
+        if (!this.#pending.delete(id)) return;
+        finish();
+        reject(
+          new UserBrowserCdpOutcomeUnknownError(
+            method,
+            "outcome timed out after dispatch",
+          ),
+        );
+        if (onLateResponse !== undefined) {
+          this.#retainLateResponse(id, onLateResponse);
+        }
+      }, outcomeTimeoutMs);
+      signal?.addEventListener("abort", abort, { once: true });
+      if (signal?.aborted === true) {
+        abort();
+        return;
+      }
+      try {
+        beforeDispatch?.();
+        this.#socket.send(
+          JSON.stringify({
+            id,
+            method,
+            params,
+            ...(sessionId === undefined ? {} : { sessionId }),
+          }),
+        );
+        dispatched = true;
+        pending.dispatched = true;
+        onDispatched?.();
+      } catch (error) {
+        this.#pending.delete(id);
+        finish();
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  #retainLateResponse(
+    id: number,
+    receive: (message: Record<string, unknown>) => Promise<void>,
+  ): void {
+    if (this.#lateResponses.size >= USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      const oldest = this.#lateResponses.keys().next().value as
+        number | undefined;
+      if (oldest !== undefined) {
+        const evicted = this.#lateResponses.get(oldest);
+        if (evicted !== undefined) clearTimeout(evicted.expires);
+        this.#lateResponses.delete(oldest);
+      }
+      this.#recordConnectionTaint("late-response cleanup exceeded its bound");
+    }
+    const expires = setTimeout(() => {
+      this.#lateResponses.delete(id);
+    }, USER_BROWSER_LATE_RESPONSE_RETENTION_MS);
+    this.#lateResponses.set(id, { receive, expires });
+  }
+
+  #receive(raw: string): void {
+    let message: Record<string, unknown> | undefined;
+    try {
+      message = asRecord(JSON.parse(raw));
+    } catch {
+      this.#failAll(new Error("User browser CDP returned invalid JSON"));
+      return;
+    }
+    if (message === undefined) return;
+    if (typeof message.id !== "number") {
+      this.#receiveEvent(message);
+      return;
+    }
+    const pending = this.#pending.get(message.id);
+    if (pending === undefined) {
+      const late = this.#lateResponses.get(message.id);
+      if (late === undefined) return;
+      clearTimeout(late.expires);
+      this.#lateResponses.delete(message.id);
+      void late
+        .receive(message)
+        .catch((error: unknown) =>
+          this.#recordConnectionTaint(
+            `late-response compensation failed (${describeError(error)})`,
+          ),
+        );
+      return;
+    }
+    this.#pending.delete(message.id);
+    const error = asRecord(message.error);
+    if (error !== undefined) {
+      pending.reject(
+        new Error(
+          `User browser CDP command failed: ${String(error.message ?? "unknown error")}`,
+        ),
+      );
+    } else {
+      pending.resolve(message.result);
+    }
+  }
+
+  #receiveEvent(message: Record<string, unknown>): void {
+    const method = message.method;
+    const params = asRecord(message.params);
+    if (typeof method !== "string" || params === undefined) return;
+    if (
+      method === "Target.targetDestroyed" &&
+      typeof params.targetId === "string"
+    ) {
+      this.#reapTarget(params.targetId, true);
+      return;
+    }
+    if (
+      method === "Target.detachedFromTarget" &&
+      typeof params.sessionId === "string"
+    ) {
+      const epoch = this.#sessionEpochs.get(params.sessionId);
+      if (epoch !== undefined) {
+        this.#reapEpoch(epoch, true);
+        return;
+      }
+      if (this.#retiredSessionIds.has(params.sessionId)) return;
+      const pending =
+        typeof params.targetId === "string"
+          ? this.#targetAttachments.get(params.targetId)
+          : undefined;
+      if (pending !== undefined) {
+        if (
+          pending.pendingDetachSessionIds.size <
+            USER_BROWSER_MAX_OPERATION_EVIDENCE ||
+          pending.pendingDetachSessionIds.has(params.sessionId)
+        ) {
+          pending.pendingDetachSessionIds.add(params.sessionId);
+        } else {
+          this.#recordLifecycleEvidence(
+            pending.epoch,
+            "pending detach evidence exceeded its bound",
+          );
+        }
+        return;
+      }
+      const current =
+        typeof params.targetId === "string"
+          ? this.#attachmentClosures.get(params.targetId)
+          : undefined;
+      if (current !== undefined) {
+        this.#recordLifecycleEvidence(
+          current,
+          `unrecognized detached session ${params.sessionId}`,
+        );
+      } else {
+        this.#recordConnectionTaint(
+          `unrecognized detached session ${params.sessionId}`,
+        );
+      }
+      return;
+    }
+    if (
+      method === "Inspector.detached" &&
+      typeof message.sessionId === "string"
+    ) {
+      const targetId = this.#sessionTargets.get(message.sessionId);
+      const epoch = this.#sessionEpochs.get(message.sessionId);
+      if (targetId !== undefined && epoch !== undefined)
+        this.#reapEpoch(epoch, true);
+      return;
+    }
+    if (typeof message.sessionId !== "string") return;
+    const targetId = this.#sessionTargets.get(message.sessionId);
+    if (targetId === undefined) return;
+    const document = this.#targetDocuments.get(targetId);
+    if (
+      document !== undefined &&
+      document.frameId.length === 0 &&
+      typeof params.frameId === "string" &&
+      (method === "Page.navigatedWithinDocument" ||
+        method === "Page.frameStartedNavigating" ||
+        method === "Page.frameStartedLoading" ||
+        method === "Page.backForwardCacheNotUsed")
+    ) {
+      if (
+        document.pendingFrameInvalidations.size <
+          USER_BROWSER_MAX_OPERATION_EVIDENCE ||
+        document.pendingFrameInvalidations.has(params.frameId)
+      ) {
+        document.pendingFrameInvalidations.add(params.frameId);
+      } else {
+        document.revision += 1;
+      }
+      return;
+    }
+    if (
+      userBrowserDocumentEventInvalidates(
+        method,
+        params,
+        this.#targetDocuments.get(targetId)?.frameId,
+      )
+    ) {
+      this.#invalidateTarget(targetId, false);
+    }
+  }
+
+  #invalidateTarget(targetId: string, disappeared: boolean): void {
+    const state = this.#targetDocuments.get(targetId) ?? {
+      revision: 0,
+      frameId: "",
+      loaderId: "",
+      url: "",
+      alive: true,
+      pendingFrameInvalidations: new Set<string>(),
+    };
+    state.revision += 1;
+    state.alive = !disappeared;
+    this.#targetDocuments.set(targetId, state);
+  }
+
+  #reapTarget(targetId: string, ownershipClosed = false): void {
+    const attaching = this.#targetAttachments.get(targetId);
+    if (attaching !== undefined) attaching.invalidated = true;
+    const epoch = this.#attachmentClosures.get(targetId);
+    if (epoch?.cdpSessionId !== undefined) {
+      this.#reapEpoch(epoch, ownershipClosed);
+      return;
+    }
+    if (attaching === undefined) {
+      this.#targetSessions.delete(targetId);
+      this.#targetDocuments.delete(targetId);
+      if (ownershipClosed && this.#attachmentProblem(epoch) === undefined) {
+        this.#attachmentClosures.delete(targetId);
+      }
+    }
+  }
+
+  #reapEpoch(
+    epoch: UserBrowserAttachmentEpoch | undefined,
+    ownershipClosed: boolean,
+  ): void {
+    if (epoch === undefined) return;
+    const sessionId = epoch.cdpSessionId;
+    if (sessionId !== undefined) {
+      this.#sessionTargets.delete(sessionId);
+      this.#sessionEpochs.delete(sessionId);
+      this.#rememberRetiredSession(sessionId);
+      if (
+        this.#targetSessions.get(epoch.targetId) === sessionId &&
+        this.#attachmentClosures.get(epoch.targetId) === epoch
+      ) {
+        this.#targetSessions.delete(epoch.targetId);
+        this.#targetDocuments.delete(epoch.targetId);
+      }
+    }
+    if (
+      ownershipClosed &&
+      this.#attachmentClosures.get(epoch.targetId) === epoch &&
+      this.#attachmentProblem(epoch) === undefined
+    ) {
+      this.#attachmentClosures.delete(epoch.targetId);
+    }
+  }
+
+  #retireEpoch(epoch: UserBrowserAttachmentEpoch): void {
+    if (epoch.cdpSessionId !== undefined) {
+      this.#rememberRetiredSession(epoch.cdpSessionId);
+      this.#sessionEpochs.delete(epoch.cdpSessionId);
+    }
+    if (this.#attachmentClosures.get(epoch.targetId) === epoch) {
+      this.#attachmentClosures.delete(epoch.targetId);
+    }
+  }
+
+  #rememberRetiredSession(sessionId: string): void {
+    if (this.#retiredSessionIds.has(sessionId)) return;
+    if (this.#retiredSessionIds.size >= USER_BROWSER_MAX_TARGET_EVIDENCE) {
+      const oldest = this.#retiredSessionIds.values().next().value as
+        string | undefined;
+      if (oldest !== undefined) this.#retiredSessionIds.delete(oldest);
+    }
+    this.#retiredSessionIds.add(sessionId);
+  }
+
+  #recordLifecycleEvidence(
+    epoch: UserBrowserAttachmentEpoch,
+    detail: string,
+  ): void {
+    if (epoch.lifecycleEvidence.includes(detail)) return;
+    if (epoch.lifecycleEvidence.length < USER_BROWSER_MAX_OPERATION_EVIDENCE) {
+      epoch.lifecycleEvidence.push(detail);
+      return;
+    }
+    epoch.lifecycleEvidence[epoch.lifecycleEvidence.length - 1] =
+      "attachment lifecycle evidence exceeded its bound";
+  }
+
+  #assertAttachmentClosedForOperation(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    method: string,
+  ): void {
+    const epoch = this.#attachmentClosures.get(targetId);
+    if (epoch === undefined || !sameAttachmentOwner(epoch, owner)) {
+      throw new UserBrowserCdpOutcomeUnknownError(
+        method,
+        "attachment ownership changed during operation",
+      );
+    }
+    const problem = this.#attachmentProblem(epoch);
+    if (problem !== undefined) {
+      throw new UserBrowserCdpOutcomeUnknownError(method, problem);
+    }
+  }
+
+  #attachmentProblem(
+    closure: UserBrowserAttachmentEpoch | undefined,
+  ): string | undefined {
+    if (closure === undefined) return undefined;
+    const unknown = Object.values(closure.unknownEvidence);
+    const evidence = [
+      ...unknown,
+      ...closure.lifecycleEvidence,
+      ...(closure.taint === undefined ? [] : [closure.taint]),
+    ];
+    return evidence.length === 0 ? undefined : evidence.join("; ");
+  }
+
+  #failAll(error: Error): void {
+    this.#providerRevision += 1;
+    this.#closed = true;
+    if (!this.#closing && this.#attachmentClosures.size > 0) {
+      this.#recordConnectionTaint(`connection failed (${error.message})`);
+    }
+    this.#targetSessions.clear();
+    this.#sessionTargets.clear();
+    this.#targetDocuments.clear();
+    for (const pending of this.#pending.values()) {
+      pending.reject(
+        pending.dispatched
+          ? new UserBrowserCdpOutcomeUnknownError(
+              pending.method,
+              `connection failed after dispatch (${error.message})`,
+            )
+          : error,
+      );
+    }
+    this.#pending.clear();
+  }
+}
+
+export function userBrowserDocumentEventInvalidates(
+  method: string,
+  params: Record<string, unknown>,
+  mainFrameId?: string,
+): boolean {
+  if (method === "Page.frameNavigated") {
+    const frame = asRecord(params.frame);
+    return frame !== undefined && frame.parentId === undefined;
+  }
+  if (
+    method !== "Page.navigatedWithinDocument" &&
+    method !== "Page.frameStartedNavigating" &&
+    method !== "Page.frameStartedLoading" &&
+    method !== "Page.backForwardCacheNotUsed"
+  ) {
+    return false;
+  }
+  return typeof params.frameId === "string" && params.frameId === mainFrameId;
+}
+
+function validateCdpEndpoint(raw: string): URL {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error("User browser CDP endpoint is not a valid URL");
+  }
+  if (
+    url.protocol !== "http:" ||
+    !isLoopbackHostname(url.hostname) ||
+    url.username.length > 0 ||
+    url.password.length > 0 ||
+    url.search.length > 0 ||
+    url.hash.length > 0
+  ) {
+    throw new Error(
+      "User browser CDP endpoint must be an unauthenticated loopback http:// URL",
+    );
+  }
+  return url;
+}
+
+export function windowsBrowserExecutableCandidates(
+  environment: NodeJS.ProcessEnv,
+): string[] {
+  const roots = [
+    environment.ProgramFiles,
+    environment["ProgramFiles(x86)"],
+    environment.LOCALAPPDATA,
+  ].filter((entry): entry is string => entry !== undefined && entry.length > 0);
+  return [
+    ...roots.map((root) =>
+      path.win32.join(root, "Google", "Chrome", "Application", "chrome.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Microsoft", "Edge", "Application", "msedge.exe"),
+    ),
+    ...roots.map((root) =>
+      path.win32.join(root, "Chromium", "Application", "chrome.exe"),
+    ),
+  ];
+}
+
+function describeError(error: unknown): string {
+  return (error instanceof Error ? error.message : String(error)).slice(0, 512);
+}
+
+function sameAttachmentOwner(
+  epoch: UserBrowserAttachmentOwner,
+  owner: UserBrowserAttachmentOwner,
+): boolean {
+  return (
+    epoch.logicalSessionId === owner.logicalSessionId &&
+    epoch.logicalSessionIncarnation === owner.logicalSessionIncarnation
+  );
+}
+
+export class UserBrowserDocumentChangedBeforeDispatchError extends Error {
+  constructor() {
+    super("User browser document changed before action dispatch");
+  }
+}
+
+export class UserBrowserDocumentChangedAfterDispatchError extends Error {
+  constructor(detail = "document identity changed") {
+    super(detail);
+  }
+}
+
+export class UserBrowserMutationOutcomeUnknownError extends Error {
+  constructor(operation: string, detail: string) {
+    super(`${operation} outcome is unknown (${detail})`);
+  }
+}
+
+export class UserBrowserCdpOutcomeUnknownError extends Error {
+  constructor(method: string, detail: string) {
+    super(`User browser CDP ${method} outcome is unknown (${detail})`);
+  }
+}
+class ActionRejectedError extends Error {}
+
+async function raceAbort<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal === undefined) return await operation;
+  if (signal.aborted) throw abortReason(signal);
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(abortReason(signal));
+    signal.addEventListener("abort", abort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
+function abortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("cancelled", "AbortError");
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted === true) throw abortReason(signal);
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  if (hostname === "[::1]") return true;
+  const octets = hostname.split(".");
+  return (
+    octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((octet) => /^\d{1,3}$/u.test(octet)) &&
+    octets.every((octet) => Number(octet) <= 255)
+  );
+}
+
+function effectivePort(url: URL): string {
+  if (url.port.length > 0) return url.port;
+  return url.protocol === "http:" || url.protocol === "ws:" ? "80" : "";
+}
+
+function isInspectableUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function summarizeTarget(
+  sessionId: string,
+  target: UserBrowserCdpTarget,
+): BrowserTabSummary {
+  return {
+    sessionId,
+    tabId: target.targetId,
+    title: target.title.slice(0, 256),
+    url: redactBrowserUrl(target.url),
+    loading: false,
+  };
+}
+
+function requireFingerprint(value: unknown): BrowserTargetFingerprint {
+  const target = asRecord(value);
+  const actions = target?.actions;
+  if (
+    target === undefined ||
+    ![
+      "selector",
+      "tag",
+      "role",
+      "name",
+      "type",
+      "id",
+      "fieldName",
+      "autocomplete",
+      "href",
+    ].every((key) => typeof target[key] === "string") ||
+    typeof target.secure !== "boolean" ||
+    !Array.isArray(actions) ||
+    !actions.every((action) => action === "click" || action === "type") ||
+    (target.value !== undefined && typeof target.value !== "string")
+  ) {
+    throw new Error("User browser CDP inspection target is invalid");
+  }
+  return {
+    selector: target.selector as string,
+    tag: target.tag as string,
+    role: target.role as string,
+    name: target.name as string,
+    type: target.type as string,
+    id: target.id as string,
+    fieldName: target.fieldName as string,
+    autocomplete: target.autocomplete as string,
+    href: target.href as string,
+    secure: target.secure,
+    actions: [...actions],
+    ...(target.value === undefined ? {} : { value: target.value }),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -70,12 +70,19 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
             manifest: undefined,
             diagnostics: [],
           };
-    this.#registry.register(
-      new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
-      "bundled",
-    );
+    if (browser.backend !== undefined) {
+      this.#registry.register(
+        new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
+        "bundled",
+      );
+    }
     for (const diagnostic of browser.diagnostics) {
       this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+    if (browser.backend === undefined) {
+      this.#registry.recordDiscoveryError(
+        `Browser provider: ${browser.diagnostics[0]?.reason ?? "unavailable"}`,
+      );
     }
     const computer =
       this.#computerBackend === undefined

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -92,19 +92,20 @@ void app.whenReady().then(async () => {
     const password = inspected.targets.find(({ name }) => name === "Password");
     assert.equal(password?.secure, true);
     assert.equal(password?.value, undefined);
-    assert.equal(password?.actions.includes("type"), false);
+    assert.equal(password?.actions.includes("type"), true);
     if (password !== undefined) {
-      await assert.rejects(
-        invoke(registry, "browser_type", {
-          sessionId: "desktop-smoke",
-          tabId,
-          observationId: inspected.observationId,
-          targetId: password.targetId,
-          text: "not-a-secret",
-        }),
-        /password or secure controls/u,
-      );
+      await invoke(registry, "browser_type", {
+        sessionId: "desktop-smoke",
+        tabId,
+        observationId: inspected.observationId,
+        targetId: password.targetId,
+        text: "ordinary-argument",
+      });
     }
+    inspected = (await invoke(registry, "browser_inspect", {
+      sessionId: "desktop-smoke",
+      tabId,
+    })) as BrowserInspection;
     const input = requiredBrowserTarget(inspected, "Name", "type");
     await invoke(registry, "browser_type", {
       sessionId: "desktop-smoke",
@@ -236,7 +237,7 @@ void app.whenReady().then(async () => {
     assert.equal(foregroundAfter.bundleId, foregroundBefore.bundleId);
 
     console.log(
-      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, changed, and password targets; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
+      "ZenX capability desktop smoke passed: opaque browser observe/act IDs reject forged, stale, hidden, and changed targets while password input dispatches normally; close-session resets cookie/session storage before same-ID reopen; foreground helper compiled without running input; pointer and foreground app unchanged",
     );
   } catch (error) {
     console.error("ZenX capability desktop smoke failed", error);

--- a/apps/zenx/src/main/provider-smoke.ts
+++ b/apps/zenx/src/main/provider-smoke.ts
@@ -30,6 +30,10 @@ void app.whenReady().then(async () => {
     const selectedBrowser = browser.diagnostics.find(
       (diagnostic) => diagnostic.status === "selected",
     );
+    assert.ok(
+      browser.backend,
+      `Browser provider is unavailable: ${JSON.stringify(browser.diagnostics)}`,
+    );
     if (process.env.ZENX_REQUIRE_PLAYWRIGHT === "1") {
       assert.equal(
         selectedBrowser?.providerId,

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -8,7 +8,10 @@ import path from "node:path";
 import WebSocket, { type RawData } from "ws";
 
 import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
-import { windowsBrowserExecutableCandidates } from "./capabilities/user-browser-provider.js";
+import {
+  UserBrowserDocumentChangedBeforeDispatchError,
+  windowsBrowserExecutableCandidates,
+} from "./capabilities/user-browser-provider.js";
 
 if (process.platform !== "win32") {
   throw new Error("The real user-browser CDP smoke is Windows-only");
@@ -83,7 +86,9 @@ try {
   });
   const account = tabs.find((tab) => tab.url.includes("/account"));
   assert.ok(account, "Expected the already-running authenticated account tab");
-  const inspection = await backend.inspect("windows-smoke", account.tabId);
+  const inspection = await retryDocumentInspection(() =>
+    backend.inspect("windows-smoke", account.tabId),
+  );
   assert.match(
     inspection.visibleText,
     /Signed in through existing browser state/u,
@@ -108,7 +113,9 @@ try {
     const snapshot = await browserTargetSnapshot(endpoint, fixtureBrowserHwnd);
     return snapshot.activeTargetId === account.tabId ? snapshot : undefined;
   });
-  const verified = await backend.inspect("windows-smoke", account.tabId);
+  const verified = await retryDocumentInspection(() =>
+    backend.inspect("windows-smoke", account.tabId),
+  );
   assert.match(verified.visibleText, /Attached action complete/u);
   const accountVisibilityBeforeOpen = visibilityState(verified.visibleText);
   const foregroundBeforeOpen = foregroundWindowHandle();
@@ -145,16 +152,17 @@ try {
     "hidden",
     "the provider-created target must be hidden at the browser target boundary",
   );
-  const accountAfterOpen = await backend.inspect(
-    "windows-smoke",
-    account.tabId,
+  const accountAfterOpen = await retryDocumentInspection(() =>
+    backend.inspect("windows-smoke", account.tabId),
   );
   assert.equal(
     visibilityState(accountAfterOpen.visibleText),
     accountVisibilityBeforeOpen,
     "background_safe browser_open must preserve existing-tab visibility",
   );
-  const openedInspection = await backend.inspect("windows-smoke", opened.tabId);
+  const openedInspection = await retryDocumentInspection(() =>
+    backend.inspect("windows-smoke", opened.tabId),
+  );
   assert.equal(
     visibilityState(openedInspection.visibleText),
     "hidden",
@@ -465,6 +473,21 @@ async function retry<T>(operation: () => Promise<T | undefined>): Promise<T> {
   throw new Error(
     "Timed out waiting for the real user browser CDP smoke fixture",
   );
+}
+
+async function retryDocumentInspection<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  return await retry(async () => {
+    try {
+      return await operation();
+    } catch (error) {
+      if (error instanceof UserBrowserDocumentChangedBeforeDispatchError) {
+        return undefined;
+      }
+      throw error;
+    }
+  });
 }
 
 async function listen(): Promise<number> {

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -1,0 +1,499 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
+import { createServer } from "node:http";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import WebSocket, { type RawData } from "ws";
+
+import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
+import { windowsBrowserExecutableCandidates } from "./capabilities/user-browser-provider.js";
+
+if (process.platform !== "win32") {
+  throw new Error("The real user-browser CDP smoke is Windows-only");
+}
+
+const server = createServer((request, response) => {
+  if (request.url === "/seed") {
+    response.statusCode = 302;
+    response.setHeader(
+      "set-cookie",
+      "zenx_smoke_auth=present; HttpOnly; SameSite=Lax",
+    );
+    response.setHeader("location", "/account");
+    response.end();
+    return;
+  }
+  const authenticated =
+    request.headers.cookie?.includes("zenx_smoke_auth=present") === true;
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  const title =
+    request.url === "/opened"
+      ? "ZenX provider background target"
+      : "ZenX original active target";
+  response.end(
+    `<!doctype html><title>${title}</title><main><p>${authenticated ? "Signed in through existing browser state" : "Signed out"}</p><p id="visibility">Visibility ${"${document.visibilityState}"}</p><button id="continue" onclick="this.textContent='Attached action complete'">Continue</button><script>const visibility = document.querySelector('#visibility'); const updateVisibility = () => visibility.textContent = 'Visibility ' + document.visibilityState; updateVisibility(); document.addEventListener('visibilitychange', updateVisibility);</script></main>`,
+  );
+});
+
+let browser: ChildProcess | undefined;
+let directory: string | undefined;
+
+try {
+  const executable = await findBrowserExecutable();
+  directory = await mkdtemp(path.join(os.tmpdir(), "zenx-user-browser-smoke-"));
+  const port = await listen();
+  browser = spawn(
+    executable,
+    [
+      `--user-data-dir=${directory}`,
+      "--remote-debugging-port=0",
+      "--no-first-run",
+      "--no-default-browser-check",
+      `http://127.0.0.1:${String(port)}/seed`,
+    ],
+    { stdio: "ignore", windowsHide: true },
+  );
+  const debuggingPort = await readDevToolsPort(directory);
+  const endpoint = `http://127.0.0.1:${debuggingPort}`;
+  const selection = await selectBrowserProvider({
+    userDataDirectory: directory,
+    platform: "win32",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: endpoint,
+    },
+  });
+  const backend = selection.backend;
+  assert.ok(
+    backend,
+    `Expected user-browser provider: ${JSON.stringify(selection.diagnostics)}`,
+  );
+  const selected = selection.diagnostics.find(
+    (diagnostic) => diagnostic.status === "selected",
+  );
+  assert.equal(selected?.providerId, "user-browser-cdp");
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  const tabs = await retry(async () => {
+    const current = await backend.listTabs("windows-smoke");
+    return current.some((tab) => tab.url.includes("/account"))
+      ? current
+      : undefined;
+  });
+  const account = tabs.find((tab) => tab.url.includes("/account"));
+  assert.ok(account, "Expected the already-running authenticated account tab");
+  const inspection = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(
+    inspection.visibleText,
+    /Signed in through existing browser state/u,
+  );
+  assert.doesNotMatch(
+    JSON.stringify(inspection),
+    /zenx_smoke_auth|cookie|storageState|authorization/iu,
+  );
+  const target = inspection.targets.find(
+    (candidate) => candidate.name === "Continue",
+  );
+  assert.ok(target, "Expected the existing user tab action target");
+  await backend.click(
+    "windows-smoke",
+    account.tabId,
+    inspection.observationId,
+    target.targetId,
+  );
+  await activateBrowserTarget(endpoint, account.tabId);
+  const fixtureBrowserHwnd = foregroundSmokeBrowserWindow();
+  await retry(async () => {
+    const snapshot = await browserTargetSnapshot(endpoint, fixtureBrowserHwnd);
+    return snapshot.activeTargetId === account.tabId ? snapshot : undefined;
+  });
+  const verified = await backend.inspect("windows-smoke", account.tabId);
+  assert.match(verified.visibleText, /Attached action complete/u);
+  const accountVisibilityBeforeOpen = visibilityState(verified.visibleText);
+  const foregroundBeforeOpen = foregroundWindowHandle();
+  const targetsBeforeOpen = await browserTargetSnapshot(
+    endpoint,
+    fixtureBrowserHwnd,
+  );
+  assert.equal(
+    targetsBeforeOpen.activeTargetId,
+    account.tabId,
+    "the authenticated fixture must be the actual active target before open",
+  );
+  const opened = await backend.open(
+    "windows-smoke",
+    `http://127.0.0.1:${String(port)}/opened`,
+  );
+  const foregroundAfterOpen = foregroundWindowHandle();
+  const targetsAfterOpen = await browserTargetSnapshot(
+    endpoint,
+    fixtureBrowserHwnd,
+  );
+  assert.equal(
+    foregroundAfterOpen,
+    foregroundBeforeOpen,
+    "background_safe browser_open must not change the foreground window",
+  );
+  assert.equal(
+    targetsAfterOpen.activeTargetId,
+    targetsBeforeOpen.activeTargetId,
+    "background_safe browser_open must preserve the actual active target",
+  );
+  assert.equal(
+    targetsAfterOpen.visibilityByTarget.get(opened.tabId),
+    "hidden",
+    "the provider-created target must be hidden at the browser target boundary",
+  );
+  const accountAfterOpen = await backend.inspect(
+    "windows-smoke",
+    account.tabId,
+  );
+  assert.equal(
+    visibilityState(accountAfterOpen.visibleText),
+    accountVisibilityBeforeOpen,
+    "background_safe browser_open must preserve existing-tab visibility",
+  );
+  const openedInspection = await backend.inspect("windows-smoke", opened.tabId);
+  assert.equal(
+    visibilityState(openedInspection.visibleText),
+    "hidden",
+    "background_safe browser_open must leave the created tab hidden",
+  );
+  const detached = await backend.closeSession("windows-smoke");
+  await backend.close();
+  const foregroundAfterClose = foregroundWindowHandle();
+  const targetsAfterClose = await browserTargetSnapshot(
+    endpoint,
+    fixtureBrowserHwnd,
+  );
+  assert.equal(detached, tabs.length + 1);
+  assert.equal(
+    browser.exitCode,
+    null,
+    "Closing ZenX must leave the user browser running",
+  );
+  assert.equal(
+    foregroundAfterClose,
+    foregroundBeforeOpen,
+    "provider close must preserve the foreground window",
+  );
+  assert.equal(
+    targetsAfterClose.activeTargetId,
+    targetsBeforeOpen.activeTargetId,
+    "provider close must preserve the actual active target",
+  );
+  assert.equal(
+    targetsAfterClose.visibilityByTarget.get(account.tabId),
+    accountVisibilityBeforeOpen,
+    "the original target must survive close with its visibility unchanged",
+  );
+  assert.equal(
+    targetsAfterClose.visibilityByTarget.get(opened.tabId),
+    "hidden",
+    "the provider-created target must survive detach in the background",
+  );
+  const browserTargets = targetsAfterClose.targetIds;
+  assert.ok(
+    browserTargets.length > 0,
+    "Closing ZenX must leave user tabs intact",
+  );
+  console.log(
+    JSON.stringify({
+      passed: true,
+      provider: "user-browser-cdp",
+      product: selected?.version,
+      inheritedAuthenticatedState: true,
+      agentReceivedSessionMaterial: false,
+      browserAndTabsSurvivedDetach: true,
+      providerOpenPreservedForegroundWindow: true,
+      providerClosePreservedForegroundWindow: true,
+      activeTargetBeforeOpen: targetsBeforeOpen.activeTargetId,
+      activeTargetAfterOpen: targetsAfterOpen.activeTargetId,
+      activeTargetAfterClose: targetsAfterClose.activeTargetId,
+      originalTargetSurvived: targetsAfterClose.targetIds.includes(
+        account.tabId,
+      ),
+      providerCreatedTargetSurvivedHidden:
+        targetsAfterClose.visibilityByTarget.get(opened.tabId) === "hidden",
+    }),
+  );
+} finally {
+  await closeServer();
+  if (browser?.pid !== undefined) {
+    await stopProcessTree(browser.pid);
+  }
+  if (directory !== undefined) {
+    await rm(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 250,
+    });
+  }
+}
+
+function foregroundWindowHandle(): string {
+  const script = [
+    "Add-Type -TypeDefinition 'using System; using System.Runtime.InteropServices; public static class ZenXForeground { [DllImport(\"user32.dll\")] public static extern IntPtr GetForegroundWindow(); }'",
+    "[ZenXForeground]::GetForegroundWindow().ToInt64()",
+  ].join("; ");
+  return execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", windowsHide: true },
+  ).trim();
+}
+
+function foregroundSmokeBrowserWindow(): string {
+  const script = [
+    'Add-Type -TypeDefinition \'using System; using System.Runtime.InteropServices; public static class ZenXSmokeWindow { [DllImport("user32.dll")] public static extern bool ShowWindowAsync(IntPtr hWnd, int nCmdShow); [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd); }\'',
+    "$process = Get-Process | Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -like '*ZenX original active target*' } | Select-Object -First 1",
+    "if ($null -eq $process) { throw 'Smoke browser window was not found' }",
+    "[void][ZenXSmokeWindow]::ShowWindowAsync($process.MainWindowHandle, 9)",
+    "[void][ZenXSmokeWindow]::SetForegroundWindow($process.MainWindowHandle)",
+    "$process.MainWindowHandle.ToInt64()",
+  ].join("; ");
+  return execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", windowsHide: true },
+  ).trim();
+}
+
+function visibilityState(visibleText: string): "visible" | "hidden" {
+  const match = /Visibility (visible|hidden)/u.exec(visibleText);
+  assert.ok(match, "Expected the smoke page to expose document visibility");
+  return match[1] as "visible" | "hidden";
+}
+
+async function browserTargetSnapshot(
+  endpoint: string,
+  browserHwnd: string,
+): Promise<{
+  activeTargetId: string;
+  targetIds: string[];
+  visibilityByTarget: Map<string, "visible" | "hidden">;
+}> {
+  const response = await fetch(`${endpoint}/json/list`, {
+    signal: AbortSignal.timeout(5_000),
+    redirect: "error",
+  });
+  assert.equal(response.ok, true, "Expected the real browser target list");
+  const raw: unknown = await response.json();
+  assert.ok(Array.isArray(raw), "Expected a real browser target array");
+  const targets = raw.filter(
+    (value): value is Record<string, unknown> =>
+      typeof value === "object" && value !== null && !Array.isArray(value),
+  );
+  const visibilityByTarget = new Map<string, "visible" | "hidden">();
+  const titleByTarget = new Map<string, string>();
+  for (const target of targets) {
+    if (
+      target.type !== "page" ||
+      typeof target.id !== "string" ||
+      typeof target.webSocketDebuggerUrl !== "string"
+    ) {
+      continue;
+    }
+    const visibility = await evaluateTargetVisibility(
+      target.webSocketDebuggerUrl,
+    );
+    visibilityByTarget.set(target.id, visibility);
+    if (typeof target.title === "string") {
+      titleByTarget.set(target.id, target.title);
+    }
+  }
+  const nativeWindowTitle = browserWindowTitle(browserHwnd);
+  const active = [...titleByTarget].filter(
+    ([, title]) => title.length > 0 && nativeWindowTitle.includes(title),
+  );
+  assert.equal(
+    active.length,
+    1,
+    `Expected the native browser window title to identify one target: ${JSON.stringify({ nativeWindowTitle, targets: [...titleByTarget] })}`,
+  );
+  return {
+    activeTargetId: active[0]?.[0] ?? "",
+    targetIds: [...visibilityByTarget.keys()],
+    visibilityByTarget,
+  };
+}
+
+function browserWindowTitle(browserHwnd: string): string {
+  const script = [
+    `$handle = [Int64]${browserHwnd}`,
+    "$process = Get-Process | Where-Object { $_.MainWindowHandle.ToInt64() -eq $handle } | Select-Object -First 1",
+    "if ($null -eq $process) { throw 'Smoke browser HWND no longer exists' }",
+    "$process.MainWindowTitle",
+  ].join("; ");
+  return execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { encoding: "utf8", windowsHide: true },
+  ).trim();
+}
+
+async function evaluateTargetVisibility(
+  webSocketDebuggerUrl: string,
+): Promise<"visible" | "hidden"> {
+  const response = await sendCdpCommand(
+    webSocketDebuggerUrl,
+    "Runtime.evaluate",
+    {
+      expression: "document.visibilityState",
+      returnByValue: true,
+    },
+  );
+  const value = (
+    response.result as { result?: { value?: unknown } } | undefined
+  )?.result?.value;
+  assert.ok(
+    value === "visible" || value === "hidden",
+    "Expected a real target visibility state",
+  );
+  return value;
+}
+
+async function activateBrowserTarget(
+  endpoint: string,
+  targetId: string,
+): Promise<void> {
+  const version = (await (
+    await fetch(`${endpoint}/json/version`, {
+      signal: AbortSignal.timeout(5_000),
+      redirect: "error",
+    })
+  ).json()) as { webSocketDebuggerUrl?: unknown };
+  assert.equal(
+    typeof version.webSocketDebuggerUrl,
+    "string",
+    "Expected the real browser websocket endpoint",
+  );
+  await sendCdpCommand(
+    version.webSocketDebuggerUrl as string,
+    "Target.activateTarget",
+    { targetId },
+  );
+}
+
+async function sendCdpCommand(
+  webSocketDebuggerUrl: string,
+  method: string,
+  params: Record<string, unknown>,
+): Promise<{ result?: unknown; error?: unknown }> {
+  const socket = new WebSocket(webSocketDebuggerUrl, {
+    handshakeTimeout: 5_000,
+  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    return await new Promise((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error(`${method} smoke command timed out`)),
+        5_000,
+      );
+      const receive = (raw: RawData) => {
+        const message = JSON.parse(raw.toString()) as {
+          id?: unknown;
+          result?: unknown;
+          error?: unknown;
+        };
+        if (message.id !== 1) return;
+        clearTimeout(timeout);
+        socket.off("message", receive);
+        if (message.error !== undefined) {
+          reject(new Error(`${method} smoke command failed`));
+        } else {
+          resolve(message);
+        }
+      };
+      socket.on("message", receive);
+      socket.send(JSON.stringify({ id: 1, method, params }));
+    });
+  } finally {
+    socket.close();
+  }
+}
+
+async function findBrowserExecutable(): Promise<string> {
+  const candidates = [
+    process.env.ZENX_USER_BROWSER_EXECUTABLE,
+    ...windowsBrowserExecutableCandidates(process.env),
+  ].filter(
+    (candidate): candidate is string =>
+      candidate !== undefined && candidate.length > 0,
+  );
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Keep probing the explicit finite list.
+    }
+  }
+  throw new Error(
+    "No supported Chrome or Edge executable found for the Windows user-browser smoke",
+  );
+}
+
+async function readDevToolsPort(userDataDirectory: string): Promise<string> {
+  return await retry(async () => {
+    try {
+      const [port] = (
+        await readFile(
+          path.join(userDataDirectory, "DevToolsActivePort"),
+          "utf8",
+        )
+      ).split(/\r?\n/u);
+      return /^\d+$/u.test(port ?? "") ? port : undefined;
+    } catch {
+      return undefined;
+    }
+  });
+}
+
+async function retry<T>(operation: () => Promise<T | undefined>): Promise<T> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await operation();
+    if (result !== undefined) return result;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    "Timed out waiting for the real user browser CDP smoke fixture",
+  );
+}
+
+async function listen(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("Smoke server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function closeServer(): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}
+
+async function stopProcessTree(pid: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const cleanup = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    cleanup.once("exit", () => resolve());
+    cleanup.once("error", () => resolve());
+  });
+}

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -170,6 +170,10 @@ try {
   );
   const detached = await backend.closeSession("windows-smoke");
   await backend.close();
+  const runtimeContextEventsObserved = await probeRuntimeContextEvents(
+    endpoint,
+    account.tabId,
+  );
   const foregroundAfterClose = foregroundWindowHandle();
   const targetsAfterClose = await browserTargetSnapshot(
     endpoint,
@@ -214,6 +218,7 @@ try {
       inheritedAuthenticatedState: true,
       agentReceivedSessionMaterial: false,
       browserAndTabsSurvivedDetach: true,
+      runtimeContextEventsObserved,
       providerOpenPreservedForegroundWindow: true,
       providerClosePreservedForegroundWindow: true,
       activeTargetBeforeOpen: targetsBeforeOpen.activeTargetId,
@@ -385,6 +390,128 @@ async function activateBrowserTarget(
   );
 }
 
+async function probeRuntimeContextEvents(
+  endpoint: string,
+  targetId: string,
+): Promise<number> {
+  const version = (await (
+    await fetch(`${endpoint}/json/version`, {
+      signal: AbortSignal.timeout(5_000),
+      redirect: "error",
+    })
+  ).json()) as { webSocketDebuggerUrl?: unknown };
+  assert.equal(
+    typeof version.webSocketDebuggerUrl,
+    "string",
+    "Expected the real browser websocket endpoint",
+  );
+  const socket = new WebSocket(version.webSocketDebuggerUrl as string, {
+    handshakeTimeout: 5_000,
+  });
+  const pending = new Map<
+    number,
+    {
+      resolve(value: Record<string, unknown>): void;
+      reject(error: Error): void;
+    }
+  >();
+  let nextId = 1;
+  let sessionId = "";
+  let contextEvents = 0;
+  const firstContextEvent = deferred<void>();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    socket.on("message", (raw: RawData) => {
+      const message = JSON.parse(raw.toString()) as Record<string, unknown>;
+      if (
+        message.sessionId === sessionId &&
+        (message.method === "Runtime.executionContextCreated" ||
+          message.method === "Runtime.executionContextDestroyed" ||
+          message.method === "Runtime.executionContextsCleared")
+      ) {
+        contextEvents += 1;
+        firstContextEvent.resolve();
+      }
+      if (typeof message.id !== "number") return;
+      const request = pending.get(message.id);
+      if (request === undefined) return;
+      pending.delete(message.id);
+      if (message.error !== undefined) {
+        request.reject(new Error("Runtime lifecycle probe command failed"));
+      } else {
+        request.resolve(message);
+      }
+    });
+    const send = async (
+      method: string,
+      params: Record<string, unknown>,
+      attachedSessionId?: string,
+    ): Promise<Record<string, unknown>> => {
+      const id = nextId++;
+      return await new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          pending.delete(id);
+          reject(new Error(`${method} lifecycle probe command timed out`));
+        }, 5_000);
+        pending.set(id, {
+          resolve: (value) => {
+            clearTimeout(timeout);
+            resolve(value);
+          },
+          reject: (error) => {
+            clearTimeout(timeout);
+            reject(error);
+          },
+        });
+        socket.send(
+          JSON.stringify({
+            id,
+            method,
+            params,
+            ...(attachedSessionId === undefined
+              ? {}
+              : { sessionId: attachedSessionId }),
+          }),
+        );
+      });
+    };
+    const attached = await send("Target.attachToTarget", {
+      targetId,
+      flatten: true,
+    });
+    const result = attached.result as { sessionId?: unknown } | undefined;
+    const attachedSessionId = result?.sessionId;
+    assert.equal(
+      typeof attachedSessionId,
+      "string",
+      "Expected a real attached CDP session",
+    );
+    sessionId = attachedSessionId as string;
+    await send("Runtime.enable", {}, sessionId);
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error("Runtime context event was not observed")),
+        5_000,
+      );
+      void firstContextEvent.promise.then(() => {
+        clearTimeout(timeout);
+        resolve();
+      }, reject);
+    });
+    await send("Target.detachFromTarget", { sessionId });
+    assert.ok(
+      contextEvents > 0,
+      "Runtime.enable must expose real execution-context lifecycle events",
+    );
+    return contextEvents;
+  } finally {
+    socket.close();
+  }
+}
+
 async function sendCdpCommand(
   webSocketDebuggerUrl: string,
   method: string,
@@ -424,6 +551,17 @@ async function sendCdpCommand(
   } finally {
     socket.close();
   }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 async function findBrowserExecutable(): Promise<string> {

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -177,6 +177,9 @@ export function CapabilitySettings() {
               <code>{provider.providerId}</code>
               <span>{provider.status}</span>
               <span>{provider.interactionModes.join(", ")}</span>
+              {provider.capabilityId === "browser" ? (
+                <span>{provider.sessionMode ?? "mode-unreported"}</span>
+              ) : null}
               <span>{provider.version ?? "bundled"}</span>
             </div>
           ))}

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -86,12 +86,12 @@ test("browser vertical slice targets one session/tab through structured operatio
   ]);
 });
 
-test("browser rejects stale, forged, and secure opaque targets", () => {
+test("browser rejects stale and forged targets without classifying text sensitivity", () => {
   const editable = fingerprint({ actions: ["click", "type"] });
   const password = fingerprint({
     type: "password",
     secure: true,
-    actions: ["click"],
+    actions: ["click", "type"],
   });
   const observation: BrowserObservation = {
     id: "observation-1",
@@ -133,16 +133,15 @@ test("browser rejects stale, forged, and secure opaque targets", () => {
       ),
     /forged/u,
   );
-  assert.throws(
-    () =>
-      resolveBrowserObservedTarget(
-        observation,
-        7,
-        "observation-1",
-        "password",
-        "type",
-      ),
-    /password or secure controls/u,
+  assert.equal(
+    resolveBrowserObservedTarget(
+      observation,
+      7,
+      "observation-1",
+      "password",
+      "type",
+    ),
+    password,
   );
 });
 

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -64,7 +64,7 @@ test("Playwright provider fails closed on an incompatible snapshot schema", asyn
   );
 });
 
-test("Playwright provider revalidates DOM identity and rejects secure fill", async () => {
+test("Playwright provider revalidates DOM identity and dispatches password fill normally", async () => {
   const runner = new FakePlaywrightRunner();
   const backend = new PlaywrightCliBrowserBackend({
     executable: "/opt/playwright-cli",
@@ -75,19 +75,30 @@ test("Playwright provider revalidates DOM identity and rejects secure fill", asy
   const inspected = await backend.inspect("research", opened.tabId);
   const password = inspected.targets.find(({ name }) => name === "Password");
   assert.equal(password?.secure, true);
-  assert.deepEqual(password?.actions, ["click"]);
+  assert.deepEqual(password?.actions, ["click", "type"]);
+  assert.ok(password);
+  await backend.type(
+    "research",
+    opened.tabId,
+    inspected.observationId,
+    password.targetId,
+    "ordinary argument",
+    false,
+  );
+  assert.equal(runner.calls.filter((args) => args.includes("fill")).length, 1);
+  const refreshed = await backend.inspect("research", opened.tabId);
   assert.equal(
     inspected.targets.some(({ name }) => name === "Hidden"),
     false,
   );
-  const button = inspected.targets.find(({ name }) => name === "Run");
+  const button = refreshed.targets.find(({ name }) => name === "Run");
   assert.ok(button);
   runner.changeIdentity = true;
   await assert.rejects(
     backend.click(
       "research",
       opened.tabId,
-      inspected.observationId,
+      refreshed.observationId,
       button.targetId,
     ),
     /identity, security, visibility, or actions changed/u,

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -8,7 +8,78 @@ import type {
 import {
   probePeekabooCli,
   probePlaywrightCli,
+  selectBrowserProvider,
 } from "../src/main/capabilities/provider-catalog.js";
+import {
+  BrowserZenXCapabilityPackage,
+  type ZenXBrowserBackend,
+} from "../src/main/capabilities/browser-provider.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
+
+test("requested user-session mode never falls back to an isolated provider", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "user-session" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.providerId, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.status, "unavailable");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
+  assert.match(selection.diagnostics[0]?.reason ?? "", /CDP_ENDPOINT/u);
+  assert.equal(
+    selection.diagnostics.some((entry) => entry.status === "fallback"),
+    false,
+  );
+});
+
+test("selected user-session provider is registered but hidden until explicitly granted", async () => {
+  const backend = stubBrowserBackend();
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: {
+      ZENX_BROWSER_MODE: "user-session",
+      ZENX_USER_BROWSER_CDP_ENDPOINT: "http://127.0.0.1:9222",
+    },
+    platform: "win32",
+    userBrowserConnector: async () => ({
+      backend,
+      product: "Chrome/140.0.1.2",
+    }),
+  });
+  assert.equal(selection.backend, backend);
+  assert.equal(selection.manifest.provider.id, "user-browser-cdp");
+  assert.equal(selection.diagnostics[0]?.sessionMode, "user-session");
+
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+    { platform: "win32" },
+  );
+  await registry.initialize();
+  assert.ok(selection.backend);
+  registry.register(
+    new BrowserZenXCapabilityPackage(selection.backend, selection.manifest),
+  );
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  await registry.grant("browser");
+  assert.ok(
+    registry
+      .hostSnapshot()
+      .definitions.some(({ name }) => name === "browser_list_tabs"),
+  );
+  await registry.close();
+});
+
+test("invalid browser modes are explicit instead of masquerading as isolated", async () => {
+  const selection = await selectBrowserProvider({
+    userDataDirectory: "/tmp/zenx",
+    environment: { ZENX_BROWSER_MODE: "surprise" },
+    platform: "win32",
+  });
+  assert.equal(selection.backend, undefined);
+  assert.equal(selection.diagnostics[0]?.sessionMode, "invalid");
+});
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {
   const runner = new ScriptedRunner([
@@ -152,4 +223,32 @@ class ScriptedRunner implements ExternalProviderProcessRunner {
   assertComplete(): void {
     assert.equal(this.#steps.length, 0);
   }
+}
+
+function stubBrowserBackend(): ZenXBrowserBackend {
+  return {
+    async listTabs() {
+      return [];
+    },
+    async open() {
+      throw new Error("not used");
+    },
+    async navigate() {
+      throw new Error("not used");
+    },
+    async inspect() {
+      throw new Error("not used");
+    },
+    async click() {
+      throw new Error("not used");
+    },
+    async type() {
+      throw new Error("not used");
+    },
+    closeTab() {},
+    closeSession() {
+      return 0;
+    },
+    close() {},
+  };
 }

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -55,6 +55,24 @@ test("CDP lifecycle contract invalidates history, reload, activation, and top-fr
   );
 });
 
+test("attached document acquisition enables Runtime before reading the frame tree", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const methods = cdp.methods();
+    assert.ok(
+      methods.indexOf("Runtime.enable") > methods.indexOf("Page.enable"),
+    );
+    assert.ok(
+      methods.indexOf("Runtime.enable") < methods.indexOf("Page.getFrameTree"),
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
 test("user browser mode inherits visible authenticated state without exposing session material", async () => {
   const client = new FakeUserBrowserClient();
   const backend = new UserBrowserCdpBackend(client);
@@ -1183,21 +1201,22 @@ test("attach timeout remains owned and makes session and backend close honest", 
   }
 });
 
-test("known attach and Page.enable failures remain retryable without taint", async () => {
-  for (const failure of ["attach", "enable"] as const) {
+test("known attach Page.enable and Runtime.enable failures remain retryable without taint", async () => {
+  for (const failure of ["attach", "page-enable", "runtime-enable"] as const) {
     const cdp = await createFakeCdpServer();
     try {
       const connection = await connectUserBrowserCdp(cdp.endpoint);
       await connection.backend.listTabs("work");
       if (failure === "attach") cdp.failNextAttachReply();
-      else cdp.failNextEnableReply();
+      else if (failure === "page-enable") cdp.failNextEnableReply();
+      else cdp.failNextRuntimeEnableReply();
       await assert.rejects(
         connection.backend.inspect("work", "target-1"),
         /command failed/u,
       );
       assert.equal(
         cdp.count("Target.detachFromTarget"),
-        failure === "enable" ? 1 : 0,
+        failure === "attach" ? 0 : 1,
       );
       await connection.backend.inspect("work", "target-1");
       assert.equal(await connection.backend.closeSession("work"), 1);
@@ -1417,6 +1436,27 @@ test("Page.enable timeout compensates detach and failed compensation taints clos
     } finally {
       await cdp.close();
     }
+  }
+});
+
+test("Runtime.enable timeout is attachment-owned and dispatches no page code", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.dropNextRuntimeEnableReply();
+    await assert.rejects(
+      connection.backend.inspect("work", "target-1"),
+      /Runtime.enable outcome is unknown|document changed/u,
+    );
+    assert.equal(cdp.count("Runtime.evaluate"), 0);
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
   }
 });
 
@@ -1656,20 +1696,21 @@ test("vanished target detach uncertainty transfers through list cleanup", async 
 });
 
 test("known attach or setup failure before navigate does not poison cleanup", async () => {
-  for (const failure of ["attach", "enable"] as const) {
+  for (const failure of ["attach", "page-enable", "runtime-enable"] as const) {
     const cdp = await createFakeCdpServer();
     try {
       const connection = await connectUserBrowserCdp(cdp.endpoint);
       await connection.backend.listTabs("work");
       if (failure === "attach") cdp.failNextAttachReply();
-      else cdp.failNextEnableReply();
+      else if (failure === "page-enable") cdp.failNextEnableReply();
+      else cdp.failNextRuntimeEnableReply();
       await assert.rejects(
         connection.backend.navigate(
           "work",
           "target-1",
           "https://example.test/known-failure",
         ),
-        /known attach failure|known enable failure|command failed/u,
+        /known attach failure|known enable failure|known Runtime.enable failure|command failed/u,
       );
       assert.equal(cdp.count("Page.navigate"), 0);
       assert.equal(await connection.backend.closeSession("work"), 1);
@@ -1681,7 +1722,7 @@ test("known attach or setup failure before navigate does not poison cleanup", as
 });
 
 test("known reattach or setup failure before action does not poison cleanup", async () => {
-  for (const failure of ["attach", "enable"] as const) {
+  for (const failure of ["attach", "page-enable", "runtime-enable"] as const) {
     const cdp = await createFakeCdpServer();
     try {
       const connection = await connectUserBrowserCdp(cdp.endpoint);
@@ -1695,7 +1736,8 @@ test("known reattach or setup failure before action does not poison cleanup", as
       // the same ordered CDP connection before exercising the reattach path.
       await connection.backend.listTabs("work");
       if (failure === "attach") cdp.failNextAttachReply();
-      else cdp.failNextEnableReply();
+      else if (failure === "page-enable") cdp.failNextEnableReply();
+      else cdp.failNextRuntimeEnableReply();
       await assert.rejects(
         connection.backend.click(
           "work",
@@ -1703,7 +1745,7 @@ test("known reattach or setup failure before action does not poison cleanup", as
           inspection.observationId,
           target.targetId,
         ),
-        /known attach failure|known enable failure|command failed/u,
+        /known attach failure|known enable failure|known Runtime.enable failure|command failed/u,
       );
       assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore);
       assert.equal(await connection.backend.closeSession("work"), 1);
@@ -2830,6 +2872,7 @@ async function close(server: ReturnType<typeof createServer>): Promise<void> {
 async function createFakeCdpServer(): Promise<{
   endpoint: string;
   count(method: string): number;
+  methods(): string[];
   requests(method: string): Record<string, unknown>[];
   invalidateActionAt(
     phase: "evaluate" | "confirmation",
@@ -2860,6 +2903,8 @@ async function createFakeCdpServer(): Promise<{
   confirmationResponseSent(): boolean;
   dropNextEnableReply(): void;
   failNextEnableReply(): void;
+  dropNextRuntimeEnableReply(): void;
+  failNextRuntimeEnableReply(): void;
   dropNextDetachReply(): void;
   dropDetachReplies(count: number): void;
   detachSession(): void;
@@ -2881,6 +2926,7 @@ async function createFakeCdpServer(): Promise<{
   const targets = new Map([["target-1", "https://example.test/account"]]);
   const sessionContexts = new Map<string, number>();
   const sessionTargets = new Map<string, string>();
+  const runtimeEnabledSessions = new Set<string>();
   const detachedSessionIds: string[] = [];
   let nextSession = 1;
   let latestSession = "";
@@ -2916,6 +2962,8 @@ async function createFakeCdpServer(): Promise<{
   const heldConfirmationStarted = deferred<void>();
   let dropEnableReply = false;
   let failEnableReply = false;
+  let dropRuntimeEnableReply = false;
+  let failRuntimeEnableReply = false;
   let dropDetachReplyCount = 0;
   let lateAttachReply:
     | {
@@ -3056,6 +3104,22 @@ async function createFakeCdpServer(): Promise<{
           dropEnableReply = false;
           return;
         }
+      } else if (request.method === "Runtime.enable") {
+        if (failRuntimeEnableReply) {
+          failRuntimeEnableReply = false;
+          socket.send(
+            JSON.stringify({
+              id: request.id,
+              error: { message: "known Runtime.enable failure" },
+            }),
+          );
+          return;
+        }
+        if (dropRuntimeEnableReply) {
+          dropRuntimeEnableReply = false;
+          return;
+        }
+        runtimeEnabledSessions.add(request.sessionId ?? "");
       } else if (request.method === "Page.getFrameTree") {
         result = {
           frameTree: {
@@ -3069,13 +3133,23 @@ async function createFakeCdpServer(): Promise<{
         if (setupInvalidation?.phase === "before-frame-tree-response") {
           const invalidation = setupInvalidation;
           setupInvalidation = undefined;
-          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+          emitSetupInvalidation(
+            socket,
+            request.sessionId,
+            invalidation.event,
+            runtimeEnabledSessions,
+          );
         }
         if (setupInvalidation?.phase === "after-frame-tree") {
           const invalidation = setupInvalidation;
           setupInvalidation = undefined;
           socket.send(JSON.stringify({ id: request.id, result }));
-          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+          emitSetupInvalidation(
+            socket,
+            request.sessionId,
+            invalidation.event,
+            runtimeEnabledSessions,
+          );
           return;
         }
       } else if (request.method === "Page.createIsolatedWorld") {
@@ -3090,7 +3164,12 @@ async function createFakeCdpServer(): Promise<{
           const invalidation = setupInvalidation;
           setupInvalidation = undefined;
           socket.send(JSON.stringify({ id: request.id, result }));
-          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+          emitSetupInvalidation(
+            socket,
+            request.sessionId,
+            invalidation.event,
+            runtimeEnabledSessions,
+          );
           return;
         }
       } else if (request.method === "Runtime.evaluate") {
@@ -3103,13 +3182,18 @@ async function createFakeCdpServer(): Promise<{
         ) {
           const invalidation = actionInvalidation;
           actionInvalidation = undefined;
-          socket.send(
-            JSON.stringify({
-              method: invalidation.event.method,
-              sessionId: request.sessionId,
-              params: invalidation.event.params,
-            }),
-          );
+          if (
+            !invalidation.event.method.startsWith("Runtime.") ||
+            runtimeEnabledSessions.has(request.sessionId ?? "")
+          ) {
+            socket.send(
+              JSON.stringify({
+                method: invalidation.event.method,
+                sessionId: request.sessionId,
+                params: invalidation.event.params,
+              }),
+            );
+          }
         }
         result = {
           result: {
@@ -3171,6 +3255,7 @@ async function createFakeCdpServer(): Promise<{
     endpoint,
     count: (method) =>
       methods.filter((candidate) => candidate === method).length,
+    methods: () => [...methods],
     requests: (method) =>
       requests
         .filter((candidate) => candidate.method === method)
@@ -3265,6 +3350,12 @@ async function createFakeCdpServer(): Promise<{
     failNextEnableReply: () => {
       failEnableReply = true;
     },
+    dropNextRuntimeEnableReply: () => {
+      dropRuntimeEnableReply = true;
+    },
+    failNextRuntimeEnableReply: () => {
+      failRuntimeEnableReply = true;
+    },
     dropNextDetachReply: () => {
       dropDetachReplyCount += 1;
     },
@@ -3346,6 +3437,7 @@ function emitSetupInvalidation(
   socket: WebSocket,
   sessionId: string | undefined,
   event: { method: string; params: Record<string, unknown> },
+  runtimeEnabledSessions: ReadonlySet<string>,
 ): void {
   if (event.method === "__disconnect") {
     socket.terminate();
@@ -3358,6 +3450,12 @@ function emitSetupInvalidation(
         params: { ...event.params, sessionId },
       }),
     );
+    return;
+  }
+  if (
+    event.method.startsWith("Runtime.") &&
+    !runtimeEnabledSessions.has(sessionId ?? "")
+  ) {
     return;
   }
   socket.send(JSON.stringify({ ...event, sessionId }));

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -260,6 +260,34 @@ test("outcome-unknown action survives closeSession cleanup and backend close", a
   assert.deepEqual(client.closedTargets, []);
 });
 
+test("outcome-unknown action retains the tab and session lease until late settlement", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  const settlement = deferred<void>();
+  client.actionUnknownSettlement = settlement.promise;
+
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /outcome is unknown/u,
+  );
+  const closing = backend.closeSession("work");
+  for (let turn = 0; turn < 16; turn += 1) await Promise.resolve();
+  assert.deepEqual(client.detachedTargets, []);
+
+  settlement.resolve();
+  await assert.rejects(closing, /outcome is unknown|tainted/u);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
 test("direct backend close reports action and navigation outcome-unknown taint", async () => {
   for (const mutation of ["action", "navigate"] as const) {
     const client = new FakeUserBrowserClient();
@@ -1759,6 +1787,177 @@ test("frameStartedNavigating during evaluate or confirmation makes action outcom
   }
 });
 
+test("matching execution-context invalidation after action dispatch remains outcome-unknown and tainted", async () => {
+  for (const event of [
+    {
+      method: "Runtime.executionContextDestroyed",
+      params: { executionContextId: 100 },
+    },
+    { method: "Runtime.executionContextsCleared", params: {} },
+    {
+      method: "Runtime.executionContextCreated",
+      params: {
+        context: {
+          id: 101,
+          name: "__zenx_user_browser_document__",
+          auxData: { frameId: "main", isDefault: false },
+        },
+      },
+    },
+  ]) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection = await connection.backend.inspect("work", "target-1");
+      const target = inspection.targets[0];
+      assert.ok(target);
+      const evaluationsBefore = cdp.count("Runtime.evaluate");
+      cdp.invalidateActionAt("evaluate", event);
+      await assert.rejects(
+        connection.backend.click(
+          "work",
+          "target-1",
+          inspection.observationId,
+          target.targetId,
+        ),
+        /outcome is unknown/u,
+        event.method,
+      );
+      assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore + 1);
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /tainted/u,
+      );
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("timed-out Runtime.evaluate retains detach until its late response settles", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    const inspection = await connection.backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    cdp.holdNextActionReply();
+    const action = connection.backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    );
+    await cdp.heldActionStarted();
+    await assert.rejects(action, /outcome is unknown/u);
+
+    const closing = Promise.resolve(connection.backend.closeSession("work"));
+    for (let turn = 0; turn < 16; turn += 1) await Promise.resolve();
+    assert.equal(cdp.count("Target.detachFromTarget"), 0);
+    cdp.releaseLateActionReply();
+    await assert.rejects(closing, /outcome is unknown|tainted/u);
+    assert.equal(cdp.actionResponseSent(), true);
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("timed-out post-confirmation retains detach until its late response settles", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    const inspection = await connection.backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    cdp.holdNextConfirmationReply();
+    const action = connection.backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    );
+    await cdp.heldConfirmationStarted();
+    await assert.rejects(action, /outcome is unknown/u);
+
+    const closing = Promise.resolve(connection.backend.closeSession("work"));
+    for (let turn = 0; turn < 16; turn += 1) await Promise.resolve();
+    assert.equal(cdp.count("Target.detachFromTarget"), 0);
+    cdp.releaseLateConfirmationReply();
+    await assert.rejects(closing, /outcome is unknown|tainted/u);
+    assert.equal(cdp.confirmationResponseSent(), true);
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("cancelled and invalidated dispatched action retains detach until late settlement", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    const inspection = await connection.backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    cdp.invalidateActionAt("evaluate");
+    cdp.holdNextActionReply();
+    const controller = new AbortController();
+    const action = connection.backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+      controller.signal,
+    );
+    await cdp.heldActionStarted();
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    await assert.rejects(action, /outcome is unknown/u);
+
+    const closing = Promise.resolve(connection.backend.closeSession("work"));
+    for (let turn = 0; turn < 16; turn += 1) await Promise.resolve();
+    assert.equal(cdp.count("Target.detachFromTarget"), 0);
+    cdp.releaseLateActionReply();
+    await assert.rejects(closing, /outcome is unknown|tainted/u);
+    assert.equal(cdp.actionResponseSent(), true);
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("missing late Runtime.evaluate settlement expires to explicit unknown without detach", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    const inspection = await connection.backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    cdp.holdNextActionReply();
+    const action = connection.backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    );
+    await cdp.heldActionStarted();
+    await assert.rejects(action, /outcome is unknown/u);
+
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /late settlement was not observed|outcome is unknown|tainted/u,
+    );
+    assert.equal(cdp.actionResponseSent(), false);
+    assert.equal(cdp.count("Target.detachFromTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
 test("document setup invalidation between frame tree and isolated world dispatches zero page code", async () => {
   for (const operation of ["inspect", "click", "type"] as const) {
     const cdp = await createFakeCdpServer();
@@ -1793,6 +1992,194 @@ test("document setup invalidation between frame tree and isolated world dispatch
               );
       await assert.rejects(pending, /document changed|invalidated/u, operation);
       assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore, operation);
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("main-frame loading before frame binding rejects inspect click and type without page code", async () => {
+  for (const operation of ["inspect", "click", "type"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection =
+        operation === "inspect"
+          ? undefined
+          : await connection.backend.inspect("work", "target-1");
+      const target = inspection?.targets[0];
+      if (operation !== "inspect") assert.ok(target);
+      const evaluationsBefore = cdp.count("Runtime.evaluate");
+      cdp.invalidateSetupAt("before-frame-tree-response", {
+        method: "Page.frameStartedLoading",
+        params: { frameId: "main" },
+      });
+      const pending =
+        operation === "inspect"
+          ? connection.backend.inspect("work", "target-1")
+          : operation === "click"
+            ? connection.backend.click(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+              )
+            : connection.backend.type(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+                "updated",
+                false,
+              );
+      await assert.rejects(pending, /document changed|invalidated/u, operation);
+      assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore, operation);
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("subframe loading before frame binding does not invalidate inspect click or type", async () => {
+  for (const operation of ["inspect", "click", "type"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection =
+        operation === "inspect"
+          ? undefined
+          : await connection.backend.inspect("work", "target-1");
+      const target = inspection?.targets[0];
+      if (operation !== "inspect") assert.ok(target);
+      cdp.invalidateSetupAt("before-frame-tree-response", {
+        method: "Page.frameStartedLoading",
+        params: { frameId: "child" },
+      });
+      if (operation === "inspect") {
+        const result = await connection.backend.inspect("work", "target-1");
+        assert.match(result.visibleText, /Signed in as Alice/u);
+      } else if (operation === "click") {
+        await connection.backend.click(
+          "work",
+          "target-1",
+          inspection!.observationId,
+          target!.targetId,
+        );
+      } else {
+        await connection.backend.type(
+          "work",
+          "target-1",
+          inspection!.observationId,
+          target!.targetId,
+          "updated",
+          false,
+        );
+      }
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("isolated execution-context invalidation rejects inspect click and type without page code", async () => {
+  const invalidations = [
+    {
+      name: "destroyed",
+      method: "Runtime.executionContextDestroyed",
+      params: { executionContextId: 100 },
+    },
+    {
+      name: "cleared",
+      method: "Runtime.executionContextsCleared",
+      params: {},
+    },
+    {
+      name: "replacement",
+      method: "Runtime.executionContextCreated",
+      params: {
+        context: {
+          id: 101,
+          name: "__zenx_user_browser_document__",
+          auxData: { frameId: "main", isDefault: false },
+        },
+      },
+    },
+  ];
+  for (const invalidation of invalidations) {
+    for (const operation of ["inspect", "click", "type"] as const) {
+      const cdp = await createFakeCdpServer();
+      try {
+        const connection = await connectUserBrowserCdp(cdp.endpoint);
+        await connection.backend.listTabs("work");
+        const inspection =
+          operation === "inspect"
+            ? undefined
+            : await connection.backend.inspect("work", "target-1");
+        const target = inspection?.targets[0];
+        if (operation !== "inspect") assert.ok(target);
+        const evaluationsBefore = cdp.count("Runtime.evaluate");
+        cdp.invalidateSetupAt("after-isolated-world", invalidation);
+        const pending =
+          operation === "inspect"
+            ? connection.backend.inspect("work", "target-1")
+            : operation === "click"
+              ? connection.backend.click(
+                  "work",
+                  "target-1",
+                  inspection!.observationId,
+                  target!.targetId,
+                )
+              : connection.backend.type(
+                  "work",
+                  "target-1",
+                  inspection!.observationId,
+                  target!.targetId,
+                  "updated",
+                  false,
+                );
+        await assert.rejects(
+          pending,
+          /document changed|invalidated|execution context/u,
+          `${invalidation.name}:${operation}`,
+        );
+        assert.equal(
+          cdp.count("Runtime.evaluate"),
+          evaluationsBefore,
+          `${invalidation.name}:${operation}`,
+        );
+      } finally {
+        await cdp.close();
+      }
+    }
+  }
+});
+
+test("unrelated subframe execution-context events do not invalidate the main fence", async () => {
+  for (const event of [
+    {
+      method: "Runtime.executionContextDestroyed",
+      params: { executionContextId: 999 },
+    },
+    {
+      method: "Runtime.executionContextCreated",
+      params: {
+        context: {
+          id: 101,
+          name: "__zenx_user_browser_document__",
+          auxData: { frameId: "child", isDefault: false },
+        },
+      },
+    },
+  ]) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      cdp.invalidateSetupAt("after-isolated-world", event);
+      const inspection = await connection.backend.inspect("work", "target-1");
+      assert.match(inspection.visibleText, /Signed in as Alice/u);
     } finally {
       await cdp.close();
     }
@@ -2015,6 +2402,30 @@ test("repeated setup invalidations retire their fences without unbounded live st
   }
 });
 
+test("repeated isolated-context invalidations remain bounded and recover", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    for (let index = 0; index < 64; index += 1) {
+      cdp.invalidateSetupAt("after-isolated-world", {
+        method: "Runtime.executionContextDestroyed",
+        params: { executionContextId: 100 },
+      });
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /document changed|invalidated|execution context/u,
+      );
+    }
+    assert.equal(cdp.count("Runtime.evaluate"), 0);
+    const inspection = await connection.backend.inspect("work", "target-1");
+    assert.match(inspection.visibleText, /Signed in as Alice/u);
+    assert.equal(cdp.count("Runtime.evaluate"), 2);
+  } finally {
+    await cdp.close();
+  }
+});
+
 test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
   const candidates = windowsBrowserExecutableCandidates({
     ProgramFiles: "C:\\Program Files",
@@ -2054,6 +2465,7 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   identityFailure?: Error;
   listFailureOnce?: Error;
   navigateFailureOnce?: Error;
+  actionUnknownSettlement?: Promise<void>;
   holdActions = false;
   holdNavigations = false;
   holdPostConfirmation = false;
@@ -2333,6 +2745,13 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     }
     onDispatched?.();
     this.actionCount += 1;
+    if (this.actionUnknownSettlement !== undefined) {
+      throw new UserBrowserMutationOutcomeUnknownError(
+        "Runtime.evaluate",
+        "response remains pending",
+        this.actionUnknownSettlement,
+      );
+    }
     if (this.identityChangePhase === "during-evaluate") {
       this.advanceDocument("during-evaluate");
     }
@@ -2412,9 +2831,15 @@ async function createFakeCdpServer(): Promise<{
   endpoint: string;
   count(method: string): number;
   requests(method: string): Record<string, unknown>[];
-  invalidateActionAt(phase: "evaluate" | "confirmation"): void;
+  invalidateActionAt(
+    phase: "evaluate" | "confirmation",
+    event?: { method: string; params: Record<string, unknown> },
+  ): void;
   invalidateSetupAt(
-    phase: "after-frame-tree" | "after-isolated-world",
+    phase:
+      | "before-frame-tree-response"
+      | "after-frame-tree"
+      | "after-isolated-world",
     event?: { method: string; params: Record<string, unknown> },
   ): void;
   loseNextCreateReply(): void;
@@ -2425,6 +2850,14 @@ async function createFakeCdpServer(): Promise<{
   releaseLateAttachReply(): void;
   holdNextAttachErrorReply(): void;
   releaseLateAttachErrorReply(): void;
+  holdNextActionReply(): void;
+  heldActionStarted(): Promise<void>;
+  releaseLateActionReply(): void;
+  actionResponseSent(): boolean;
+  holdNextConfirmationReply(): void;
+  heldConfirmationStarted(): Promise<void>;
+  releaseLateConfirmationReply(): void;
+  confirmationResponseSent(): boolean;
   dropNextEnableReply(): void;
   failNextEnableReply(): void;
   dropNextDetachReply(): void;
@@ -2454,10 +2887,18 @@ async function createFakeCdpServer(): Promise<{
   let nextContext = 100;
   let endpoint = "";
   let invalidateNextAttachment = false;
-  let invalidationPhase: "evaluate" | "confirmation" | undefined;
+  let actionInvalidation:
+    | {
+        phase: "evaluate" | "confirmation";
+        event: { method: string; params: Record<string, unknown> };
+      }
+    | undefined;
   let setupInvalidation:
     | {
-        phase: "after-frame-tree" | "after-isolated-world";
+        phase:
+          | "before-frame-tree-response"
+          | "after-frame-tree"
+          | "after-isolated-world";
         event: { method: string; params: Record<string, unknown> };
       }
     | undefined;
@@ -2467,6 +2908,12 @@ async function createFakeCdpServer(): Promise<{
   let failAttachReply = false;
   let holdAttachReply = false;
   let holdAttachErrorReply = false;
+  let holdActionReply = false;
+  let actionResponseSent = false;
+  const heldActionStarted = deferred<void>();
+  let holdConfirmationReply = false;
+  let confirmationResponseSent = false;
+  const heldConfirmationStarted = deferred<void>();
   let dropEnableReply = false;
   let failEnableReply = false;
   let dropDetachReplyCount = 0;
@@ -2478,6 +2925,10 @@ async function createFakeCdpServer(): Promise<{
           { result: { sessionId: string } } | { error: { message: string } };
       }
     | undefined;
+  let lateActionReply:
+    { socket: WebSocket; id: number; result: unknown } | undefined;
+  let lateConfirmationReply:
+    { socket: WebSocket; id: number; result: unknown } | undefined;
   const server = createServer((request, response) => {
     response.setHeader("content-type", "application/json");
     if (request.url === "/json/list") {
@@ -2615,6 +3066,11 @@ async function createFakeCdpServer(): Promise<{
             },
           },
         };
+        if (setupInvalidation?.phase === "before-frame-tree-response") {
+          const invalidation = setupInvalidation;
+          setupInvalidation = undefined;
+          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+        }
         if (setupInvalidation?.phase === "after-frame-tree") {
           const invalidation = setupInvalidation;
           setupInvalidation = undefined;
@@ -2642,19 +3098,16 @@ async function createFakeCdpServer(): Promise<{
         const isAction = expression.includes("const expected =");
         const isConfirmation = expression === "void 0";
         if (
-          (invalidationPhase === "evaluate" && isAction) ||
-          (invalidationPhase === "confirmation" && isConfirmation)
+          (actionInvalidation?.phase === "evaluate" && isAction) ||
+          (actionInvalidation?.phase === "confirmation" && isConfirmation)
         ) {
-          invalidationPhase = undefined;
+          const invalidation = actionInvalidation;
+          actionInvalidation = undefined;
           socket.send(
             JSON.stringify({
-              method: "Page.frameStartedNavigating",
+              method: invalidation.event.method,
               sessionId: request.sessionId,
-              params: {
-                frameId: "main",
-                url: "https://example.test/next",
-                navigationType: "reload",
-              },
+              params: invalidation.event.params,
             }),
           );
         }
@@ -2682,6 +3135,18 @@ async function createFakeCdpServer(): Promise<{
                 },
           },
         };
+        if (isAction && holdActionReply) {
+          holdActionReply = false;
+          lateActionReply = { socket, id: request.id, result };
+          heldActionStarted.resolve();
+          return;
+        }
+        if (isConfirmation && holdConfirmationReply) {
+          holdConfirmationReply = false;
+          lateConfirmationReply = { socket, id: request.id, result };
+          heldConfirmationStarted.resolve();
+          return;
+        }
       } else if (request.method === "Page.navigate") {
         const targetId = sessionTargets.get(request.sessionId ?? "");
         assert.ok(targetId);
@@ -2710,8 +3175,18 @@ async function createFakeCdpServer(): Promise<{
       requests
         .filter((candidate) => candidate.method === method)
         .map((candidate) => candidate.params),
-    invalidateActionAt: (phase) => {
-      invalidationPhase = phase;
+    invalidateActionAt: (phase, event) => {
+      actionInvalidation = {
+        phase,
+        event: event ?? {
+          method: "Page.frameStartedNavigating",
+          params: {
+            frameId: "main",
+            url: "https://example.test/next",
+            navigationType: "reload",
+          },
+        },
+      };
     },
     invalidateSetupAt: (phase, event) => {
       setupInvalidation = {
@@ -2758,6 +3233,32 @@ async function createFakeCdpServer(): Promise<{
         late.socket.send(JSON.stringify({ id: late.id, ...late.response }));
       }
     },
+    holdNextActionReply: () => {
+      holdActionReply = true;
+    },
+    heldActionStarted: async () => await heldActionStarted.promise,
+    releaseLateActionReply: () => {
+      const late = lateActionReply;
+      lateActionReply = undefined;
+      actionResponseSent = true;
+      if (late !== undefined && late.socket.readyState === late.socket.OPEN) {
+        late.socket.send(JSON.stringify({ id: late.id, result: late.result }));
+      }
+    },
+    actionResponseSent: () => actionResponseSent,
+    holdNextConfirmationReply: () => {
+      holdConfirmationReply = true;
+    },
+    heldConfirmationStarted: async () => await heldConfirmationStarted.promise,
+    releaseLateConfirmationReply: () => {
+      const late = lateConfirmationReply;
+      lateConfirmationReply = undefined;
+      confirmationResponseSent = true;
+      if (late !== undefined && late.socket.readyState === late.socket.OPEN) {
+        late.socket.send(JSON.stringify({ id: late.id, result: late.result }));
+      }
+    },
+    confirmationResponseSent: () => confirmationResponseSent,
     dropNextEnableReply: () => {
       dropEnableReply = true;
     },

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1838,6 +1838,11 @@ test("document setup invalidation after isolated world response dispatches zero 
       },
     },
     {
+      name: "main-frame-started-loading-after-bind",
+      method: "Page.frameStartedLoading",
+      params: { frameId: "main" },
+    },
+    {
       name: "main-frame-navigation",
       method: "Page.frameNavigated",
       params: {

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -1,0 +1,2858 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import test from "node:test";
+
+import { WebSocketServer, type WebSocket } from "ws";
+
+import {
+  connectUserBrowserCdp,
+  userBrowserDocumentEventInvalidates,
+  UserBrowserCdpBackend,
+  UserBrowserDocumentChangedAfterDispatchError,
+  UserBrowserDocumentChangedBeforeDispatchError,
+  UserBrowserMutationOutcomeUnknownError,
+  type UserBrowserCdpClient,
+  validateUserBrowserVersion,
+  windowsBrowserExecutableCandidates,
+} from "../src/main/capabilities/user-browser-provider.js";
+
+test("CDP lifecycle contract invalidates history, reload, activation, and top-frame navigation", () => {
+  for (const method of [
+    "Page.navigatedWithinDocument",
+    "Page.frameStartedNavigating",
+    "Page.frameStartedLoading",
+    "Page.backForwardCacheNotUsed",
+  ]) {
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "main" }, "main"),
+      true,
+      method,
+    );
+    assert.equal(
+      userBrowserDocumentEventInvalidates(method, { frameId: "child" }, "main"),
+      false,
+      `${method} subframe`,
+    );
+  }
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "main", loaderId: "loader", url: "https://example.test" },
+    }),
+    true,
+  );
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "child", parentId: "main" },
+    }),
+    false,
+  );
+  assert.equal(
+    userBrowserDocumentEventInvalidates("Page.frameNavigated", {
+      frame: { id: "main", url: "https://example.test" },
+      type: "BackForwardCacheRestore",
+    }),
+    true,
+  );
+});
+
+test("user browser mode inherits visible authenticated state without exposing session material", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+
+  const tabs = await backend.listTabs("work");
+  assert.deepEqual(tabs, [
+    {
+      sessionId: "work",
+      tabId: "target-1",
+      title: "Account",
+      url: "https://example.test/account",
+      loading: false,
+    },
+  ]);
+
+  const inspection = await backend.inspect("work", "target-1");
+  assert.match(inspection.visibleText, /Signed in as Alice/u);
+  assert.equal(inspection.targets[0]?.name, "Continue");
+  assert.doesNotMatch(
+    JSON.stringify({ tabs, inspection }),
+    /cookie|storageState|authorization|secret-cookie-value/iu,
+  );
+
+  const target = inspection.targets[0];
+  assert.ok(target);
+  await backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  assert.equal(client.actionCount, 1);
+  assert.equal(
+    client.calls.some((call) =>
+      /cookie|storage|authorization|network\./iu.test(call),
+    ),
+    false,
+  );
+});
+
+test("concurrent first listings publish one exclusive logical target owner", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  client.holdListings = true;
+
+  const listingA = backend.listTabs("A");
+  const listingB = backend.listTabs("B");
+  await waitUntil(
+    () =>
+      client.calls.filter((call) => call === "Target.getTargets").length === 2,
+  );
+  client.releaseList();
+  const [tabsA, tabsB] = await Promise.all([listingA, listingB]);
+  assert.equal(tabsA.length + tabsB.length, 1);
+
+  const winner = tabsA.length === 1 ? "A" : "B";
+  const loser = winner === "A" ? "B" : "A";
+  await backend.inspect(winner, "target-1");
+  await assert.rejects(
+    backend.inspect(loser, "target-1"),
+    /Unknown user browser tab/u,
+  );
+  assert.equal(await backend.closeSession(loser), 0);
+  assert.deepEqual(client.detachedTargets, []);
+  assert.equal(await backend.closeSession(winner), 1);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+  await backend.close();
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closing user browser capability only detaches and never closes user targets", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+
+  assert.equal(await backend.closeSession("work"), 1);
+  await backend.close();
+
+  assert.equal(client.closeCount, 1);
+  assert.equal(client.closedTargets.length, 0);
+});
+
+test("detaching a user tab keeps it open and out of the logical ZenX session", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  await backend.closeTab("work", "target-1");
+  assert.deepEqual(await backend.listTabs("work"), []);
+  assert.deepEqual(client.closedTargets, []);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("tab, session, and backend close coalesce a per-target detach lease", async () => {
+  for (const closer of ["session", "backend"] as const) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    client.holdDetaches = true;
+    const tabClose = backend.closeTab("work", "target-1");
+    await client.detachStarted;
+    const outerClose =
+      closer === "session" ? backend.closeSession("work") : backend.close();
+    await nextTurn();
+    assert.deepEqual(client.detachedTargets, ["target-1"], closer);
+    assert.equal(client.closeCount, 0, closer);
+    client.releaseDetach();
+    await tabClose;
+    await outerClose;
+    assert.deepEqual(client.closedTargets, []);
+  }
+});
+
+test("concurrent session and backend close share detach and wait through errors", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdDetaches = true;
+  client.detachFailure = new Error("detach failed");
+  const sessionClose = backend.closeSession("work");
+  await client.detachStarted;
+  const backendClose = backend.close();
+  await nextTurn();
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+  assert.equal(client.closeCount, 0);
+  client.releaseDetach();
+  await assert.rejects(sessionClose, /detach failed/u);
+  await assert.rejects(backendClose, /detach failed/u);
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closeTab detach failure is observed by a racing session close", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdDetaches = true;
+  client.detachFailure = new Error("detach failed");
+  const tabClose = backend.closeTab("work", "target-1");
+  await client.detachStarted;
+  const sessionClose = backend.closeSession("work");
+  client.releaseDetach();
+  await assert.rejects(tabClose, /detach failed/u);
+  await assert.rejects(sessionClose, /detach failed/u);
+  assert.deepEqual(client.detachedTargets, ["target-1", "target-1"]);
+});
+
+test("closeTab detach uncertainty taints every later session operation before ownership removal", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.detachFailure = new Error("detach outcome was lost");
+
+  await assert.rejects(
+    backend.closeTab("work", "target-1"),
+    /detach outcome was lost/u,
+  );
+
+  const laterOperations = [
+    () => backend.listTabs("work"),
+    () => backend.open("work", "https://example.test/new"),
+    () => backend.inspect("work", "target-1"),
+    () => backend.navigate("work", "target-1", "https://example.test/next"),
+    () => backend.click("work", "target-1", "observation", "target"),
+    () => backend.closeTab("work", "target-1"),
+  ];
+  for (const operation of laterOperations) {
+    await assert.rejects(operation, /outcome is unknown|tainted/u);
+  }
+  client.detachFailure = undefined;
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  assert.deepEqual(client.detachedTargets, ["target-1", "target-1"]);
+  await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+  assert.equal(client.closeCount, 1);
+});
+
+test("outcome-unknown action survives closeSession cleanup and backend close", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.identityChangePhase = "during-evaluate";
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /outcome is unknown/u,
+  );
+
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("direct backend close reports action and navigation outcome-unknown taint", async () => {
+  for (const mutation of ["action", "navigate"] as const) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    if (mutation === "action") {
+      const inspection = await backend.inspect("work", "target-1");
+      const target = inspection.targets[0];
+      assert.ok(target);
+      client.identityChangePhase = "during-evaluate";
+      await assert.rejects(
+        backend.click(
+          "work",
+          "target-1",
+          inspection.observationId,
+          target.targetId,
+        ),
+        /outcome is unknown/u,
+      );
+    } else {
+      client.navigateFailureOnce = new Error("navigate response was lost");
+      await assert.rejects(
+        backend.navigate("work", "target-1", "https://example.test/lost"),
+        /outcome is unknown/u,
+      );
+    }
+    await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+    assert.equal(client.closeCount, 1);
+  }
+});
+
+test("closeTab is a session-tail operation that fences every later request", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdDetaches = true;
+  const tabClose = backend.closeTab("work", "target-1");
+  await client.detachStarted;
+  let listSettled = false;
+  const listing = backend.listTabs("work").then(
+    (tabs) => {
+      listSettled = true;
+      return tabs;
+    },
+    (error: unknown) => {
+      listSettled = true;
+      throw error;
+    },
+  );
+  const opening = backend.open("work", "https://example.test/later");
+  await nextTurn();
+  assert.equal(listSettled, false);
+  assert.equal(client.calls.includes("Target.createTarget"), false);
+  client.releaseDetach();
+  await tabClose;
+  assert.deepEqual(await listing, []);
+  const opened = await opening;
+  assert.equal(opened.url, "https://example.test/later");
+});
+
+test("closeTab orders later action, session close, and backend close", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdDetaches = true;
+  const tabClose = backend.closeTab("work", "target-1");
+  await client.detachStarted;
+  const lateAction = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  const sessionClose = backend.closeSession("work");
+  const backendClose = backend.close();
+  await nextTurn();
+  assert.equal(client.actionCount, 0);
+  assert.equal(client.closeCount, 0);
+  client.releaseDetach();
+  await tabClose;
+  await assert.rejects(lateAction, /detaching|closed/u);
+  assert.equal(await sessionClose, 0);
+  await backendClose;
+  assert.equal(client.closeCount, 1);
+});
+
+test("lost createTarget reply is reconciled and retained for deterministic cleanup", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.rejectCreateAfterCreation = true;
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /recovered provider target target-2/u,
+  );
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("unreconciled create loss taints close while backend still disconnects", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.rejectCreateAfterCreation = true;
+  client.failCreateRecovery = true;
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /create outcome is unknown/u,
+  );
+  await assert.rejects(
+    backend.close(),
+    /outcome is unknown|backend is tainted/u,
+  );
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("open serializes list publication until the created target is navigated", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdNavigations = true;
+  const opening = backend.open("work", "https://example.test/new");
+  await client.navigationStarted;
+  let listed = false;
+  const listing = backend.listTabs("work").then((tabs) => {
+    listed = true;
+    return tabs;
+  });
+  await nextTurn();
+  assert.equal(listed, false);
+  client.releaseNavigation();
+  const opened = await opening;
+  assert.equal(opened.url, "https://example.test/new");
+  const tabs = await listing;
+  assert.ok(tabs.some((tab) => tab.tabId === opened.tabId));
+  await backend.closeTab("work", opened.tabId);
+});
+
+test("two opens in one session dispatch and publish in order", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  client.holdNavigations = true;
+  const first = backend.open("work", "https://example.test/first");
+  await client.navigationStarted;
+  const second = backend.open("work", "https://example.test/second");
+  await nextTurn();
+  assert.equal(
+    client.calls.filter((call) => call === "Target.createTarget").length,
+    1,
+  );
+  client.releaseNavigation();
+  const [firstTab, secondTab] = await Promise.all([first, second]);
+  assert.equal(firstTab.url, "https://example.test/first");
+  assert.equal(secondTab.url, "https://example.test/second");
+  assert.notEqual(firstTab.tabId, secondTab.tabId);
+  assert.deepEqual(
+    [...client.createdTargets.values()],
+    ["https://example.test/first", "https://example.test/second"],
+  );
+});
+
+test("a known read failure does not poison the operation tail", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  client.listFailureOnce = new Error("known list failure");
+  await assert.rejects(backend.listTabs("work"), /known list failure/u);
+  const tabs = await backend.listTabs("work");
+  assert.equal(tabs[0]?.tabId, "target-1");
+  assert.equal(await backend.closeSession("work"), 1);
+});
+
+test("marker-like user targets are never adopted across sessions", async () => {
+  const client = new FakeUserBrowserClient();
+  client.createdTargets.set(
+    "user-owned",
+    "about:blank#zenx-pending-user-owned",
+  );
+  const backend = new UserBrowserCdpBackend(client);
+  const tabs = await backend.listTabs("work");
+  assert.equal(
+    tabs.some((tab) => tab.tabId === "user-owned"),
+    false,
+  );
+  assert.equal(await backend.closeSession("work"), 1);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+});
+
+test("ambiguous duplicate create markers taint cleanup without adopting extras", async () => {
+  const client = new FakeUserBrowserClient();
+  client.duplicateCreatedMarker = true;
+  const backend = new UserBrowserCdpBackend(client);
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /marker reconciliation is ambiguous/u,
+  );
+  await assert.rejects(backend.closeSession("work"), /session is tainted/u);
+  assert.deepEqual(client.detachedTargets, ["target-2"]);
+  assert.equal(client.createdTargets.has("target-3"), true);
+});
+
+test("an exact create marker on a non-page target is ambiguous evidence", async () => {
+  const client = new FakeUserBrowserClient();
+  client.nonPageCreatedMarker = true;
+  const backend = new UserBrowserCdpBackend(client);
+  await assert.rejects(
+    backend.open("work", "https://example.test/new"),
+    /marker reconciliation is ambiguous/u,
+  );
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("session-owned ignored-target and taint evidence is explicitly bounded", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  for (let index = 0; index < 128; index += 1) {
+    const opened = await backend.open(
+      "work",
+      `https://example.test/bounded/${String(index)}`,
+    );
+    await backend.closeTab("work", opened.tabId);
+  }
+  const overflow = await backend.open(
+    "work",
+    "https://example.test/bounded/overflow",
+  );
+  await assert.rejects(
+    backend.closeTab("work", overflow.tabId),
+    /evidence exceeded its bound|tainted/u,
+  );
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closeSession fences a pending open and waits until its created target is accounted for", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const opened = backend.open("work", "https://example.test/new");
+  await client.createStarted;
+
+  let closed = false;
+  const closing = backend.closeSession("work").then((count) => {
+    closed = true;
+    return count;
+  });
+  const lateListing = backend.listTabs("work");
+  assert.equal(closed, false);
+  client.releaseCreate();
+  await opened;
+  assert.equal(await closing, 2);
+  await assert.rejects(lateListing, /session is detaching/u);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+});
+
+test("caller abort after createTarget dispatch does not orphan an untracked target", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const controller = new AbortController();
+  const opened = backend.open(
+    "work",
+    "https://example.test/new",
+    controller.signal,
+  );
+  await client.createStarted;
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  client.releaseCreate();
+  await assert.rejects(opened, /cancelled/u);
+  await client.createSettled;
+  await nextTurn();
+
+  assert.equal(await backend.closeSession("work"), 2);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("backend close fences pending open before disconnecting CDP", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.holdCreates = true;
+  const opened = backend.open("work", "https://example.test/new");
+  await client.createStarted;
+  let closed = false;
+  const closing = backend.close().then(() => {
+    closed = true;
+  });
+  assert.equal(closed, false);
+  client.releaseCreate();
+  await opened;
+  await closing;
+  assert.equal(client.closeCount, 1);
+  assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("closeSession fences pending list and inspection publication", async () => {
+  const listClient = new FakeUserBrowserClient();
+  const listBackend = new UserBrowserCdpBackend(listClient);
+  await listBackend.listTabs("work");
+  listClient.holdListings = true;
+  const listing = listBackend.listTabs("work");
+  await listClient.listStarted;
+  const listClose = listBackend.closeSession("work");
+  listClient.releaseList();
+  await listing;
+  assert.equal(await listClose, 1);
+
+  const inspectClient = new FakeUserBrowserClient();
+  const inspectBackend = new UserBrowserCdpBackend(inspectClient);
+  await inspectBackend.listTabs("work");
+  inspectClient.holdInspections = true;
+  const inspection = inspectBackend.inspect("work", "target-1");
+  await inspectClient.inspectionStarted;
+  const inspectClose = inspectBackend.closeSession("work");
+  inspectClient.releaseInspection();
+  await inspection;
+  assert.equal(await inspectClose, 1);
+});
+
+test("external navigation makes an attached-tab observation fail closed", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+
+  client.currentUrl = "https://example.test/other";
+  client.documentToken = "document-b";
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /document changed/u,
+  );
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|tainted/u,
+  );
+});
+
+test("listing after external navigation invalidates the old observation before dispatch", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.currentUrl = "https://example.test/other";
+  await backend.listTabs("work");
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|tainted/u,
+  );
+  assert.equal(client.actionCount, 0);
+});
+
+test("cancelled action is outcome-unknown and its observation cannot be retried", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.actionStarted;
+  controller.abort(new DOMException("cancelled", "AbortError"));
+  await assert.rejects(action, /outcome is unknown/u);
+  const queuedInspection = assert.rejects(
+    backend.inspect("work", "target-1"),
+    /tainted/u,
+  );
+  const queuedNavigation = assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /tainted/u,
+  );
+  await nextTurn();
+  assert.equal(client.actionCount, 1);
+  assert.equal(client.navigateCount, 0);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|tainted/u,
+  );
+  client.releaseAction();
+  await client.actionSettled;
+  await queuedInspection;
+  await queuedNavigation;
+});
+
+test("provider-owned lifecycle invalidates same-document history reload and activation observations", async () => {
+  for (const lifecycle of [
+    "pushState",
+    "replaceState-same-url",
+    "history-back-same-url-restoration",
+    "reload",
+    "bfcache-activation",
+    "main-frame-navigation",
+  ]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.advanceDocument(lifecycle);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /document changed/u,
+    );
+    assert.equal(client.actionCount, 0, lifecycle);
+  }
+});
+
+test("document identity changes during evaluate or post-confirmation are outcome-unknown", async () => {
+  for (const phase of ["during-evaluate", "post-confirmation"] as const) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.identityChangePhase = phase;
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      /outcome is unknown/u,
+      phase,
+    );
+    assert.equal(client.actionCount, 1, phase);
+    await assert.rejects(backend.inspect("work", "target-1"), /tainted/u);
+  }
+});
+
+test("inspection refuses publication when its execution document invalidates", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.invalidateInspection = true;
+  await assert.rejects(
+    backend.inspect("work", "target-1"),
+    /document changed during inspection/u,
+  );
+});
+
+test("target disappearance and disconnect are known before action dispatch", async () => {
+  for (const failure of ["target disappeared", "CDP disconnected"]) {
+    const client = new FakeUserBrowserClient();
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    client.identityFailure = new Error(failure);
+    await assert.rejects(
+      backend.click(
+        "work",
+        "target-1",
+        inspection.observationId,
+        target.targetId,
+      ),
+      new RegExp(failure, "u"),
+    );
+    assert.equal(client.actionCount, 0, failure);
+    assert.equal(await backend.closeSession("work"), 1);
+  }
+});
+
+test("post-confirmation cancellation retains the tab fence until confirmation settles", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdPostConfirmation = true;
+  const controller = new AbortController();
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+    controller.signal,
+  );
+  await client.postConfirmationStarted;
+  controller.abort();
+  await assert.rejects(action, /outcome is unknown/u);
+  const queuedInspection = assert.rejects(
+    backend.inspect("work", "target-1"),
+    /tainted/u,
+  );
+  const queuedNavigation = assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/retry"),
+    /tainted/u,
+  );
+  await nextTurn();
+  assert.equal(client.navigateCount, 0);
+  client.releasePostConfirmation();
+  await client.postConfirmationSettled;
+  await queuedInspection;
+  await queuedNavigation;
+  assert.equal(client.actionCount, 1);
+});
+
+test("navigate is exclusive and detach waits for an already dispatched action", async () => {
+  const navigationClient = new FakeUserBrowserClient();
+  const navigationBackend = new UserBrowserCdpBackend(navigationClient);
+  await navigationBackend.listTabs("work");
+  navigationClient.holdNavigations = true;
+  const firstNavigate = navigationBackend.navigate(
+    "work",
+    "target-1",
+    "https://example.test/next",
+  );
+  await navigationClient.navigationStarted;
+  const secondNavigate = navigationBackend.navigate(
+    "work",
+    "target-1",
+    "https://example.test/other",
+  );
+  assert.equal(navigationClient.navigateCount, 1);
+  navigationClient.releaseNavigation();
+  await firstNavigate;
+  await secondNavigate;
+  assert.equal(navigationClient.navigateCount, 2);
+
+  const actionClient = new FakeUserBrowserClient();
+  const actionBackend = new UserBrowserCdpBackend(actionClient);
+  await actionBackend.listTabs("work");
+  const inspection = await actionBackend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  actionClient.holdActions = true;
+  const action = actionBackend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await actionClient.actionStarted;
+  let detached = false;
+  const detach = actionBackend.closeSession("work").then((count) => {
+    detached = true;
+    return count;
+  });
+  const lateInspection = actionBackend.inspect("work", "target-1");
+  const lateOpen = actionBackend.open("work", "https://example.test/late");
+  assert.equal(detached, false);
+  assert.equal(actionClient.actionCount, 1);
+  assert.equal(actionClient.calls.includes("Target.createTarget"), false);
+  actionClient.releaseAction();
+  await action;
+  assert.equal(await detach, 1);
+  await assert.rejects(lateInspection, /session is detaching/u);
+  await assert.rejects(lateOpen, /session is detaching/u);
+  assert.equal(actionClient.actionCount, 1);
+  assert.deepEqual(actionClient.closedTargets, []);
+});
+
+test("closeTab fences the tab immediately and waits for its held mutation", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const action = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  let detached = false;
+  const closeTab = backend.closeTab("work", "target-1").then(() => {
+    detached = true;
+  });
+  const lateNavigation = backend.navigate(
+    "work",
+    "target-1",
+    "https://example.test/late",
+  );
+  assert.equal(detached, false);
+  assert.equal(client.navigateCount, 0);
+  client.releaseAction();
+  await action;
+  await closeTab;
+  await assert.rejects(lateNavigation, /detaching|closed/u);
+  assert.equal(client.actionCount, 1);
+  assert.deepEqual(client.closedTargets, []);
+});
+
+test("disconnect makes action outcome unknown and concurrent observation reuse dispatches once", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  const inspection = await backend.inspect("work", "target-1");
+  const target = inspection.targets[0];
+  assert.ok(target);
+  client.holdActions = true;
+  const first = backend.click(
+    "work",
+    "target-1",
+    inspection.observationId,
+    target.targetId,
+  );
+  await client.actionStarted;
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|already in flight/u,
+  );
+  client.rejectAction(new Error("CDP disconnected"));
+  await assert.rejects(first, /outcome is unknown/u);
+  assert.equal(client.actionCount, 1);
+  await assert.rejects(
+    backend.click(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+    ),
+    /stale or unknown|tainted/u,
+  );
+});
+
+test("password and autocomplete metadata do not block ordinary text dispatch", async () => {
+  for (const metadata of [
+    { type: "password", autocomplete: "" },
+    { type: "text", autocomplete: "current-password" },
+    { type: "text", autocomplete: "new-password" },
+    { type: "text", autocomplete: "one-time-code" },
+  ]) {
+    const client = new FakeUserBrowserClient();
+    client.inspectionTarget = {
+      ...client.inspectionTarget,
+      ...metadata,
+      secure: true,
+      actions: ["type"],
+    };
+    const backend = new UserBrowserCdpBackend(client);
+    await backend.listTabs("work");
+    const inspection = await backend.inspect("work", "target-1");
+    const target = inspection.targets[0];
+    assert.ok(target);
+    await backend.type(
+      "work",
+      "target-1",
+      inspection.observationId,
+      target.targetId,
+      "ordinary argument",
+      false,
+    );
+    assert.equal(client.actionCount, 1);
+  }
+});
+
+test("user browser contract accepts only supported Chrome Edge or Chromium products", () => {
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chrome/140.0.7339.1" }),
+    "Chrome/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Edg/140.0.7339.1" }),
+    "Edg/140.0.7339.1",
+  );
+  assert.equal(
+    validateUserBrowserVersion({ Browser: "Chromium/140.0.7339.1" }),
+    "Chromium/140.0.7339.1",
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Firefox/141.0" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+  assert.throws(
+    () => validateUserBrowserVersion({ Browser: "Chrome/99.0.1.2" }),
+    /supported Chrome, Edge, or Chromium/u,
+  );
+});
+
+test("user browser attachment rejects remote or credential-bearing CDP endpoints", async () => {
+  await assert.rejects(
+    connectUserBrowserCdp("https://example.test:9222"),
+    /unauthenticated loopback http/u,
+  );
+  await assert.rejects(
+    connectUserBrowserCdp("http://user:secret@127.0.0.1:9222"),
+    /unauthenticated loopback http/u,
+  );
+  await assert.rejects(
+    connectUserBrowserCdp("http://localhost:9222"),
+    /unauthenticated loopback http/u,
+  );
+});
+
+test("user browser attachment binds the WebSocket to the probed HTTP authority", async () => {
+  for (const mismatch of ["port", "host", "path"] as const) {
+    let endpoint = "";
+    let socketUrl = "";
+    const server = createServer((_request, response) => {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          Browser: "Chrome/140.0.1.2",
+          webSocketDebuggerUrl: socketUrl,
+        }),
+      );
+    });
+    const port = await listen(server);
+    endpoint = `http://127.0.0.1:${String(port)}`;
+    socketUrl =
+      mismatch === "port"
+        ? "ws://127.0.0.1:1/devtools/browser/id"
+        : mismatch === "host"
+          ? `ws://127.0.0.2:${String(port)}/devtools/browser/id`
+          : `ws://127.0.0.1:${String(port)}/not-a-browser-socket`;
+    await assert.rejects(
+      connectUserBrowserCdp(endpoint),
+      /same loopback authority/u,
+    );
+    await close(server);
+  }
+});
+
+test("user browser attachment rejects redirects and query-authenticated WebSockets", async () => {
+  const redirect = createServer((_request, response) => {
+    response.statusCode = 302;
+    response.setHeader("location", "http://127.0.0.1:1/json/version");
+    response.end();
+  });
+  const redirectPort = await listen(redirect);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(redirectPort)}`),
+    /fetch|redirect|failed/u,
+  );
+  await close(redirect);
+
+  let queryPort = 0;
+  const querySocket = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json");
+    response.end(
+      JSON.stringify({
+        Browser: "Chrome/140.0.1.2",
+        webSocketDebuggerUrl: `ws://127.0.0.1:${String(queryPort)}/devtools/browser/id?token=secret`,
+      }),
+    );
+  });
+  queryPort = await listen(querySocket);
+  await assert.rejects(
+    connectUserBrowserCdp(`http://127.0.0.1:${String(queryPort)}`),
+    /same loopback authority/u,
+  );
+  await close(querySocket);
+});
+
+test("CDP target attachments detach, reap, and reattach after destroy and reconnect", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const first = await connectUserBrowserCdp(cdp.endpoint);
+    assert.equal(cdp.count("Target.setDiscoverTargets"), 1);
+    await first.backend.listTabs("one");
+    await first.backend.inspect("one", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 1);
+
+    await first.backend.closeTab("one", "target-1");
+    assert.equal(cdp.count("Target.detachFromTarget"), 1);
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+
+    await first.backend.listTabs("two");
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 2);
+
+    cdp.detachSession();
+    await first.backend.listTabs("two");
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 3);
+
+    cdp.destroyTarget("target-1");
+    await first.backend.listTabs("two");
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 4);
+
+    cdp.invalidateNextAttachment();
+    cdp.detachSession();
+    await first.backend.listTabs("two");
+    await assert.rejects(
+      first.backend.inspect("two", "target-1"),
+      /detached during attachment/u,
+    );
+    await first.backend.inspect("two", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 6);
+
+    cdp.disconnect();
+    await nextTurn();
+    await assert.rejects(
+      first.backend.inspect("two", "target-1"),
+      /connection|unavailable|closed/u,
+    );
+
+    const second = await connectUserBrowserCdp(cdp.endpoint);
+    await second.backend.listTabs("three");
+    await second.backend.inspect("three", "target-1");
+    assert.equal(cdp.count("Target.attachToTarget"), 7);
+    await second.backend.closeSession("three");
+    assert.equal(cdp.count("Target.detachFromTarget"), 2);
+    await second.backend.close();
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("attach timeout remains owned and makes session and backend close honest", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.dropNextAttachReply();
+    await assert.rejects(
+      connection.backend.inspect("work", "target-1"),
+      /attachToTarget outcome is unknown|document changed/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("known attach and Page.enable failures remain retryable without taint", async () => {
+  for (const failure of ["attach", "enable"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      if (failure === "attach") cdp.failNextAttachReply();
+      else cdp.failNextEnableReply();
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /command failed/u,
+      );
+      assert.equal(
+        cdp.count("Target.detachFromTarget"),
+        failure === "enable" ? 1 : 0,
+      );
+      await connection.backend.inspect("work", "target-1");
+      assert.equal(await connection.backend.closeSession("work"), 1);
+      await connection.backend.close();
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("stale detachedFromTarget for s1 cannot reap successor s2", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const s1 = cdp.latestSessionId();
+    cdp.emitDetached(s1, "target-1");
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const s2 = cdp.latestSessionId();
+    assert.notEqual(s2, s1);
+
+    cdp.emitDetached(s1, "target-1");
+    await connection.backend.listTabs("work");
+    assert.equal(await connection.backend.closeSession("work"), 1);
+    assert.deepEqual(cdp.detachedSessionIds(), [s2]);
+    await connection.backend.close();
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("unknown detachedFromTarget cannot use deprecated targetId to reap current attachment", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const current = cdp.latestSessionId();
+    cdp.emitDetached("unknown-session", "target-1");
+    await connection.backend.listTabs("work");
+
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /lifecycle|outcome is unknown|tainted/u,
+    );
+    assert.deepEqual(cdp.detachedSessionIds(), [current]);
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("pending attach correlates a pre-response detach without leaking or reaping a successor", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.holdNextAttachReply();
+    const inspection = connection.backend.inspect("work", "target-1");
+    await waitUntil(() => cdp.count("Target.attachToTarget") === 1);
+    const pendingSession = cdp.latestSessionId();
+    cdp.emitDetached(pendingSession, "target-1");
+    cdp.releaseLateAttachReply();
+    await assert.rejects(inspection, /detached during attachment/u);
+
+    await connection.backend.inspect("work", "target-1");
+    const successor = cdp.latestSessionId();
+    assert.notEqual(successor, pendingSession);
+    assert.equal(await connection.backend.closeSession("work"), 1);
+    assert.deepEqual(cdp.detachedSessionIds(), [successor]);
+    await connection.backend.close();
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("repeated stale and unknown detach evidence stays bounded and preserves current ownership", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const s1 = cdp.latestSessionId();
+    cdp.emitDetached(s1, "target-1");
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    const s2 = cdp.latestSessionId();
+    for (let index = 0; index < 256; index += 1) {
+      cdp.emitDetached(s1, "target-1");
+      cdp.emitDetached("unknown-session", "target-1");
+    }
+    await connection.backend.listTabs("work");
+
+    const failure = await Promise.resolve(
+      connection.backend.closeSession("work"),
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    assert.ok(failure instanceof Error);
+    assert.match(failure.message, /lifecycle|outcome is unknown|tainted/u);
+    assert.ok(failure.message.length < 2_000, "diagnostics must stay bounded");
+    assert.deepEqual(cdp.detachedSessionIds(), [s2]);
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("late attach compensation preserves bounded historical unknown evidence", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.holdNextAttachReply();
+    await assert.rejects(
+      connection.backend.inspect("work", "target-1"),
+      /attachToTarget outcome is unknown|document changed/u,
+    );
+    cdp.releaseLateAttachReply();
+    await waitUntil(() => cdp.count("Target.detachFromTarget") === 1);
+    const lateSession = cdp.latestSessionId();
+    assert.deepEqual(cdp.detachedSessionIds(), [lateSession]);
+    const sessionFailure = await Promise.resolve(
+      connection.backend.closeSession("work"),
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    assert.ok(sessionFailure instanceof Error);
+    assert.match(sessionFailure.message, /outcome is unknown|tainted/u);
+    assert.ok(sessionFailure.message.length < 2_000);
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    assert.deepEqual(cdp.detachedSessionIds(), [lateSession]);
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+    assert.deepEqual(cdp.detachedSessionIds(), [lateSession]);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("late attach protocol error preserves bounded historical unknown evidence", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.holdNextAttachErrorReply();
+    await assert.rejects(
+      connection.backend.inspect("work", "target-1"),
+      /attachToTarget outcome is unknown|document changed/u,
+    );
+    cdp.releaseLateAttachErrorReply();
+    await nextTurn();
+    const sessionFailure = await Promise.resolve(
+      connection.backend.closeSession("work"),
+    ).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    assert.ok(sessionFailure instanceof Error);
+    assert.match(sessionFailure.message, /outcome is unknown|tainted/u);
+    assert.ok(sessionFailure.message.length < 2_000);
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+    assert.equal(cdp.count("Target.detachFromTarget"), 0);
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("Page.enable timeout compensates detach and failed compensation taints close", async () => {
+  for (const detachReply of ["reply", "drop-once"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      cdp.dropNextEnableReply();
+      if (detachReply === "drop-once") cdp.dropNextDetachReply();
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /Page.enable outcome is unknown|document changed/u,
+      );
+      assert.equal(cdp.count("Target.detachFromTarget"), 1);
+      await assert.rejects(
+        async () => await connection.backend.closeSession("work"),
+        /outcome is unknown|tainted/u,
+      );
+      assert.equal(
+        cdp.count("Target.detachFromTarget"),
+        detachReply === "drop-once" ? 2 : 1,
+      );
+      await assert.rejects(
+        async () => await connection.backend.close(),
+        /outcome is unknown|tainted/u,
+      );
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("wire target discovery rejects oversized collections without leaking state", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    cdp.addTargets(513);
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await assert.rejects(
+      connection.backend.listTabs("work"),
+      /target list exceeded its bound/u,
+    );
+    await connection.backend.closeSession("work");
+    await connection.backend.close();
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("CDP open creates a background non-focused target before navigating", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    const opened = await connection.backend.open(
+      "work",
+      "https://example.test/new",
+    );
+    assert.equal(opened.url, "https://example.test/new");
+    const create = cdp.requests("Target.createTarget")[0];
+    assert.equal(create?.background, true);
+    assert.equal(create?.focus, false);
+    assert.match(String(create?.url), /^about:blank#zenx-pending-/u);
+    assert.equal(cdp.requests("Page.navigate")[0]?.url, opened.url);
+    await connection.backend.closeSession("work");
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("CDP create reply loss reconciles the marker over HTTP after disconnect", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.loseNextCreateReply();
+    await assert.rejects(
+      connection.backend.open("work", "https://example.test/new"),
+      /recovered provider target target-2/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+    assert.equal(cdp.count("Target.closeTarget"), 0);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("healthy-socket create reply loss reaches a bounded reconciled close", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.dropNextCreateReply();
+    const controller = new AbortController();
+    const opening = connection.backend.open(
+      "work",
+      "https://example.test/new",
+      controller.signal,
+    );
+    await waitUntil(() => cdp.count("Target.createTarget") === 1);
+    controller.abort(new DOMException("cancelled", "AbortError"));
+    await assert.rejects(opening, /cancelled/u);
+    const started = Date.now();
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    assert.ok(
+      Date.now() - started < 5_000,
+      "close must have a bounded outcome",
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("attachment uncertainty survives target destroy and detach lifecycle reaping", async () => {
+  for (const lifecycle of [
+    "destroy",
+    "target-detach",
+    "inspector-detach",
+  ] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      cdp.dropNextAttachReply();
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /attachToTarget outcome is unknown|document changed/u,
+      );
+      if (lifecycle === "destroy") cdp.destroyTarget("target-1");
+      else if (lifecycle === "target-detach") cdp.detachSession();
+      else cdp.detachInspector();
+      await nextTurn();
+      await assert.rejects(
+        async () => await connection.backend.closeSession("work"),
+        /outcome is unknown|tainted/u,
+      );
+      await assert.rejects(
+        async () => await connection.backend.close(),
+        /outcome is unknown|tainted/u,
+      );
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("tainted mutation survives target disappearance and map cleanup", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  client.navigateFailureOnce = new Error("navigate outcome was lost");
+  await assert.rejects(
+    backend.navigate("work", "target-1", "https://example.test/lost"),
+    /outcome is unknown/u,
+  );
+  client.primaryTargetPresent = false;
+  await assert.rejects(backend.listTabs("work"), /outcome is unknown|tainted/u);
+  assert.deepEqual(client.detachedTargets, ["target-1"]);
+  await assert.rejects(
+    backend.closeSession("work"),
+    /outcome is unknown|tainted/u,
+  );
+  await assert.rejects(backend.close(), /outcome is unknown|tainted/u);
+});
+
+test("unknown detach mapping cannot be reused by a reopened logical session", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    cdp.dropNextDetachReply();
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      connection.backend.listTabs("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("connection loss after attach dispatch remains session-owned uncertainty", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.holdNextAttachReply();
+    const inspection = connection.backend.inspect("work", "target-1");
+    await waitUntil(() => cdp.count("Target.attachToTarget") === 1);
+    cdp.disconnect();
+    await assert.rejects(inspection, /connection|outcome is unknown/u);
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("post-attach connection loss taints closeSession before backend cleanup", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    cdp.disconnect();
+    await nextTurn();
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /connection|outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /connection|outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("vanished target detach uncertainty transfers through list cleanup", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    cdp.dropNextDetachReply();
+    cdp.removeTarget("target-1");
+    await assert.rejects(
+      connection.backend.listTabs("work"),
+      /detach|outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /detach|outcome is unknown|tainted/u,
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /detach|outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("known attach or setup failure before navigate does not poison cleanup", async () => {
+  for (const failure of ["attach", "enable"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      if (failure === "attach") cdp.failNextAttachReply();
+      else cdp.failNextEnableReply();
+      await assert.rejects(
+        connection.backend.navigate(
+          "work",
+          "target-1",
+          "https://example.test/known-failure",
+        ),
+        /known attach failure|known enable failure|command failed/u,
+      );
+      assert.equal(cdp.count("Page.navigate"), 0);
+      assert.equal(await connection.backend.closeSession("work"), 1);
+      await connection.backend.close();
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("known reattach or setup failure before action does not poison cleanup", async () => {
+  for (const failure of ["attach", "enable"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection = await connection.backend.inspect("work", "target-1");
+      const target = inspection.targets[0];
+      assert.ok(target);
+      const evaluationsBefore = cdp.count("Runtime.evaluate");
+      cdp.detachSession();
+      // Fence delivery of the preceding Target.detachedFromTarget notification on
+      // the same ordered CDP connection before exercising the reattach path.
+      await connection.backend.listTabs("work");
+      if (failure === "attach") cdp.failNextAttachReply();
+      else cdp.failNextEnableReply();
+      await assert.rejects(
+        connection.backend.click(
+          "work",
+          "target-1",
+          inspection.observationId,
+          target.targetId,
+        ),
+        /known attach failure|known enable failure|command failed/u,
+      );
+      assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore);
+      assert.equal(await connection.backend.closeSession("work"), 1);
+      await connection.backend.close();
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("logical user-browser session admission is explicitly bounded", async () => {
+  const client = new FakeUserBrowserClient();
+  const backend = new UserBrowserCdpBackend(client);
+  const sessionIds = Array.from(
+    { length: 32 },
+    (_, index) => `bounded-session-${String(index)}`,
+  );
+  for (const sessionId of sessionIds) await backend.listTabs(sessionId);
+  await assert.rejects(
+    backend.listTabs("bounded-session-overflow"),
+    /session.*bound|capacity/u,
+  );
+  for (const sessionId of sessionIds) await backend.closeSession(sessionId);
+  await backend.listTabs("bounded-session-after-close");
+  await backend.closeSession("bounded-session-after-close");
+  await backend.close();
+});
+
+test("healthy-socket detach reply loss terminates close with an explicit error", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    await connection.backend.inspect("work", "target-1");
+    cdp.dropNextDetachReply();
+    const started = Date.now();
+    await assert.rejects(
+      async () => await connection.backend.closeSession("work"),
+      /detachFromTarget outcome is unknown|detach outcome is unknown/u,
+    );
+    assert.ok(
+      Date.now() - started < 5_000,
+      "detach must have a bounded outcome",
+    );
+    await assert.rejects(
+      async () => await connection.backend.close(),
+      /backend close outcome is unknown|tainted/u,
+    );
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("frameStartedNavigating during evaluate or confirmation makes action outcome unknown", async () => {
+  for (const phase of ["evaluate", "confirmation"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection = await connection.backend.inspect("work", "target-1");
+      const target = inspection.targets[0];
+      assert.ok(target);
+      cdp.invalidateActionAt(phase);
+      await assert.rejects(
+        connection.backend.click(
+          "work",
+          "target-1",
+          inspection.observationId,
+          target.targetId,
+        ),
+        /outcome is unknown/u,
+        phase,
+      );
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /tainted/u,
+      );
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("document setup invalidation between frame tree and isolated world dispatches zero page code", async () => {
+  for (const operation of ["inspect", "click", "type"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection =
+        operation === "inspect"
+          ? undefined
+          : await connection.backend.inspect("work", "target-1");
+      const target = inspection?.targets[0];
+      if (operation !== "inspect") assert.ok(target);
+      const evaluationsBefore = cdp.count("Runtime.evaluate");
+      cdp.invalidateSetupAt("after-frame-tree");
+      const pending =
+        operation === "inspect"
+          ? connection.backend.inspect("work", "target-1")
+          : operation === "click"
+            ? connection.backend.click(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+              )
+            : connection.backend.type(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+                "updated",
+                false,
+              );
+      await assert.rejects(pending, /document changed|invalidated/u, operation);
+      assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore, operation);
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("document setup invalidation after isolated world response dispatches zero page code", async () => {
+  for (const lifecycle of [
+    {
+      name: "same-url-pushState",
+      method: "Page.navigatedWithinDocument",
+      params: {
+        frameId: "main",
+        url: "https://example.test/account",
+        navigationType: "historyApi",
+      },
+    },
+    {
+      name: "same-url-replaceState",
+      method: "Page.navigatedWithinDocument",
+      params: {
+        frameId: "main",
+        url: "https://example.test/account",
+        navigationType: "historyApi",
+      },
+    },
+    {
+      name: "same-url-back-restoration",
+      method: "Page.navigatedWithinDocument",
+      params: {
+        frameId: "main",
+        url: "https://example.test/account",
+        navigationType: "fragment",
+      },
+    },
+    {
+      name: "reload",
+      method: "Page.frameStartedNavigating",
+      params: {
+        frameId: "main",
+        url: "https://example.test/account",
+        navigationType: "reload",
+      },
+    },
+    {
+      name: "main-frame-navigation",
+      method: "Page.frameNavigated",
+      params: {
+        frame: {
+          id: "main",
+          loaderId: "loader-next",
+          url: "https://example.test/next",
+        },
+      },
+    },
+    {
+      name: "bfcache-restore",
+      method: "Page.frameNavigated",
+      params: {
+        frame: {
+          id: "main",
+          loaderId: "loader",
+          url: "https://example.test/account",
+        },
+        type: "BackForwardCacheRestore",
+      },
+    },
+  ]) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      cdp.invalidateSetupAt("after-isolated-world", lifecycle);
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /document changed|invalidated/u,
+        lifecycle.name,
+      );
+      assert.equal(cdp.count("Runtime.evaluate"), 0, lifecycle.name);
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("inspect click and type share the post-isolated-world dispatch fence", async () => {
+  for (const operation of ["inspect", "click", "type"] as const) {
+    const cdp = await createFakeCdpServer();
+    try {
+      const connection = await connectUserBrowserCdp(cdp.endpoint);
+      await connection.backend.listTabs("work");
+      const inspection =
+        operation === "inspect"
+          ? undefined
+          : await connection.backend.inspect("work", "target-1");
+      const target = inspection?.targets[0];
+      if (operation !== "inspect") assert.ok(target);
+      const evaluationsBefore = cdp.count("Runtime.evaluate");
+      cdp.invalidateSetupAt("after-isolated-world");
+      const pending =
+        operation === "inspect"
+          ? connection.backend.inspect("work", "target-1")
+          : operation === "click"
+            ? connection.backend.click(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+              )
+            : connection.backend.type(
+                "work",
+                "target-1",
+                inspection!.observationId,
+                target!.targetId,
+                "updated",
+                false,
+              );
+      await assert.rejects(pending, /document changed|invalidated/u, operation);
+      assert.equal(cdp.count("Runtime.evaluate"), evaluationsBefore, operation);
+    } finally {
+      await cdp.close();
+    }
+  }
+});
+
+test("detach destroy inspector detach and disconnect across setup reject before page code", async () => {
+  for (const event of [
+    {
+      method: "Target.detachedFromTarget",
+      params: {},
+      expected: /document changed|detached/u,
+    },
+    {
+      method: "Target.targetDestroyed",
+      params: { targetId: "target-1" },
+      expected: /document changed|disappeared/u,
+    },
+    {
+      method: "Inspector.detached",
+      params: { reason: "target_closed" },
+      expected: /document changed|detached/u,
+    },
+    {
+      method: "__disconnect",
+      params: {},
+      expected: /connection|closed|unavailable/u,
+    },
+  ]) {
+    for (const phase of ["after-frame-tree", "after-isolated-world"] as const) {
+      const cdp = await createFakeCdpServer();
+      try {
+        const connection = await connectUserBrowserCdp(cdp.endpoint);
+        await connection.backend.listTabs("work");
+        cdp.invalidateSetupAt(phase, event);
+        await assert.rejects(
+          connection.backend.inspect("work", "target-1"),
+          event.expected,
+          `${event.method}:${phase}`,
+        );
+        assert.equal(
+          cdp.count("Runtime.evaluate"),
+          0,
+          `${event.method}:${phase}`,
+        );
+      } finally {
+        await cdp.close();
+      }
+    }
+  }
+});
+
+test("subframe setup lifecycle does not invalidate the main document fence", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    cdp.invalidateSetupAt("after-frame-tree", {
+      method: "Page.frameStartedNavigating",
+      params: {
+        frameId: "child",
+        url: "https://example.test/frame",
+        navigationType: "differentDocument",
+      },
+    });
+    const inspection = await connection.backend.inspect("work", "target-1");
+    assert.match(inspection.visibleText, /Signed in as Alice/u);
+    assert.equal(cdp.count("Runtime.evaluate"), 2);
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("repeated setup invalidations retire their fences without unbounded live state", async () => {
+  const cdp = await createFakeCdpServer();
+  try {
+    const connection = await connectUserBrowserCdp(cdp.endpoint);
+    await connection.backend.listTabs("work");
+    for (let index = 0; index < 64; index += 1) {
+      cdp.invalidateSetupAt(
+        index % 2 === 0 ? "after-frame-tree" : "after-isolated-world",
+      );
+      await assert.rejects(
+        connection.backend.inspect("work", "target-1"),
+        /document changed|invalidated/u,
+      );
+    }
+    assert.equal(cdp.count("Runtime.evaluate"), 0);
+    const inspection = await connection.backend.inspect("work", "target-1");
+    assert.match(inspection.visibleText, /Signed in as Alice/u);
+    assert.equal(cdp.count("Runtime.evaluate"), 2);
+    await connection.backend.closeSession("work");
+    await connection.backend.close();
+  } finally {
+    await cdp.close();
+  }
+});
+
+test("Windows browser discovery covers machine and per-user Chrome Edge and Chromium", () => {
+  const candidates = windowsBrowserExecutableCandidates({
+    ProgramFiles: "C:\\Program Files",
+    "ProgramFiles(x86)": "C:\\Program Files (x86)",
+    LOCALAPPDATA: "C:\\Users\\me\\AppData\\Local",
+  });
+  assert.ok(
+    candidates.includes(
+      "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Microsoft\\Edge\\Application\\msedge.exe",
+    ),
+  );
+  assert.ok(
+    candidates.includes("C:\\Program Files\\Chromium\\Application\\chrome.exe"),
+  );
+  assert.ok(
+    candidates.includes(
+      "C:\\Users\\me\\AppData\\Local\\Chromium\\Application\\chrome.exe",
+    ),
+  );
+});
+
+class FakeUserBrowserClient implements UserBrowserCdpClient {
+  actionCount = 0;
+  navigateCount = 0;
+  closeCount = 0;
+  readonly closedTargets: string[] = [];
+  readonly detachedTargets: string[] = [];
+  readonly calls: string[] = [];
+  currentUrl = "https://example.test/account";
+  primaryTargetPresent = true;
+  documentToken = "document-a";
+  identityFailure?: Error;
+  listFailureOnce?: Error;
+  navigateFailureOnce?: Error;
+  holdActions = false;
+  holdNavigations = false;
+  holdPostConfirmation = false;
+  holdCreates = false;
+  holdListings = false;
+  holdInspections = false;
+  holdDetaches = false;
+  detachFailure?: Error;
+  rejectCreateAfterCreation = false;
+  failCreateRecovery = false;
+  duplicateCreatedMarker = false;
+  nonPageCreatedMarker = false;
+  createdUrl?: string;
+  readonly createdTargets = new Map<string, string>();
+  nextCreatedTarget = 2;
+  identityChangePhase?: "during-evaluate" | "post-confirmation";
+  invalidateInspection = false;
+  inspectionTarget = {
+    selector: "#continue",
+    tag: "button",
+    role: "button",
+    name: "Continue",
+    type: "",
+    id: "continue",
+    fieldName: "",
+    autocomplete: "",
+    href: "",
+    secure: false,
+    actions: ["click"] as Array<"click" | "type">,
+  };
+  readonly #actionStarted = deferred<void>();
+  #heldAction = deferred<void>();
+  readonly #actionSettled = deferred<void>();
+  readonly #navigationStarted = deferred<void>();
+  readonly #heldNavigation = deferred<void>();
+  readonly #postConfirmationStarted = deferred<void>();
+  readonly #heldPostConfirmation = deferred<void>();
+  readonly #postConfirmationSettled = deferred<void>();
+  readonly #createStarted = deferred<void>();
+  readonly #heldCreate = deferred<void>();
+  readonly #createSettled = deferred<void>();
+  readonly #listStarted = deferred<void>();
+  readonly #heldList = deferred<void>();
+  readonly #inspectionStarted = deferred<void>();
+  readonly #heldInspection = deferred<void>();
+  readonly #detachStarted = deferred<void>();
+  readonly #heldDetach = deferred<void>();
+
+  get actionStarted(): Promise<void> {
+    return this.#actionStarted.promise;
+  }
+
+  get actionSettled(): Promise<void> {
+    return this.#actionSettled.promise;
+  }
+
+  get navigationStarted(): Promise<void> {
+    return this.#navigationStarted.promise;
+  }
+
+  get postConfirmationStarted(): Promise<void> {
+    return this.#postConfirmationStarted.promise;
+  }
+
+  get postConfirmationSettled(): Promise<void> {
+    return this.#postConfirmationSettled.promise;
+  }
+
+  get createStarted(): Promise<void> {
+    return this.#createStarted.promise;
+  }
+
+  get createSettled(): Promise<void> {
+    return this.#createSettled.promise;
+  }
+
+  get listStarted(): Promise<void> {
+    return this.#listStarted.promise;
+  }
+
+  get inspectionStarted(): Promise<void> {
+    return this.#inspectionStarted.promise;
+  }
+
+  get detachStarted(): Promise<void> {
+    return this.#detachStarted.promise;
+  }
+
+  advanceDocument(reason: string): void {
+    this.documentToken = `${this.documentToken}:${reason}`;
+  }
+
+  releaseAction(): void {
+    this.#heldAction.resolve();
+  }
+
+  releaseNavigation(): void {
+    this.#heldNavigation.resolve();
+  }
+
+  releasePostConfirmation(): void {
+    this.#heldPostConfirmation.resolve();
+  }
+
+  releaseCreate(): void {
+    this.#heldCreate.resolve();
+  }
+
+  releaseList(): void {
+    this.#heldList.resolve();
+  }
+
+  releaseInspection(): void {
+    this.#heldInspection.resolve();
+  }
+
+  releaseDetach(): void {
+    this.#heldDetach.resolve();
+  }
+
+  rejectAction(error: Error): void {
+    this.#heldAction.reject(error);
+  }
+
+  async listTargets() {
+    this.calls.push("Target.getTargets");
+    if (this.listFailureOnce !== undefined) {
+      const error = this.listFailureOnce;
+      this.listFailureOnce = undefined;
+      throw error;
+    }
+    if (this.holdListings) {
+      this.#listStarted.resolve();
+      await this.#heldList.promise;
+      this.holdListings = false;
+    }
+    if (this.holdPostConfirmation && this.actionCount > 0) {
+      this.#postConfirmationStarted.resolve();
+      await this.#heldPostConfirmation.promise;
+      this.#postConfirmationSettled.resolve();
+      this.holdPostConfirmation = false;
+    }
+    return [
+      ...(this.primaryTargetPresent
+        ? [
+            {
+              targetId: "target-1",
+              type: "page",
+              title: "Account",
+              url: this.currentUrl,
+            },
+          ]
+        : []),
+      ...[...this.createdTargets].map(([targetId, url]) => ({
+        targetId,
+        type: "page",
+        title: "",
+        url,
+      })),
+    ];
+  }
+
+  async createTarget(url: string) {
+    this.calls.push("Target.createTarget");
+    this.createdUrl = url;
+    const targetId = `target-${String(this.nextCreatedTarget++)}`;
+    this.createdTargets.set(targetId, url);
+    if (this.duplicateCreatedMarker) {
+      const duplicateId = `target-${String(this.nextCreatedTarget++)}`;
+      this.createdTargets.set(duplicateId, url);
+    }
+    if (this.nonPageCreatedMarker) {
+      this.createdTargets.set("worker-marker", url);
+    }
+    if (this.holdCreates) {
+      this.#createStarted.resolve();
+      await this.#heldCreate.promise;
+      this.#createSettled.resolve();
+      this.holdCreates = false;
+    }
+    if (this.rejectCreateAfterCreation) throw new Error("CDP response lost");
+    return targetId;
+  }
+
+  async findTargetsByUrl(url: string) {
+    if (this.failCreateRecovery) return [];
+    return [...this.createdTargets]
+      .filter(([, targetUrl]) => targetUrl === url)
+      .map(([targetId]) => ({
+        targetId,
+        type: targetId === "worker-marker" ? "worker" : "page",
+        title: "",
+        url,
+      }));
+  }
+
+  async detachTarget(targetId: string) {
+    this.calls.push("Target.detachFromTarget");
+    this.detachedTargets.push(targetId);
+    if (this.holdDetaches) {
+      this.#detachStarted.resolve();
+      await this.#heldDetach.promise;
+    }
+    if (this.detachFailure !== undefined) throw this.detachFailure;
+  }
+
+  closureProblem(): string | undefined {
+    return undefined;
+  }
+
+  async navigate(
+    targetId: string,
+    url: string,
+    _owner: {
+      logicalSessionId: string;
+      logicalSessionIncarnation: number;
+    },
+    _signal?: AbortSignal,
+    onDispatched?: () => void,
+  ) {
+    onDispatched?.();
+    this.calls.push("Page.navigate");
+    this.navigateCount += 1;
+    if (this.holdNavigations) {
+      this.#navigationStarted.resolve();
+      await this.#heldNavigation.promise;
+    }
+    if (this.navigateFailureOnce !== undefined) {
+      const error = this.navigateFailureOnce;
+      this.navigateFailureOnce = undefined;
+      throw new UserBrowserMutationOutcomeUnknownError(
+        "Page.navigate",
+        error.message,
+      );
+    }
+    this.createdTargets.set(targetId, url);
+  }
+
+  async evaluateDocument(
+    _targetId: string,
+    expression: string,
+    _owner: {
+      logicalSessionId: string;
+      logicalSessionIncarnation: number;
+    },
+    expectedDocumentIdentity?: string,
+    _signal?: AbortSignal,
+    onDispatched?: () => void,
+  ): Promise<{ value: unknown; documentIdentity: string }> {
+    this.calls.push("Runtime.evaluate");
+    if (this.identityFailure !== undefined) throw this.identityFailure;
+    const before = this.documentToken;
+    if (
+      expectedDocumentIdentity !== undefined &&
+      before !== expectedDocumentIdentity
+    ) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    if (!expression.includes("const expected =")) {
+      if (this.holdInspections) {
+        this.#inspectionStarted.resolve();
+        await this.#heldInspection.promise;
+        this.holdInspections = false;
+      }
+      const result = {
+        value: {
+          visibleText: "Signed in as Alice",
+          targets: [this.inspectionTarget],
+        },
+        documentIdentity: this.documentToken,
+      };
+      if (this.invalidateInspection) {
+        this.advanceDocument("inspection-evaluate");
+        throw new UserBrowserDocumentChangedAfterDispatchError();
+      }
+      return result;
+    }
+    onDispatched?.();
+    this.actionCount += 1;
+    if (this.identityChangePhase === "during-evaluate") {
+      this.advanceDocument("during-evaluate");
+    }
+    if (this.holdActions) {
+      this.#actionStarted.resolve();
+      try {
+        await this.#heldAction.promise;
+      } catch (error) {
+        throw new UserBrowserMutationOutcomeUnknownError(
+          "Runtime.evaluate",
+          error instanceof Error ? error.message : String(error),
+        );
+      } finally {
+        this.#actionSettled.resolve();
+      }
+    }
+    const response = { ok: true };
+    if (this.identityChangePhase === "post-confirmation") {
+      queueMicrotask(() => this.advanceDocument("post-confirmation"));
+    }
+    await nextTurn();
+    if (this.documentToken !== before) {
+      throw new UserBrowserDocumentChangedAfterDispatchError();
+    }
+    return { value: response, documentIdentity: this.documentToken };
+  }
+
+  async close() {
+    this.closeCount += 1;
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function nextTurn(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("test condition timed out");
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function listen(
+  server: ReturnType<typeof createServer>,
+): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      const address = server.address();
+      if (address === null || typeof address === "string")
+        reject(new Error("test server did not bind"));
+      else resolve(address.port);
+    });
+  });
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error === undefined ? resolve() : reject(error))),
+  );
+}
+
+async function createFakeCdpServer(): Promise<{
+  endpoint: string;
+  count(method: string): number;
+  requests(method: string): Record<string, unknown>[];
+  invalidateActionAt(phase: "evaluate" | "confirmation"): void;
+  invalidateSetupAt(
+    phase: "after-frame-tree" | "after-isolated-world",
+    event?: { method: string; params: Record<string, unknown> },
+  ): void;
+  loseNextCreateReply(): void;
+  dropNextCreateReply(): void;
+  dropNextAttachReply(): void;
+  failNextAttachReply(): void;
+  holdNextAttachReply(): void;
+  releaseLateAttachReply(): void;
+  holdNextAttachErrorReply(): void;
+  releaseLateAttachErrorReply(): void;
+  dropNextEnableReply(): void;
+  failNextEnableReply(): void;
+  dropNextDetachReply(): void;
+  dropDetachReplies(count: number): void;
+  detachSession(): void;
+  emitDetached(sessionId: string, targetId?: string): void;
+  latestSessionId(): string;
+  detachedSessionIds(): string[];
+  detachInspector(): void;
+  invalidateNextAttachment(): void;
+  destroyTarget(targetId: string): void;
+  removeTarget(targetId: string): void;
+  addTargets(count: number): void;
+  disconnect(): void;
+  close(): Promise<void>;
+}> {
+  const sockets = new Set<WebSocket>();
+  const methods: string[] = [];
+  const requests: Array<{ method: string; params: Record<string, unknown> }> =
+    [];
+  const targets = new Map([["target-1", "https://example.test/account"]]);
+  const sessionContexts = new Map<string, number>();
+  const sessionTargets = new Map<string, string>();
+  const detachedSessionIds: string[] = [];
+  let nextSession = 1;
+  let latestSession = "";
+  let nextContext = 100;
+  let endpoint = "";
+  let invalidateNextAttachment = false;
+  let invalidationPhase: "evaluate" | "confirmation" | undefined;
+  let setupInvalidation:
+    | {
+        phase: "after-frame-tree" | "after-isolated-world";
+        event: { method: string; params: Record<string, unknown> };
+      }
+    | undefined;
+  let loseCreateReply = false;
+  let dropCreateReply = false;
+  let dropAttachReply = false;
+  let failAttachReply = false;
+  let holdAttachReply = false;
+  let holdAttachErrorReply = false;
+  let dropEnableReply = false;
+  let failEnableReply = false;
+  let dropDetachReplyCount = 0;
+  let lateAttachReply:
+    | {
+        socket: WebSocket;
+        id: number;
+        response:
+          { result: { sessionId: string } } | { error: { message: string } };
+      }
+    | undefined;
+  const server = createServer((request, response) => {
+    response.setHeader("content-type", "application/json");
+    if (request.url === "/json/list") {
+      response.end(
+        JSON.stringify(
+          [...targets].map(([id, url]) => ({
+            id,
+            type: "page",
+            title: "",
+            url,
+          })),
+        ),
+      );
+      return;
+    }
+    response.end(
+      JSON.stringify({
+        Browser: "Chrome/140.0.1.2",
+        webSocketDebuggerUrl:
+          endpoint.replace("http:", "ws:") + "/devtools/browser/id",
+      }),
+    );
+  });
+  const webSockets = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (request, socket, head) => {
+    webSockets.handleUpgrade(request, socket, head, (webSocket) => {
+      webSockets.emit("connection", webSocket, request);
+    });
+  });
+  webSockets.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("message", (raw) => {
+      const request = JSON.parse(raw.toString()) as {
+        id: number;
+        method: string;
+        params: Record<string, unknown>;
+        sessionId?: string;
+      };
+      methods.push(request.method);
+      requests.push({ method: request.method, params: request.params });
+      let result: unknown = {};
+      if (request.method === "Target.getTargets") {
+        result = {
+          targetInfos: [...targets].map(([targetId, url]) => ({
+            targetId,
+            type: "page",
+            title: targetId === "target-1" ? "Account" : "",
+            url,
+          })),
+        };
+      } else if (request.method === "Target.createTarget") {
+        const targetId = `target-${String(targets.size + 1)}`;
+        targets.set(targetId, String(request.params.url ?? "about:blank"));
+        if (loseCreateReply) {
+          loseCreateReply = false;
+          socket.terminate();
+          return;
+        }
+        if (dropCreateReply) {
+          dropCreateReply = false;
+          return;
+        }
+        result = { targetId };
+      } else if (request.method === "Target.attachToTarget") {
+        if (holdAttachErrorReply) {
+          holdAttachErrorReply = false;
+          lateAttachReply = {
+            socket,
+            id: request.id,
+            response: { error: { message: "known late attach failure" } },
+          };
+          return;
+        }
+        if (failAttachReply) {
+          failAttachReply = false;
+          socket.send(
+            JSON.stringify({
+              id: request.id,
+              error: { message: "known attach failure" },
+            }),
+          );
+          return;
+        }
+        latestSession = `session-${String(nextSession++)}`;
+        sessionTargets.set(
+          latestSession,
+          String(request.params.targetId ?? "target-1"),
+        );
+        if (invalidateNextAttachment) {
+          invalidateNextAttachment = false;
+          socket.send(
+            JSON.stringify({
+              method: "Target.detachedFromTarget",
+              params: { sessionId: latestSession, targetId: "target-1" },
+            }),
+          );
+        }
+        result = { sessionId: latestSession };
+        if (dropAttachReply) {
+          dropAttachReply = false;
+          return;
+        }
+        if (holdAttachReply) {
+          holdAttachReply = false;
+          lateAttachReply = {
+            socket,
+            id: request.id,
+            response: { result: { sessionId: latestSession } },
+          };
+          return;
+        }
+      } else if (request.method === "Page.enable") {
+        if (failEnableReply) {
+          failEnableReply = false;
+          socket.send(
+            JSON.stringify({
+              id: request.id,
+              error: { message: "known enable failure" },
+            }),
+          );
+          return;
+        }
+        if (dropEnableReply) {
+          dropEnableReply = false;
+          return;
+        }
+      } else if (request.method === "Page.getFrameTree") {
+        result = {
+          frameTree: {
+            frame: {
+              id: "main",
+              loaderId: "loader",
+              url: "https://example.test/account",
+            },
+          },
+        };
+        if (setupInvalidation?.phase === "after-frame-tree") {
+          const invalidation = setupInvalidation;
+          setupInvalidation = undefined;
+          socket.send(JSON.stringify({ id: request.id, result }));
+          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+          return;
+        }
+      } else if (request.method === "Page.createIsolatedWorld") {
+        const sessionId = request.sessionId ?? "";
+        let context = sessionContexts.get(sessionId);
+        if (context === undefined) {
+          context = nextContext++;
+          sessionContexts.set(sessionId, context);
+        }
+        result = { executionContextId: context };
+        if (setupInvalidation?.phase === "after-isolated-world") {
+          const invalidation = setupInvalidation;
+          setupInvalidation = undefined;
+          socket.send(JSON.stringify({ id: request.id, result }));
+          emitSetupInvalidation(socket, request.sessionId, invalidation.event);
+          return;
+        }
+      } else if (request.method === "Runtime.evaluate") {
+        const expression = String(request.params.expression ?? "");
+        const isAction = expression.includes("const expected =");
+        const isConfirmation = expression === "void 0";
+        if (
+          (invalidationPhase === "evaluate" && isAction) ||
+          (invalidationPhase === "confirmation" && isConfirmation)
+        ) {
+          invalidationPhase = undefined;
+          socket.send(
+            JSON.stringify({
+              method: "Page.frameStartedNavigating",
+              sessionId: request.sessionId,
+              params: {
+                frameId: "main",
+                url: "https://example.test/next",
+                navigationType: "reload",
+              },
+            }),
+          );
+        }
+        result = {
+          result: {
+            value: expression.includes("const expected =")
+              ? { ok: true }
+              : {
+                  visibleText: "Signed in as Alice",
+                  targets: [
+                    {
+                      selector: "#continue",
+                      tag: "input",
+                      role: "input",
+                      name: "Continue",
+                      type: "text",
+                      id: "continue",
+                      fieldName: "",
+                      autocomplete: "",
+                      href: "",
+                      secure: false,
+                      actions: ["click", "type"],
+                    },
+                  ],
+                },
+          },
+        };
+      } else if (request.method === "Page.navigate") {
+        const targetId = sessionTargets.get(request.sessionId ?? "");
+        assert.ok(targetId);
+        targets.set(targetId, String(request.params.url ?? "about:blank"));
+      } else if (
+        request.method === "Target.detachFromTarget" &&
+        dropDetachReplyCount > 0
+      ) {
+        dropDetachReplyCount -= 1;
+        return;
+      } else if (request.method === "Target.detachFromTarget") {
+        const sessionId = String(request.params.sessionId ?? "");
+        detachedSessionIds.push(sessionId);
+        sessionTargets.delete(sessionId);
+      }
+      socket.send(JSON.stringify({ id: request.id, result }));
+    });
+  });
+  const port = await listen(server);
+  endpoint = `http://127.0.0.1:${String(port)}`;
+  return {
+    endpoint,
+    count: (method) =>
+      methods.filter((candidate) => candidate === method).length,
+    requests: (method) =>
+      requests
+        .filter((candidate) => candidate.method === method)
+        .map((candidate) => candidate.params),
+    invalidateActionAt: (phase) => {
+      invalidationPhase = phase;
+    },
+    invalidateSetupAt: (phase, event) => {
+      setupInvalidation = {
+        phase,
+        event: event ?? {
+          method: "Page.frameStartedNavigating",
+          params: {
+            frameId: "main",
+            url: "https://example.test/next",
+            navigationType: "reload",
+          },
+        },
+      };
+    },
+    loseNextCreateReply: () => {
+      loseCreateReply = true;
+    },
+    dropNextCreateReply: () => {
+      dropCreateReply = true;
+    },
+    dropNextAttachReply: () => {
+      dropAttachReply = true;
+    },
+    failNextAttachReply: () => {
+      failAttachReply = true;
+    },
+    holdNextAttachReply: () => {
+      holdAttachReply = true;
+    },
+    releaseLateAttachReply: () => {
+      const late = lateAttachReply;
+      lateAttachReply = undefined;
+      if (late !== undefined && late.socket.readyState === late.socket.OPEN) {
+        late.socket.send(JSON.stringify({ id: late.id, ...late.response }));
+      }
+    },
+    holdNextAttachErrorReply: () => {
+      holdAttachErrorReply = true;
+    },
+    releaseLateAttachErrorReply: () => {
+      const late = lateAttachReply;
+      lateAttachReply = undefined;
+      if (late !== undefined && late.socket.readyState === late.socket.OPEN) {
+        late.socket.send(JSON.stringify({ id: late.id, ...late.response }));
+      }
+    },
+    dropNextEnableReply: () => {
+      dropEnableReply = true;
+    },
+    failNextEnableReply: () => {
+      failEnableReply = true;
+    },
+    dropNextDetachReply: () => {
+      dropDetachReplyCount += 1;
+    },
+    dropDetachReplies: (count) => {
+      dropDetachReplyCount += count;
+    },
+    detachSession: () => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.detachedFromTarget",
+            params: { sessionId: latestSession, targetId: "target-1" },
+          }),
+        );
+      }
+    },
+    emitDetached: (sessionId, targetId) => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.detachedFromTarget",
+            params: {
+              sessionId,
+              ...(targetId === undefined ? {} : { targetId }),
+            },
+          }),
+        );
+      }
+    },
+    latestSessionId: () => latestSession,
+    detachedSessionIds: () => [...detachedSessionIds],
+    detachInspector: () => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Inspector.detached",
+            sessionId: latestSession,
+            params: { reason: "target_closed" },
+          }),
+        );
+      }
+    },
+    invalidateNextAttachment: () => {
+      invalidateNextAttachment = true;
+    },
+    destroyTarget: (targetId) => {
+      for (const socket of sockets) {
+        socket.send(
+          JSON.stringify({
+            method: "Target.targetDestroyed",
+            params: { targetId },
+          }),
+        );
+      }
+    },
+    removeTarget: (targetId) => {
+      targets.delete(targetId);
+    },
+    addTargets: (count) => {
+      for (let index = targets.size; index < count; index += 1) {
+        targets.set(
+          `stress-${String(index)}`,
+          `https://example.test/stress/${String(index)}`,
+        );
+      }
+    },
+    disconnect: () => {
+      for (const socket of sockets) socket.terminate();
+    },
+    close: async () => {
+      for (const socket of sockets) socket.terminate();
+      await new Promise<void>((resolve) => webSockets.close(() => resolve()));
+      await close(server);
+    },
+  };
+}
+
+function emitSetupInvalidation(
+  socket: WebSocket,
+  sessionId: string | undefined,
+  event: { method: string; params: Record<string, unknown> },
+): void {
+  if (event.method === "__disconnect") {
+    socket.terminate();
+    return;
+  }
+  if (event.method === "Target.detachedFromTarget") {
+    socket.send(
+      JSON.stringify({
+        method: event.method,
+        params: { ...event.params, sessionId },
+      }),
+    );
+    return;
+  }
+  socket.send(JSON.stringify({ ...event, sessionId }));
+}


### PR DESCRIPTION
## Summary

- add the provider-owned transient `ZenXUserBrowserDocumentExecutionFence`
- bind exact target/attachment epoch/CDP session, logical owner/incarnation, main-frame identity, isolated context, document revision, and provider revision
- revalidate through ordered CDP setup barriers and synchronously immediately before each `Runtime.evaluate` send
- preserve post-dispatch outcome-unknown/taint/lease semantics and the accepted Issue #71 attachment, ownership, admission, marker, input, authority, and detach-only surfaces
- integrate attached user-browser mode, Windows smoke coverage, and deterministic regression tests

## Root cause

The historical #71 implementation sampled document revision before awaiting isolated-world creation and did not revalidate the complete provider-owned identity before `Runtime.evaluate`. A known main-frame invalidation during setup could therefore receive page code.

## Validation

- user-browser provider suite: 74/74 passed
- adjacent browser/provider suite: 16/16 passed
- #75 focused ordered-barrier suite: 6/6 passed
- real Windows attached user-browser smoke: passed locally, including inherited auth, background open, foreground preservation, and detach-only survival
- ZenX typecheck: passed
- ZenX production build: passed
- root lint: passed
- staged diff/format checks: passed
- full Windows local baselines retain only pre-existing clean-main failures involving POSIX `printf`, POSIX path expectations, Unix mode bits, and one Windows spawn fixture; all user-browser tests pass

Base: `28977c8f509441f9767b3b99bde0fc50a8dc9bc3`
Head: `e90ed25a3176fa97dd20111bb6338ae970af83e3`

Closes #75
