### PR TITLE
feat(zenx): converge Trigger and Room automation control

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -144,6 +144,9 @@
 - **ZenXTriggerProgramRunner** — ZenX 外层以一次性、有界的本地子进程执行 Trigger predicate/action，
   通过稳定 invocation id、显式 stdin/stdout JSON、cwd/env、超时、取消与平台化进程树终止把结果归约为
   Trigger 历史中的明确 outcome；它不是 sandbox、队列、重试器或第二个 Runtime。
+- **ZenXTransientProcessContainment** — ZenX 本地程序 runner 以 OS-specific process identity、
+  bounded termination 与反复 quiescence 证明约束瞬时子进程树；它不进入 durable state、scheduler 或 retry system，
+  无法证明 containment 时只产生明确失败。
 - **ZenXAutomationControlCapability** — ZenX capability registry 中由独立 read/write 权限保护的 Trigger
   与 Room 工具集合；工具只调用现有 Trigger/Room store 和 App Server port，不拥有 Agent、Thread、Turn
   或 transcript 语义。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,11 +142,14 @@
   与取消句柄绑定到一次可退休的进程内代数；迟到异步结果只能观察其创建代数，不能修改新代数或
   重新占用已释放的唤醒名额。
 - **ZenXTriggerProgramRunner** — ZenX 外层以一次性、有界的本地子进程执行 Trigger predicate/action，
-  通过稳定 invocation id、显式 stdin/stdout JSON、cwd/env、超时和取消把结果归约为 Trigger 历史中的
-  明确 outcome；它不是 sandbox、队列、重试器或第二个 Runtime。
+  通过稳定 invocation id、显式 stdin/stdout JSON、cwd/env、超时、取消与平台化进程树终止把结果归约为
+  Trigger 历史中的明确 outcome；它不是 sandbox、队列、重试器或第二个 Runtime。
 - **ZenXAutomationControlCapability** — ZenX capability registry 中由独立 read/write 权限保护的 Trigger
   与 Room 工具集合；工具只调用现有 Trigger/Room store 和 App Server port，不拥有 Agent、Thread、Turn
   或 transcript 语义。
+- **ZenXTriggerRoomRetention** — Trigger/Room canonical registry 在单次 mutation 中执行显式数量、字段与
+  UTF-8 字节上限；保留全部非 terminal wakeup，并只保留 bounded terminal audit 与 Room 消息，同时保留
+  admission-failure audit，确保 65th admission-failure 事实不会被同一 mutation 淘汰。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -138,6 +138,15 @@
   domain/root 健康后才可成功，不能返回一个其 `snapshot` 已不可用的 coordinator。
 - **ZenXThreadTitleNotificationObserver** — ZenX 主进程在 App Server canonical
   `userMessage` 完成通知处幂等补观察跨客户端首条输入，失败只记录 warning 且不影响 Turn。
+- **ZenXTriggerLifecycleGeneration** — Trigger 服务把定时器、瞬态完成证据、唤醒 admission
+  与取消句柄绑定到一次可退休的进程内代数；迟到异步结果只能观察其创建代数，不能修改新代数或
+  重新占用已释放的唤醒名额。
+- **ZenXTriggerProgramRunner** — ZenX 外层以一次性、有界的本地子进程执行 Trigger predicate/action，
+  通过稳定 invocation id、显式 stdin/stdout JSON、cwd/env、超时和取消把结果归约为 Trigger 历史中的
+  明确 outcome；它不是 sandbox、队列、重试器或第二个 Runtime。
+- **ZenXAutomationControlCapability** — ZenX capability registry 中由独立 read/write 权限保护的 Trigger
+  与 Room 工具集合；工具只调用现有 Trigger/Room store 和 App Server port，不拥有 Agent、Thread、Turn
+  或 transcript 语义。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
 （cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -28,9 +28,19 @@ simulator for local testing. A hit persists an auditable occurrence with a stabl
 client message ID, then starts a normal App Server Turn. Failures remain visible
 and are never silently retried.
 
-Agent-callable `trigger.create` / `trigger.cancel` tools and a production external
-signal ingress are not part of this slice. They remain follow-up ZenX-host
-features; neither should be added to Zen Core or the Codex-compatible protocol.
+The bundled `zenx-automation-control` capability exposes separately permissioned
+read and write tools for Trigger list/create/update/cancel/delete and Room
+list/create/rename/delete/member/post operations. It uses the same Trigger/Room
+store and the same ordinary App Server `turn/start` path; it adds no protocol
+methods, Core Items, queue, or transcript. A wakeup owns its original Room reply
+route, and Room deletion is rejected while that route is nonterminal. Admission
+is bounded to 64 nonterminal wakeups; the next wakeup produces one failed audit
+and no dispatch, while each terminal outcome releases one slot.
+
+Programmable Trigger predicates/actions are one-attempt local JSON programs with
+bounded input/output, explicit timeout/cancellation, cwd/env, regex matching,
+stable invocation IDs, and durable success/failure outcomes. A process restart
+marks uncertain in-flight work failed and does not retry it.
 
 A Room is shared transcription and routing, not an Agent Thread. Only an explicit
 member mention with a matching trigger delivers Room content to that member's

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -10,6 +10,27 @@ import type {
   ZenXRoom,
   ZenXTrigger,
 } from "../trigger-types.js";
+import {
+  MAX_ID_BYTES,
+  MAX_MEMBER_NAME_BYTES,
+  MAX_MESSAGE_TEXT_BYTES,
+  MAX_PROGRAM_ARGUMENT_BYTES,
+  MAX_PROGRAM_ARGUMENTS,
+  MAX_PROGRAM_COMMAND_BYTES,
+  MAX_PROGRAM_CWD_BYTES,
+  MAX_PROGRAM_ENV_BYTES,
+  MAX_PROGRAM_ENV_ENTRIES,
+  MAX_PROGRAM_ENV_KEY_BYTES,
+  MAX_PROGRAM_ENV_VALUE_BYTES,
+  MAX_PROGRAM_FLAGS_BYTES,
+  MAX_PROGRAM_MATCH_REGEX_BYTES,
+  MAX_ROOM_MEMBERS,
+  MAX_ROOM_NAME_BYTES,
+  MAX_TRIGGER_LABEL_BYTES,
+  MAX_TRIGGER_PROMPT_BYTES,
+  utf8Bytes,
+  withinBytes,
+} from "../trigger-limits.js";
 import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
 
 export const ZENX_AUTOMATION_CONTROL_CAPABILITY_ID = "zenx-automation-control";
@@ -33,10 +54,18 @@ export interface ZenXAutomationControlPort {
 const programSpecSchema = {
   type: "object",
   properties: {
-    command: { type: "string" },
-    args: { type: "array", items: { type: "string" }, maxItems: 64 },
-    cwd: { type: "string" },
-    env: { type: "object", additionalProperties: { type: "string" } },
+    command: { type: "string", maxLength: MAX_PROGRAM_COMMAND_BYTES },
+    args: {
+      type: "array",
+      items: { type: "string", maxLength: MAX_PROGRAM_ARGUMENT_BYTES },
+      maxItems: MAX_PROGRAM_ARGUMENTS,
+    },
+    cwd: { type: "string", maxLength: MAX_PROGRAM_CWD_BYTES },
+    env: {
+      type: "object",
+      maxProperties: MAX_PROGRAM_ENV_ENTRIES,
+      additionalProperties: { type: "string" },
+    },
     timeoutMs: { type: "number", minimum: 1, maximum: 120000 },
     maxOutputBytes: { type: "integer", minimum: 256, maximum: 1048576 },
   },
@@ -53,8 +82,8 @@ const programSchema = {
       type: "object",
       properties: {
         field: { type: "string", enum: ["completedItemText"] },
-        regex: { type: "string" },
-        flags: { type: "string" },
+        regex: { type: "string", maxLength: MAX_PROGRAM_MATCH_REGEX_BYTES },
+        flags: { type: "string", maxLength: MAX_PROGRAM_FLAGS_BYTES },
       },
       required: ["field", "regex"],
       additionalProperties: false,
@@ -64,16 +93,16 @@ const programSchema = {
 };
 
 const triggerProperties = {
-  threadId: { type: "string" },
+  threadId: { type: "string", maxLength: MAX_ID_BYTES },
   kind: { type: "string", enum: ["timer", "thread", "roomMention", "signal"] },
-  label: { type: "string" },
-  prompt: { type: "string" },
+  label: { type: "string", maxLength: MAX_TRIGGER_LABEL_BYTES },
+  prompt: { type: "string", maxLength: MAX_TRIGGER_PROMPT_BYTES },
   runAt: { type: "number" },
   intervalMinutes: { type: "number" },
-  watchedThreadId: { type: "string" },
-  roomId: { type: "string" },
-  mention: { type: "string" },
-  signalName: { type: "string" },
+  watchedThreadId: { type: "string", maxLength: MAX_ID_BYTES },
+  roomId: { type: "string", maxLength: MAX_ID_BYTES },
+  mention: { type: "string", maxLength: MAX_MEMBER_NAME_BYTES },
+  signalName: { type: "string", maxLength: MAX_ID_BYTES },
   program: programSchema,
 };
 
@@ -123,7 +152,7 @@ const manifest: ZenXCapabilityManifest = {
     tool(
       "zenx_triggers_update",
       "Replace an existing Trigger definition while preserving its identity and active state.",
-      { id: { type: "string" }, ...triggerProperties },
+      { id: { type: "string", maxLength: MAX_ID_BYTES }, ...triggerProperties },
       ["id", "threadId", "kind", "label", "prompt"],
     ),
     tool(
@@ -148,41 +177,53 @@ const manifest: ZenXCapabilityManifest = {
     tool(
       "zenx_rooms_create",
       "Create a Room with named Thread members.",
-      { name: { type: "string" }, members: membersSchema() },
+      {
+        name: { type: "string", maxLength: MAX_ROOM_NAME_BYTES },
+        members: membersSchema(),
+      },
       ["name", "members"],
     ),
     tool(
       "zenx_rooms_rename",
       "Rename an existing Room.",
-      { roomId: { type: "string" }, name: { type: "string" } },
+      {
+        roomId: { type: "string", maxLength: MAX_ID_BYTES },
+        name: { type: "string", maxLength: MAX_ROOM_NAME_BYTES },
+      },
       ["roomId", "name"],
     ),
     tool(
       "zenx_rooms_delete",
       "Delete a Room when no nonterminal wakeup owns its reply route.",
-      { roomId: { type: "string" } },
+      { roomId: { type: "string", maxLength: MAX_ID_BYTES } },
       ["roomId"],
     ),
     tool(
       "zenx_rooms_add_member",
       "Add a named Thread member to a Room.",
       {
-        roomId: { type: "string" },
-        name: { type: "string" },
-        threadId: { type: "string" },
+        roomId: { type: "string", maxLength: MAX_ID_BYTES },
+        name: { type: "string", maxLength: MAX_MEMBER_NAME_BYTES },
+        threadId: { type: "string", maxLength: MAX_ID_BYTES },
       },
       ["roomId", "name", "threadId"],
     ),
     tool(
       "zenx_rooms_remove_member",
       "Remove a Thread member from a Room.",
-      { roomId: { type: "string" }, threadId: { type: "string" } },
+      {
+        roomId: { type: "string", maxLength: MAX_ID_BYTES },
+        threadId: { type: "string", maxLength: MAX_ID_BYTES },
+      },
       ["roomId", "threadId"],
     ),
     tool(
       "zenx_rooms_post_message",
       "Post an Agent-attributed Room message; explicit mentions may wake registered members.",
-      { roomId: { type: "string" }, text: { type: "string" } },
+      {
+        roomId: { type: "string", maxLength: MAX_ID_BYTES },
+        text: { type: "string", maxLength: MAX_MESSAGE_TEXT_BYTES },
+      },
       ["roomId", "text"],
     ),
   ],
@@ -206,22 +247,22 @@ export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPac
       case "zenx_triggers_list": {
         const snapshot = this.#port.snapshot();
         return {
-          triggers: snapshot.triggers,
-          history: snapshot.history.slice(0, 50),
+          triggers: snapshot.triggers.map(readSafeTrigger),
+          history: snapshot.history.slice(0, 50).map(readSafeHistory),
         };
       }
       case "zenx_triggers_create":
         return await this.#port.create(triggerInput(args));
       case "zenx_triggers_update":
         return await this.#port.update({
-          id: string(args, "id"),
+          id: string(args, "id", MAX_ID_BYTES),
           ...triggerInput(args),
         });
       case "zenx_triggers_cancel":
-        await this.#port.cancel(string(args, "triggerId"));
+        await this.#port.cancel(string(args, "triggerId", MAX_ID_BYTES));
         return { cancelled: true };
       case "zenx_triggers_delete":
-        await this.#port.delete(string(args, "triggerId"));
+        await this.#port.delete(string(args, "triggerId", MAX_ID_BYTES));
         return { deleted: true };
       case "zenx_rooms_list":
         return {
@@ -232,40 +273,85 @@ export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPac
         };
       case "zenx_rooms_create":
         return await this.#port.createRoom({
-          name: string(args, "name"),
+          name: string(args, "name", MAX_ROOM_NAME_BYTES),
           members: members(args.members),
         });
       case "zenx_rooms_rename":
         await this.#port.renameRoom(
-          string(args, "roomId"),
-          string(args, "name"),
+          string(args, "roomId", MAX_ID_BYTES),
+          string(args, "name", MAX_ROOM_NAME_BYTES),
         );
         return { renamed: true };
       case "zenx_rooms_delete":
-        await this.#port.deleteRoom(string(args, "roomId"));
+        await this.#port.deleteRoom(string(args, "roomId", MAX_ID_BYTES));
         return { deleted: true };
       case "zenx_rooms_add_member":
-        await this.#port.addRoomMember(string(args, "roomId"), {
-          name: string(args, "name"),
-          threadId: string(args, "threadId"),
+        await this.#port.addRoomMember(string(args, "roomId", MAX_ID_BYTES), {
+          name: string(args, "name", MAX_MEMBER_NAME_BYTES),
+          threadId: string(args, "threadId", MAX_ID_BYTES),
         });
         return { added: true };
       case "zenx_rooms_remove_member":
         await this.#port.removeRoomMember(
-          string(args, "roomId"),
-          string(args, "threadId"),
+          string(args, "roomId", MAX_ID_BYTES),
+          string(args, "threadId", MAX_ID_BYTES),
         );
         return { removed: true };
       case "zenx_rooms_post_message":
         await this.#port.postAgentRoomMessage(
-          string(args, "roomId"),
-          string(args, "text"),
+          string(args, "roomId", MAX_ID_BYTES),
+          string(args, "text", MAX_MESSAGE_TEXT_BYTES),
         );
         return { posted: true };
       default:
         throw new Error(`Unsupported ZenX automation tool: ${name}`);
     }
   }
+}
+
+function readSafeTrigger(trigger: ZenXTrigger): unknown {
+  return {
+    ...trigger,
+    ...(trigger.program === undefined
+      ? {}
+      : { program: readSafeProgram(trigger.program) }),
+  };
+}
+
+function readSafeProgram(program: TriggerProgramConfig): TriggerProgramConfig {
+  return {
+    ...(program.predicate === undefined
+      ? {}
+      : { predicate: readSafeProgramSpec(program.predicate) }),
+    ...(program.action === undefined
+      ? {}
+      : { action: readSafeProgramSpec(program.action) }),
+    ...(program.match === undefined ? {} : { match: { ...program.match } }),
+  };
+}
+
+function readSafeProgramSpec(spec: TriggerProgramSpec): TriggerProgramSpec {
+  const safe = { ...spec };
+  delete safe.env;
+  return safe;
+}
+
+function readSafeHistory(entry: TriggerSnapshot["history"][number]): unknown {
+  return {
+    ...entry,
+    error: entry.programOutcome === null ? entry.error : null,
+    programOutcome:
+      entry.programOutcome === null
+        ? null
+        : readSafeOutcome(entry.programOutcome),
+    programOutcomes: entry.programOutcomes.map(readSafeOutcome),
+  };
+}
+
+function readSafeOutcome(
+  outcome: NonNullable<TriggerSnapshot["history"][number]["programOutcome"]>,
+) {
+  return { ...outcome, output: null, error: null };
 }
 
 function tool(
@@ -299,12 +385,12 @@ function tool(
 
 function triggerInput(args: Record<string, unknown>): CreateTriggerInput {
   const common = {
-    threadId: string(args, "threadId"),
-    label: string(args, "label"),
-    prompt: string(args, "prompt"),
+    threadId: string(args, "threadId", MAX_ID_BYTES),
+    label: string(args, "label", MAX_TRIGGER_LABEL_BYTES),
+    prompt: string(args, "prompt", MAX_TRIGGER_PROMPT_BYTES),
     ...programInput(args),
   };
-  const kind = string(args, "kind");
+  const kind = string(args, "kind", MAX_ID_BYTES);
   if (kind === "timer")
     return {
       ...common,
@@ -318,17 +404,21 @@ function triggerInput(args: Record<string, unknown>): CreateTriggerInput {
     return {
       ...common,
       kind,
-      watchedThreadId: string(args, "watchedThreadId"),
+      watchedThreadId: string(args, "watchedThreadId", MAX_ID_BYTES),
     };
   if (kind === "roomMention")
     return {
       ...common,
       kind,
-      roomId: string(args, "roomId"),
-      mention: string(args, "mention"),
+      roomId: string(args, "roomId", MAX_ID_BYTES),
+      mention: string(args, "mention", MAX_MEMBER_NAME_BYTES),
     };
   if (kind === "signal")
-    return { ...common, kind, signalName: string(args, "signalName") };
+    return {
+      ...common,
+      kind,
+      signalName: string(args, "signalName", MAX_ID_BYTES),
+    };
   throw new Error("kind must be timer, thread, roomMention, or signal");
 }
 
@@ -356,13 +446,15 @@ function programInput(args: Record<string, unknown>): {
     )
       throw new Error("match must be an object");
     const match = value.match as Record<string, unknown>;
-    const field = string(match, "field");
+    const field = string(match, "field", MAX_ID_BYTES);
     if (field !== "completedItemText")
       throw new Error("match field must be completedItemText");
     program.match = {
       field,
-      regex: string(match, "regex"),
-      ...(match.flags === undefined ? {} : { flags: string(match, "flags") }),
+      regex: string(match, "regex", MAX_PROGRAM_MATCH_REGEX_BYTES),
+      ...(match.flags === undefined
+        ? {}
+        : { flags: string(match, "flags", MAX_PROGRAM_FLAGS_BYTES) }),
     };
   }
   return { program };
@@ -379,9 +471,11 @@ function programSpec(value: unknown, label: string): TriggerProgramSpec {
   const env =
     spec.env === undefined ? undefined : environment(spec.env, `${label}.env`);
   return {
-    command: string(spec, "command"),
+    command: string(spec, "command", MAX_PROGRAM_COMMAND_BYTES),
     ...(args === undefined ? {} : { args }),
-    ...(spec.cwd === undefined ? {} : { cwd: string(spec, "cwd") }),
+    ...(spec.cwd === undefined
+      ? {}
+      : { cwd: string(spec, "cwd", MAX_PROGRAM_CWD_BYTES) }),
     ...(env === undefined ? {} : { env }),
     ...(spec.timeoutMs === undefined
       ? {}
@@ -394,13 +488,17 @@ function programSpec(value: unknown, label: string): TriggerProgramSpec {
 
 function members(value: unknown): RoomMember[] {
   if (!Array.isArray(value)) throw new Error("members must be an array");
+  if (value.length === 0 || value.length > MAX_ROOM_MEMBERS)
+    throw new Error(
+      `members must contain 1-${String(MAX_ROOM_MEMBERS)} entries`,
+    );
   return value.map((entry) => {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry))
       throw new Error("member must be an object");
     const member = entry as Record<string, unknown>;
     return {
-      name: string(member, "name"),
-      threadId: string(member, "threadId"),
+      name: string(member, "name", MAX_MEMBER_NAME_BYTES),
+      threadId: string(member, "threadId", MAX_ID_BYTES),
     };
   });
 }
@@ -408,9 +506,14 @@ function members(value: unknown): RoomMember[] {
 function membersSchema() {
   return {
     type: "array",
+    minItems: 1,
+    maxItems: MAX_ROOM_MEMBERS,
     items: {
       type: "object",
-      properties: { name: { type: "string" }, threadId: { type: "string" } },
+      properties: {
+        name: { type: "string", maxLength: MAX_MEMBER_NAME_BYTES },
+        threadId: { type: "string", maxLength: MAX_ID_BYTES },
+      },
       required: ["name", "threadId"],
       additionalProperties: false,
     },
@@ -421,23 +524,49 @@ function environment(value: unknown, label: string): Record<string, string> {
   if (typeof value !== "object" || value === null || Array.isArray(value))
     throw new Error(`${label} must be an object`);
   const result: Record<string, string> = {};
+  if (Object.keys(value as object).length > MAX_PROGRAM_ENV_ENTRIES)
+    throw new Error(`${label} has too many entries`);
+  let bytes = 0;
   for (const [key, entry] of Object.entries(value)) {
-    if (typeof entry !== "string")
+    if (
+      !withinBytes(key, MAX_PROGRAM_ENV_KEY_BYTES) ||
+      typeof entry !== "string" ||
+      !withinBytes(entry, MAX_PROGRAM_ENV_VALUE_BYTES)
+    )
       throw new Error(`${label}.${key} must be a string`);
+    bytes += utf8Bytes(key) + utf8Bytes(entry);
+    if (bytes > MAX_PROGRAM_ENV_BYTES)
+      throw new Error(`${label} exceeds its byte bound`);
     result[key] = entry;
   }
   return result;
 }
 
 function arrayOfStrings(value: unknown, label: string): string[] {
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_PROGRAM_ARGUMENTS ||
+    value.some(
+      (entry) =>
+        typeof entry !== "string" ||
+        !withinBytes(entry, MAX_PROGRAM_ARGUMENT_BYTES),
+    )
+  )
     throw new Error(`${label} must be an array of strings`);
   return value;
 }
 
-function string(args: Record<string, unknown>, key: string): string {
+function string(
+  args: Record<string, unknown>,
+  key: string,
+  maximum = MAX_ID_BYTES,
+): string {
   const value = args[key];
-  if (typeof value !== "string" || value.trim().length === 0)
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    !withinBytes(value.trim(), maximum)
+  )
     throw new Error(`${key} must be a non-empty string`);
   return value.trim();
 }

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -24,6 +24,7 @@ import {
   MAX_PROGRAM_ENV_VALUE_BYTES,
   MAX_PROGRAM_FLAGS_BYTES,
   MAX_PROGRAM_MATCH_REGEX_BYTES,
+  MAX_PROGRAM_TIMEOUT_MS,
   MAX_ROOM_MEMBERS,
   MAX_ROOM_NAME_BYTES,
   MAX_TRIGGER_LABEL_BYTES,
@@ -66,7 +67,7 @@ const programSpecSchema = {
       maxProperties: MAX_PROGRAM_ENV_ENTRIES,
       additionalProperties: { type: "string" },
     },
-    timeoutMs: { type: "number", minimum: 1, maximum: 120000 },
+    timeoutMs: { type: "number", minimum: 1, maximum: MAX_PROGRAM_TIMEOUT_MS },
     maxOutputBytes: { type: "integer", minimum: 256, maximum: 1048576 },
   },
   required: ["command"],
@@ -479,7 +480,14 @@ function programSpec(value: unknown, label: string): TriggerProgramSpec {
     ...(env === undefined ? {} : { env }),
     ...(spec.timeoutMs === undefined
       ? {}
-      : { timeoutMs: number(spec, "timeoutMs") }),
+      : {
+          timeoutMs: boundedNumber(
+            spec,
+            "timeoutMs",
+            1,
+            MAX_PROGRAM_TIMEOUT_MS,
+          ),
+        }),
     ...(spec.maxOutputBytes === undefined
       ? {}
       : { maxOutputBytes: integer(spec, "maxOutputBytes") }),
@@ -575,6 +583,20 @@ function number(args: Record<string, unknown>, key: string): number {
   const value = args[key];
   if (typeof value !== "number" || !Number.isFinite(value))
     throw new Error(`${key} must be a finite number`);
+  return value;
+}
+
+function boundedNumber(
+  args: Record<string, unknown>,
+  key: string,
+  minimum: number,
+  maximum: number,
+): number {
+  const value = number(args, key);
+  if (value < minimum || value > maximum)
+    throw new Error(
+      `${key} must be between ${String(minimum)} and ${String(maximum)}`,
+    );
   return value;
 }
 

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -267,10 +267,7 @@ export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPac
         return { deleted: true };
       case "zenx_rooms_list":
         return {
-          rooms: this.#port.snapshot().rooms.map((room) => ({
-            ...room,
-            messages: room.messages.slice(-50),
-          })),
+          rooms: this.#port.snapshot().rooms.map(readSafeRoom),
         };
       case "zenx_rooms_create":
         return await this.#port.createRoom({
@@ -311,11 +308,48 @@ export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPac
 }
 
 function readSafeTrigger(trigger: ZenXTrigger): unknown {
-  return {
-    ...trigger,
+  const common = {
+    id: trigger.id,
+    threadId: trigger.threadId,
+    label: trigger.label,
+    prompt: trigger.prompt,
+    createdAt: trigger.createdAt,
+    active: trigger.active,
     ...(trigger.program === undefined
       ? {}
       : { program: readSafeProgram(trigger.program) }),
+  };
+  if (trigger.kind === "timer")
+    return {
+      ...common,
+      kind: "timer",
+      timer: {
+        nextRunAt: trigger.timer?.nextRunAt,
+        intervalMinutes: trigger.timer?.intervalMinutes,
+      },
+    };
+  if (trigger.kind === "thread")
+    return {
+      ...common,
+      kind: "thread",
+      watch: {
+        threadId: trigger.watch?.threadId,
+        event: trigger.watch?.event,
+      },
+    };
+  if (trigger.kind === "roomMention")
+    return {
+      ...common,
+      kind: "roomMention",
+      room: {
+        roomId: trigger.room?.roomId,
+        mention: trigger.room?.mention,
+      },
+    };
+  return {
+    ...common,
+    kind: "signal",
+    signal: { name: trigger.signal?.name },
   };
 }
 
@@ -327,20 +361,53 @@ function readSafeProgram(program: TriggerProgramConfig): TriggerProgramConfig {
     ...(program.action === undefined
       ? {}
       : { action: readSafeProgramSpec(program.action) }),
-    ...(program.match === undefined ? {} : { match: { ...program.match } }),
+    ...(program.match === undefined
+      ? {}
+      : {
+          match: {
+            field: program.match.field,
+            regex: program.match.regex,
+            ...(program.match.flags === undefined
+              ? {}
+              : { flags: program.match.flags }),
+          },
+        }),
   };
 }
 
 function readSafeProgramSpec(spec: TriggerProgramSpec): TriggerProgramSpec {
-  const safe = { ...spec };
-  delete safe.env;
-  return safe;
+  return {
+    command: spec.command,
+    ...(spec.args === undefined ? {} : { args: [...spec.args] }),
+    ...(spec.cwd === undefined ? {} : { cwd: spec.cwd }),
+    ...(spec.timeoutMs === undefined ? {} : { timeoutMs: spec.timeoutMs }),
+    ...(spec.maxOutputBytes === undefined
+      ? {}
+      : { maxOutputBytes: spec.maxOutputBytes }),
+  };
 }
 
 function readSafeHistory(entry: TriggerSnapshot["history"][number]): unknown {
   return {
-    ...entry,
+    id: entry.id,
+    triggerId: entry.triggerId,
+    threadId: entry.threadId,
+    kind: entry.kind,
+    reason: entry.reason,
+    prompt: entry.prompt,
+    clientUserMessageId: entry.clientUserMessageId,
+    startedAt: entry.startedAt,
+    completedAt: entry.completedAt,
+    status: entry.status,
+    turnId: entry.turnId,
+    sourceThreadId: entry.sourceThreadId,
+    sourceTurnId: entry.sourceTurnId,
+    sourceRoomId: entry.sourceRoomId,
+    sourceRoomMessageId: entry.sourceRoomMessageId,
+    replyRoomId: entry.replyRoomId,
+    replyAuthor: entry.replyAuthor,
     error: entry.programOutcome === null ? entry.error : null,
+    programInvocationId: entry.programInvocationId,
     programOutcome:
       entry.programOutcome === null
         ? null
@@ -349,10 +416,39 @@ function readSafeHistory(entry: TriggerSnapshot["history"][number]): unknown {
   };
 }
 
+function readSafeRoom(room: ZenXRoom): unknown {
+  return {
+    id: room.id,
+    name: room.name,
+    createdAt: room.createdAt,
+    members: room.members.map((member) => ({
+      name: member.name,
+      threadId: member.threadId,
+    })),
+    messages: room.messages.slice(-50).map((message) => ({
+      id: message.id,
+      roomId: message.roomId,
+      author: message.author,
+      text: message.text,
+      createdAt: message.createdAt,
+      kind: message.kind,
+      originThreadId: message.originThreadId,
+      originTurnId: message.originTurnId,
+    })),
+  };
+}
+
 function readSafeOutcome(
   outcome: NonNullable<TriggerSnapshot["history"][number]["programOutcome"]>,
 ) {
-  return { ...outcome, output: null, error: null };
+  return {
+    stage: outcome.stage,
+    invocationId: outcome.invocationId,
+    status: outcome.status,
+    output: null,
+    exitCode: outcome.exitCode,
+    error: null,
+  };
 }
 
 function tool(

--- a/apps/zenx/src/main/capabilities/automation-control-package.ts
+++ b/apps/zenx/src/main/capabilities/automation-control-package.ts
@@ -1,0 +1,457 @@
+import type { ToolInvocation } from "../../../../../src/tool.js";
+import type {
+  CreateRoomInput,
+  CreateTriggerInput,
+  RoomMember,
+  TriggerProgramConfig,
+  TriggerProgramSpec,
+  TriggerSnapshot,
+  UpdateTriggerInput,
+  ZenXRoom,
+  ZenXTrigger,
+} from "../trigger-types.js";
+import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
+
+export const ZENX_AUTOMATION_CONTROL_CAPABILITY_ID = "zenx-automation-control";
+export const ZENX_AUTOMATION_READ_PERMISSION = "zenx-automation-control.read";
+export const ZENX_AUTOMATION_WRITE_PERMISSION = "zenx-automation-control.write";
+
+export interface ZenXAutomationControlPort {
+  snapshot(): TriggerSnapshot;
+  create(input: CreateTriggerInput): Promise<ZenXTrigger>;
+  update(input: UpdateTriggerInput): Promise<ZenXTrigger>;
+  cancel(triggerId: string): Promise<void>;
+  delete(triggerId: string): Promise<void>;
+  createRoom(input: CreateRoomInput): Promise<ZenXRoom>;
+  renameRoom(roomId: string, name: string): Promise<void>;
+  deleteRoom(roomId: string): Promise<void>;
+  addRoomMember(roomId: string, member: RoomMember): Promise<void>;
+  removeRoomMember(roomId: string, threadId: string): Promise<void>;
+  postAgentRoomMessage(roomId: string, text: string): Promise<void>;
+}
+
+const programSpecSchema = {
+  type: "object",
+  properties: {
+    command: { type: "string" },
+    args: { type: "array", items: { type: "string" }, maxItems: 64 },
+    cwd: { type: "string" },
+    env: { type: "object", additionalProperties: { type: "string" } },
+    timeoutMs: { type: "number", minimum: 1, maximum: 120000 },
+    maxOutputBytes: { type: "integer", minimum: 256, maximum: 1048576 },
+  },
+  required: ["command"],
+  additionalProperties: false,
+};
+
+const programSchema = {
+  type: "object",
+  properties: {
+    predicate: programSpecSchema,
+    action: programSpecSchema,
+    match: {
+      type: "object",
+      properties: {
+        field: { type: "string", enum: ["completedItemText"] },
+        regex: { type: "string" },
+        flags: { type: "string" },
+      },
+      required: ["field", "regex"],
+      additionalProperties: false,
+    },
+  },
+  additionalProperties: false,
+};
+
+const triggerProperties = {
+  threadId: { type: "string" },
+  kind: { type: "string", enum: ["timer", "thread", "roomMention", "signal"] },
+  label: { type: "string" },
+  prompt: { type: "string" },
+  runAt: { type: "number" },
+  intervalMinutes: { type: "number" },
+  watchedThreadId: { type: "string" },
+  roomId: { type: "string" },
+  mention: { type: "string" },
+  signalName: { type: "string" },
+  program: programSchema,
+};
+
+const manifest: ZenXCapabilityManifest = {
+  schemaVersion: 1,
+  id: ZENX_AUTOMATION_CONTROL_CAPABILITY_ID,
+  displayName: "ZenX Triggers and Rooms",
+  version: "1.0.0",
+  description:
+    "Inspect and manage Trigger wakeups and collaborative Rooms through the existing ZenX service.",
+  provider: {
+    id: "zenx-automation-service",
+    platforms: ["*"],
+    interactionModes: ["background_safe"],
+    capabilities: ["zenx.triggers.manage", "zenx.rooms.manage"],
+  },
+  permissions: [
+    {
+      id: ZENX_AUTOMATION_READ_PERMISSION,
+      title: "Read Triggers and Rooms",
+      description:
+        "List Trigger definitions, bounded wakeup history, Rooms, and messages.",
+      scope: "workspace",
+    },
+    {
+      id: ZENX_AUTOMATION_WRITE_PERMISSION,
+      title: "Manage Triggers and Rooms",
+      description:
+        "Create, update, cancel, and delete Triggers and manage Room collaboration.",
+      scope: "local-device",
+    },
+  ],
+  tools: [
+    tool(
+      "zenx_triggers_list",
+      "List Trigger definitions and bounded wakeup history.",
+      {},
+      [],
+      false,
+    ),
+    tool(
+      "zenx_triggers_create",
+      "Create a timer, Thread watcher, Room mention, or signal Trigger, optionally with a local predicate/action.",
+      triggerProperties,
+      ["threadId", "kind", "label", "prompt"],
+    ),
+    tool(
+      "zenx_triggers_update",
+      "Replace an existing Trigger definition while preserving its identity and active state.",
+      { id: { type: "string" }, ...triggerProperties },
+      ["id", "threadId", "kind", "label", "prompt"],
+    ),
+    tool(
+      "zenx_triggers_cancel",
+      "Deactivate a Trigger without deleting its definition or history.",
+      { triggerId: { type: "string" } },
+      ["triggerId"],
+    ),
+    tool(
+      "zenx_triggers_delete",
+      "Delete a Trigger definition while preserving audit history.",
+      { triggerId: { type: "string" } },
+      ["triggerId"],
+    ),
+    tool(
+      "zenx_rooms_list",
+      "List Rooms, members, and bounded recent messages.",
+      {},
+      [],
+      false,
+    ),
+    tool(
+      "zenx_rooms_create",
+      "Create a Room with named Thread members.",
+      { name: { type: "string" }, members: membersSchema() },
+      ["name", "members"],
+    ),
+    tool(
+      "zenx_rooms_rename",
+      "Rename an existing Room.",
+      { roomId: { type: "string" }, name: { type: "string" } },
+      ["roomId", "name"],
+    ),
+    tool(
+      "zenx_rooms_delete",
+      "Delete a Room when no nonterminal wakeup owns its reply route.",
+      { roomId: { type: "string" } },
+      ["roomId"],
+    ),
+    tool(
+      "zenx_rooms_add_member",
+      "Add a named Thread member to a Room.",
+      {
+        roomId: { type: "string" },
+        name: { type: "string" },
+        threadId: { type: "string" },
+      },
+      ["roomId", "name", "threadId"],
+    ),
+    tool(
+      "zenx_rooms_remove_member",
+      "Remove a Thread member from a Room.",
+      { roomId: { type: "string" }, threadId: { type: "string" } },
+      ["roomId", "threadId"],
+    ),
+    tool(
+      "zenx_rooms_post_message",
+      "Post an Agent-attributed Room message; explicit mentions may wake registered members.",
+      { roomId: { type: "string" }, text: { type: "string" } },
+      ["roomId", "text"],
+    ),
+  ],
+  resources: [],
+};
+
+export class ZenXAutomationControlCapabilityPackage implements ZenXCapabilityPackage {
+  readonly manifest = manifest;
+  readonly #port: ZenXAutomationControlPort;
+
+  constructor(port: ZenXAutomationControlPort) {
+    this.#port = port;
+  }
+
+  async invoke(name: string, invocation: ToolInvocation): Promise<unknown> {
+    if (name !== invocation.name)
+      throw new Error("Automation tool name mismatch");
+    invocation.signal.throwIfAborted();
+    const args = invocation.arguments;
+    switch (name) {
+      case "zenx_triggers_list": {
+        const snapshot = this.#port.snapshot();
+        return {
+          triggers: snapshot.triggers,
+          history: snapshot.history.slice(0, 50),
+        };
+      }
+      case "zenx_triggers_create":
+        return await this.#port.create(triggerInput(args));
+      case "zenx_triggers_update":
+        return await this.#port.update({
+          id: string(args, "id"),
+          ...triggerInput(args),
+        });
+      case "zenx_triggers_cancel":
+        await this.#port.cancel(string(args, "triggerId"));
+        return { cancelled: true };
+      case "zenx_triggers_delete":
+        await this.#port.delete(string(args, "triggerId"));
+        return { deleted: true };
+      case "zenx_rooms_list":
+        return {
+          rooms: this.#port.snapshot().rooms.map((room) => ({
+            ...room,
+            messages: room.messages.slice(-50),
+          })),
+        };
+      case "zenx_rooms_create":
+        return await this.#port.createRoom({
+          name: string(args, "name"),
+          members: members(args.members),
+        });
+      case "zenx_rooms_rename":
+        await this.#port.renameRoom(
+          string(args, "roomId"),
+          string(args, "name"),
+        );
+        return { renamed: true };
+      case "zenx_rooms_delete":
+        await this.#port.deleteRoom(string(args, "roomId"));
+        return { deleted: true };
+      case "zenx_rooms_add_member":
+        await this.#port.addRoomMember(string(args, "roomId"), {
+          name: string(args, "name"),
+          threadId: string(args, "threadId"),
+        });
+        return { added: true };
+      case "zenx_rooms_remove_member":
+        await this.#port.removeRoomMember(
+          string(args, "roomId"),
+          string(args, "threadId"),
+        );
+        return { removed: true };
+      case "zenx_rooms_post_message":
+        await this.#port.postAgentRoomMessage(
+          string(args, "roomId"),
+          string(args, "text"),
+        );
+        return { posted: true };
+      default:
+        throw new Error(`Unsupported ZenX automation tool: ${name}`);
+    }
+  }
+}
+
+function tool(
+  name: string,
+  description: string,
+  properties: Record<string, unknown>,
+  required: string[] = [],
+  write = true,
+) {
+  return {
+    name,
+    description,
+    inputSchema: {
+      type: "object",
+      properties,
+      required,
+      additionalProperties: false,
+    },
+    permissions: write
+      ? [ZENX_AUTOMATION_WRITE_PERMISSION]
+      : [ZENX_AUTOMATION_READ_PERMISSION],
+    interactionMode: "background_safe" as const,
+    capabilities: [
+      name.startsWith("zenx_rooms")
+        ? "zenx.rooms.manage"
+        : "zenx.triggers.manage",
+    ],
+    maxOutputBytes: 64 * 1024,
+  };
+}
+
+function triggerInput(args: Record<string, unknown>): CreateTriggerInput {
+  const common = {
+    threadId: string(args, "threadId"),
+    label: string(args, "label"),
+    prompt: string(args, "prompt"),
+    ...programInput(args),
+  };
+  const kind = string(args, "kind");
+  if (kind === "timer")
+    return {
+      ...common,
+      kind,
+      runAt: number(args, "runAt"),
+      ...(args.intervalMinutes === undefined
+        ? {}
+        : { intervalMinutes: number(args, "intervalMinutes") }),
+    };
+  if (kind === "thread")
+    return {
+      ...common,
+      kind,
+      watchedThreadId: string(args, "watchedThreadId"),
+    };
+  if (kind === "roomMention")
+    return {
+      ...common,
+      kind,
+      roomId: string(args, "roomId"),
+      mention: string(args, "mention"),
+    };
+  if (kind === "signal")
+    return { ...common, kind, signalName: string(args, "signalName") };
+  throw new Error("kind must be timer, thread, roomMention, or signal");
+}
+
+function programInput(args: Record<string, unknown>): {
+  program?: TriggerProgramConfig;
+} {
+  if (args.program === undefined) return {};
+  if (
+    typeof args.program !== "object" ||
+    args.program === null ||
+    Array.isArray(args.program)
+  )
+    throw new Error("program must be an object");
+  const value = args.program as Record<string, unknown>;
+  const program: TriggerProgramConfig = {};
+  if (value.predicate !== undefined)
+    program.predicate = programSpec(value.predicate, "predicate");
+  if (value.action !== undefined)
+    program.action = programSpec(value.action, "action");
+  if (value.match !== undefined) {
+    if (
+      typeof value.match !== "object" ||
+      value.match === null ||
+      Array.isArray(value.match)
+    )
+      throw new Error("match must be an object");
+    const match = value.match as Record<string, unknown>;
+    const field = string(match, "field");
+    if (field !== "completedItemText")
+      throw new Error("match field must be completedItemText");
+    program.match = {
+      field,
+      regex: string(match, "regex"),
+      ...(match.flags === undefined ? {} : { flags: string(match, "flags") }),
+    };
+  }
+  return { program };
+}
+
+function programSpec(value: unknown, label: string): TriggerProgramSpec {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  const spec = value as Record<string, unknown>;
+  const args =
+    spec.args === undefined
+      ? undefined
+      : arrayOfStrings(spec.args, `${label}.args`);
+  const env =
+    spec.env === undefined ? undefined : environment(spec.env, `${label}.env`);
+  return {
+    command: string(spec, "command"),
+    ...(args === undefined ? {} : { args }),
+    ...(spec.cwd === undefined ? {} : { cwd: string(spec, "cwd") }),
+    ...(env === undefined ? {} : { env }),
+    ...(spec.timeoutMs === undefined
+      ? {}
+      : { timeoutMs: number(spec, "timeoutMs") }),
+    ...(spec.maxOutputBytes === undefined
+      ? {}
+      : { maxOutputBytes: integer(spec, "maxOutputBytes") }),
+  };
+}
+
+function members(value: unknown): RoomMember[] {
+  if (!Array.isArray(value)) throw new Error("members must be an array");
+  return value.map((entry) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+      throw new Error("member must be an object");
+    const member = entry as Record<string, unknown>;
+    return {
+      name: string(member, "name"),
+      threadId: string(member, "threadId"),
+    };
+  });
+}
+
+function membersSchema() {
+  return {
+    type: "array",
+    items: {
+      type: "object",
+      properties: { name: { type: "string" }, threadId: { type: "string" } },
+      required: ["name", "threadId"],
+      additionalProperties: false,
+    },
+  };
+}
+
+function environment(value: unknown, label: string): Record<string, string> {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    throw new Error(`${label} must be an object`);
+  const result: Record<string, string> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string")
+      throw new Error(`${label}.${key} must be a string`);
+    result[key] = entry;
+  }
+  return result;
+}
+
+function arrayOfStrings(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))
+    throw new Error(`${label} must be an array of strings`);
+  return value;
+}
+
+function string(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  if (typeof value !== "string" || value.trim().length === 0)
+    throw new Error(`${key} must be a non-empty string`);
+  return value.trim();
+}
+
+function number(args: Record<string, unknown>, key: string): number {
+  const value = args[key];
+  if (typeof value !== "number" || !Number.isFinite(value))
+    throw new Error(`${key} must be a finite number`);
+  return value;
+}
+
+function integer(args: Record<string, unknown>, key: string): number {
+  const value = number(args, key);
+  if (!Number.isSafeInteger(value))
+    throw new Error(`${key} must be an integer`);
+  return value;
+}

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -22,6 +22,7 @@ import { ZenXSettingsService } from "./settings-service.js";
 import { zenXProviderTransport } from "./system-proxy.js";
 import { ZenXTriggerService } from "./trigger-service.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
+import { ZenXAutomationControlCapabilityPackage } from "./capabilities/automation-control-package.js";
 import { ZenXThreadTitleCoordinator } from "./thread-title-coordinator.js";
 import { normalizeTitleOwnershipFailure } from "./thread-title-failure.js";
 import { ZenXThreadTitleStore } from "./thread-title-store.js";
@@ -145,6 +146,9 @@ app.whenReady().then(async () => {
       new ZenXTriggerStore(join(userDataDirectory, "trigger-registry.json")),
       { titles: titleCoordinator },
     );
+    capabilityService.register(
+      new ZenXAutomationControlCapabilityPackage(triggerService),
+    );
     await triggerService.start();
     installTriggerIpc(triggerService);
     if (startupError === undefined) await appServerManager.start();
@@ -208,9 +212,13 @@ app.on("before-quit", (event) => {
   if (quitting || appServerManager === undefined) return;
   event.preventDefault();
   quitting = true;
-  triggerService?.stop();
   void (async () => {
     const errors: unknown[] = [];
+    try {
+      await triggerService?.stop();
+    } catch (error) {
+      errors.push(normalizeTitleOwnershipFailure(error));
+    }
     try {
       await titleCoordinator?.close();
     } catch (error) {

--- a/apps/zenx/src/main/trigger-limits.ts
+++ b/apps/zenx/src/main/trigger-limits.ts
@@ -1,0 +1,65 @@
+export const MAX_TRIGGER_COUNT = 256;
+export const MAX_HISTORY_COUNT = 256;
+export const MAX_ROOM_COUNT = 128;
+export const MAX_ROOM_MEMBERS = 64;
+export const MAX_ROOM_MESSAGES = 256;
+
+export const MAX_ID_BYTES = 512;
+export const MAX_TRIGGER_LABEL_BYTES = 256;
+export const MAX_TRIGGER_PROMPT_BYTES = 4_096;
+export const MAX_REASON_BYTES = 4_000;
+export const MAX_ERROR_BYTES = 4_000;
+export const MAX_ROOM_NAME_BYTES = 256;
+export const MAX_MEMBER_NAME_BYTES = 128;
+export const MAX_MESSAGE_AUTHOR_BYTES = 256;
+export const MAX_MESSAGE_TEXT_BYTES = 8_000;
+
+export const MAX_PROGRAM_COMMAND_BYTES = 4_096;
+export const MAX_PROGRAM_ARGUMENTS = 64;
+export const MAX_PROGRAM_ARGUMENT_BYTES = 4_096;
+export const MAX_PROGRAM_CWD_BYTES = 4_096;
+export const MAX_PROGRAM_ENV_ENTRIES = 64;
+export const MAX_PROGRAM_ENV_KEY_BYTES = 256;
+export const MAX_PROGRAM_ENV_VALUE_BYTES = 4_096;
+export const MAX_PROGRAM_ENV_BYTES = 16 * 1_024;
+export const MAX_PROGRAM_MATCH_REGEX_BYTES = 4_096;
+export const MAX_PROGRAM_FLAGS_BYTES = 64;
+export const MAX_PROGRAM_OUTCOMES = 4;
+
+export function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+export function withinBytes(value: string, maximum: number): boolean {
+  return utf8Bytes(value) <= maximum;
+}
+
+export function retainHistory<
+  T extends { status: string; error?: string | null },
+>(history: T[]): T[] {
+  const live = history.filter(
+    (entry) => entry.status === "starting" || entry.status === "running",
+  ).length;
+  if (live > 64)
+    throw new Error("ZenX trigger registry has too many live wakeups");
+  let terminalBudget = Math.max(0, MAX_HISTORY_COUNT - live);
+  const admission = history.find((entry) =>
+    entry.error?.includes("wakeup admission is full"),
+  );
+  const selected = new Set<T>(
+    history.filter(
+      (entry) => entry.status === "starting" || entry.status === "running",
+    ),
+  );
+  if (admission !== undefined && terminalBudget > 0) {
+    selected.add(admission);
+    terminalBudget -= 1;
+  }
+  for (const entry of history) {
+    if (entry.status === "starting" || entry.status === "running") continue;
+    if (entry === admission || terminalBudget === 0) continue;
+    selected.add(entry);
+    terminalBudget -= 1;
+  }
+  return history.filter((entry) => selected.has(entry));
+}

--- a/apps/zenx/src/main/trigger-limits.ts
+++ b/apps/zenx/src/main/trigger-limits.ts
@@ -25,6 +25,7 @@ export const MAX_PROGRAM_ENV_BYTES = 16 * 1_024;
 export const MAX_PROGRAM_MATCH_REGEX_BYTES = 4_096;
 export const MAX_PROGRAM_FLAGS_BYTES = 64;
 export const MAX_PROGRAM_OUTCOMES = 4;
+export const MAX_PROGRAM_TIMEOUT_MS = 120_000;
 
 export function utf8Bytes(value: string): number {
   return Buffer.byteLength(value, "utf8");

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 
 import type {
   TriggerProgramSpec,
@@ -10,6 +10,9 @@ export const DEFAULT_PROGRAM_OUTPUT_BYTES = 64 * 1024;
 export const MAX_PROGRAM_OUTPUT_BYTES = 1024 * 1024;
 export const DEFAULT_PROGRAM_TIMEOUT_MS = 30_000;
 export const MAX_PROGRAM_TIMEOUT_MS = 120_000;
+const PROGRAM_TERM_GRACE_MS = 250;
+const PROGRAM_FORCE_SETTLEMENT_MS = 1_000;
+const MAX_PROGRAM_STDERR_BYTES = 8 * 1_024;
 
 export interface TriggerProgramRunInput {
   invocationId: string;
@@ -81,12 +84,13 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       ...(spec.env ?? {}),
     };
     return await new Promise<TriggerProgramRunResult>((resolve) => {
-      let child;
+      let child: ChildProcessWithoutNullStreams;
       try {
         child = spawn(spec.command, spec.args ?? [], {
           cwd: spec.cwd ?? process.cwd(),
           env: environment,
           shell: false,
+          detached: process.platform !== "win32",
           stdio: ["pipe", "pipe", "pipe"],
         });
       } catch (error) {
@@ -96,25 +100,55 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
       let stdoutBytes = 0;
+      let stderrBytes = 0;
       let settled = false;
-      let timer: ReturnType<typeof setTimeout> | undefined;
+      let collecting = true;
+      let requested: TriggerProgramRunResult | null = null;
+      let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+      let forceTimer: ReturnType<typeof setTimeout> | undefined;
+      let settlementTimer: ReturnType<typeof setTimeout> | undefined;
       const cleanup = (): void => {
-        if (timer !== undefined) clearTimeout(timer);
+        if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
+        if (forceTimer !== undefined) clearTimeout(forceTimer);
+        if (settlementTimer !== undefined) clearTimeout(settlementTimer);
         signal.removeEventListener("abort", abort);
+      };
+      const stopCollection = (): void => {
+        if (!collecting) return;
+        collecting = false;
+        child.stdout.removeAllListeners("data");
+        child.stderr.removeAllListeners("data");
+        child.stdout.destroy();
+        child.stderr.destroy();
       };
       const finish = (value: TriggerProgramRunResult): void => {
         if (settled) return;
         settled = true;
         cleanup();
+        stopCollection();
+        child.stdin.destroy();
         resolve(value);
       };
-      const terminate = (signalName: NodeJS.Signals): void => {
-        if (child.exitCode === null && child.signalCode === null)
-          child.kill(signalName);
+      const terminate = (force: boolean): void => {
+        terminateProcessTree(child, force);
+      };
+      const requestTermination = (value: TriggerProgramRunResult): void => {
+        if (settled || requested !== null) return;
+        requested = value;
+        stopCollection();
+        child.stdin.destroy();
+        terminate(false);
+        forceTimer = setTimeout(() => {
+          forceTimer = undefined;
+          terminate(true);
+          settlementTimer = setTimeout(
+            () => finish(value),
+            PROGRAM_FORCE_SETTLEMENT_MS,
+          );
+        }, PROGRAM_TERM_GRACE_MS);
       };
       const abort = (): void => {
-        terminate("SIGTERM");
-        finish(
+        requestTermination(
           result(
             "cancelled",
             null,
@@ -125,9 +159,8 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
           ),
         );
       };
-      timer = setTimeout(() => {
-        terminate("SIGTERM");
-        finish(
+      timeoutTimer = setTimeout(() => {
+        requestTermination(
           result(
             "timed_out",
             null,
@@ -138,11 +171,11 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       }, timeoutMs);
       signal.addEventListener("abort", abort, { once: true });
       child.stdout.on("data", (chunk: Buffer | string) => {
+        if (!collecting || settled || requested !== null) return;
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
         stdoutBytes += buffer.length;
         if (stdoutBytes > maxOutputBytes) {
-          terminate("SIGTERM");
-          finish(
+          requestTermination(
             result(
               "oversized_output",
               null,
@@ -155,13 +188,48 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         stdout.push(buffer);
       });
       child.stderr.on("data", (chunk: Buffer | string) => {
+        if (!collecting || settled || requested !== null) return;
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        if (Buffer.concat(stderr).length < 8 * 1024) stderr.push(buffer);
+        const remaining = MAX_PROGRAM_STDERR_BYTES - stderrBytes;
+        if (remaining <= 0) return;
+        const bounded = buffer.subarray(0, remaining);
+        stderrBytes += bounded.length;
+        stderr.push(bounded);
+      });
+      child.stdin.once("error", (error: unknown) => {
+        if (requested === null && !settled)
+          requestTermination(
+            result("failed", null, null, describeError(error)),
+          );
+      });
+      child.stdout.once("error", (error: unknown) => {
+        if (requested === null && !settled)
+          requestTermination(
+            result("failed", null, null, describeError(error)),
+          );
+      });
+      child.stderr.once("error", (error: unknown) => {
+        if (requested === null && !settled)
+          requestTermination(
+            result("failed", null, null, describeError(error)),
+          );
       });
       child.once("error", (error: unknown) => {
-        finish(result("failed", null, null, describeError(error)));
+        if (requested === null)
+          requestTermination(
+            result("failed", null, null, describeError(error)),
+          );
       });
       child.once("close", (code: number | null) => {
+        if (requested !== null) {
+          if (forceTimer !== undefined) {
+            clearTimeout(forceTimer);
+            forceTimer = undefined;
+            terminate(true);
+          }
+          finish(requested);
+          return;
+        }
         if (settled) return;
         const text = Buffer.concat(stdout).toString("utf8").trim();
         if (code !== 0) {
@@ -237,6 +305,47 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       });
       child.stdin.end(`${serializedInput}\n`);
     });
+  }
+}
+
+function terminateProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  force: boolean,
+): void {
+  if (child.pid === undefined || (child.exitCode !== null && !force)) return;
+  if (process.platform === "win32") {
+    if (!force) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The bounded force phase below is the containment fallback.
+      }
+      return;
+    }
+    try {
+      const killer = spawn(
+        "taskkill",
+        ["/PID", String(child.pid), "/T", "/F"],
+        { windowsHide: true, stdio: "ignore" },
+      );
+      killer.once("error", () => undefined);
+    } catch {
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // The settlement deadline remains bounded even if the OS rejects kill.
+      }
+    }
+    return;
+  }
+  try {
+    process.kill(-child.pid, force ? "SIGKILL" : "SIGTERM");
+  } catch {
+    try {
+      child.kill(force ? "SIGKILL" : "SIGTERM");
+    } catch {
+      // The bounded settlement deadline remains the final containment fence.
+    }
   }
 }
 

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -4,14 +4,17 @@ import type {
   TriggerProgramSpec,
   TriggerProgramStage,
 } from "./trigger-types.js";
+import { MAX_PROGRAM_TIMEOUT_MS } from "./trigger-limits.js";
+
+export { MAX_PROGRAM_TIMEOUT_MS } from "./trigger-limits.js";
 
 export const MAX_PROGRAM_INPUT_BYTES = 64 * 1024;
 export const DEFAULT_PROGRAM_OUTPUT_BYTES = 64 * 1024;
 export const MAX_PROGRAM_OUTPUT_BYTES = 1024 * 1024;
 export const DEFAULT_PROGRAM_TIMEOUT_MS = 30_000;
-export const MAX_PROGRAM_TIMEOUT_MS = 120_000;
 const PROGRAM_TERM_GRACE_MS = 250;
 const PROGRAM_FORCE_SETTLEMENT_MS = 1_000;
+const PROGRAM_QUIESCENCE_MS = 100;
 const MAX_PROGRAM_STDERR_BYTES = 8 * 1_024;
 
 export interface TriggerProgramRunInput {
@@ -106,11 +109,12 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       let requested: TriggerProgramRunResult | null = null;
       let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
       let forceTimer: ReturnType<typeof setTimeout> | undefined;
-      let settlementTimer: ReturnType<typeof setTimeout> | undefined;
+      let termination: Promise<TerminationResult> | undefined;
+      let containment: Promise<TerminationResult> | undefined;
+      let forceStarted = false;
       const cleanup = (): void => {
         if (timeoutTimer !== undefined) clearTimeout(timeoutTimer);
         if (forceTimer !== undefined) clearTimeout(forceTimer);
-        if (settlementTimer !== undefined) clearTimeout(settlementTimer);
         signal.removeEventListener("abort", abort);
       };
       const stopCollection = (): void => {
@@ -129,24 +133,90 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         child.stdin.destroy();
         resolve(value);
       };
-      const terminate = (force: boolean): void => {
-        terminateProcessTree(child, force);
+      const forceAndFinish = async (): Promise<void> => {
+        if (settled || requested === null || forceStarted) return;
+        forceStarted = true;
+        if (forceTimer !== undefined) {
+          clearTimeout(forceTimer);
+          forceTimer = undefined;
+        }
+        containment ??= (
+          termination ?? Promise.resolve({ ok: true, error: "" })
+        ).then(async (softTermination) => {
+          const forced = await terminateProcessTree(child, true, capturedTree);
+          if (
+            !softTermination.ok &&
+            softTermination.error.startsWith(
+              "process-tree snapshot unavailable",
+            )
+          )
+            return forced.ok
+              ? softTermination
+              : {
+                  ok: false,
+                  error: `${softTermination.error}; ${forced.error}`,
+                };
+          return forced;
+        });
+        const terminationResult = await withDeadline(
+          containment,
+          PROGRAM_FORCE_SETTLEMENT_MS,
+          {
+            ok: false,
+            error: "bounded process-tree termination deadline expired",
+          },
+        );
+        await delay(PROGRAM_QUIESCENCE_MS);
+        if (settled || requested === null) return;
+        if (terminationResult.ok) finish(requested);
+        else
+          finish(
+            result(
+              "failed",
+              null,
+              null,
+              `Program ${requested.status} did not prove process-tree containment: ${terminationResult.error}`,
+            ),
+          );
       };
       const requestTermination = (value: TriggerProgramRunResult): void => {
         if (settled || requested !== null) return;
         requested = value;
         stopCollection();
         child.stdin.destroy();
-        terminate(false);
+        if (process.platform === "win32") {
+          termination = captureProcessTree(child.pid)
+            .then((tree) => {
+              capturedTree = tree;
+              return terminateProcessTree(child, false, tree);
+            })
+            .catch(async (error: unknown) => {
+              await terminateProcessTree(child, false);
+              return {
+                ok: false as const,
+                error: `process-tree snapshot unavailable: ${describeError(error)}`,
+              };
+            });
+        } else {
+          termination = captureProcessTree(child.pid)
+            .then((tree) => {
+              capturedTree = tree;
+              return terminateProcessTree(child, false, tree);
+            })
+            .catch(async (error: unknown) => {
+              await terminateProcessTree(child, false);
+              return {
+                ok: false as const,
+                error: `process-tree snapshot unavailable: ${describeError(error)}`,
+              };
+            });
+        }
         forceTimer = setTimeout(() => {
           forceTimer = undefined;
-          terminate(true);
-          settlementTimer = setTimeout(
-            () => finish(value),
-            PROGRAM_FORCE_SETTLEMENT_MS,
-          );
+          void forceAndFinish();
         }, PROGRAM_TERM_GRACE_MS);
       };
+      let capturedTree: ProcessTreeSnapshot | undefined;
       const abort = (): void => {
         requestTermination(
           result(
@@ -222,12 +292,7 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
       });
       child.once("close", (code: number | null) => {
         if (requested !== null) {
-          if (forceTimer !== undefined) {
-            clearTimeout(forceTimer);
-            forceTimer = undefined;
-            terminate(true);
-          }
-          finish(requested);
+          void forceAndFinish();
           return;
         }
         if (settled) return;
@@ -308,45 +373,263 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
   }
 }
 
+interface ProcessTreeSnapshot {
+  descendants: number[];
+}
+
+interface TerminationResult {
+  ok: boolean;
+  error: string;
+}
+
 function terminateProcessTree(
   child: ChildProcessWithoutNullStreams,
   force: boolean,
-): void {
-  if (child.pid === undefined || (child.exitCode !== null && !force)) return;
-  if (process.platform === "win32") {
-    if (!force) {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // The bounded force phase below is the containment fallback.
-      }
-      return;
-    }
+  tree?: ProcessTreeSnapshot,
+): Promise<TerminationResult> {
+  if (child.pid === undefined)
+    return Promise.resolve({
+      ok: false,
+      error: "the child process did not expose a PID",
+    });
+  if (!force && child.exitCode !== null)
+    return Promise.resolve({ ok: true, error: "" });
+  if (process.platform === "win32")
+    return terminateWindowsProcessTree(child, force, tree);
+  return terminatePosixProcessTree(child, force, tree);
+}
+
+async function terminateWindowsProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  force: boolean,
+  tree?: ProcessTreeSnapshot,
+): Promise<TerminationResult> {
+  if (child.pid === undefined)
+    return { ok: false, error: "the child process did not expose a PID" };
+  if (!force) {
     try {
-      const killer = spawn(
+      child.kill("SIGTERM");
+      return { ok: true, error: "" };
+    } catch (error) {
+      return { ok: false, error: describeError(error) };
+    }
+  }
+  const errors: string[] = [];
+  const root = await runTaskkill(child.pid, true);
+  if (!root.ok && root.error !== "process was not found")
+    errors.push(root.error);
+  for (const pid of tree?.descendants ?? []) {
+    const result = await runTaskkill(pid, true);
+    if (!result.ok && result.error !== "process was not found")
+      errors.push(`PID ${String(pid)}: ${result.error}`);
+  }
+  return errors.length === 0
+    ? { ok: true, error: "" }
+    : { ok: false, error: errors.join("; ") };
+}
+
+async function terminatePosixProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  force: boolean,
+  tree?: ProcessTreeSnapshot,
+): Promise<TerminationResult> {
+  if (child.pid === undefined)
+    return { ok: false, error: "the child process did not expose a PID" };
+  const signal = force ? "SIGKILL" : "SIGTERM";
+  const errors: string[] = [];
+  try {
+    process.kill(-child.pid, signal);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") errors.push(describeError(error));
+  }
+  if (force) {
+    for (const pid of tree?.descendants ?? []) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ESRCH")
+          errors.push(`PID ${String(pid)}: ${describeError(error)}`);
+      }
+    }
+  }
+  return errors.length === 0
+    ? { ok: true, error: "" }
+    : { ok: false, error: errors.join("; ") };
+}
+
+async function runTaskkill(
+  pid: number,
+  tree: boolean,
+): Promise<{ ok: boolean; error: string }> {
+  return await new Promise((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let killer: ReturnType<typeof spawn> | undefined;
+    const finish = (value: { ok: boolean; error: string }): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(value);
+    };
+    try {
+      killer = spawn(
         "taskkill",
-        ["/PID", String(child.pid), "/T", "/F"],
+        tree ? ["/PID", String(pid), "/T", "/F"] : ["/PID", String(pid), "/F"],
         { windowsHide: true, stdio: "ignore" },
       );
-      killer.once("error", () => undefined);
-    } catch {
-      try {
-        child.kill("SIGKILL");
-      } catch {
-        // The settlement deadline remains bounded even if the OS rejects kill.
+    } catch (error) {
+      finish({ ok: false, error: describeError(error) });
+      return;
+    }
+    timer = setTimeout(() => {
+      killer?.kill("SIGKILL");
+      finish({ ok: false, error: "taskkill timed out" });
+    }, 750);
+    killer.once("error", (error: unknown) =>
+      finish({ ok: false, error: describeError(error) }),
+    );
+    killer.once("close", (code: number | null) =>
+      finish(
+        code === 0
+          ? { ok: true, error: "" }
+          : code === 128
+            ? { ok: false, error: "process was not found" }
+            : { ok: false, error: `taskkill exited with code ${String(code)}` },
+      ),
+    );
+  });
+}
+
+function captureProcessTree(
+  pid: number | undefined,
+): Promise<ProcessTreeSnapshot> {
+  if (pid === undefined)
+    return Promise.reject(new Error("the child process did not expose a PID"));
+  if (process.platform === "win32")
+    return captureProcessTreeWithCommand(
+      "wmic.exe",
+      ["process", "get", "ProcessId,ParentProcessId", "/format:list"],
+      pid,
+    );
+  return captureProcessTreeWithCommand("ps", ["-eo", "pid=,ppid="], pid);
+}
+
+async function captureProcessTreeWithCommand(
+  command: string,
+  args: string[],
+  rootPid: number,
+): Promise<ProcessTreeSnapshot> {
+  const output = await new Promise<string>((resolve, reject) => {
+    let text = "";
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let processHandle: ReturnType<typeof spawn> | undefined;
+    const finish = (error: Error | null): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      if (error !== null) reject(error);
+      else resolve(text);
+    };
+    try {
+      processHandle = spawn(command, args, {
+        windowsHide: true,
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+      processHandle.stdout?.setEncoding("utf8");
+      processHandle.stdout?.on("data", (chunk: string) => {
+        if (text.length < 128 * 1024) text += chunk;
+      });
+      processHandle.once("error", (error: unknown) =>
+        finish(new Error(describeError(error))),
+      );
+      processHandle.once("close", (code: number | null) => {
+        if (code === 0) finish(null);
+        else finish(new Error(`${command} exited with code ${String(code)}`));
+      });
+      timer = setTimeout(() => {
+        processHandle?.kill("SIGKILL");
+        finish(new Error(`${command} process-tree snapshot timed out`));
+      }, 750);
+    } catch (error) {
+      finish(new Error(describeError(error)));
+    }
+  });
+  const relationships: Array<[number, number]> = [];
+  let processId: number | undefined;
+  let parentProcessId: number | undefined;
+  for (const line of output.split(/\r?\n/u)) {
+    const processMatch = line.trim().match(/^ProcessId=(\d+)$/u);
+    const parentMatch = line.trim().match(/^ParentProcessId=(\d+)$/u);
+    const csvMatch = line.trim().match(/^(\d+)[,\s]+(\d+)$/u);
+    if (processMatch !== null) processId = Number(processMatch[1]);
+    else if (parentMatch !== null) parentProcessId = Number(parentMatch[1]);
+    else if (csvMatch !== null)
+      relationships.push([Number(csvMatch[1]), Number(csvMatch[2])]);
+    else if (
+      line.trim() === "" &&
+      processId !== undefined &&
+      parentProcessId !== undefined
+    ) {
+      relationships.push([processId, parentProcessId]);
+      processId = undefined;
+      parentProcessId = undefined;
+    }
+  }
+  if (processId !== undefined && parentProcessId !== undefined)
+    relationships.push([processId, parentProcessId]);
+  const descendants = new Set<number>();
+  let parents = new Set<number>([rootPid]);
+  while (parents.size > 0) {
+    const next = new Set<number>();
+    for (const [childPid, parentPid] of relationships) {
+      if (
+        parents.has(parentPid) &&
+        childPid !== rootPid &&
+        !descendants.has(childPid)
+      ) {
+        descendants.add(childPid);
+        next.add(childPid);
       }
     }
-    return;
+    parents = next;
   }
-  try {
-    process.kill(-child.pid, force ? "SIGKILL" : "SIGTERM");
-  } catch {
-    try {
-      child.kill(force ? "SIGKILL" : "SIGTERM");
-    } catch {
-      // The bounded settlement deadline remains the final containment fence.
-    }
-  }
+  return { descendants: [...descendants] };
+}
+
+async function withDeadline<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  fallback: T,
+): Promise<T> {
+  return await new Promise<T>((resolve) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolve(fallback);
+    }, milliseconds);
+    void promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(fallback);
+      },
+    );
+  });
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 function result(
@@ -388,8 +671,22 @@ function boundedError(value: string): string | null {
 }
 
 function bound(value: string | null): string | null {
-  if (value === null || value.length <= 2_048) return value;
-  return `${value.slice(0, 2_024)}…[truncated]`;
+  if (value === null || Buffer.byteLength(value, "utf8") <= 2_048) return value;
+  const suffix = "…[truncated]";
+  const available = Math.max(0, 2_048 - Buffer.byteLength(suffix, "utf8"));
+  return `${prefixByBytes(value, available)}${suffix}`;
+}
+
+function prefixByBytes(value: string, limit: number): string {
+  let bytes = 0;
+  let prefix = "";
+  for (const character of value) {
+    const characterBytes = Buffer.byteLength(character, "utf8");
+    if (bytes + characterBytes > limit) break;
+    prefix += character;
+    bytes += characterBytes;
+  }
+  return prefix;
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -13,8 +13,10 @@ export const DEFAULT_PROGRAM_OUTPUT_BYTES = 64 * 1024;
 export const MAX_PROGRAM_OUTPUT_BYTES = 1024 * 1024;
 export const DEFAULT_PROGRAM_TIMEOUT_MS = 30_000;
 const PROGRAM_TERM_GRACE_MS = 250;
-const PROGRAM_FORCE_SETTLEMENT_MS = 1_000;
-const PROGRAM_QUIESCENCE_MS = 100;
+const PROGRAM_FORCE_SETTLEMENT_MS = 1_500;
+const PROGRAM_QUIESCENCE_TIMEOUT_MS = 900;
+const PROGRAM_QUIESCENCE_PASSES = 2;
+const PROGRAM_QUIESCENCE_POLL_MS = 40;
 const MAX_PROGRAM_STDERR_BYTES = 8 * 1_024;
 
 export interface TriggerProgramRunInput {
@@ -100,6 +102,7 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         resolve(result("failed", null, null, describeError(error)));
         return;
       }
+      const initialTree = captureProcessTree(child.pid).catch(() => undefined);
       const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
       let stdoutBytes = 0;
@@ -122,8 +125,6 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         collecting = false;
         child.stdout.removeAllListeners("data");
         child.stderr.removeAllListeners("data");
-        child.stdout.destroy();
-        child.stderr.destroy();
       };
       const finish = (value: TriggerProgramRunResult): void => {
         if (settled) return;
@@ -131,6 +132,8 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         cleanup();
         stopCollection();
         child.stdin.destroy();
+        child.stdout.destroy();
+        child.stderr.destroy();
         resolve(value);
       };
       const forceAndFinish = async (): Promise<void> => {
@@ -139,6 +142,14 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         if (forceTimer !== undefined) {
           clearTimeout(forceTimer);
           forceTimer = undefined;
+        }
+        if (capturedTree === undefined && child.exitCode !== null) {
+          const exited = await verifyExitedChild(child);
+          if (settled || requested === null) return;
+          if (exited.ok) {
+            finish(requested);
+            return;
+          }
         }
         containment ??= (
           termination ?? Promise.resolve({ ok: true, error: "" })
@@ -166,7 +177,6 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
             error: "bounded process-tree termination deadline expired",
           },
         );
-        await delay(PROGRAM_QUIESCENCE_MS);
         if (settled || requested === null) return;
         if (terminationResult.ok) finish(requested);
         else
@@ -184,33 +194,23 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         requested = value;
         stopCollection();
         child.stdin.destroy();
-        if (process.platform === "win32") {
-          termination = captureProcessTree(child.pid)
-            .then((tree) => {
-              capturedTree = tree;
-              return terminateProcessTree(child, false, tree);
-            })
-            .catch(async (error: unknown) => {
-              await terminateProcessTree(child, false);
-              return {
-                ok: false as const,
-                error: `process-tree snapshot unavailable: ${describeError(error)}`,
-              };
-            });
-        } else {
-          termination = captureProcessTree(child.pid)
-            .then((tree) => {
-              capturedTree = tree;
-              return terminateProcessTree(child, false, tree);
-            })
-            .catch(async (error: unknown) => {
-              await terminateProcessTree(child, false);
-              return {
-                ok: false as const,
-                error: `process-tree snapshot unavailable: ${describeError(error)}`,
-              };
-            });
-        }
+        const treeAtTermination = captureProcessTree(child.pid).catch(
+          () => initialTree,
+        );
+        termination = treeAtTermination.then(async (tree) => {
+          if (tree !== undefined) {
+            capturedTree = tree;
+            return await terminateProcessTree(child, false, tree);
+          }
+          await terminateProcessTree(child, false);
+          const exited = await verifyExitedChild(child);
+          if (exited.ok) return exited;
+          return {
+            ok: false as const,
+            error:
+              "process-tree snapshot unavailable; containment was not proven",
+          };
+        });
         forceTimer = setTimeout(() => {
           forceTimer = undefined;
           void forceAndFinish();
@@ -373,8 +373,21 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
   }
 }
 
+interface ProcessIdentity {
+  pid: number;
+  parentPid: number;
+  processGroupId: number | null;
+  sessionId: number | null;
+  startTime: string | null;
+}
+
+interface ProcessTableSnapshot {
+  entries: ProcessIdentity[];
+}
+
 interface ProcessTreeSnapshot {
-  descendants: number[];
+  root: ProcessIdentity;
+  descendants: ProcessIdentity[];
 }
 
 interface TerminationResult {
@@ -414,18 +427,13 @@ async function terminateWindowsProcessTree(
       return { ok: false, error: describeError(error) };
     }
   }
-  const errors: string[] = [];
-  const root = await runTaskkill(child.pid, true);
-  if (!root.ok && root.error !== "process was not found")
-    errors.push(root.error);
-  for (const pid of tree?.descendants ?? []) {
-    const result = await runTaskkill(pid, true);
-    if (!result.ok && result.error !== "process was not found")
-      errors.push(`PID ${String(pid)}: ${result.error}`);
-  }
-  return errors.length === 0
-    ? { ok: true, error: "" }
-    : { ok: false, error: errors.join("; ") };
+  if (tree === undefined)
+    return {
+      ok: false,
+      error:
+        "process-tree identity was unavailable; containment was not proven",
+    };
+  return await verifyAndTerminateWindows(child.pid, tree);
 }
 
 async function terminatePosixProcessTree(
@@ -435,28 +443,225 @@ async function terminatePosixProcessTree(
 ): Promise<TerminationResult> {
   if (child.pid === undefined)
     return { ok: false, error: "the child process did not expose a PID" };
-  const signal = force ? "SIGKILL" : "SIGTERM";
-  const errors: string[] = [];
+  if (!force) return sendPosixSignal(-child.pid, "SIGTERM");
+  if (tree === undefined)
+    return {
+      ok: false,
+      error:
+        "process-tree identity was unavailable; containment was not proven",
+    };
+  return await verifyAndTerminatePosix(child.pid, tree);
+}
+
+async function verifyExitedChild(
+  child: ChildProcessWithoutNullStreams,
+): Promise<TerminationResult> {
+  if (child.pid === undefined || child.exitCode === null)
+    return {
+      ok: false,
+      error: "the child process identity was unavailable before termination",
+    };
   try {
-    process.kill(-child.pid, signal);
+    const table = await captureProcessTable();
+    const survivors = table.entries.filter(
+      (entry) =>
+        entry.parentPid === child.pid || entry.processGroupId === child.pid,
+    );
+    return survivors.length === 0
+      ? { ok: true, error: "" }
+      : {
+          ok: false,
+          error:
+            "the child exited before its process tree was captured; descendant containment was not proven",
+        };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `process-table verification failed: ${describeError(error)}`,
+    };
+  }
+}
+
+async function verifyAndTerminateWindows(
+  rootPid: number,
+  tree: ProcessTreeSnapshot,
+): Promise<TerminationResult> {
+  let stableAbsentPasses = 0;
+  const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
+  let tracked = [tree.root, ...tree.descendants];
+  while (Date.now() < deadline) {
+    const table = await captureProcessTable();
+    const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
+    if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
+    tracked = addDescendants(tracked, table.entries);
+    const identityError = validateTrackedIdentities(tracked, table.entries);
+    if (identityError !== null) return { ok: false, error: identityError };
+    const live = tracked.filter((identity) =>
+      table.entries.some((candidate) => candidate.pid === identity.pid),
+    );
+    if (live.length === 0) {
+      stableAbsentPasses += 1;
+      if (stableAbsentPasses >= PROGRAM_QUIESCENCE_PASSES)
+        return { ok: true, error: "" };
+    } else {
+      stableAbsentPasses = 0;
+      const currentRoot = table.entries.find(
+        (candidate) => candidate.pid === tree.root.pid,
+      );
+      if (currentRoot !== undefined) {
+        if (!identityMatches(tree.root, currentRoot))
+          return {
+            ok: false,
+            error: `PID ${String(tree.root.pid)} identity changed; containment was not proven`,
+          };
+        const rootResult = await runTaskkill(rootPid, true);
+        if (!rootResult.ok && rootResult.error !== "process was not found")
+          return { ok: false, error: rootResult.error };
+      }
+      for (const identity of live) {
+        const current = table.entries.find(
+          (candidate) => candidate.pid === identity.pid,
+        );
+        if (!identityMatches(identity, current))
+          return {
+            ok: false,
+            error: `PID ${String(identity.pid)} identity changed; containment was not proven`,
+          };
+        const result = await runTaskkill(identity.pid, false);
+        if (!result.ok && result.error !== "process was not found")
+          return {
+            ok: false,
+            error: `PID ${String(identity.pid)}: ${result.error}`,
+          };
+      }
+    }
+    await delay(PROGRAM_QUIESCENCE_POLL_MS);
+  }
+  return {
+    ok: false,
+    error:
+      "process-tree quiescence could not be proven before the bounded deadline",
+  };
+}
+
+async function verifyAndTerminatePosix(
+  rootPid: number,
+  tree: ProcessTreeSnapshot,
+): Promise<TerminationResult> {
+  let stableAbsentPasses = 0;
+  const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
+  let tracked = [tree.root, ...tree.descendants];
+  while (Date.now() < deadline) {
+    const table = await captureProcessTable();
+    const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
+    if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
+    tracked = addDescendants(tracked, table.entries);
+    const identityError = validateTrackedIdentities(tracked, table.entries);
+    if (identityError !== null) return { ok: false, error: identityError };
+    const live = tracked.filter((identity) =>
+      table.entries.some((candidate) => candidate.pid === identity.pid),
+    );
+    if (live.length === 0) {
+      stableAbsentPasses += 1;
+      if (stableAbsentPasses >= PROGRAM_QUIESCENCE_PASSES)
+        return { ok: true, error: "" };
+    } else {
+      stableAbsentPasses = 0;
+      const groupIds = new Set(
+        live
+          .map((identity) => identity.processGroupId)
+          .filter((value): value is number => value !== null),
+      );
+      for (const groupId of groupIds) {
+        const groupResult = sendPosixSignal(-groupId, "SIGKILL");
+        if (!groupResult.ok) return groupResult;
+      }
+      for (const identity of live) {
+        const current = table.entries.find(
+          (candidate) => candidate.pid === identity.pid,
+        );
+        if (!identityMatches(identity, current))
+          return {
+            ok: false,
+            error: `PID ${String(identity.pid)} identity changed; containment was not proven`,
+          };
+        const result = sendPosixSignal(identity.pid, "SIGKILL");
+        if (!result.ok)
+          return {
+            ok: false,
+            error: `PID ${String(identity.pid)}: ${result.error}`,
+          };
+      }
+    }
+    await delay(PROGRAM_QUIESCENCE_POLL_MS);
+  }
+  return {
+    ok: false,
+    error:
+      "process-tree quiescence could not be proven before the bounded deadline",
+  };
+}
+
+function sendPosixSignal(
+  pid: number,
+  signal: NodeJS.Signals,
+): TerminationResult {
+  try {
+    process.kill(pid, signal);
+    return { ok: true, error: "" };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code !== "ESRCH") errors.push(describeError(error));
+    return code === "ESRCH"
+      ? { ok: true, error: "" }
+      : { ok: false, error: describeError(error) };
   }
-  if (force) {
-    for (const pid of tree?.descendants ?? []) {
-      try {
-        process.kill(pid, "SIGKILL");
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException).code;
-        if (code !== "ESRCH")
-          errors.push(`PID ${String(pid)}: ${describeError(error)}`);
+}
+
+function validateTrackedIdentities(
+  tracked: readonly ProcessIdentity[],
+  entries: readonly ProcessIdentity[],
+): string | null {
+  for (const identity of tracked) {
+    if (identity.startTime === null)
+      return `PID ${String(identity.pid)} has unknown process identity; containment was not proven`;
+    const current = entries.find((candidate) => candidate.pid === identity.pid);
+    if (current !== undefined && !identityMatches(identity, current))
+      return `PID ${String(identity.pid)} identity changed; containment was not proven`;
+  }
+  return null;
+}
+
+function identityMatches(
+  expected: ProcessIdentity,
+  actual: ProcessIdentity | undefined,
+): boolean {
+  return (
+    actual !== undefined &&
+    expected.startTime !== null &&
+    actual.startTime !== null &&
+    expected.startTime === actual.startTime
+  );
+}
+
+function addDescendants(
+  tracked: readonly ProcessIdentity[],
+  entries: readonly ProcessIdentity[],
+): ProcessIdentity[] {
+  const result = [...tracked];
+  const known = new Set(result.map((identity) => identity.pid));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const entry of entries) {
+      if (known.has(entry.pid)) continue;
+      if (result.some((identity) => identity.pid === entry.parentPid)) {
+        result.push(entry);
+        known.add(entry.pid);
+        changed = true;
       }
     }
   }
-  return errors.length === 0
-    ? { ok: true, error: "" }
-    : { ok: false, error: errors.join("; ") };
+  return result;
 }
 
 async function runTaskkill(
@@ -507,20 +712,30 @@ function captureProcessTree(
 ): Promise<ProcessTreeSnapshot> {
   if (pid === undefined)
     return Promise.reject(new Error("the child process did not expose a PID"));
-  if (process.platform === "win32")
-    return captureProcessTreeWithCommand(
-      "wmic.exe",
-      ["process", "get", "ProcessId,ParentProcessId", "/format:list"],
-      pid,
+  return captureProcessTable().then((table) => {
+    const root = table.entries.find((entry) => entry.pid === pid);
+    if (root === undefined || root.startTime === null)
+      throw new Error("root process identity was unavailable");
+    const descendants = addDescendants([root], table.entries).filter(
+      (entry) => entry.pid !== root.pid,
     );
-  return captureProcessTreeWithCommand("ps", ["-eo", "pid=,ppid="], pid);
+    if (descendants.some((entry) => entry.startTime === null))
+      throw new Error("descendant process identity was unavailable");
+    return { root, descendants };
+  });
 }
 
-async function captureProcessTreeWithCommand(
-  command: string,
-  args: string[],
-  rootPid: number,
-): Promise<ProcessTreeSnapshot> {
+async function captureProcessTable(): Promise<ProcessTableSnapshot> {
+  const command = process.platform === "win32" ? "wmic.exe" : "ps";
+  const args =
+    process.platform === "win32"
+      ? [
+          "process",
+          "get",
+          "ProcessId,ParentProcessId,CreationDate",
+          "/format:list",
+        ]
+      : ["-eo", "pid=,ppid=,pgid=,sid=,lstart="];
   const output = await new Promise<string>((resolve, reject) => {
     let text = "";
     let settled = false;
@@ -557,46 +772,62 @@ async function captureProcessTreeWithCommand(
       finish(new Error(describeError(error)));
     }
   });
-  const relationships: Array<[number, number]> = [];
-  let processId: number | undefined;
-  let parentProcessId: number | undefined;
+  return process.platform === "win32"
+    ? parseWindowsProcessTable(output)
+    : parsePosixProcessTable(output);
+}
+
+function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
+  const entries: ProcessIdentity[] = [];
+  let record: {
+    pid?: number;
+    parentPid?: number;
+    startTime?: string | null;
+  } = {};
+  const flush = (): void => {
+    if (record.pid !== undefined && record.parentPid !== undefined)
+      entries.push({
+        pid: record.pid,
+        parentPid: record.parentPid,
+        processGroupId: null,
+        sessionId: null,
+        startTime: record.startTime ?? null,
+      });
+    record = {};
+  };
   for (const line of output.split(/\r?\n/u)) {
-    const processMatch = line.trim().match(/^ProcessId=(\d+)$/u);
-    const parentMatch = line.trim().match(/^ParentProcessId=(\d+)$/u);
-    const csvMatch = line.trim().match(/^(\d+)[,\s]+(\d+)$/u);
-    if (processMatch !== null) processId = Number(processMatch[1]);
-    else if (parentMatch !== null) parentProcessId = Number(parentMatch[1]);
-    else if (csvMatch !== null)
-      relationships.push([Number(csvMatch[1]), Number(csvMatch[2])]);
-    else if (
-      line.trim() === "" &&
-      processId !== undefined &&
-      parentProcessId !== undefined
-    ) {
-      relationships.push([processId, parentProcessId]);
-      processId = undefined;
-      parentProcessId = undefined;
+    const trimmed = line.trim();
+    if (trimmed === "") {
+      flush();
+      continue;
     }
+    const match = trimmed.match(
+      /^(ProcessId|ParentProcessId|CreationDate)=(.*)$/u,
+    );
+    if (match === null) continue;
+    if (match[1] === "ProcessId") record.pid = Number(match[2]!);
+    else if (match[1] === "ParentProcessId")
+      record.parentPid = Number(match[2]!);
+    else record.startTime = match[2]!.trim() || null;
   }
-  if (processId !== undefined && parentProcessId !== undefined)
-    relationships.push([processId, parentProcessId]);
-  const descendants = new Set<number>();
-  let parents = new Set<number>([rootPid]);
-  while (parents.size > 0) {
-    const next = new Set<number>();
-    for (const [childPid, parentPid] of relationships) {
-      if (
-        parents.has(parentPid) &&
-        childPid !== rootPid &&
-        !descendants.has(childPid)
-      ) {
-        descendants.add(childPid);
-        next.add(childPid);
-      }
-    }
-    parents = next;
+  flush();
+  return { entries };
+}
+
+function parsePosixProcessTable(output: string): ProcessTableSnapshot {
+  const entries: ProcessIdentity[] = [];
+  for (const line of output.split(/\r?\n/u)) {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u);
+    if (match === null) continue;
+    entries.push({
+      pid: Number(match[1]!),
+      parentPid: Number(match[2]!),
+      processGroupId: Number(match[3]!),
+      sessionId: Number(match[4]!),
+      startTime: match[5]!.trim() || null,
+    });
   }
-  return { descendants: [...descendants] };
+  return { entries };
 }
 
 async function withDeadline<T>(

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -1,0 +1,288 @@
+import { spawn } from "node:child_process";
+
+import type {
+  TriggerProgramSpec,
+  TriggerProgramStage,
+} from "./trigger-types.js";
+
+export const MAX_PROGRAM_INPUT_BYTES = 64 * 1024;
+export const DEFAULT_PROGRAM_OUTPUT_BYTES = 64 * 1024;
+export const MAX_PROGRAM_OUTPUT_BYTES = 1024 * 1024;
+export const DEFAULT_PROGRAM_TIMEOUT_MS = 30_000;
+export const MAX_PROGRAM_TIMEOUT_MS = 120_000;
+
+export interface TriggerProgramRunInput {
+  invocationId: string;
+  stage: TriggerProgramStage;
+  event: unknown;
+}
+
+export interface TriggerProgramRunResult {
+  status:
+    | "matched"
+    | "non_match"
+    | "completed"
+    | "failed"
+    | "cancelled"
+    | "timed_out"
+    | "nonzero_exit"
+    | "malformed_output"
+    | "oversized_output";
+  output: string | null;
+  exitCode: number | null;
+  error: string | null;
+}
+
+export interface TriggerProgramRunner {
+  run(
+    spec: TriggerProgramSpec,
+    input: TriggerProgramRunInput,
+    signal: AbortSignal,
+  ): Promise<TriggerProgramRunResult>;
+}
+
+export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
+  async run(
+    spec: TriggerProgramSpec,
+    input: TriggerProgramRunInput,
+    signal: AbortSignal,
+  ): Promise<TriggerProgramRunResult> {
+    if (signal.aborted)
+      return result(
+        "cancelled",
+        null,
+        null,
+        describeError(
+          signal.reason ?? new DOMException("Aborted", "AbortError"),
+        ),
+      );
+    const serializedInput = JSON.stringify(input);
+    if (Buffer.byteLength(serializedInput, "utf8") > MAX_PROGRAM_INPUT_BYTES) {
+      return result(
+        "failed",
+        null,
+        null,
+        "Program input exceeded its 64 KiB bound",
+      );
+    }
+    const maxOutputBytes = Math.min(
+      MAX_PROGRAM_OUTPUT_BYTES,
+      Math.max(
+        256,
+        Math.floor(spec.maxOutputBytes ?? DEFAULT_PROGRAM_OUTPUT_BYTES),
+      ),
+    );
+    const timeoutMs = Math.min(
+      MAX_PROGRAM_TIMEOUT_MS,
+      Math.max(1, Math.floor(spec.timeoutMs ?? DEFAULT_PROGRAM_TIMEOUT_MS)),
+    );
+    const environment = {
+      ...minimalEnvironment(process.env),
+      ...(spec.env ?? {}),
+    };
+    return await new Promise<TriggerProgramRunResult>((resolve) => {
+      let child;
+      try {
+        child = spawn(spec.command, spec.args ?? [], {
+          cwd: spec.cwd ?? process.cwd(),
+          env: environment,
+          shell: false,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+      } catch (error) {
+        resolve(result("failed", null, null, describeError(error)));
+        return;
+      }
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let stdoutBytes = 0;
+      let settled = false;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const cleanup = (): void => {
+        if (timer !== undefined) clearTimeout(timer);
+        signal.removeEventListener("abort", abort);
+      };
+      const finish = (value: TriggerProgramRunResult): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(value);
+      };
+      const terminate = (signalName: NodeJS.Signals): void => {
+        if (child.exitCode === null && child.signalCode === null)
+          child.kill(signalName);
+      };
+      const abort = (): void => {
+        terminate("SIGTERM");
+        finish(
+          result(
+            "cancelled",
+            null,
+            null,
+            describeError(
+              signal.reason ?? new DOMException("Aborted", "AbortError"),
+            ),
+          ),
+        );
+      };
+      timer = setTimeout(() => {
+        terminate("SIGTERM");
+        finish(
+          result(
+            "timed_out",
+            null,
+            null,
+            `Program timed out after ${String(timeoutMs)}ms`,
+          ),
+        );
+      }, timeoutMs);
+      signal.addEventListener("abort", abort, { once: true });
+      child.stdout.on("data", (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        stdoutBytes += buffer.length;
+        if (stdoutBytes > maxOutputBytes) {
+          terminate("SIGTERM");
+          finish(
+            result(
+              "oversized_output",
+              null,
+              null,
+              `Program output exceeded its ${String(maxOutputBytes)} byte bound`,
+            ),
+          );
+          return;
+        }
+        stdout.push(buffer);
+      });
+      child.stderr.on("data", (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        if (Buffer.concat(stderr).length < 8 * 1024) stderr.push(buffer);
+      });
+      child.once("error", (error: unknown) => {
+        finish(result("failed", null, null, describeError(error)));
+      });
+      child.once("close", (code: number | null) => {
+        if (settled) return;
+        const text = Buffer.concat(stdout).toString("utf8").trim();
+        if (code !== 0) {
+          finish(
+            result(
+              "nonzero_exit",
+              text.length === 0 ? null : text,
+              code,
+              boundedError(Buffer.concat(stderr).toString("utf8")),
+            ),
+          );
+          return;
+        }
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(text) as unknown;
+        } catch (error) {
+          finish(
+            result(
+              "malformed_output",
+              text || null,
+              code,
+              describeError(error),
+            ),
+          );
+          return;
+        }
+        const object = record(parsed);
+        if (object === null) {
+          finish(
+            result(
+              "malformed_output",
+              text,
+              code,
+              "Program output must be a JSON object",
+            ),
+          );
+          return;
+        }
+        if (input.stage === "predicate") {
+          if (typeof object["match"] !== "boolean") {
+            finish(
+              result(
+                "malformed_output",
+                text,
+                code,
+                "Predicate output must contain boolean match",
+              ),
+            );
+            return;
+          }
+          finish(
+            result(object["match"] ? "matched" : "non_match", text, code, null),
+          );
+          return;
+        }
+        if (object["ok"] !== undefined && typeof object["ok"] !== "boolean") {
+          finish(
+            result(
+              "malformed_output",
+              text,
+              code,
+              "Action output ok must be boolean",
+            ),
+          );
+          return;
+        }
+        if (object["ok"] === false) {
+          finish(result("failed", text, code, "Action returned ok=false"));
+          return;
+        }
+        finish(result("completed", text, code, null));
+      });
+      child.stdin.end(`${serializedInput}\n`);
+    });
+  }
+}
+
+function result(
+  status: TriggerProgramRunResult["status"],
+  output: string | null,
+  exitCode: number | null,
+  error: string | null,
+): TriggerProgramRunResult {
+  return { status, output: bound(output), exitCode, error: bound(error) };
+}
+
+function minimalEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = {};
+  for (const name of [
+    "HOME",
+    "LANG",
+    "PATH",
+    "Path",
+    "PATHEXT",
+    "SHELL",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+  ]) {
+    if (source[name] !== undefined) environment[name] = source[name];
+  }
+  return environment;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function boundedError(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : bound(trimmed);
+}
+
+function bound(value: string | null): string | null {
+  if (value === null || value.length <= 2_048) return value;
+  return `${value.slice(0, 2_024)}…[truncated]`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -12,6 +12,34 @@ import {
   ZenXTriggerProgramRunner,
   type TriggerProgramRunner,
 } from "./trigger-program-runner.js";
+import {
+  MAX_ERROR_BYTES,
+  MAX_ID_BYTES,
+  MAX_MEMBER_NAME_BYTES,
+  MAX_MESSAGE_AUTHOR_BYTES,
+  MAX_MESSAGE_TEXT_BYTES,
+  MAX_PROGRAM_ARGUMENT_BYTES,
+  MAX_PROGRAM_ARGUMENTS,
+  MAX_PROGRAM_COMMAND_BYTES,
+  MAX_PROGRAM_CWD_BYTES,
+  MAX_PROGRAM_ENV_BYTES,
+  MAX_PROGRAM_ENV_ENTRIES,
+  MAX_PROGRAM_ENV_KEY_BYTES,
+  MAX_PROGRAM_ENV_VALUE_BYTES,
+  MAX_PROGRAM_FLAGS_BYTES,
+  MAX_PROGRAM_MATCH_REGEX_BYTES,
+  MAX_REASON_BYTES,
+  MAX_ROOM_COUNT,
+  MAX_ROOM_MEMBERS,
+  MAX_ROOM_MESSAGES,
+  MAX_ROOM_NAME_BYTES,
+  MAX_TRIGGER_COUNT,
+  MAX_TRIGGER_LABEL_BYTES,
+  MAX_TRIGGER_PROMPT_BYTES,
+  retainHistory,
+  utf8Bytes,
+  withinBytes,
+} from "./trigger-limits.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
 import type {
   CreateRoomInput,
@@ -153,7 +181,11 @@ export class ZenXTriggerService {
                 "The previous process ended before the local program outcome was known",
             };
             entry.programOutcome = outcome;
-            entry.programOutcomes = [outcome];
+            entry.programOutcomes = appendProgramOutcome(
+              entry.programOutcomes,
+              outcome,
+            );
+            entry.programInvocationId = null;
           }
         }
       }
@@ -219,10 +251,11 @@ export class ZenXTriggerService {
                   "Trigger generation retired while local work was in flight",
               };
               entry.programOutcome = outcome;
-              entry.programOutcomes = [
-                ...(entry.programOutcomes ?? []),
+              entry.programOutcomes = appendProgramOutcome(
+                entry.programOutcomes,
                 outcome,
-              ].slice(-MAX_PROGRAM_OUTCOMES);
+              );
+              entry.programInvocationId = null;
             }
           }
           generation.activeWakeups.clear();
@@ -262,6 +295,8 @@ export class ZenXTriggerService {
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
     const generation = this.#runningGeneration();
     const trigger = await this.#mutate(generation, async (snapshot) => {
+      if (snapshot.triggers.length >= MAX_TRIGGER_COUNT)
+        throw new Error(`ZenX Trigger limit is ${String(MAX_TRIGGER_COUNT)}`);
       const value = triggerFromInput(
         input,
         randomUUID(),
@@ -329,8 +364,8 @@ export class ZenXTriggerService {
 
   async signal(name: string, detail: string): Promise<void> {
     const generation = this.#runningGeneration();
-    const signalName = required(name, "signal name");
-    const signalDetail = detail.trim();
+    const signalName = required(name, "signal name", MAX_ID_BYTES);
+    const signalDetail = bounded(detail.trim(), MAX_REASON_BYTES);
     const matches = this.#snapshot.triggers
       .filter(
         (trigger) =>
@@ -341,9 +376,9 @@ export class ZenXTriggerService {
       .map((trigger) => trigger.id);
     for (const triggerId of matches) {
       await this.#fire(generation, triggerId, {
-        reason: `External signal ${signalName}: ${bounded(signalDetail, 4_000)}`,
+        reason: `External signal ${signalName}: ${signalDetail}`,
         occurrenceKey: `signal:${randomUUID()}`,
-        projection: `Signal name: ${signalName}\nSignal detail: ${bounded(signalDetail, 4_000)}`,
+        projection: `Signal name: ${signalName}\nSignal detail: ${signalDetail}`,
       });
     }
   }
@@ -351,9 +386,11 @@ export class ZenXTriggerService {
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
     const generation = this.#runningGeneration();
     const room = await this.#mutate(generation, async (snapshot) => {
+      if (snapshot.rooms.length >= MAX_ROOM_COUNT)
+        throw new Error(`ZenX Room limit is ${String(MAX_ROOM_COUNT)}`);
       const value: ZenXRoom = {
         id: randomUUID(),
-        name: required(input.name, "room name"),
+        name: required(input.name, "room name", MAX_ROOM_NAME_BYTES),
         members: validateMembers(input.members),
         messages: [],
         createdAt: this.#now(),
@@ -368,17 +405,17 @@ export class ZenXTriggerService {
     const generation = this.#runningGeneration();
     await this.#mutate(generation, async (snapshot) => {
       const room = snapshot.rooms.find(
-        (candidate) => candidate.id === required(roomId, "room"),
+        (candidate) => candidate.id === required(roomId, "room", MAX_ID_BYTES),
       );
       if (room === undefined) throw new Error("Room was not found");
-      room.name = required(name, "room name");
+      room.name = required(name, "room name", MAX_ROOM_NAME_BYTES);
     });
   }
 
   async deleteRoom(roomId: string): Promise<void> {
     const generation = this.#runningGeneration();
     await this.#mutate(generation, async (snapshot) => {
-      const normalized = required(roomId, "room");
+      const normalized = required(roomId, "room", MAX_ID_BYTES);
       const room = snapshot.rooms.find(
         (candidate) => candidate.id === normalized,
       );
@@ -402,7 +439,7 @@ export class ZenXTriggerService {
     const generation = this.#runningGeneration();
     await this.#mutate(generation, async (snapshot) => {
       const room = snapshot.rooms.find(
-        (entry) => entry.id === required(roomId, "room"),
+        (entry) => entry.id === required(roomId, "room", MAX_ID_BYTES),
       );
       if (room === undefined) throw new Error("Room was not found");
       room.members = validateMembers([...room.members, member]);
@@ -413,10 +450,10 @@ export class ZenXTriggerService {
     const generation = this.#runningGeneration();
     await this.#mutate(generation, async (snapshot) => {
       const room = snapshot.rooms.find(
-        (entry) => entry.id === required(roomId, "room"),
+        (entry) => entry.id === required(roomId, "room", MAX_ID_BYTES),
       );
       if (room === undefined) throw new Error("Room was not found");
-      const normalized = required(threadId, "member thread");
+      const normalized = required(threadId, "member thread", MAX_ID_BYTES);
       if (!room.members.some((member) => member.threadId === normalized))
         throw new Error("Room member was not found");
       room.members = room.members.filter(
@@ -446,25 +483,36 @@ export class ZenXTriggerService {
     originTurnId: string | null,
   ): Promise<void> {
     const generation = this.#runningGeneration();
+    const normalizedRoomId = required(roomId, "room", MAX_ID_BYTES);
+    const normalizedAuthor = required(
+      author,
+      "author",
+      MAX_MESSAGE_AUTHOR_BYTES,
+    );
+    const normalizedText = required(text, "message", MAX_MESSAGE_TEXT_BYTES);
     const posted = await this.#mutate(generation, async (snapshot) => {
       const room = snapshot.rooms.find(
-        (entry) => entry.id === required(roomId, "room"),
+        (entry) => entry.id === normalizedRoomId,
       );
       if (room === undefined) throw new Error("Room was not found");
       const value = message(
         room.id,
-        required(author, "author"),
-        required(text, "message"),
+        normalizedAuthor,
+        normalizedText,
         kind,
         originThreadId,
         originTurnId,
         this.#now(),
       );
       room.messages.push(value);
-      return { posted: value, room: structuredClone(room) };
+      return { posted: value };
     });
-    const mentions = posted.room.members.filter((member) =>
-      mentionMatches(text, member.name),
+    const postedRoom = this.#snapshot.rooms.find(
+      (room) => room.id === posted.posted.roomId,
+    );
+    if (postedRoom === undefined) throw new StaleGenerationError();
+    const mentions = postedRoom.members.filter((member) =>
+      mentionMatches(normalizedText, member.name),
     );
     for (const member of mentions) {
       const triggerIds = this.#snapshot.triggers
@@ -473,18 +521,18 @@ export class ZenXTriggerService {
             trigger.active &&
             trigger.threadId === member.threadId &&
             trigger.kind === "roomMention" &&
-            trigger.room?.roomId === roomId &&
+            trigger.room?.roomId === normalizedRoomId &&
             trigger.room.mention.toLocaleLowerCase() ===
               member.name.toLocaleLowerCase(),
         )
         .map((trigger) => trigger.id);
       for (const triggerId of triggerIds) {
         await this.#fire(generation, triggerId, {
-          reason: `Room #${posted.room.name} mention from ${posted.posted.author}: ${posted.posted.text}`,
-          occurrenceKey: `room:${posted.room.id}:${posted.posted.id}`,
-          sourceRoomId: posted.room.id,
+          reason: `Room #${postedRoom.name} mention from ${posted.posted.author}: ${posted.posted.text}`,
+          occurrenceKey: `room:${postedRoom.id}:${posted.posted.id}`,
+          sourceRoomId: postedRoom.id,
           sourceRoomMessageId: posted.posted.id,
-          projection: projectRoomContext(posted.room),
+          projection: projectRoomContext(postedRoom),
           eventText: posted.posted.text,
         });
       }
@@ -674,8 +722,8 @@ export class ZenXTriggerService {
           triggerId: trigger.id,
           threadId: trigger.threadId,
           kind: trigger.kind,
-          reason: bounded(wakeup.reason, 4_000),
-          prompt: bounded(trigger.prompt, 4_000),
+          reason: bounded(wakeup.reason, MAX_REASON_BYTES),
+          prompt: bounded(trigger.prompt, MAX_TRIGGER_PROMPT_BYTES),
           clientUserMessageId,
           startedAt: this.#now(),
           completedAt: rejected ? this.#now() : null,
@@ -749,7 +797,7 @@ export class ZenXTriggerService {
           program.match.regex,
           program.match.flags ?? "u",
         );
-        const matched = regex.test(wakeup.eventText ?? wakeup.projection ?? "");
+        const matched = regex.test(wakeup.eventText ?? "");
         const outcome = this.#programOutcome(
           "predicate",
           stableProgramInvocationId(active.clientUserMessageId, "predicate"),
@@ -1002,10 +1050,11 @@ export class ZenXTriggerService {
         (candidate) => candidate.id === active.historyId,
       );
       if (entry === undefined || isTerminal(entry.status)) return;
-      entry.programInvocationId = outcome.invocationId;
+      entry.programInvocationId = null;
       entry.programOutcome = outcome;
-      entry.programOutcomes = [...(entry.programOutcomes ?? []), outcome].slice(
-        -MAX_PROGRAM_OUTCOMES,
+      entry.programOutcomes = appendProgramOutcome(
+        entry.programOutcomes,
+        outcome,
       );
     });
   }
@@ -1040,10 +1089,11 @@ export class ZenXTriggerService {
       entry.status = status;
       entry.completedAt = this.#now();
       entry.error = error;
-      entry.programInvocationId = outcome.invocationId;
+      entry.programInvocationId = null;
       entry.programOutcome = outcome;
-      entry.programOutcomes = [...(entry.programOutcomes ?? []), outcome].slice(
-        -MAX_PROGRAM_OUTCOMES,
+      entry.programOutcomes = appendProgramOutcome(
+        entry.programOutcomes,
+        outcome,
       );
       released = true;
     });
@@ -1063,7 +1113,7 @@ export class ZenXTriggerService {
       if (entry === undefined || isTerminal(entry.status)) return;
       entry.status = "failed";
       entry.completedAt = this.#now();
-      entry.error = bounded(error, 4_000);
+      entry.error = bounded(error, MAX_ERROR_BYTES);
       released = true;
     });
     if (released) {
@@ -1146,6 +1196,7 @@ export class ZenXTriggerService {
       const snapshot = structuredClone(this.#snapshot);
       const result = await operation(snapshot);
       this.#assertMutationGeneration(generation, allowRetiring);
+      retainSnapshot(snapshot);
       await this.#store.write(snapshot);
       this.#assertMutationGeneration(generation, allowRetiring);
       this.#snapshot = snapshot;
@@ -1205,7 +1256,7 @@ export class ZenXTriggerService {
       status,
       output: bounded(output ?? "", 8_000) || null,
       exitCode,
-      error: bounded(error ?? "", 2_048) || null,
+      error: bounded(error ?? "", MAX_ERROR_BYTES) || null,
     };
   }
 
@@ -1243,10 +1294,10 @@ function triggerFromInput(
 ): ZenXTrigger {
   const common = {
     id,
-    threadId: required(input.threadId, "thread"),
+    threadId: required(input.threadId, "thread", MAX_ID_BYTES),
     kind: input.kind,
-    label: required(input.label, "label"),
-    prompt: required(input.prompt, "prompt"),
+    label: required(input.label, "label", MAX_TRIGGER_LABEL_BYTES),
+    prompt: required(input.prompt, "prompt", MAX_TRIGGER_PROMPT_BYTES),
     createdAt,
     active,
     ...(programFromInput(input) === undefined
@@ -1271,7 +1322,11 @@ function triggerFromInput(
       ...common,
       kind: "thread",
       watch: {
-        threadId: required(input.watchedThreadId, "watched thread"),
+        threadId: required(
+          input.watchedThreadId,
+          "watched thread",
+          MAX_ID_BYTES,
+        ),
         event: "turn_completed",
       },
     };
@@ -1281,15 +1336,15 @@ function triggerFromInput(
       ...common,
       kind: "roomMention",
       room: {
-        roomId: required(input.roomId, "room"),
-        mention: required(input.mention, "mention"),
+        roomId: required(input.roomId, "room", MAX_ID_BYTES),
+        mention: required(input.mention, "mention", MAX_MEMBER_NAME_BYTES),
       },
     };
   }
   return {
     ...common,
     kind: "signal",
-    signal: { name: required(input.signalName, "signal name") },
+    signal: { name: required(input.signalName, "signal name", MAX_ID_BYTES) },
   };
 }
 
@@ -1324,15 +1379,17 @@ function validateProgram(program: TriggerProgramConfig): void {
     ["action", program.action],
   ] as const) {
     if (spec === undefined) continue;
-    if (required(spec.command, `${stage} command`).length > 4_096)
-      throw new Error(`${stage} command is too long`);
-    if ((spec.args?.length ?? 0) > 64)
+    required(spec.command, `${stage} command`, MAX_PROGRAM_COMMAND_BYTES);
+    if ((spec.args?.length ?? 0) > MAX_PROGRAM_ARGUMENTS)
       throw new Error(`${stage} has too many arguments`);
-    if (spec.args?.some((arg) => arg.length > 4_096))
+    if (spec.args?.some((arg) => !withinBytes(arg, MAX_PROGRAM_ARGUMENT_BYTES)))
       throw new Error(`${stage} argument is too long`);
     if (
       spec.cwd !== undefined &&
-      required(spec.cwd, `${stage} cwd`).length > 4_096
+      !withinBytes(
+        required(spec.cwd, `${stage} cwd`, MAX_PROGRAM_CWD_BYTES),
+        MAX_PROGRAM_CWD_BYTES,
+      )
     )
       throw new Error(`${stage} cwd is too long`);
     if (
@@ -1353,17 +1410,33 @@ function validateProgram(program: TriggerProgramConfig): void {
       );
     if (
       spec.env !== undefined &&
-      Object.entries(spec.env).some(
-        ([key, value]) =>
-          key.length === 0 || key.length > 256 || value.length > 4_096,
-      )
+      (Object.keys(spec.env).length > MAX_PROGRAM_ENV_ENTRIES ||
+        Object.entries(spec.env).some(
+          ([key, value]) =>
+            key.length === 0 ||
+            !withinBytes(key, MAX_PROGRAM_ENV_KEY_BYTES) ||
+            !withinBytes(value, MAX_PROGRAM_ENV_VALUE_BYTES),
+        ) ||
+        Object.entries(spec.env).reduce(
+          (total, [key, value]) => total + utf8Bytes(key) + utf8Bytes(value),
+          0,
+        ) > MAX_PROGRAM_ENV_BYTES)
     )
       throw new Error(`${stage} env is invalid`);
   }
   if (program.match !== undefined) {
     if (
       program.match.field !== "completedItemText" ||
-      required(program.match.regex, "match regex").length > 4_096
+      !withinBytes(
+        required(
+          program.match.regex,
+          "match regex",
+          MAX_PROGRAM_MATCH_REGEX_BYTES,
+        ),
+        MAX_PROGRAM_MATCH_REGEX_BYTES,
+      ) ||
+      (program.match.flags !== undefined &&
+        !withinBytes(program.match.flags, MAX_PROGRAM_FLAGS_BYTES))
     )
       throw new Error("Trigger match is invalid");
     try {
@@ -1433,10 +1506,19 @@ function message(
   };
 }
 
-function required(value: string, label: string): string {
+function required(
+  value: string,
+  label: string,
+  maximum = MAX_ID_BYTES,
+): string {
   if (typeof value !== "string" || value.trim().length === 0)
     throw new Error(`Trigger ${label} is required`);
-  return value.trim();
+  const normalized = value.trim();
+  if (!withinBytes(normalized, maximum))
+    throw new Error(
+      `Trigger ${label} exceeds its ${String(maximum)} byte bound`,
+    );
+  return normalized;
 }
 
 function positive(value: number): number {
@@ -1453,9 +1535,13 @@ function validFuture(value: number, now: number): number {
 
 function validateMembers(members: readonly RoomMember[]): RoomMember[] {
   if (members.length === 0) throw new Error("Room needs at least one member");
+  if (members.length > MAX_ROOM_MEMBERS)
+    throw new Error(
+      `Room cannot have more than ${String(MAX_ROOM_MEMBERS)} members`,
+    );
   const normalized = members.map((member) => ({
-    name: required(member.name, "member name"),
-    threadId: required(member.threadId, "member thread"),
+    name: required(member.name, "member name", MAX_MEMBER_NAME_BYTES),
+    threadId: required(member.threadId, "member thread", MAX_ID_BYTES),
   }));
   const names = new Set<string>();
   const threads = new Set<string>();
@@ -1517,6 +1603,28 @@ function setBounded<K, V>(
     map.delete(oldest);
     onEvict(oldest);
   }
+}
+
+function retainSnapshot(snapshot: TriggerSnapshot): void {
+  if (snapshot.triggers.length > MAX_TRIGGER_COUNT)
+    throw new Error(`ZenX Trigger limit is ${String(MAX_TRIGGER_COUNT)}`);
+  if (snapshot.rooms.length > MAX_ROOM_COUNT)
+    throw new Error(`ZenX Room limit is ${String(MAX_ROOM_COUNT)}`);
+  snapshot.history = retainHistory(snapshot.history);
+  for (const room of snapshot.rooms) {
+    if (room.members.length > MAX_ROOM_MEMBERS)
+      throw new Error(
+        `Room cannot have more than ${String(MAX_ROOM_MEMBERS)} members`,
+      );
+    room.messages = room.messages.slice(-MAX_ROOM_MESSAGES);
+  }
+}
+
+function appendProgramOutcome(
+  outcomes: TriggerProgramOutcome[] | undefined,
+  outcome: TriggerProgramOutcome,
+): TriggerProgramOutcome[] {
+  return [...(outcomes ?? []), outcome].slice(-MAX_PROGRAM_OUTCOMES);
 }
 
 function isTerminal(status: TriggerHistoryEntry["status"]): boolean {
@@ -1641,8 +1749,12 @@ function mergeCompletedItems(
 }
 
 function bounded(value: string, limit: number): string {
-  if (value.length <= limit) return value;
-  return `${value.slice(0, Math.max(0, limit - 24))}\n…[truncated by ZenX]`;
+  if (utf8Bytes(value) <= limit) return value;
+  const suffix = "\n…[truncated by ZenX]";
+  const prefix = Buffer.from(value, "utf8")
+    .subarray(0, Math.max(0, limit - utf8Bytes(suffix)))
+    .toString("utf8");
+  return `${prefix}${suffix}`;
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -99,6 +99,15 @@ interface ActiveWakeup {
   generationId: string;
 }
 
+interface CommittedWakeup {
+  historyId: string;
+  clientUserMessageId: string;
+  trigger: ZenXTrigger;
+  wakeup: WakeupEvent;
+}
+
+type WakeupCommitResult = CommittedWakeup | { rejected: true } | undefined;
+
 interface CompletedItemBuffer {
   threadId: string;
   items: ThreadItem[];
@@ -115,6 +124,7 @@ interface TriggerGeneration {
   id: string;
   active: boolean;
   retiring: boolean;
+  storeUnavailable: boolean;
   timers: Map<string, unknown>;
   completedTurnItems: Map<string, CompletedItemBuffer>;
   pendingCompletedTurns: Map<string, PendingCompletion>;
@@ -491,7 +501,7 @@ export class ZenXTriggerService {
       MAX_MESSAGE_AUTHOR_BYTES,
     );
     const normalizedText = required(text, "message", MAX_MESSAGE_TEXT_BYTES);
-    const posted = await this.#mutate(generation, async (snapshot) => {
+    const committed = await this.#mutate(generation, async (snapshot) => {
       const room = snapshot.rooms.find(
         (entry) => entry.id === normalizedRoomId,
       );
@@ -506,37 +516,39 @@ export class ZenXTriggerService {
         this.#now(),
       );
       room.messages.push(value);
-      return { posted: value };
-    });
-    const postedRoom = this.#snapshot.rooms.find(
-      (room) => room.id === posted.posted.roomId,
-    );
-    if (postedRoom === undefined) throw new StaleGenerationError();
-    const mentions = postedRoom.members.filter((member) =>
-      mentionMatches(normalizedText, member.name),
-    );
-    for (const member of mentions) {
-      const triggerIds = this.#snapshot.triggers
-        .filter(
-          (trigger) =>
-            trigger.active &&
-            trigger.threadId === member.threadId &&
-            trigger.kind === "roomMention" &&
-            trigger.room?.roomId === normalizedRoomId &&
-            trigger.room.mention.toLocaleLowerCase() ===
-              member.name.toLocaleLowerCase(),
-        )
-        .map((trigger) => trigger.id);
-      for (const triggerId of triggerIds) {
-        await this.#fire(generation, triggerId, {
-          reason: `Room #${postedRoom.name} mention from ${posted.posted.author}: ${posted.posted.text}`,
-          occurrenceKey: `room:${postedRoom.id}:${posted.posted.id}`,
-          sourceRoomId: postedRoom.id,
-          sourceRoomMessageId: posted.posted.id,
-          projection: projectRoomContext(postedRoom),
-        });
+      const wakeups: CommittedWakeup[] = [];
+      const mentions = room.members.filter((member) =>
+        mentionMatches(normalizedText, member.name),
+      );
+      for (const member of mentions) {
+        const triggerIds = snapshot.triggers
+          .filter(
+            (trigger) =>
+              trigger.active &&
+              trigger.threadId === member.threadId &&
+              trigger.kind === "roomMention" &&
+              trigger.room?.roomId === normalizedRoomId &&
+              trigger.room.mention.toLocaleLowerCase() ===
+                member.name.toLocaleLowerCase(),
+          )
+          .map((trigger) => trigger.id);
+        for (const triggerId of triggerIds) {
+          const commit = this.#commitWakeup(snapshot, triggerId, {
+            reason: `Room #${room.name} mention from ${value.author}: ${value.text}`,
+            occurrenceKey: `room:${room.id}:${value.id}`,
+            sourceRoomId: room.id,
+            sourceRoomMessageId: value.id,
+            projection: projectRoomContext(room),
+          });
+          if (commit !== undefined && !("rejected" in commit))
+            wakeups.push(commit);
+        }
       }
-    }
+      return { wakeups };
+    });
+    this.#rescheduleTimers(generation);
+    for (const wakeup of committed.wakeups)
+      await this.#runCommittedWakeup(generation, wakeup);
   }
 
   async #handleTurnCompleted(
@@ -570,9 +582,7 @@ export class ZenXTriggerService {
               `Trigger completion could not be persisted: ${describeError(error)}`,
             );
           } catch (failureError) {
-            console.warn(
-              `Could not persist Trigger completion failure: ${describeError(failureError)}`,
-            );
+            this.#markStoreUnavailable(generation, running.id, failureError);
           }
         }
       }
@@ -705,85 +715,100 @@ export class ZenXTriggerService {
     wakeup: WakeupEvent,
   ): Promise<void> {
     if (!this.#isOperational(generation)) return;
-    let committed;
+    let committed: WakeupCommitResult;
     try {
-      committed = await this.#mutate(generation, async (snapshot) => {
-        const trigger = snapshot.triggers.find(
-          (item) => item.id === triggerId && item.active,
-        );
-        if (trigger === undefined) return undefined;
-        if (
-          trigger.kind === "roomMention" &&
-          (trigger.room === undefined ||
-            !snapshot.rooms.some((room) => room.id === trigger.room?.roomId))
-        )
-          return undefined;
-        const clientUserMessageId = stableWakeupId(
-          trigger.id,
-          wakeup.occurrenceKey,
-        );
-        if (
-          snapshot.history.some(
-            (entry) => entry.clientUserMessageId === clientUserMessageId,
-          )
-        )
-          return undefined;
-        const nonterminal = snapshot.history.filter(
-          (entry) => entry.status === "starting" || entry.status === "running",
-        ).length;
-        const rejected = nonterminal >= MAX_WAKEUPS;
-        const history: TriggerHistoryEntry = {
-          id: randomUUID(),
-          triggerId: trigger.id,
-          threadId: trigger.threadId,
-          kind: trigger.kind,
-          reason: bounded(wakeup.reason, MAX_REASON_BYTES),
-          prompt: bounded(trigger.prompt, MAX_TRIGGER_PROMPT_BYTES),
-          clientUserMessageId,
-          startedAt: this.#now(),
-          completedAt: rejected ? this.#now() : null,
-          status: rejected ? "failed" : "starting",
-          turnId: null,
-          error: rejected
-            ? `ZenX Trigger wakeup admission is full at ${String(MAX_WAKEUPS)} nonterminal wakeups; this wakeup was not dispatched.`
-            : null,
-          sourceThreadId: wakeup.sourceThreadId ?? null,
-          sourceTurnId: wakeup.sourceTurnId ?? null,
-          sourceRoomId: wakeup.sourceRoomId ?? null,
-          sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-          replyRoomId: trigger.room?.roomId ?? null,
-          replyAuthor: trigger.room?.mention ?? null,
-          programInvocationId: null,
-          programOutcome: null,
-          programOutcomes: [],
-        };
-        snapshot.history.unshift(history);
-        if (trigger.timer !== undefined) {
-          if (trigger.timer.intervalMinutes === null) trigger.active = false;
-          else {
-            trigger.timer.nextRunAt =
-              Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-              trigger.timer.intervalMinutes * 60_000;
-          }
-        }
-        return rejected
-          ? { rejected: true as const }
-          : {
-              rejected: false as const,
-              trigger: structuredClone(trigger),
-              historyId: history.id,
-              clientUserMessageId,
-            };
-      });
+      committed = await this.#mutate(generation, async (snapshot) =>
+        this.#commitWakeup(snapshot, triggerId, wakeup),
+      );
     } catch (error) {
       if (error instanceof StaleGenerationError) return;
       throw error;
     }
-    if (committed === undefined || committed.rejected) {
+    if (committed === undefined || "rejected" in committed) {
       this.#rescheduleTimers(generation);
       return;
     }
     this.#rescheduleTimers(generation);
+    await this.#runCommittedWakeup(generation, committed);
+  }
+
+  #commitWakeup(
+    snapshot: TriggerSnapshot,
+    triggerId: string,
+    wakeup: WakeupEvent,
+  ): WakeupCommitResult {
+    const trigger = snapshot.triggers.find(
+      (item) => item.id === triggerId && item.active,
+    );
+    if (trigger === undefined) return undefined;
+    if (
+      trigger.kind === "roomMention" &&
+      (trigger.room === undefined ||
+        !snapshot.rooms.some((room) => room.id === trigger.room?.roomId))
+    )
+      return undefined;
+    const clientUserMessageId = stableWakeupId(
+      trigger.id,
+      wakeup.occurrenceKey,
+    );
+    if (
+      snapshot.history.some(
+        (entry) => entry.clientUserMessageId === clientUserMessageId,
+      )
+    )
+      return undefined;
+    const nonterminal = snapshot.history.filter(
+      (entry) => entry.status === "starting" || entry.status === "running",
+    ).length;
+    const rejected = nonterminal >= MAX_WAKEUPS;
+    const history: TriggerHistoryEntry = {
+      id: randomUUID(),
+      triggerId: trigger.id,
+      threadId: trigger.threadId,
+      kind: trigger.kind,
+      reason: bounded(wakeup.reason, MAX_REASON_BYTES),
+      prompt: bounded(trigger.prompt, MAX_TRIGGER_PROMPT_BYTES),
+      clientUserMessageId,
+      startedAt: this.#now(),
+      completedAt: rejected ? this.#now() : null,
+      status: rejected ? "failed" : "starting",
+      turnId: null,
+      error: rejected
+        ? `ZenX Trigger wakeup admission is full at ${String(MAX_WAKEUPS)} nonterminal wakeups; this wakeup was not dispatched.`
+        : null,
+      sourceThreadId: wakeup.sourceThreadId ?? null,
+      sourceTurnId: wakeup.sourceTurnId ?? null,
+      sourceRoomId: wakeup.sourceRoomId ?? null,
+      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+      replyRoomId: trigger.room?.roomId ?? null,
+      replyAuthor: trigger.room?.mention ?? null,
+      programInvocationId: null,
+      programOutcome: null,
+      programOutcomes: [],
+    };
+    snapshot.history.unshift(history);
+    if (trigger.timer !== undefined) {
+      if (trigger.timer.intervalMinutes === null) trigger.active = false;
+      else {
+        trigger.timer.nextRunAt =
+          Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
+          trigger.timer.intervalMinutes * 60_000;
+      }
+    }
+    return rejected
+      ? { rejected: true }
+      : {
+          trigger: structuredClone(trigger),
+          historyId: history.id,
+          clientUserMessageId,
+          wakeup: structuredClone(wakeup),
+        };
+  }
+
+  async #runCommittedWakeup(
+    generation: TriggerGeneration,
+    committed: CommittedWakeup,
+  ): Promise<void> {
     const active: ActiveWakeup = {
       historyId: committed.historyId,
       threadId: committed.trigger.threadId,
@@ -792,7 +817,7 @@ export class ZenXTriggerService {
       generationId: generation.id,
     };
     generation.activeWakeups.set(active.clientUserMessageId, active);
-    await this.#executeWakeup(generation, active, wakeup);
+    await this.#executeWakeup(generation, active, committed.wakeup);
   }
 
   async #executeWakeup(
@@ -953,12 +978,21 @@ export class ZenXTriggerService {
       }
     } catch (error) {
       if (error instanceof StaleGenerationError) return;
-      if (this.#isOperational(generation))
-        await this.#failHistory(
-          generation,
-          active.historyId,
-          describeError(error),
-        );
+      if (this.#isOperational(generation)) {
+        try {
+          await this.#failHistory(
+            generation,
+            active.historyId,
+            describeError(error),
+          );
+        } catch (failureError) {
+          this.#markStoreUnavailable(
+            generation,
+            active.historyId,
+            failureError,
+          );
+        }
+      }
     } finally {
       generation.programControllers.delete(active.historyId);
     }
@@ -1047,13 +1081,7 @@ export class ZenXTriggerService {
       }
       released = true;
     });
-    if (released) {
-      const active = [...generation.activeWakeups.values()].find(
-        (candidate) => candidate.historyId === historyId,
-      );
-      if (active !== undefined)
-        generation.activeWakeups.delete(active.clientUserMessageId);
-    }
+    if (released) this.#releaseActiveWakeup(generation, historyId);
   }
 
   async #recordProgramOutcome(
@@ -1113,7 +1141,7 @@ export class ZenXTriggerService {
       );
       released = true;
     });
-    if (released) generation.activeWakeups.delete(active.clientUserMessageId);
+    if (released) this.#releaseActiveWakeup(generation, active.historyId);
   }
 
   async #failHistory(
@@ -1132,13 +1160,7 @@ export class ZenXTriggerService {
       entry.error = bounded(error, MAX_ERROR_BYTES);
       released = true;
     });
-    if (released) {
-      const active = [...generation.activeWakeups.values()].find(
-        (candidate) => candidate.historyId === historyId,
-      );
-      if (active !== undefined)
-        generation.activeWakeups.delete(active.clientUserMessageId);
-    }
+    if (released) this.#releaseActiveWakeup(generation, historyId);
   }
 
   async #observeTitle(
@@ -1234,6 +1256,7 @@ export class ZenXTriggerService {
     return (
       generation.active &&
       !generation.retiring &&
+      !generation.storeUnavailable &&
       this.#generation === generation
     );
   }
@@ -1277,7 +1300,40 @@ export class ZenXTriggerService {
   }
 
   #notify(): void {
-    for (const listener of this.#listeners) listener(this.snapshot());
+    for (const listener of this.#listeners) {
+      try {
+        listener(this.snapshot());
+      } catch (error) {
+        console.warn(
+          `ZenX Trigger change listener failed after the mutation committed: ${bounded(
+            describeError(error),
+            MAX_ERROR_BYTES,
+          )}`,
+        );
+      }
+    }
+  }
+
+  #releaseActiveWakeup(generation: TriggerGeneration, historyId: string): void {
+    for (const [clientUserMessageId, active] of generation.activeWakeups) {
+      if (active.historyId === historyId)
+        generation.activeWakeups.delete(clientUserMessageId);
+    }
+  }
+
+  #markStoreUnavailable(
+    generation: TriggerGeneration,
+    historyId: string,
+    error: unknown,
+  ): void {
+    generation.storeUnavailable = true;
+    this.#releaseActiveWakeup(generation, historyId);
+    console.warn(
+      `ZenX Trigger persistence is unavailable; no new wakeups will dispatch: ${bounded(
+        describeError(error),
+        MAX_ERROR_BYTES,
+      )}`,
+    );
   }
 }
 
@@ -1292,6 +1348,7 @@ function newGeneration(): TriggerGeneration {
     id: randomUUID(),
     active: true,
     retiring: false,
+    storeUnavailable: false,
     timers: new Map(),
     completedTurnItems: new Map(),
     pendingCompletedTurns: new Map(),

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -28,6 +28,7 @@ import {
   MAX_PROGRAM_ENV_VALUE_BYTES,
   MAX_PROGRAM_FLAGS_BYTES,
   MAX_PROGRAM_MATCH_REGEX_BYTES,
+  MAX_PROGRAM_TIMEOUT_MS,
   MAX_REASON_BYTES,
   MAX_ROOM_COUNT,
   MAX_ROOM_MEMBERS,
@@ -533,7 +534,6 @@ export class ZenXTriggerService {
           sourceRoomId: postedRoom.id,
           sourceRoomMessageId: posted.posted.id,
           projection: projectRoomContext(postedRoom),
-          eventText: posted.posted.text,
         });
       }
     }
@@ -558,7 +558,24 @@ export class ZenXTriggerService {
         generation.activeWakeups.has(entry.clientUserMessageId),
     );
     if (running !== undefined) {
-      await this.#completeTurn(generation, running.id, event, completedItems);
+      try {
+        await this.#completeTurn(generation, running.id, event, completedItems);
+      } catch (error) {
+        if (error instanceof StaleGenerationError) return;
+        if (this.#isOperational(generation)) {
+          try {
+            await this.#failHistory(
+              generation,
+              running.id,
+              `Trigger completion could not be persisted: ${describeError(error)}`,
+            );
+          } catch (failureError) {
+            console.warn(
+              `Could not persist Trigger completion failure: ${describeError(failureError)}`,
+            );
+          }
+        }
+      }
       clearTransientTurn(generation, event.threadId, event.turn.id);
     } else {
       this.#bufferEarlyCompletion(generation, event, completedItems);
@@ -572,6 +589,7 @@ export class ZenXTriggerService {
           trigger.watch?.threadId === event.threadId,
       )
       .map((trigger) => trigger.id);
+    const eventText = completedItemText(completedItems);
     for (const triggerId of watchers) {
       await this.#fire(generation, triggerId, {
         reason: `Thread ${event.threadId} emitted turn_completed for ${event.turn.id}`,
@@ -582,10 +600,7 @@ export class ZenXTriggerService {
           ...event.turn,
           items: completedItems,
         }),
-        eventText: projectCompletedTurn(event.threadId, {
-          ...event.turn,
-          items: completedItems,
-        }),
+        ...(eventText === undefined ? {} : { eventText }),
       });
     }
   }
@@ -999,7 +1014,8 @@ export class ZenXTriggerService {
       entry.turnId = event.turn.id;
       entry.status = event.turn.status === "completed" ? "completed" : "failed";
       entry.completedAt = this.#now();
-      entry.error = event.turn.error?.message ?? null;
+      entry.error =
+        bounded(event.turn.error?.message ?? "", MAX_ERROR_BYTES) || null;
       if (
         entry.status === "completed" &&
         entry.replyRoomId != null &&
@@ -1020,7 +1036,7 @@ export class ZenXTriggerService {
             message(
               room.id,
               entry.replyAuthor,
-              bounded(answer.text, 8_000),
+              bounded(answer.text, MAX_MESSAGE_TEXT_BYTES),
               "agent",
               entry.threadId,
               event.turn.id,
@@ -1088,7 +1104,7 @@ export class ZenXTriggerService {
       if (entry === undefined || isTerminal(entry.status)) return;
       entry.status = status;
       entry.completedAt = this.#now();
-      entry.error = error;
+      entry.error = error === null ? null : bounded(error, MAX_ERROR_BYTES);
       entry.programInvocationId = null;
       entry.programOutcome = outcome;
       entry.programOutcomes = appendProgramOutcome(
@@ -1396,9 +1412,11 @@ function validateProgram(program: TriggerProgramConfig): void {
       spec.timeoutMs !== undefined &&
       (!Number.isFinite(spec.timeoutMs) ||
         spec.timeoutMs <= 0 ||
-        spec.timeoutMs > 120_000)
+        spec.timeoutMs > MAX_PROGRAM_TIMEOUT_MS)
     )
-      throw new Error(`${stage} timeoutMs must be between 1 and 120000`);
+      throw new Error(
+        `${stage} timeoutMs must be between 1 and ${String(MAX_PROGRAM_TIMEOUT_MS)}`,
+      );
     if (
       spec.maxOutputBytes !== undefined &&
       (!Number.isSafeInteger(spec.maxOutputBytes) ||
@@ -1748,13 +1766,35 @@ function mergeCompletedItems(
   return merged;
 }
 
+function completedItemText(items: readonly ThreadItem[]): string | undefined {
+  const answer = [...items]
+    .reverse()
+    .find(
+      (item): item is Extract<ThreadItem, { type: "agentMessage" }> =>
+        item.type === "agentMessage",
+    );
+  return answer?.text;
+}
+
 function bounded(value: string, limit: number): string {
   if (utf8Bytes(value) <= limit) return value;
+  if (limit <= 0) return "";
   const suffix = "\n…[truncated by ZenX]";
-  const prefix = Buffer.from(value, "utf8")
-    .subarray(0, Math.max(0, limit - utf8Bytes(suffix)))
-    .toString("utf8");
-  return `${prefix}${suffix}`;
+  const suffixBytes = utf8Bytes(suffix);
+  if (suffixBytes > limit) return prefixByBytes(suffix, limit);
+  return `${prefixByBytes(value, limit - suffixBytes)}${suffix}`;
+}
+
+function prefixByBytes(value: string, limit: number): string {
+  let bytes = 0;
+  let prefix = "";
+  for (const character of value) {
+    const characterBytes = utf8Bytes(character);
+    if (bytes + characterBytes > limit) break;
+    prefix += character;
+    bytes += characterBytes;
+  }
+  return prefix;
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/trigger-service.ts
+++ b/apps/zenx/src/main/trigger-service.ts
@@ -8,6 +8,10 @@ import type {
   ThreadItem,
   Turn,
 } from "../protocol-client/index.js";
+import {
+  ZenXTriggerProgramRunner,
+  type TriggerProgramRunner,
+} from "./trigger-program-runner.js";
 import { ZenXTriggerStore } from "./trigger-store.js";
 import type {
   CreateRoomInput,
@@ -15,7 +19,11 @@ import type {
   RoomMember,
   RoomMessage,
   TriggerHistoryEntry,
+  TriggerProgramConfig,
+  TriggerProgramOutcome,
+  TriggerProgramSpec,
   TriggerSnapshot,
+  UpdateTriggerInput,
   ZenXRoom,
   ZenXTrigger,
 } from "./trigger-types.js";
@@ -37,19 +45,67 @@ export interface ZenXTriggerTitlePort {
   observe(threadId: string, input: string): Promise<unknown>;
 }
 
+const MAX_WAKEUPS = 64;
+const MAX_TRANSIENT_TURNS = 64;
+const MAX_ITEMS_PER_TURN = 64;
+const MAX_PROGRAM_OUTCOMES = 4;
+
+interface WakeupEvent {
+  reason: string;
+  occurrenceKey: string;
+  projection?: string;
+  eventText?: string;
+  sourceThreadId?: string;
+  sourceTurnId?: string;
+  sourceRoomId?: string;
+  sourceRoomMessageId?: string;
+  scheduledAt?: number;
+}
+
+interface ActiveWakeup {
+  historyId: string;
+  threadId: string;
+  clientUserMessageId: string;
+  trigger: ZenXTrigger;
+  generationId: string;
+}
+
+interface CompletedItemBuffer {
+  threadId: string;
+  items: ThreadItem[];
+}
+
+interface PendingCompletion {
+  event: ServerNotificationParams["turn/completed"];
+  clientUserMessageId: string | null;
+  rejected: boolean;
+  claimed: boolean;
+}
+
+interface TriggerGeneration {
+  id: string;
+  active: boolean;
+  retiring: boolean;
+  timers: Map<string, unknown>;
+  completedTurnItems: Map<string, CompletedItemBuffer>;
+  pendingCompletedTurns: Map<string, PendingCompletion>;
+  activeWakeups: Map<string, ActiveWakeup>;
+  programControllers: Map<string, AbortController>;
+  disposeNotifications: (() => void) | undefined;
+}
+
 export class ZenXTriggerService {
   readonly #manager: ZenXTriggerAppServerPort;
   readonly #store: ZenXTriggerStore;
   readonly #titles: ZenXTriggerTitlePort | undefined;
+  readonly #programs: TriggerProgramRunner;
   readonly #listeners = new Set<(snapshot: TriggerSnapshot) => void>();
-  readonly #timers = new Map<string, unknown>();
-  readonly #completedAgentMessages = new Map<string, string>();
-  readonly #completedTurnItems = new Map<string, ThreadItem[]>();
   readonly #now: () => number;
   readonly #schedule: (callback: () => void, delayMs: number) => unknown;
   readonly #cancelScheduled: (handle: unknown) => void;
   #snapshot: TriggerSnapshot = { triggers: [], history: [], rooms: [] };
   #mutation: Promise<void> = Promise.resolve();
+  #generation: TriggerGeneration | null = null;
 
   constructor(
     manager: ZenXTriggerAppServerPort,
@@ -59,11 +115,13 @@ export class ZenXTriggerService {
       schedule?: (callback: () => void, delayMs: number) => unknown;
       cancelScheduled?: (handle: unknown) => void;
       titles?: ZenXTriggerTitlePort;
+      programs?: TriggerProgramRunner;
     } = {},
   ) {
     this.#manager = manager;
     this.#store = store;
     this.#titles = options.titles;
+    this.#programs = options.programs ?? new ZenXTriggerProgramRunner();
     this.#now = options.now ?? Date.now;
     this.#schedule = options.schedule ?? setTimeout;
     this.#cancelScheduled =
@@ -72,146 +130,278 @@ export class ZenXTriggerService {
   }
 
   async start(): Promise<void> {
-    this.#snapshot = await this.#store.read();
-    for (const entry of this.#snapshot.history) {
-      if (entry.status === "starting" || entry.status === "running") {
-        entry.status = "failed";
-        entry.completedAt = this.#now();
-        entry.error =
-          "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
-      }
-    }
-    await this.#persist();
-    this.#rescheduleTimers();
-    this.#manager.onNotification((method, params) => {
-      if (method === "item/completed") {
-        const event = params as ServerNotificationParams["item/completed"];
-        const items = this.#completedTurnItems.get(event.turnId) ?? [];
-        const next = items.filter((item) => item.id !== event.item.id);
-        next.push(event.item);
-        this.#completedTurnItems.set(event.turnId, next);
-        if (event.item.type === "agentMessage") {
-          this.#completedAgentMessages.set(event.turnId, event.item.text);
+    if (this.#generation !== null) await this.stop();
+    const generation = newGeneration();
+    this.#generation = generation;
+    try {
+      await this.#mutation;
+      const snapshot = await this.#store.read();
+      for (const entry of snapshot.history) {
+        if (entry.status === "starting" || entry.status === "running") {
+          entry.status = "failed";
+          entry.completedAt = this.#now();
+          entry.error =
+            "ZenX stopped before this wakeup reached a visible terminal result; it was not retried.";
+          if (entry.programInvocationId != null) {
+            const outcome: TriggerProgramOutcome = {
+              stage: programStageForInvocation(entry.programInvocationId),
+              invocationId: entry.programInvocationId,
+              status: "uncertain",
+              output: null,
+              exitCode: null,
+              error:
+                "The previous process ended before the local program outcome was known",
+            };
+            entry.programOutcome = outcome;
+            entry.programOutcomes = [outcome];
+          }
         }
-      } else if (method === "turn/completed") {
-        void this.#handleTurnCompleted(
-          params as ServerNotificationParams["turn/completed"],
-        );
       }
-    });
+      await this.#store.write(snapshot);
+      this.#assertMutationGeneration(generation);
+      this.#snapshot = snapshot;
+      this.#notify();
+      this.#rescheduleTimers(generation);
+      generation.disposeNotifications = this.#manager.onNotification(
+        (method, params) => {
+          if (!this.#isOperational(generation)) return;
+          if (method === "item/completed") {
+            this.#handleItemCompleted(
+              generation,
+              params as ServerNotificationParams["item/completed"],
+            );
+          } else if (method === "turn/completed") {
+            void this.#handleTurnCompleted(
+              generation,
+              params as ServerNotificationParams["turn/completed"],
+            ).catch((error: unknown) => {
+              if (this.#isOperational(generation))
+                console.warn(
+                  `Could not process Trigger completion: ${describeError(error)}`,
+                );
+            });
+          }
+        },
+      );
+    } catch (error) {
+      generation.active = false;
+      if (this.#generation === generation) this.#generation = null;
+      generation.disposeNotifications?.();
+      generation.disposeNotifications = undefined;
+      throw error;
+    }
   }
 
-  stop(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async stop(): Promise<void> {
+    const generation = this.#generation;
+    if (generation === null) return;
+    generation.retiring = true;
+    for (const controller of generation.programControllers.values())
+      controller.abort();
+    try {
+      await this.#mutate(
+        generation,
+        async (snapshot) => {
+          for (const entry of snapshot.history) {
+            if (isTerminal(entry.status)) continue;
+            entry.status = "failed";
+            entry.completedAt = this.#now();
+            entry.error =
+              "ZenX Trigger generation retired before this wakeup reached a visible terminal result; it was not retried.";
+            if (entry.programInvocationId != null) {
+              const outcome: TriggerProgramOutcome = {
+                stage: programStageForInvocation(entry.programInvocationId),
+                invocationId: entry.programInvocationId,
+                status: "uncertain",
+                output: null,
+                exitCode: null,
+                error:
+                  "Trigger generation retired while local work was in flight",
+              };
+              entry.programOutcome = outcome;
+              entry.programOutcomes = [
+                ...(entry.programOutcomes ?? []),
+                outcome,
+              ].slice(-MAX_PROGRAM_OUTCOMES);
+            }
+          }
+          generation.activeWakeups.clear();
+          return undefined;
+        },
+        true,
+      );
+    } finally {
+      generation.active = false;
+      if (this.#generation === generation) this.#generation = null;
+      generation.disposeNotifications?.();
+      generation.disposeNotifications = undefined;
+      for (const timer of generation.timers.values())
+        this.#cancelScheduled(timer);
+      generation.timers.clear();
+      generation.completedTurnItems.clear();
+      generation.pendingCompletedTurns.clear();
+      generation.activeWakeups.clear();
+      generation.programControllers.clear();
+    }
   }
+
+  async close(): Promise<void> {
+    await this.stop();
+    this.#listeners.clear();
+  }
+
   snapshot(): TriggerSnapshot {
     return structuredClone(this.#snapshot);
   }
+
   onChange(listener: (snapshot: TriggerSnapshot) => void): () => void {
     this.#listeners.add(listener);
     return () => this.#listeners.delete(listener);
   }
 
   async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
-    return await this.#mutate(async () => {
-      const common = {
-        id: randomUUID(),
-        threadId: required(input.threadId, "thread"),
-        kind: input.kind,
-        label: required(input.label, "label"),
-        prompt: required(input.prompt, "prompt"),
-        createdAt: this.#now(),
-        active: true,
-      };
-      const trigger: ZenXTrigger =
-        input.kind === "timer"
-          ? {
-              ...common,
-              timer: {
-                nextRunAt: validFuture(input.runAt, this.#now()),
-                intervalMinutes:
-                  input.intervalMinutes === undefined
-                    ? null
-                    : positive(input.intervalMinutes),
-              },
-            }
-          : input.kind === "thread"
-            ? {
-                ...common,
-                watch: {
-                  threadId: required(input.watchedThreadId, "watched thread"),
-                  event: "turn_completed",
-                },
-              }
-            : input.kind === "roomMention"
-              ? {
-                  ...common,
-                  room: {
-                    roomId: required(input.roomId, "room"),
-                    mention: required(input.mention, "mention"),
-                  },
-                }
-              : {
-                  ...common,
-                  signal: { name: required(input.signalName, "signal name") },
-                };
-      this.#snapshot.triggers.push(trigger);
-      return trigger;
-    }).then((trigger) => {
-      this.#rescheduleTimers();
-      return trigger;
+    const generation = this.#runningGeneration();
+    const trigger = await this.#mutate(generation, async (snapshot) => {
+      const value = triggerFromInput(
+        input,
+        randomUUID(),
+        this.#now(),
+        true,
+        this.#now(),
+      );
+      snapshot.triggers.push(value);
+      return value;
     });
+    this.#rescheduleTimers(generation);
+    return structuredClone(trigger);
+  }
+
+  async update(input: UpdateTriggerInput): Promise<ZenXTrigger> {
+    const generation = this.#runningGeneration();
+    const trigger = await this.#mutate(generation, async (snapshot) => {
+      const index = snapshot.triggers.findIndex(
+        (candidate) => candidate.id === input.id,
+      );
+      if (index < 0) throw new Error("Trigger was not found");
+      const existing = snapshot.triggers[index]!;
+      const replacement = triggerFromInput(
+        input,
+        existing.id,
+        existing.createdAt,
+        existing.active,
+        this.#now(),
+      );
+      snapshot.triggers[index] = replacement;
+      return replacement;
+    });
+    this.#rescheduleTimers(generation);
+    return structuredClone(trigger);
   }
 
   async cancel(triggerId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const trigger = this.#snapshot.triggers.find(
-        (item) => item.id === triggerId,
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const trigger = snapshot.triggers.find(
+        (item) => item.id === required(triggerId, "trigger"),
       );
       if (trigger === undefined) throw new Error("Trigger was not found");
       trigger.active = false;
-      const timer = this.#timers.get(trigger.id);
+      const timer = generation.timers.get(trigger.id);
       if (timer !== undefined) this.#cancelScheduled(timer);
-      this.#timers.delete(trigger.id);
+      generation.timers.delete(trigger.id);
+    });
+  }
+
+  async delete(triggerId: string): Promise<void> {
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const normalized = required(triggerId, "trigger");
+      const index = snapshot.triggers.findIndex(
+        (item) => item.id === normalized,
+      );
+      if (index < 0) throw new Error("Trigger was not found");
+      snapshot.triggers.splice(index, 1);
+      const timer = generation.timers.get(normalized);
+      if (timer !== undefined) this.#cancelScheduled(timer);
+      generation.timers.delete(normalized);
     });
   }
 
   async signal(name: string, detail: string): Promise<void> {
+    const generation = this.#runningGeneration();
     const signalName = required(name, "signal name");
     const signalDetail = detail.trim();
-    const matches = this.#snapshot.triggers.filter(
-      (trigger) =>
-        trigger.active &&
-        trigger.kind === "signal" &&
-        trigger.signal?.name === signalName,
-    );
-    for (const trigger of matches)
-      await this.#fire(trigger.id, {
-        reason: `External signal ${signalName}: ${signalDetail}`,
+    const matches = this.#snapshot.triggers
+      .filter(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "signal" &&
+          trigger.signal?.name === signalName,
+      )
+      .map((trigger) => trigger.id);
+    for (const triggerId of matches) {
+      await this.#fire(generation, triggerId, {
+        reason: `External signal ${signalName}: ${bounded(signalDetail, 4_000)}`,
         occurrenceKey: `signal:${randomUUID()}`,
         projection: `Signal name: ${signalName}\nSignal detail: ${bounded(signalDetail, 4_000)}`,
       });
+    }
   }
 
   async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
-    return await this.#mutate(async () => {
-      const members = validateMembers(input.members);
-      const room: ZenXRoom = {
+    const generation = this.#runningGeneration();
+    const room = await this.#mutate(generation, async (snapshot) => {
+      const value: ZenXRoom = {
         id: randomUUID(),
         name: required(input.name, "room name"),
-        members,
+        members: validateMembers(input.members),
         messages: [],
         createdAt: this.#now(),
       };
-      this.#snapshot.rooms.push(room);
-      return room;
+      snapshot.rooms.push(value);
+      return value;
+    });
+    return structuredClone(room);
+  }
+
+  async renameRoom(roomId: string, name: string): Promise<void> {
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
+        (candidate) => candidate.id === required(roomId, "room"),
+      );
+      if (room === undefined) throw new Error("Room was not found");
+      room.name = required(name, "room name");
+    });
+  }
+
+  async deleteRoom(roomId: string): Promise<void> {
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const normalized = required(roomId, "room");
+      const room = snapshot.rooms.find(
+        (candidate) => candidate.id === normalized,
+      );
+      if (room === undefined) throw new Error("Room was not found");
+      const owner = snapshot.history.find(
+        (entry) =>
+          entry.replyRoomId === normalized &&
+          (entry.status === "starting" || entry.status === "running"),
+      );
+      if (owner !== undefined)
+        throw new Error(
+          "Room cannot be deleted while a nonterminal wakeup owns its reply route",
+        );
+      snapshot.rooms = snapshot.rooms.filter(
+        (candidate) => candidate.id !== normalized,
+      );
     });
   }
 
   async addRoomMember(roomId: string, member: RoomMember): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
@@ -220,18 +410,17 @@ export class ZenXTriggerService {
   }
 
   async removeRoomMember(roomId: string, threadId: string): Promise<void> {
-    await this.#mutate(async () => {
-      const room = this.#snapshot.rooms.find(
+    const generation = this.#runningGeneration();
+    await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
         (entry) => entry.id === required(roomId, "room"),
       );
       if (room === undefined) throw new Error("Room was not found");
-      const normalizedThreadId = required(threadId, "member thread");
-      if (
-        !room.members.some((member) => member.threadId === normalizedThreadId)
-      )
+      const normalized = required(threadId, "member thread");
+      if (!room.members.some((member) => member.threadId === normalized))
         throw new Error("Room member was not found");
       room.members = room.members.filter(
-        (member) => member.threadId !== normalizedThreadId,
+        (member) => member.threadId !== normalized,
       );
     });
   }
@@ -241,103 +430,102 @@ export class ZenXTriggerService {
     author: string,
     text: string,
   ): Promise<void> {
-    const room = this.#snapshot.rooms.find((entry) => entry.id === roomId);
-    if (room === undefined) throw new Error("Room was not found");
-    const posted = message(
-      room.id,
-      required(author, "author"),
-      required(text, "message"),
-      "human",
-      null,
-      null,
-      this.#now(),
-    );
-    await this.#mutate(async () => {
-      room.messages.push(posted);
+    await this.#postRoomMessage(roomId, author, text, "human", null, null);
+  }
+
+  async postAgentRoomMessage(roomId: string, text: string): Promise<void> {
+    await this.#postRoomMessage(roomId, "Agent", text, "agent", null, null);
+  }
+
+  async #postRoomMessage(
+    roomId: string,
+    author: string,
+    text: string,
+    kind: RoomMessage["kind"],
+    originThreadId: string | null,
+    originTurnId: string | null,
+  ): Promise<void> {
+    const generation = this.#runningGeneration();
+    const posted = await this.#mutate(generation, async (snapshot) => {
+      const room = snapshot.rooms.find(
+        (entry) => entry.id === required(roomId, "room"),
+      );
+      if (room === undefined) throw new Error("Room was not found");
+      const value = message(
+        room.id,
+        required(author, "author"),
+        required(text, "message"),
+        kind,
+        originThreadId,
+        originTurnId,
+        this.#now(),
+      );
+      room.messages.push(value);
+      return { posted: value, room: structuredClone(room) };
     });
-    const mentions = room.members.filter((member) =>
-      new RegExp(
-        `(^|\\s)@${escapeRegExp(member.name)}(?=\\s|$|[,.!?])`,
-        "iu",
-      ).test(text),
+    const mentions = posted.room.members.filter((member) =>
+      mentionMatches(text, member.name),
     );
     for (const member of mentions) {
-      const matches = this.#snapshot.triggers.filter(
-        (trigger) =>
-          trigger.active &&
-          trigger.threadId === member.threadId &&
-          trigger.kind === "roomMention" &&
-          trigger.room?.roomId === roomId &&
-          trigger.room.mention.toLocaleLowerCase() ===
-            member.name.toLocaleLowerCase(),
-      );
-      for (const trigger of matches)
-        await this.#fire(trigger.id, {
-          reason: `Room #${room.name} mention from ${posted.author}: ${posted.text}`,
-          occurrenceKey: `room:${room.id}:${posted.id}`,
-          sourceRoomId: room.id,
-          sourceRoomMessageId: posted.id,
-          projection: projectRoomContext(room),
+      const triggerIds = this.#snapshot.triggers
+        .filter(
+          (trigger) =>
+            trigger.active &&
+            trigger.threadId === member.threadId &&
+            trigger.kind === "roomMention" &&
+            trigger.room?.roomId === roomId &&
+            trigger.room.mention.toLocaleLowerCase() ===
+              member.name.toLocaleLowerCase(),
+        )
+        .map((trigger) => trigger.id);
+      for (const triggerId of triggerIds) {
+        await this.#fire(generation, triggerId, {
+          reason: `Room #${posted.room.name} mention from ${posted.posted.author}: ${posted.posted.text}`,
+          occurrenceKey: `room:${posted.room.id}:${posted.posted.id}`,
+          sourceRoomId: posted.room.id,
+          sourceRoomMessageId: posted.posted.id,
+          projection: projectRoomContext(posted.room),
+          eventText: posted.posted.text,
         });
+      }
     }
   }
 
   async #handleTurnCompleted(
+    generation: TriggerGeneration,
     event: ServerNotificationParams["turn/completed"],
   ): Promise<void> {
+    if (!this.#isOperational(generation)) return;
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const buffered = generation.completedTurnItems.get(key);
     const completedItems = mergeCompletedItems(
       event.turn.items,
-      this.#completedTurnItems.get(event.turn.id) ?? [],
+      buffered?.threadId === event.threadId ? buffered.items : [],
     );
-    await this.#mutate(async () => {
-      const entry = this.#snapshot.history.find(
-        (item) => item.turnId === event.turn.id && item.status === "running",
-      );
-      if (entry !== undefined) {
-        entry.status =
-          event.turn.status === "completed" ? "completed" : "failed";
-        entry.completedAt = this.#now();
-        entry.error = event.turn.error?.message ?? null;
-        const trigger = this.#snapshot.triggers.find(
-          (item) => item.id === entry.triggerId,
-        );
-        if (trigger?.kind === "roomMention" && trigger.room !== undefined) {
-          const room = this.#snapshot.rooms.find(
-            (item) => item.id === trigger.room?.roomId,
-          );
-          const projectedAnswer = [...completedItems]
-            .reverse()
-            .find((item) => item.type === "agentMessage");
-          const answer =
-            projectedAnswer?.type === "agentMessage"
-              ? projectedAnswer.text
-              : (this.#completedAgentMessages.get(event.turn.id) ?? "");
-          if (room !== undefined && answer.length > 0) {
-            room.messages.push(
-              message(
-                room.id,
-                trigger.room.mention,
-                answer,
-                "agent",
-                entry.threadId,
-                event.turn.id,
-                this.#now(),
-              ),
-            );
-          }
-        }
-      }
-    });
-    this.#completedAgentMessages.delete(event.turn.id);
-    this.#completedTurnItems.delete(event.turn.id);
-    const watchers = this.#snapshot.triggers.filter(
-      (trigger) =>
-        trigger.active &&
-        trigger.kind === "thread" &&
-        trigger.watch?.threadId === event.threadId,
+    const running = this.#snapshot.history.find(
+      (entry) =>
+        entry.threadId === event.threadId &&
+        entry.turnId === event.turn.id &&
+        (entry.status === "starting" || entry.status === "running") &&
+        generation.activeWakeups.has(entry.clientUserMessageId),
     );
-    for (const trigger of watchers)
-      await this.#fire(trigger.id, {
+    if (running !== undefined) {
+      await this.#completeTurn(generation, running.id, event, completedItems);
+      clearTransientTurn(generation, event.threadId, event.turn.id);
+    } else {
+      this.#bufferEarlyCompletion(generation, event, completedItems);
+    }
+    if (!this.#isOperational(generation)) return;
+    const watchers = this.#snapshot.triggers
+      .filter(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "thread" &&
+          trigger.watch?.threadId === event.threadId,
+      )
+      .map((trigger) => trigger.id);
+    for (const triggerId of watchers) {
+      await this.#fire(generation, triggerId, {
         reason: `Thread ${event.threadId} emitted turn_completed for ${event.turn.id}`,
         occurrenceKey: `thread:${event.threadId}:${event.turn.id}`,
         sourceThreadId: event.threadId,
@@ -346,165 +534,882 @@ export class ZenXTriggerService {
           ...event.turn,
           items: completedItems,
         }),
+        eventText: projectCompletedTurn(event.threadId, {
+          ...event.turn,
+          items: completedItems,
+        }),
       });
+    }
+  }
+
+  #handleItemCompleted(
+    generation: TriggerGeneration,
+    event: ServerNotificationParams["item/completed"],
+  ): void {
+    if (!this.#isOperational(generation)) return;
+    if (!this.#isPotentialTurn(generation, event.threadId, event.turnId))
+      return;
+    const key = transientTurnKey(event.threadId, event.turnId);
+    const current = generation.completedTurnItems.get(key);
+    const items = (current?.items ?? []).filter(
+      (item) => item.id !== event.item.id,
+    );
+    items.push(event.item);
+    setBounded(
+      generation.completedTurnItems,
+      key,
+      { threadId: event.threadId, items: items.slice(-MAX_ITEMS_PER_TURN) },
+      (evicted) => generation.pendingCompletedTurns.delete(evicted),
+    );
+  }
+
+  #isPotentialTurn(
+    generation: TriggerGeneration,
+    threadId: string,
+    turnId: string,
+  ): boolean {
+    const key = transientTurnKey(threadId, turnId);
+    return (
+      generation.completedTurnItems.has(key) ||
+      generation.pendingCompletedTurns.has(key) ||
+      [...generation.activeWakeups.values()].some(
+        (entry) => entry.threadId === threadId,
+      ) ||
+      this.#snapshot.triggers.some(
+        (trigger) =>
+          trigger.active &&
+          trigger.kind === "thread" &&
+          trigger.watch?.threadId === threadId,
+      )
+    );
+  }
+
+  #bufferEarlyCompletion(
+    generation: TriggerGeneration,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): void {
+    const candidates = [...generation.activeWakeups.values()].filter(
+      (entry) =>
+        entry.threadId === event.threadId &&
+        this.#snapshot.history.find((history) => history.id === entry.historyId)
+          ?.status === "starting" &&
+        this.#snapshot.history.find((history) => history.id === entry.historyId)
+          ?.turnId === null,
+    );
+    if (candidates.length === 0) return;
+    const key = transientTurnKey(event.threadId, event.turn.id);
+    const existing = generation.pendingCompletedTurns.get(key);
+    if (existing?.claimed || existing?.rejected) return;
+    const clientIds = [
+      ...new Set(
+        completedItems
+          .filter(
+            (item): item is Extract<ThreadItem, { type: "userMessage" }> =>
+              item.type === "userMessage",
+          )
+          .map((item) => item.clientId)
+          .filter((value): value is string => value !== null),
+      ),
+    ];
+    const exact =
+      clientIds.length === 1 &&
+      candidates.some((entry) => entry.clientUserMessageId === clientIds[0])
+        ? clientIds[0]!
+        : null;
+    if (existing !== undefined) {
+      if (exact !== null && existing.clientUserMessageId === exact) return;
+      existing.rejected = true;
+      existing.clientUserMessageId = null;
+      return;
+    }
+    setBounded(
+      generation.pendingCompletedTurns,
+      key,
+      {
+        event,
+        clientUserMessageId: exact,
+        rejected: exact === null,
+        claimed: false,
+      },
+      (evicted) => generation.completedTurnItems.delete(evicted),
+    );
   }
 
   async #fire(
+    generation: TriggerGeneration,
     triggerId: string,
-    wakeup: {
-      reason: string;
-      occurrenceKey: string;
-      projection?: string;
-      sourceThreadId?: string;
-      sourceTurnId?: string;
-      sourceRoomId?: string;
-      sourceRoomMessageId?: string;
-      scheduledAt?: number;
-    },
+    wakeup: WakeupEvent,
   ): Promise<void> {
-    const trigger = this.#snapshot.triggers.find(
-      (item) => item.id === triggerId && item.active,
-    );
-    if (trigger === undefined) return;
-    const clientUserMessageId = stableWakeupId(
-      trigger.id,
-      wakeup.occurrenceKey,
-    );
-    if (
-      this.#snapshot.history.some(
-        (entry) => entry.clientUserMessageId === clientUserMessageId,
-      )
-    )
-      return;
-    const history: TriggerHistoryEntry = {
-      id: randomUUID(),
-      triggerId: trigger.id,
-      threadId: trigger.threadId,
-      kind: trigger.kind,
-      reason: wakeup.reason,
-      prompt: trigger.prompt,
-      clientUserMessageId,
-      startedAt: this.#now(),
-      completedAt: null,
-      status: "starting",
-      turnId: null,
-      error: null,
-      sourceThreadId: wakeup.sourceThreadId ?? null,
-      sourceTurnId: wakeup.sourceTurnId ?? null,
-      sourceRoomId: wakeup.sourceRoomId ?? null,
-      sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
-    };
-    await this.#mutate(async () => {
-      this.#snapshot.history.unshift(history);
-      if (trigger.timer !== undefined) {
-        if (trigger.timer.intervalMinutes === null) trigger.active = false;
-        else
-          trigger.timer.nextRunAt =
-            Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
-            trigger.timer.intervalMinutes * 60_000;
-      }
-    });
-    this.#rescheduleTimers();
+    if (!this.#isOperational(generation)) return;
+    let committed;
     try {
-      await this.#titles
-        ?.observe(
-          trigger.threadId,
-          meaningfulWakeupTitleInput(trigger, wakeup.projection),
-        )
-        .catch((error: unknown) =>
-          console.warn(
-            `Could not stage trigger title: ${error instanceof Error ? error.message : String(error)}`,
-          ),
+      committed = await this.#mutate(generation, async (snapshot) => {
+        const trigger = snapshot.triggers.find(
+          (item) => item.id === triggerId && item.active,
         );
+        if (trigger === undefined) return undefined;
+        if (
+          trigger.kind === "roomMention" &&
+          (trigger.room === undefined ||
+            !snapshot.rooms.some((room) => room.id === trigger.room?.roomId))
+        )
+          return undefined;
+        const clientUserMessageId = stableWakeupId(
+          trigger.id,
+          wakeup.occurrenceKey,
+        );
+        if (
+          snapshot.history.some(
+            (entry) => entry.clientUserMessageId === clientUserMessageId,
+          )
+        )
+          return undefined;
+        const nonterminal = snapshot.history.filter(
+          (entry) => entry.status === "starting" || entry.status === "running",
+        ).length;
+        const rejected = nonterminal >= MAX_WAKEUPS;
+        const history: TriggerHistoryEntry = {
+          id: randomUUID(),
+          triggerId: trigger.id,
+          threadId: trigger.threadId,
+          kind: trigger.kind,
+          reason: bounded(wakeup.reason, 4_000),
+          prompt: bounded(trigger.prompt, 4_000),
+          clientUserMessageId,
+          startedAt: this.#now(),
+          completedAt: rejected ? this.#now() : null,
+          status: rejected ? "failed" : "starting",
+          turnId: null,
+          error: rejected
+            ? `ZenX Trigger wakeup admission is full at ${String(MAX_WAKEUPS)} nonterminal wakeups; this wakeup was not dispatched.`
+            : null,
+          sourceThreadId: wakeup.sourceThreadId ?? null,
+          sourceTurnId: wakeup.sourceTurnId ?? null,
+          sourceRoomId: wakeup.sourceRoomId ?? null,
+          sourceRoomMessageId: wakeup.sourceRoomMessageId ?? null,
+          replyRoomId: trigger.room?.roomId ?? null,
+          replyAuthor: trigger.room?.mention ?? null,
+          programInvocationId: null,
+          programOutcome: null,
+          programOutcomes: [],
+        };
+        snapshot.history.unshift(history);
+        if (trigger.timer !== undefined) {
+          if (trigger.timer.intervalMinutes === null) trigger.active = false;
+          else {
+            trigger.timer.nextRunAt =
+              Math.max(this.#now(), wakeup.scheduledAt ?? this.#now()) +
+              trigger.timer.intervalMinutes * 60_000;
+          }
+        }
+        return rejected
+          ? { rejected: true as const }
+          : {
+              rejected: false as const,
+              trigger: structuredClone(trigger),
+              historyId: history.id,
+              clientUserMessageId,
+            };
+      });
+    } catch (error) {
+      if (error instanceof StaleGenerationError) return;
+      throw error;
+    }
+    if (committed === undefined || committed.rejected) {
+      this.#rescheduleTimers(generation);
+      return;
+    }
+    this.#rescheduleTimers(generation);
+    const active: ActiveWakeup = {
+      historyId: committed.historyId,
+      threadId: committed.trigger.threadId,
+      clientUserMessageId: committed.clientUserMessageId,
+      trigger: committed.trigger,
+      generationId: generation.id,
+    };
+    generation.activeWakeups.set(active.clientUserMessageId, active);
+    await this.#executeWakeup(generation, active, wakeup);
+  }
+
+  async #executeWakeup(
+    generation: TriggerGeneration,
+    active: ActiveWakeup,
+    wakeup: WakeupEvent,
+  ): Promise<void> {
+    const trigger = active.trigger;
+    const controller = new AbortController();
+    generation.programControllers.set(active.historyId, controller);
+    try {
+      await this.#observeTitle(trigger, wakeup.projection);
+      if (!this.#isOperational(generation)) return;
+      const program = trigger.program;
+      if (program?.match !== undefined) {
+        const regex = new RegExp(
+          program.match.regex,
+          program.match.flags ?? "u",
+        );
+        const matched = regex.test(wakeup.eventText ?? wakeup.projection ?? "");
+        const outcome = this.#programOutcome(
+          "predicate",
+          stableProgramInvocationId(active.clientUserMessageId, "predicate"),
+          matched ? "matched" : "non_match",
+          null,
+          null,
+          null,
+        );
+        if (!matched) {
+          await this.#finishProgram(
+            generation,
+            active,
+            outcome,
+            "completed",
+            null,
+          );
+          return;
+        }
+        await this.#recordProgramOutcome(generation, active, outcome);
+      }
+      if (program?.predicate !== undefined) {
+        const invocationId = stableProgramInvocationId(
+          active.clientUserMessageId,
+          "predicate",
+        );
+        await this.#recordProgramInvocation(generation, active, invocationId);
+        const result = await this.#programs.run(
+          program.predicate,
+          {
+            invocationId,
+            stage: "predicate",
+            event: programInput(active, wakeup),
+          },
+          controller.signal,
+        );
+        const outcome = this.#programOutcome(
+          "predicate",
+          invocationId,
+          result.status,
+          result.output,
+          result.exitCode,
+          result.error,
+        );
+        if (result.status !== "matched") {
+          await this.#finishProgram(
+            generation,
+            active,
+            outcome,
+            result.status === "non_match" ? "completed" : "failed",
+            result.status === "non_match" ? null : result.error,
+          );
+          return;
+        }
+        await this.#recordProgramOutcome(generation, active, outcome);
+      }
+      if (program?.action !== undefined) {
+        const invocationId = stableProgramInvocationId(
+          active.clientUserMessageId,
+          "action",
+        );
+        await this.#recordProgramInvocation(generation, active, invocationId);
+        const result = await this.#programs.run(
+          program.action,
+          {
+            invocationId,
+            stage: "action",
+            event: programInput(active, wakeup),
+          },
+          controller.signal,
+        );
+        const outcome = this.#programOutcome(
+          "action",
+          invocationId,
+          result.status,
+          result.output,
+          result.exitCode,
+          result.error,
+        );
+        await this.#finishProgram(
+          generation,
+          active,
+          outcome,
+          result.status === "completed" ? "completed" : "failed",
+          result.status === "completed" ? null : result.error,
+        );
+        return;
+      }
+      if (!this.#isOperational(generation)) return;
       const result = await this.#manager.request("turn/start", {
         threadId: trigger.threadId,
-        clientUserMessageId,
+        clientUserMessageId: active.clientUserMessageId,
         input: [
           {
             type: "text",
-            text: wakeupInput(trigger, history, wakeup.projection),
+            text: wakeupInput(
+              trigger,
+              this.#history(active.historyId),
+              wakeup.projection,
+            ),
           },
         ],
       });
-      await this.#mutate(async () => {
+      if (!this.#isOperational(generation)) return;
+      const wasStarted = await this.#mutate(generation, async (snapshot) => {
+        const history = snapshot.history.find(
+          (entry) => entry.id === active.historyId,
+        );
+        if (history === undefined || history.status !== "starting")
+          return false;
+        const collision = snapshot.history.find(
+          (entry) =>
+            entry.id !== history.id &&
+            entry.threadId === trigger.threadId &&
+            entry.turnId === result.turn.id &&
+            (entry.status === "starting" || entry.status === "running"),
+        );
+        if (collision !== undefined)
+          throw new Error("Turn identity was already owned by another wakeup");
         history.status = "running";
         history.turnId = result.turn.id;
+        return true;
       });
+      if (!wasStarted) return;
+      await this.#consumePendingCompletion(generation, active, result.turn.id);
+      if (
+        result.turn.status === "completed" ||
+        result.turn.status === "interrupted"
+      ) {
+        await this.#completeTurn(
+          generation,
+          active.historyId,
+          {
+            threadId: trigger.threadId,
+            turn: result.turn,
+          },
+          result.turn.items,
+        );
+      }
     } catch (error) {
-      await this.#mutate(async () => {
-        history.status = "failed";
-        history.completedAt = this.#now();
-        history.error = error instanceof Error ? error.message : String(error);
-      });
+      if (error instanceof StaleGenerationError) return;
+      if (this.#isOperational(generation))
+        await this.#failHistory(
+          generation,
+          active.historyId,
+          describeError(error),
+        );
+    } finally {
+      generation.programControllers.delete(active.historyId);
     }
   }
 
-  #rescheduleTimers(): void {
-    for (const timer of this.#timers.values()) this.#cancelScheduled(timer);
-    this.#timers.clear();
+  async #consumePendingCompletion(
+    generation: TriggerGeneration,
+    active: ActiveWakeup,
+    turnId: string,
+  ): Promise<void> {
+    const key = transientTurnKey(active.threadId, turnId);
+    const pending = generation.pendingCompletedTurns.get(key);
+    if (
+      pending === undefined ||
+      pending.claimed ||
+      pending.rejected ||
+      pending.clientUserMessageId !== active.clientUserMessageId
+    )
+      return;
+    pending.claimed = true;
+    await this.#completeTurn(
+      generation,
+      active.historyId,
+      pending.event,
+      mergeCompletedItems(
+        pending.event.turn.items,
+        generation.completedTurnItems.get(key)?.items ?? [],
+      ),
+    );
+    if (generation.pendingCompletedTurns.get(key) === pending)
+      generation.pendingCompletedTurns.delete(key);
+    generation.completedTurnItems.delete(key);
+  }
+
+  async #completeTurn(
+    generation: TriggerGeneration,
+    historyId: string,
+    event: ServerNotificationParams["turn/completed"],
+    completedItems: readonly ThreadItem[],
+  ): Promise<void> {
+    let released = false;
+    await this.#mutate(generation, async (snapshot) => {
+      const entry = snapshot.history.find(
+        (candidate) => candidate.id === historyId,
+      );
+      if (
+        entry === undefined ||
+        isTerminal(entry.status) ||
+        entry.threadId !== event.threadId ||
+        (entry.turnId !== null && entry.turnId !== event.turn.id)
+      )
+        return;
+      entry.turnId = event.turn.id;
+      entry.status = event.turn.status === "completed" ? "completed" : "failed";
+      entry.completedAt = this.#now();
+      entry.error = event.turn.error?.message ?? null;
+      if (
+        entry.status === "completed" &&
+        entry.replyRoomId != null &&
+        entry.replyAuthor != null
+      ) {
+        const room = snapshot.rooms.find(
+          (candidate) => candidate.id === entry.replyRoomId,
+        );
+        const answer = [...completedItems]
+          .reverse()
+          .find((item) => item.type === "agentMessage");
+        if (
+          room !== undefined &&
+          answer?.type === "agentMessage" &&
+          answer.text.length > 0
+        ) {
+          room.messages.push(
+            message(
+              room.id,
+              entry.replyAuthor,
+              bounded(answer.text, 8_000),
+              "agent",
+              entry.threadId,
+              event.turn.id,
+              this.#now(),
+            ),
+          );
+        }
+      }
+      released = true;
+    });
+    if (released) {
+      const active = [...generation.activeWakeups.values()].find(
+        (candidate) => candidate.historyId === historyId,
+      );
+      if (active !== undefined)
+        generation.activeWakeups.delete(active.clientUserMessageId);
+    }
+  }
+
+  async #recordProgramOutcome(
+    generation: TriggerGeneration,
+    active: ActiveWakeup,
+    outcome: TriggerProgramOutcome,
+  ): Promise<void> {
+    await this.#mutate(generation, async (snapshot) => {
+      const entry = snapshot.history.find(
+        (candidate) => candidate.id === active.historyId,
+      );
+      if (entry === undefined || isTerminal(entry.status)) return;
+      entry.programInvocationId = outcome.invocationId;
+      entry.programOutcome = outcome;
+      entry.programOutcomes = [...(entry.programOutcomes ?? []), outcome].slice(
+        -MAX_PROGRAM_OUTCOMES,
+      );
+    });
+  }
+
+  async #recordProgramInvocation(
+    generation: TriggerGeneration,
+    active: ActiveWakeup,
+    invocationId: string,
+  ): Promise<void> {
+    await this.#mutate(generation, async (snapshot) => {
+      const entry = snapshot.history.find(
+        (candidate) => candidate.id === active.historyId,
+      );
+      if (entry === undefined || isTerminal(entry.status)) return;
+      entry.programInvocationId = invocationId;
+    });
+  }
+
+  async #finishProgram(
+    generation: TriggerGeneration,
+    active: ActiveWakeup,
+    outcome: TriggerProgramOutcome,
+    status: "completed" | "failed",
+    error: string | null,
+  ): Promise<void> {
+    let released = false;
+    await this.#mutate(generation, async (snapshot) => {
+      const entry = snapshot.history.find(
+        (candidate) => candidate.id === active.historyId,
+      );
+      if (entry === undefined || isTerminal(entry.status)) return;
+      entry.status = status;
+      entry.completedAt = this.#now();
+      entry.error = error;
+      entry.programInvocationId = outcome.invocationId;
+      entry.programOutcome = outcome;
+      entry.programOutcomes = [...(entry.programOutcomes ?? []), outcome].slice(
+        -MAX_PROGRAM_OUTCOMES,
+      );
+      released = true;
+    });
+    if (released) generation.activeWakeups.delete(active.clientUserMessageId);
+  }
+
+  async #failHistory(
+    generation: TriggerGeneration,
+    historyId: string,
+    error: string,
+  ): Promise<void> {
+    let released = false;
+    await this.#mutate(generation, async (snapshot) => {
+      const entry = snapshot.history.find(
+        (candidate) => candidate.id === historyId,
+      );
+      if (entry === undefined || isTerminal(entry.status)) return;
+      entry.status = "failed";
+      entry.completedAt = this.#now();
+      entry.error = bounded(error, 4_000);
+      released = true;
+    });
+    if (released) {
+      const active = [...generation.activeWakeups.values()].find(
+        (candidate) => candidate.historyId === historyId,
+      );
+      if (active !== undefined)
+        generation.activeWakeups.delete(active.clientUserMessageId);
+    }
+  }
+
+  async #observeTitle(
+    trigger: ZenXTrigger,
+    projection?: string,
+  ): Promise<void> {
+    if (this.#titles === undefined) return;
+    try {
+      await this.#titles.observe(
+        trigger.threadId,
+        meaningfulWakeupTitleInput(trigger, projection),
+      );
+    } catch (error) {
+      console.warn(`Could not stage trigger title: ${describeError(error)}`);
+    }
+  }
+
+  #rescheduleTimers(generation: TriggerGeneration): void {
+    if (!this.#isOperational(generation)) return;
+    for (const timer of generation.timers.values())
+      this.#cancelScheduled(timer);
+    generation.timers.clear();
     for (const trigger of this.#snapshot.triggers) {
-      if (!trigger.active || trigger.timer === undefined) continue;
-      this.#scheduleTimer(trigger.id, trigger.timer.nextRunAt);
+      if (trigger.active && trigger.timer !== undefined)
+        this.#scheduleTimer(generation, trigger.id, trigger.timer.nextRunAt);
     }
   }
 
-  #scheduleTimer(triggerId: string, scheduledAt: number): void {
+  #scheduleTimer(
+    generation: TriggerGeneration,
+    triggerId: string,
+    scheduledAt: number,
+  ): void {
     const delay = Math.max(
       0,
       Math.min(2_147_000_000, scheduledAt - this.#now()),
     );
     const timer = this.#schedule(() => {
-      this.#timers.delete(triggerId);
+      if (!this.#isOperational(generation)) return;
+      generation.timers.delete(triggerId);
       if (this.#now() < scheduledAt) {
-        this.#scheduleTimer(triggerId, scheduledAt);
+        this.#scheduleTimer(generation, triggerId, scheduledAt);
         return;
       }
-      void this.#fire(triggerId, {
+      void this.#fire(generation, triggerId, {
         reason: `Timer reached ${new Date(scheduledAt).toISOString()}`,
         occurrenceKey: `timer:${scheduledAt}`,
         scheduledAt,
+      }).catch((error: unknown) => {
+        if (this.#isOperational(generation))
+          console.warn(`Could not fire Timer: ${describeError(error)}`);
       });
     }, delay);
-    this.#timers.set(triggerId, timer);
+    generation.timers.set(triggerId, timer);
   }
 
-  async #mutate<T>(operation: () => Promise<T>): Promise<T> {
+  async #mutate<T>(
+    generation: TriggerGeneration,
+    operation: (snapshot: TriggerSnapshot) => Promise<T>,
+    allowRetiring = false,
+  ): Promise<T> {
+    this.#assertMutationGeneration(generation, allowRetiring);
     const previous = this.#mutation;
     let release!: () => void;
     this.#mutation = new Promise<void>((resolve) => {
       release = resolve;
     });
     await previous;
-    const previousSnapshot = structuredClone(this.#snapshot);
     try {
-      const result = await operation();
-      await this.#persist();
+      this.#assertMutationGeneration(generation, allowRetiring);
+      const snapshot = structuredClone(this.#snapshot);
+      const result = await operation(snapshot);
+      this.#assertMutationGeneration(generation, allowRetiring);
+      await this.#store.write(snapshot);
+      this.#assertMutationGeneration(generation, allowRetiring);
+      this.#snapshot = snapshot;
+      this.#notify();
       return result;
-    } catch (error) {
-      this.#snapshot = previousSnapshot;
-      throw error;
     } finally {
       release();
     }
   }
 
-  async #persist(): Promise<void> {
-    await this.#store.write(this.#snapshot);
+  #runningGeneration(): TriggerGeneration {
+    const generation = this.#generation;
+    if (generation === null || !this.#isOperational(generation))
+      throw new Error("ZenX Trigger service is not running");
+    return generation;
+  }
+
+  #isOperational(generation: TriggerGeneration): boolean {
+    return (
+      generation.active &&
+      !generation.retiring &&
+      this.#generation === generation
+    );
+  }
+
+  #assertMutationGeneration(
+    generation: TriggerGeneration,
+    allowRetiring = false,
+  ): void {
+    if (
+      !generation.active ||
+      this.#generation !== generation ||
+      (generation.retiring && !allowRetiring)
+    )
+      throw new StaleGenerationError();
+  }
+
+  #history(historyId: string): TriggerHistoryEntry {
+    const entry = this.#snapshot.history.find(
+      (candidate) => candidate.id === historyId,
+    );
+    if (entry === undefined) throw new StaleGenerationError();
+    return entry;
+  }
+
+  #programOutcome(
+    stage: "predicate" | "action",
+    invocationId: string,
+    status: TriggerProgramOutcome["status"],
+    output: string | null,
+    exitCode: number | null,
+    error: string | null,
+  ): TriggerProgramOutcome {
+    return {
+      stage,
+      invocationId,
+      status,
+      output: bounded(output ?? "", 8_000) || null,
+      exitCode,
+      error: bounded(error ?? "", 2_048) || null,
+    };
+  }
+
+  #notify(): void {
     for (const listener of this.#listeners) listener(this.snapshot());
   }
 }
 
-function meaningfulWakeupTitleInput(
-  trigger: ZenXTrigger,
-  projection?: string,
+class StaleGenerationError extends Error {
+  constructor() {
+    super("ZenX Trigger service lifecycle changed");
+  }
+}
+
+function newGeneration(): TriggerGeneration {
+  return {
+    id: randomUUID(),
+    active: true,
+    retiring: false,
+    timers: new Map(),
+    completedTurnItems: new Map(),
+    pendingCompletedTurns: new Map(),
+    activeWakeups: new Map(),
+    programControllers: new Map(),
+    disposeNotifications: undefined,
+  };
+}
+
+function triggerFromInput(
+  input: CreateTriggerInput,
+  id: string,
+  createdAt: number,
+  active: boolean,
+  now: number,
+): ZenXTrigger {
+  const common = {
+    id,
+    threadId: required(input.threadId, "thread"),
+    kind: input.kind,
+    label: required(input.label, "label"),
+    prompt: required(input.prompt, "prompt"),
+    createdAt,
+    active,
+    ...(programFromInput(input) === undefined
+      ? {}
+      : { program: programFromInput(input) }),
+  };
+  if (input.kind === "timer") {
+    return {
+      ...common,
+      kind: "timer",
+      timer: {
+        nextRunAt: validFuture(input.runAt, now),
+        intervalMinutes:
+          input.intervalMinutes === undefined
+            ? null
+            : positive(input.intervalMinutes),
+      },
+    };
+  }
+  if (input.kind === "thread") {
+    return {
+      ...common,
+      kind: "thread",
+      watch: {
+        threadId: required(input.watchedThreadId, "watched thread"),
+        event: "turn_completed",
+      },
+    };
+  }
+  if (input.kind === "roomMention") {
+    return {
+      ...common,
+      kind: "roomMention",
+      room: {
+        roomId: required(input.roomId, "room"),
+        mention: required(input.mention, "mention"),
+      },
+    };
+  }
+  return {
+    ...common,
+    kind: "signal",
+    signal: { name: required(input.signalName, "signal name") },
+  };
+}
+
+function programFromInput(
+  input: CreateTriggerInput | UpdateTriggerInput,
+): TriggerProgramConfig | undefined {
+  const value = input as CreateTriggerInput & {
+    program?: TriggerProgramConfig;
+    predicate?: TriggerProgramSpec;
+    action?: TriggerProgramSpec;
+    match?: TriggerProgramConfig["match"];
+  };
+  const program = value.program ?? {
+    ...(value.predicate === undefined ? {} : { predicate: value.predicate }),
+    ...(value.action === undefined ? {} : { action: value.action }),
+    ...(value.match === undefined ? {} : { match: value.match }),
+  };
+  if (Object.keys(program).length === 0) return undefined;
+  validateProgram(program);
+  return structuredClone(program);
+}
+
+function validateProgram(program: TriggerProgramConfig): void {
+  if (
+    program.predicate === undefined &&
+    program.action === undefined &&
+    program.match === undefined
+  )
+    throw new Error("Trigger program must define predicate, action, or match");
+  for (const [stage, spec] of [
+    ["predicate", program.predicate],
+    ["action", program.action],
+  ] as const) {
+    if (spec === undefined) continue;
+    if (required(spec.command, `${stage} command`).length > 4_096)
+      throw new Error(`${stage} command is too long`);
+    if ((spec.args?.length ?? 0) > 64)
+      throw new Error(`${stage} has too many arguments`);
+    if (spec.args?.some((arg) => arg.length > 4_096))
+      throw new Error(`${stage} argument is too long`);
+    if (
+      spec.cwd !== undefined &&
+      required(spec.cwd, `${stage} cwd`).length > 4_096
+    )
+      throw new Error(`${stage} cwd is too long`);
+    if (
+      spec.timeoutMs !== undefined &&
+      (!Number.isFinite(spec.timeoutMs) ||
+        spec.timeoutMs <= 0 ||
+        spec.timeoutMs > 120_000)
+    )
+      throw new Error(`${stage} timeoutMs must be between 1 and 120000`);
+    if (
+      spec.maxOutputBytes !== undefined &&
+      (!Number.isSafeInteger(spec.maxOutputBytes) ||
+        spec.maxOutputBytes < 256 ||
+        spec.maxOutputBytes > 1024 * 1024)
+    )
+      throw new Error(
+        `${stage} maxOutputBytes must be between 256 and 1048576`,
+      );
+    if (
+      spec.env !== undefined &&
+      Object.entries(spec.env).some(
+        ([key, value]) =>
+          key.length === 0 || key.length > 256 || value.length > 4_096,
+      )
+    )
+      throw new Error(`${stage} env is invalid`);
+  }
+  if (program.match !== undefined) {
+    if (
+      program.match.field !== "completedItemText" ||
+      required(program.match.regex, "match regex").length > 4_096
+    )
+      throw new Error("Trigger match is invalid");
+    try {
+      new RegExp(program.match.regex, program.match.flags ?? "u");
+    } catch (error) {
+      throw new Error(
+        `Trigger match regex is invalid: ${describeError(error)}`,
+      );
+    }
+  }
+}
+
+function programInput(active: ActiveWakeup, wakeup: WakeupEvent): unknown {
+  return {
+    triggerId: active.trigger.id,
+    historyId: active.historyId,
+    generationId: active.generationId,
+    clientUserMessageId: active.clientUserMessageId,
+    occurrenceKey: wakeup.occurrenceKey,
+    reason: bounded(wakeup.reason, 4_000),
+    source: {
+      threadId: wakeup.sourceThreadId ?? null,
+      turnId: wakeup.sourceTurnId ?? null,
+      roomId: wakeup.sourceRoomId ?? null,
+      roomMessageId: wakeup.sourceRoomMessageId ?? null,
+    },
+    completedItemText: bounded(wakeup.eventText ?? "", 8_000),
+    projection: bounded(wakeup.projection ?? "", 8_000),
+  };
+}
+
+function stableProgramInvocationId(
+  clientUserMessageId: string,
+  stage: "predicate" | "action",
 ): string {
-  return [
-    `Trigger: ${trigger.label}`,
-    `Task: ${trigger.prompt}`,
-    ...(projection === undefined
-      ? []
-      : [`Source context: ${bounded(projection, 1_200)}`]),
-  ].join("\n");
+  const digest = createHash("sha256")
+    .update(`${clientUserMessageId}:${stage}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `zenx-program:${stage}:${digest}`;
+}
+
+function programStageForInvocation(
+  invocationId: string,
+): "predicate" | "action" {
+  return invocationId.includes(":predicate:") ? "predicate" : "action";
 }
 
 function message(
@@ -527,23 +1432,23 @@ function message(
     originTurnId,
   };
 }
+
 function required(value: string, label: string): string {
-  if (value.trim().length === 0)
+  if (typeof value !== "string" || value.trim().length === 0)
     throw new Error(`Trigger ${label} is required`);
   return value.trim();
 }
+
 function positive(value: number): number {
   if (!Number.isFinite(value) || value <= 0)
     throw new Error("Timer interval must be positive");
   return value;
 }
+
 function validFuture(value: number, now: number): number {
   if (!Number.isFinite(value) || value <= now)
     throw new Error("Timer must be scheduled in the future");
   return value;
-}
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }
 
 function validateMembers(members: readonly RoomMember[]): RoomMember[] {
@@ -566,12 +1471,69 @@ function validateMembers(members: readonly RoomMember[]): RoomMember[] {
   return normalized;
 }
 
+function mentionMatches(text: string, name: string): boolean {
+  return new RegExp(`(^|\\s)@${escapeRegExp(name)}(?=\\s|$|[,.!?])`, "iu").test(
+    text,
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 function stableWakeupId(triggerId: string, occurrenceKey: string): string {
   const occurrence = createHash("sha256")
     .update(occurrenceKey)
     .digest("hex")
     .slice(0, 24);
   return `zenx-wakeup:${triggerId}:${occurrence}`;
+}
+
+function transientTurnKey(threadId: string, turnId: string): string {
+  return `${String(threadId.length)}:${threadId}:${turnId}`;
+}
+
+function clearTransientTurn(
+  generation: TriggerGeneration,
+  threadId: string,
+  turnId: string,
+): void {
+  const key = transientTurnKey(threadId, turnId);
+  generation.completedTurnItems.delete(key);
+  generation.pendingCompletedTurns.delete(key);
+}
+
+function setBounded<K, V>(
+  map: Map<K, V>,
+  key: K,
+  value: V,
+  onEvict: (key: K) => void,
+): void {
+  map.delete(key);
+  map.set(key, value);
+  while (map.size > MAX_TRANSIENT_TURNS) {
+    const oldest = map.keys().next().value as K | undefined;
+    if (oldest === undefined) return;
+    map.delete(oldest);
+    onEvict(oldest);
+  }
+}
+
+function isTerminal(status: TriggerHistoryEntry["status"]): boolean {
+  return status === "completed" || status === "failed";
+}
+
+function meaningfulWakeupTitleInput(
+  trigger: ZenXTrigger,
+  projection?: string,
+): string {
+  return [
+    `Trigger: ${trigger.label}`,
+    `Task: ${trigger.prompt}`,
+    ...(projection === undefined
+      ? []
+      : [`Source context: ${bounded(projection, 1_200)}`]),
+  ].join("\n");
 }
 
 function wakeupInput(
@@ -604,7 +1566,11 @@ function wakeupInput(
     trigger.prompt,
     ...(projection === undefined
       ? []
-      : ["", "Bounded source context (read-only projection):", projection]),
+      : [
+          "",
+          "Bounded source context (read-only projection):",
+          bounded(projection, 6_000),
+        ]),
   ].join("\n");
 }
 
@@ -623,23 +1589,27 @@ export function projectCompletedTurn(threadId: string, turn: Turn): string {
     .slice(-2)
     .map(
       (item) =>
-        `$ ${bounded(item.command, 500)}\nStatus: ${item.status}${
-          item.exitCode === null ? "" : ` (exit ${item.exitCode})`
-        }\n${bounded(item.aggregatedOutput ?? "No captured output", 1_000)}`,
+        `$ ${bounded(item.command, 500)}\nStatus: ${item.status}${item.exitCode === null ? "" : ` (exit ${item.exitCode})`}\n${bounded(item.aggregatedOutput ?? "No captured output", 1_000)}`,
     );
-  const sections = [
-    `Source Thread: ${threadId}`,
-    `Source Turn: ${turn.id}`,
-    `Status: ${turn.status}`,
-    userInputs.length === 0 ? null : `User input:\n${userInputs.join("\n\n")}`,
-    commands.length === 0
-      ? null
-      : `Command/result summary:\n${commands.join("\n\n")}`,
-    conclusion?.type === "agentMessage"
-      ? `Agent conclusion:\n${bounded(conclusion.text, 1_800)}`
-      : "Agent conclusion:\nNo final Agent message was emitted.",
-  ].filter((section): section is string => section !== null);
-  return bounded(sections.join("\n\n"), 6_000);
+  return bounded(
+    [
+      `Source Thread: ${threadId}`,
+      `Source Turn: ${turn.id}`,
+      `Status: ${turn.status}`,
+      userInputs.length === 0
+        ? null
+        : `User input:\n${userInputs.join("\n\n")}`,
+      commands.length === 0
+        ? null
+        : `Command/result summary:\n${commands.join("\n\n")}`,
+      conclusion?.type === "agentMessage"
+        ? `Agent conclusion:\n${bounded(conclusion.text, 1_800)}`
+        : "Agent conclusion:\nNo final Agent message was emitted.",
+    ]
+      .filter((section): section is string => section !== null)
+      .join("\n\n"),
+    6_000,
+  );
 }
 
 export function projectRoomContext(room: ZenXRoom): string {
@@ -665,13 +1635,16 @@ function mergeCompletedItems(
   const completed = new Map(completedItems.map((item) => [item.id, item]));
   const merged = turnItems.map((item) => completed.get(item.id) ?? item);
   const included = new Set(merged.map((item) => item.id));
-  for (const item of completedItems) {
+  for (const item of completedItems)
     if (!included.has(item.id)) merged.push(item);
-  }
   return merged;
 }
 
 function bounded(value: string, limit: number): string {
   if (value.length <= limit) return value;
   return `${value.slice(0, Math.max(0, limit - 24))}\n…[truncated by ZenX]`;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -12,6 +12,35 @@ import type {
   ZenXRoom,
   ZenXTrigger,
 } from "./trigger-types.js";
+import {
+  MAX_ERROR_BYTES,
+  MAX_HISTORY_COUNT,
+  MAX_ID_BYTES,
+  MAX_MEMBER_NAME_BYTES,
+  MAX_MESSAGE_AUTHOR_BYTES,
+  MAX_MESSAGE_TEXT_BYTES,
+  MAX_PROGRAM_ARGUMENT_BYTES,
+  MAX_PROGRAM_ARGUMENTS,
+  MAX_PROGRAM_COMMAND_BYTES,
+  MAX_PROGRAM_CWD_BYTES,
+  MAX_PROGRAM_ENV_BYTES,
+  MAX_PROGRAM_ENV_ENTRIES,
+  MAX_PROGRAM_ENV_KEY_BYTES,
+  MAX_PROGRAM_ENV_VALUE_BYTES,
+  MAX_PROGRAM_FLAGS_BYTES,
+  MAX_PROGRAM_MATCH_REGEX_BYTES,
+  MAX_PROGRAM_OUTCOMES,
+  MAX_REASON_BYTES,
+  MAX_ROOM_COUNT,
+  MAX_ROOM_MEMBERS,
+  MAX_ROOM_MESSAGES,
+  MAX_ROOM_NAME_BYTES,
+  MAX_TRIGGER_COUNT,
+  MAX_TRIGGER_LABEL_BYTES,
+  MAX_TRIGGER_PROMPT_BYTES,
+  utf8Bytes,
+  withinBytes,
+} from "./trigger-limits.js";
 
 interface StoredState extends TriggerSnapshot {
   version: 3;
@@ -143,9 +172,9 @@ function isStoredState(value: unknown): value is StoredState {
   return (
     state !== null &&
     state["version"] === 3 &&
-    arrayOf(state["triggers"], isTrigger) &&
-    arrayOf(state["history"], isHistory) &&
-    arrayOf(state["rooms"], isRoom)
+    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(state["history"], isHistory, MAX_HISTORY_COUNT) &&
+    arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
 }
 
@@ -154,9 +183,9 @@ function isVersion2StoredState(value: unknown): value is Version2StoredState {
   return (
     state !== null &&
     state["version"] === 2 &&
-    arrayOf(state["triggers"], isTrigger) &&
-    arrayOf(state["history"], isVersion2History) &&
-    arrayOf(state["rooms"], isRoom)
+    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(state["history"], isVersion2History, MAX_HISTORY_COUNT) &&
+    arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
 }
 
@@ -165,9 +194,9 @@ function isLegacyStoredState(value: unknown): value is LegacyStoredState {
   return (
     state !== null &&
     state["version"] === 1 &&
-    arrayOf(state["triggers"], isTrigger) &&
-    arrayOf(state["history"], isLegacyHistory) &&
-    arrayOf(state["rooms"], isRoom)
+    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(state["history"], isLegacyHistory, MAX_HISTORY_COUNT) &&
+    arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
 }
 
@@ -175,11 +204,11 @@ function isTrigger(value: unknown): value is ZenXTrigger {
   const trigger = record(value);
   if (
     trigger === null ||
-    !string(trigger["id"]) ||
-    !string(trigger["threadId"]) ||
+    !string(trigger["id"], MAX_ID_BYTES) ||
+    !string(trigger["threadId"], MAX_ID_BYTES) ||
     !triggerKind(trigger["kind"]) ||
-    !string(trigger["label"]) ||
-    !string(trigger["prompt"]) ||
+    !string(trigger["label"], MAX_TRIGGER_LABEL_BYTES) ||
+    !string(trigger["prompt"], MAX_TRIGGER_PROMPT_BYTES) ||
     !finiteNumber(trigger["createdAt"]) ||
     typeof trigger["active"] !== "boolean" ||
     (trigger["program"] !== undefined && !isProgramConfig(trigger["program"]))
@@ -199,16 +228,20 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const watch = record(trigger["watch"]);
     return (
       watch !== null &&
-      string(watch["threadId"]) &&
+      string(watch["threadId"], MAX_ID_BYTES) &&
       watch["event"] === "turn_completed"
     );
   }
   if (trigger["kind"] === "roomMention") {
     const room = record(trigger["room"]);
-    return room !== null && string(room["roomId"]) && string(room["mention"]);
+    return (
+      room !== null &&
+      string(room["roomId"], MAX_ID_BYTES) &&
+      string(room["mention"], MAX_MEMBER_NAME_BYTES)
+    );
   }
   const signal = record(trigger["signal"]);
-  return signal !== null && string(signal["name"]);
+  return signal !== null && string(signal["name"], MAX_ID_BYTES);
 }
 
 function isHistory(value: unknown): value is TriggerHistoryEntry {
@@ -216,12 +249,12 @@ function isHistory(value: unknown): value is TriggerHistoryEntry {
   return (
     isVersion2History(value) &&
     entry !== null &&
-    nullableString(entry["replyRoomId"]) &&
-    nullableString(entry["replyAuthor"]) &&
-    nullableString(entry["programInvocationId"]) &&
+    nullableString(entry["replyRoomId"], MAX_ID_BYTES) &&
+    nullableString(entry["replyAuthor"], MAX_MEMBER_NAME_BYTES) &&
+    nullableString(entry["programInvocationId"], MAX_ID_BYTES) &&
     (entry["programOutcome"] === null ||
       isProgramOutcome(entry["programOutcome"])) &&
-    arrayOf(entry["programOutcomes"], isProgramOutcome)
+    arrayOf(entry["programOutcomes"], isProgramOutcome, MAX_PROGRAM_OUTCOMES)
   );
 }
 
@@ -232,10 +265,10 @@ function isVersion2History(
   return (
     isLegacyHistory(value) &&
     entry !== null &&
-    nullableString(entry["sourceThreadId"]) &&
-    nullableString(entry["sourceTurnId"]) &&
-    nullableString(entry["sourceRoomId"]) &&
-    nullableString(entry["sourceRoomMessageId"])
+    nullableString(entry["sourceThreadId"], MAX_ID_BYTES) &&
+    nullableString(entry["sourceTurnId"], MAX_ID_BYTES) &&
+    nullableString(entry["sourceRoomId"], MAX_ID_BYTES) &&
+    nullableString(entry["sourceRoomMessageId"], MAX_ID_BYTES)
   );
 }
 
@@ -245,18 +278,18 @@ function isLegacyHistory(
   const entry = record(value);
   return (
     entry !== null &&
-    string(entry["id"]) &&
-    string(entry["triggerId"]) &&
-    string(entry["threadId"]) &&
+    string(entry["id"], MAX_ID_BYTES) &&
+    string(entry["triggerId"], MAX_ID_BYTES) &&
+    string(entry["threadId"], MAX_ID_BYTES) &&
     triggerKind(entry["kind"]) &&
-    string(entry["reason"]) &&
-    string(entry["prompt"]) &&
-    string(entry["clientUserMessageId"]) &&
+    string(entry["reason"], MAX_REASON_BYTES) &&
+    string(entry["prompt"], MAX_TRIGGER_PROMPT_BYTES) &&
+    string(entry["clientUserMessageId"], MAX_ID_BYTES) &&
     finiteNumber(entry["startedAt"]) &&
     nullableNumber(entry["completedAt"]) &&
     historyStatus(entry["status"]) &&
-    nullableString(entry["turnId"]) &&
-    nullableString(entry["error"])
+    nullableString(entry["turnId"], MAX_ID_BYTES) &&
+    nullableString(entry["error"], MAX_ERROR_BYTES)
   );
 }
 
@@ -277,18 +310,34 @@ function isProgramSpec(value: unknown): value is TriggerProgramSpec {
   const spec = record(value);
   if (
     spec === null ||
-    !string(spec["command"]) ||
+    !string(spec["command"], MAX_PROGRAM_COMMAND_BYTES) ||
     (spec["args"] !== undefined &&
       !arrayOf(
         spec["args"],
-        (entry): entry is string => typeof entry === "string",
+        (entry): entry is string =>
+          typeof entry === "string" &&
+          withinBytes(entry, MAX_PROGRAM_ARGUMENT_BYTES),
+        MAX_PROGRAM_ARGUMENTS,
       )) ||
-    (spec["cwd"] !== undefined && !string(spec["cwd"])) ||
+    (spec["cwd"] !== undefined &&
+      !string(spec["cwd"], MAX_PROGRAM_CWD_BYTES)) ||
     (spec["env"] !== undefined &&
       (record(spec["env"]) === null ||
-        Object.values(spec["env"] as Record<string, unknown>).some(
-          (entry) => typeof entry !== "string",
-        ))) ||
+        Object.keys(spec["env"] as Record<string, unknown>).length >
+          MAX_PROGRAM_ENV_ENTRIES ||
+        Object.entries(spec["env"] as Record<string, unknown>).some(
+          ([key, entry]) =>
+            !withinBytes(key, MAX_PROGRAM_ENV_KEY_BYTES) ||
+            typeof entry !== "string" ||
+            !withinBytes(entry, MAX_PROGRAM_ENV_VALUE_BYTES),
+        ) ||
+        Object.entries(spec["env"] as Record<string, unknown>).reduce(
+          (total, [key, entry]) =>
+            total +
+            utf8Bytes(key) +
+            (typeof entry === "string" ? utf8Bytes(entry) : 0),
+          0,
+        ) > MAX_PROGRAM_ENV_BYTES)) ||
     (spec["timeoutMs"] !== undefined &&
       (!finiteNumber(spec["timeoutMs"]) || spec["timeoutMs"] <= 0)) ||
     (spec["maxOutputBytes"] !== undefined &&
@@ -305,8 +354,9 @@ function isMatch(value: unknown): boolean {
   if (
     match === null ||
     match["field"] !== "completedItemText" ||
-    !string(match["regex"]) ||
-    (match["flags"] !== undefined && !string(match["flags"]))
+    !string(match["regex"], MAX_PROGRAM_MATCH_REGEX_BYTES) ||
+    (match["flags"] !== undefined &&
+      !string(match["flags"], MAX_PROGRAM_FLAGS_BYTES))
   )
     return false;
   try {
@@ -323,10 +373,10 @@ function isProgramOutcome(value: unknown): value is TriggerProgramOutcome {
     outcome !== null &&
     (outcome["stage"] === "predicate" || outcome["stage"] === "action") &&
     programStatus(outcome["status"]) &&
-    string(outcome["invocationId"]) &&
-    nullableString(outcome["output"]) &&
+    string(outcome["invocationId"], MAX_ID_BYTES) &&
+    nullableString(outcome["output"], 8_000) &&
     nullableNumber(outcome["exitCode"]) &&
-    nullableString(outcome["error"])
+    nullableString(outcome["error"], MAX_ERROR_BYTES)
   );
 }
 
@@ -334,10 +384,10 @@ function isRoom(value: unknown): value is ZenXRoom {
   const room = record(value);
   if (
     room === null ||
-    !string(room["id"]) ||
-    !string(room["name"]) ||
-    !arrayOf(room["members"], isRoomMember) ||
-    !arrayOf(room["messages"], isRoomMessage) ||
+    !string(room["id"], MAX_ID_BYTES) ||
+    !string(room["name"], MAX_ROOM_NAME_BYTES) ||
+    !arrayOf(room["members"], isRoomMember, MAX_ROOM_MEMBERS) ||
+    !arrayOf(room["messages"], isRoomMessage, MAX_ROOM_MESSAGES) ||
     !finiteNumber(room["createdAt"])
   )
     return false;
@@ -355,7 +405,9 @@ function isRoom(value: unknown): value is ZenXRoom {
 function isRoomMember(value: unknown): value is RoomMember {
   const member = record(value);
   return (
-    member !== null && string(member["name"]) && string(member["threadId"])
+    member !== null &&
+    string(member["name"], MAX_MEMBER_NAME_BYTES) &&
+    string(member["threadId"], MAX_ID_BYTES)
   );
 }
 
@@ -363,16 +415,16 @@ function isRoomMessage(value: unknown): value is RoomMessage {
   const message = record(value);
   return (
     message !== null &&
-    string(message["id"]) &&
-    string(message["roomId"]) &&
-    string(message["author"]) &&
-    string(message["text"]) &&
+    string(message["id"], MAX_ID_BYTES) &&
+    string(message["roomId"], MAX_ID_BYTES) &&
+    string(message["author"], MAX_MESSAGE_AUTHOR_BYTES) &&
+    string(message["text"], MAX_MESSAGE_TEXT_BYTES) &&
     finiteNumber(message["createdAt"]) &&
     (message["kind"] === "human" ||
       message["kind"] === "agent" ||
       message["kind"] === "system") &&
-    nullableString(message["originThreadId"]) &&
-    nullableString(message["originTurnId"])
+    nullableString(message["originThreadId"], MAX_ID_BYTES) &&
+    nullableString(message["originTurnId"], MAX_ID_BYTES)
   );
 }
 
@@ -385,16 +437,26 @@ function record(value: unknown): Record<string, unknown> | null {
 function arrayOf<T>(
   value: unknown,
   predicate: (entry: unknown) => entry is T,
+  maximum?: number,
 ): value is T[] {
-  return Array.isArray(value) && value.every(predicate);
+  return (
+    Array.isArray(value) &&
+    (maximum === undefined || value.length <= maximum) &&
+    value.every(predicate)
+  );
 }
 
-function string(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
+function string(value: unknown, maximum = MAX_ID_BYTES): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && withinBytes(value, maximum)
+  );
 }
 
-function nullableString(value: unknown): value is string | null {
-  return value === null || string(value);
+function nullableString(
+  value: unknown,
+  maximum = MAX_ID_BYTES,
+): value is string | null {
+  return value === null || string(value, maximum);
 }
 
 function finiteNumber(value: unknown): value is number {

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -5,13 +5,30 @@ import type {
   RoomMember,
   RoomMessage,
   TriggerHistoryEntry,
+  TriggerProgramConfig,
+  TriggerProgramOutcome,
+  TriggerProgramSpec,
   TriggerSnapshot,
   ZenXRoom,
   ZenXTrigger,
 } from "./trigger-types.js";
 
 interface StoredState extends TriggerSnapshot {
+  version: 3;
+}
+
+interface Version2StoredState extends Omit<TriggerSnapshot, "history"> {
   version: 2;
+  history: Array<
+    Omit<
+      TriggerHistoryEntry,
+      | "replyRoomId"
+      | "replyAuthor"
+      | "programInvocationId"
+      | "programOutcome"
+      | "programOutcomes"
+    >
+  >;
 }
 
 interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
@@ -19,13 +36,21 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
   history: Array<
     Omit<
       TriggerHistoryEntry,
-      "sourceThreadId" | "sourceTurnId" | "sourceRoomId" | "sourceRoomMessageId"
+      | "sourceThreadId"
+      | "sourceTurnId"
+      | "sourceRoomId"
+      | "sourceRoomMessageId"
+      | "replyRoomId"
+      | "replyAuthor"
+      | "programInvocationId"
+      | "programOutcome"
     >
   >;
 }
 
 export class ZenXTriggerStore {
   readonly #filePath: string;
+
   constructor(filePath: string) {
     this.#filePath = path.resolve(filePath);
   }
@@ -42,6 +67,20 @@ export class ZenXTriggerStore {
     try {
       const value = JSON.parse(await handle.readFile("utf8")) as unknown;
       if (isStoredState(value)) return snapshotFrom(value);
+      if (isVersion2StoredState(value)) {
+        return {
+          triggers: value.triggers,
+          history: value.history.map((entry) => ({
+            ...entry,
+            replyRoomId: null,
+            replyAuthor: null,
+            programInvocationId: null,
+            programOutcome: null,
+            programOutcomes: [],
+          })),
+          rooms: value.rooms,
+        };
+      }
       if (isLegacyStoredState(value)) {
         return {
           triggers: value.triggers,
@@ -51,6 +90,11 @@ export class ZenXTriggerStore {
             sourceTurnId: null,
             sourceRoomId: null,
             sourceRoomMessageId: null,
+            replyRoomId: null,
+            replyAuthor: null,
+            programInvocationId: null,
+            programOutcome: null,
+            programOutcomes: [],
           })),
           rooms: value.rooms,
         };
@@ -71,7 +115,7 @@ export class ZenXTriggerStore {
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
     const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    const value: StoredState = { version: 2, ...snapshot };
+    const value: StoredState = { version: 3, ...snapshot };
     if (!isStoredState(value))
       throw new Error("ZenX refused to persist an invalid trigger registry");
     await writeFile(temporary, `${JSON.stringify(value, null, 2)}\n`, {
@@ -98,9 +142,20 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
-    state["version"] === 2 &&
+    state["version"] === 3 &&
     arrayOf(state["triggers"], isTrigger) &&
     arrayOf(state["history"], isHistory) &&
+    arrayOf(state["rooms"], isRoom)
+  );
+}
+
+function isVersion2StoredState(value: unknown): value is Version2StoredState {
+  const state = record(value);
+  return (
+    state !== null &&
+    state["version"] === 2 &&
+    arrayOf(state["triggers"], isTrigger) &&
+    arrayOf(state["history"], isVersion2History) &&
     arrayOf(state["rooms"], isRoom)
   );
 }
@@ -126,7 +181,8 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     !string(trigger["label"]) ||
     !string(trigger["prompt"]) ||
     !finiteNumber(trigger["createdAt"]) ||
-    typeof trigger["active"] !== "boolean"
+    typeof trigger["active"] !== "boolean" ||
+    (trigger["program"] !== undefined && !isProgramConfig(trigger["program"]))
   )
     return false;
   if (trigger["kind"] === "timer") {
@@ -158,6 +214,22 @@ function isTrigger(value: unknown): value is ZenXTrigger {
 function isHistory(value: unknown): value is TriggerHistoryEntry {
   const entry = record(value);
   return (
+    isVersion2History(value) &&
+    entry !== null &&
+    nullableString(entry["replyRoomId"]) &&
+    nullableString(entry["replyAuthor"]) &&
+    nullableString(entry["programInvocationId"]) &&
+    (entry["programOutcome"] === null ||
+      isProgramOutcome(entry["programOutcome"])) &&
+    arrayOf(entry["programOutcomes"], isProgramOutcome)
+  );
+}
+
+function isVersion2History(
+  value: unknown,
+): value is Version2StoredState["history"][number] {
+  const entry = record(value);
+  return (
     isLegacyHistory(value) &&
     entry !== null &&
     nullableString(entry["sourceThreadId"]) &&
@@ -185,6 +257,76 @@ function isLegacyHistory(
     historyStatus(entry["status"]) &&
     nullableString(entry["turnId"]) &&
     nullableString(entry["error"])
+  );
+}
+
+function isProgramConfig(value: unknown): value is TriggerProgramConfig {
+  const config = record(value);
+  return (
+    config !== null &&
+    (config["predicate"] === undefined || isProgramSpec(config["predicate"])) &&
+    (config["action"] === undefined || isProgramSpec(config["action"])) &&
+    (config["match"] === undefined || isMatch(config["match"])) &&
+    (config["predicate"] !== undefined ||
+      config["action"] !== undefined ||
+      config["match"] !== undefined)
+  );
+}
+
+function isProgramSpec(value: unknown): value is TriggerProgramSpec {
+  const spec = record(value);
+  if (
+    spec === null ||
+    !string(spec["command"]) ||
+    (spec["args"] !== undefined &&
+      !arrayOf(
+        spec["args"],
+        (entry): entry is string => typeof entry === "string",
+      )) ||
+    (spec["cwd"] !== undefined && !string(spec["cwd"])) ||
+    (spec["env"] !== undefined &&
+      (record(spec["env"]) === null ||
+        Object.values(spec["env"] as Record<string, unknown>).some(
+          (entry) => typeof entry !== "string",
+        ))) ||
+    (spec["timeoutMs"] !== undefined &&
+      (!finiteNumber(spec["timeoutMs"]) || spec["timeoutMs"] <= 0)) ||
+    (spec["maxOutputBytes"] !== undefined &&
+      (!Number.isSafeInteger(spec["maxOutputBytes"]) ||
+        (spec["maxOutputBytes"] as number) < 256 ||
+        (spec["maxOutputBytes"] as number) > 1024 * 1024))
+  )
+    return false;
+  return true;
+}
+
+function isMatch(value: unknown): boolean {
+  const match = record(value);
+  if (
+    match === null ||
+    match["field"] !== "completedItemText" ||
+    !string(match["regex"]) ||
+    (match["flags"] !== undefined && !string(match["flags"]))
+  )
+    return false;
+  try {
+    new RegExp(match["regex"] as string, (match["flags"] as string) ?? "u");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isProgramOutcome(value: unknown): value is TriggerProgramOutcome {
+  const outcome = record(value);
+  return (
+    outcome !== null &&
+    (outcome["stage"] === "predicate" || outcome["stage"] === "action") &&
+    programStatus(outcome["status"]) &&
+    string(outcome["invocationId"]) &&
+    nullableString(outcome["output"]) &&
+    nullableNumber(outcome["exitCode"]) &&
+    nullableString(outcome["error"])
   );
 }
 
@@ -278,5 +420,22 @@ function historyStatus(value: unknown): value is TriggerHistoryEntry["status"] {
     value === "running" ||
     value === "completed" ||
     value === "failed"
+  );
+}
+
+function programStatus(
+  value: unknown,
+): value is TriggerProgramOutcome["status"] {
+  return (
+    value === "matched" ||
+    value === "non_match" ||
+    value === "completed" ||
+    value === "failed" ||
+    value === "cancelled" ||
+    value === "timed_out" ||
+    value === "nonzero_exit" ||
+    value === "malformed_output" ||
+    value === "oversized_output" ||
+    value === "uncertain"
   );
 }

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -80,7 +80,7 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
 }
 
 const STORED_STATE_KEYS = ["version", "triggers", "history", "rooms"] as const;
-const TRIGGER_KEYS = [
+const TRIGGER_BASE_KEYS = [
   "id",
   "threadId",
   "kind",
@@ -88,11 +88,6 @@ const TRIGGER_KEYS = [
   "prompt",
   "createdAt",
   "active",
-  "timer",
-  "watch",
-  "room",
-  "signal",
-  "program",
 ] as const;
 const TIMER_KEYS = ["nextRunAt", "intervalMinutes"] as const;
 const WATCH_KEYS = ["threadId", "event"] as const;
@@ -180,7 +175,9 @@ export class ZenXTriggerStore {
       if (isStoredState(value)) return snapshotFrom(value);
       if (isVersion2StoredState(value)) {
         return {
-          triggers: value.triggers.map(canonicalTrigger),
+          triggers: value.triggers.map((trigger) =>
+            canonicalTrigger(trigger, "v2"),
+          ),
           history: value.history.map((entry) => ({
             ...canonicalBaseHistory(entry),
             sourceThreadId: entry.sourceThreadId,
@@ -198,7 +195,9 @@ export class ZenXTriggerStore {
       }
       if (isLegacyStoredState(value)) {
         return {
-          triggers: value.triggers.map(canonicalTrigger),
+          triggers: value.triggers.map((trigger) =>
+            canonicalTrigger(trigger, "v1"),
+          ),
           history: value.history.map((entry) => ({
             ...canonicalBaseHistory(entry),
             sourceThreadId: null,
@@ -247,14 +246,17 @@ function emptySnapshot(): TriggerSnapshot {
 
 function snapshotFrom(value: StoredState): TriggerSnapshot {
   return {
-    triggers: value.triggers.map(canonicalTrigger),
+    triggers: value.triggers.map((trigger) => canonicalTrigger(trigger, "v3")),
     history: value.history.map(canonicalHistory),
     rooms: value.rooms.map(canonicalRoom),
   };
 }
 
-function canonicalTrigger(trigger: ZenXTrigger): ZenXTrigger {
-  return {
+function canonicalTrigger(
+  trigger: ZenXTrigger,
+  version: "v1" | "v2" | "v3",
+): ZenXTrigger {
+  const common = {
     id: trigger.id,
     threadId: trigger.threadId,
     kind: trigger.kind,
@@ -262,13 +264,46 @@ function canonicalTrigger(trigger: ZenXTrigger): ZenXTrigger {
     prompt: trigger.prompt,
     createdAt: trigger.createdAt,
     active: trigger.active,
-    ...(trigger.timer === undefined ? {} : { timer: { ...trigger.timer } }),
-    ...(trigger.watch === undefined ? {} : { watch: { ...trigger.watch } }),
-    ...(trigger.room === undefined ? {} : { room: { ...trigger.room } }),
-    ...(trigger.signal === undefined ? {} : { signal: { ...trigger.signal } }),
-    ...(trigger.program === undefined
-      ? {}
-      : { program: canonicalProgramConfig(trigger.program) }),
+  };
+  const program =
+    version === "v3" && trigger.program !== undefined
+      ? { program: canonicalProgramConfig(trigger.program) }
+      : {};
+  if (trigger.kind === "timer")
+    return {
+      ...common,
+      kind: "timer",
+      timer: {
+        nextRunAt: trigger.timer!.nextRunAt,
+        intervalMinutes: trigger.timer!.intervalMinutes,
+      },
+      ...program,
+    };
+  if (trigger.kind === "thread")
+    return {
+      ...common,
+      kind: "thread",
+      watch: {
+        threadId: trigger.watch!.threadId,
+        event: trigger.watch!.event,
+      },
+      ...program,
+    };
+  if (trigger.kind === "roomMention")
+    return {
+      ...common,
+      kind: "roomMention",
+      room: {
+        roomId: trigger.room!.roomId,
+        mention: trigger.room!.mention,
+      },
+      ...program,
+    };
+  return {
+    ...common,
+    kind: "signal",
+    signal: { name: trigger.signal!.name },
+    ...program,
   };
 }
 
@@ -330,7 +365,17 @@ function canonicalProgramConfig(
     ...(config.action === undefined
       ? {}
       : { action: canonicalProgramSpec(config.action) }),
-    ...(config.match === undefined ? {} : { match: { ...config.match } }),
+    ...(config.match === undefined
+      ? {}
+      : {
+          match: {
+            field: config.match.field,
+            regex: config.match.regex,
+            ...(config.match.flags === undefined
+              ? {}
+              : { flags: config.match.flags }),
+          },
+        }),
   };
 }
 
@@ -350,15 +395,34 @@ function canonicalProgramSpec(spec: TriggerProgramSpec): TriggerProgramSpec {
 function canonicalProgramOutcome(
   outcome: TriggerProgramOutcome,
 ): TriggerProgramOutcome {
-  return { ...outcome };
+  return {
+    stage: outcome.stage,
+    invocationId: outcome.invocationId,
+    status: outcome.status,
+    output: outcome.output,
+    exitCode: outcome.exitCode,
+    error: outcome.error,
+  };
 }
 
 function canonicalRoom(room: ZenXRoom): ZenXRoom {
   return {
     id: room.id,
     name: room.name,
-    members: room.members.map((member) => ({ ...member })),
-    messages: room.messages.map((message) => ({ ...message })),
+    members: room.members.map((member) => ({
+      name: member.name,
+      threadId: member.threadId,
+    })),
+    messages: room.messages.map((message) => ({
+      id: message.id,
+      roomId: message.roomId,
+      author: message.author,
+      text: message.text,
+      createdAt: message.createdAt,
+      kind: message.kind,
+      originThreadId: message.originThreadId,
+      originTurnId: message.originTurnId,
+    })),
     createdAt: room.createdAt,
   };
 }
@@ -367,9 +431,13 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
-    onlyKeys(state, STORED_STATE_KEYS) &&
+    exactKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 3 &&
-    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(
+      state["triggers"],
+      (entry): entry is ZenXTrigger => isTrigger(entry, "v3"),
+      MAX_TRIGGER_COUNT,
+    ) &&
     arrayOf(state["history"], isHistory, MAX_HISTORY_COUNT) &&
     arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
@@ -379,9 +447,13 @@ function isVersion2StoredState(value: unknown): value is Version2StoredState {
   const state = record(value);
   return (
     state !== null &&
-    onlyKeys(state, STORED_STATE_KEYS) &&
+    exactKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 2 &&
-    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(
+      state["triggers"],
+      (entry): entry is ZenXTrigger => isTrigger(entry, "v2"),
+      MAX_TRIGGER_COUNT,
+    ) &&
     arrayOf(state["history"], isVersion2History, MAX_HISTORY_COUNT) &&
     arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
@@ -391,26 +463,50 @@ function isLegacyStoredState(value: unknown): value is LegacyStoredState {
   const state = record(value);
   return (
     state !== null &&
-    onlyKeys(state, STORED_STATE_KEYS) &&
+    exactKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 1 &&
-    arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
+    arrayOf(
+      state["triggers"],
+      (entry): entry is ZenXTrigger => isTrigger(entry, "v1"),
+      MAX_TRIGGER_COUNT,
+    ) &&
     arrayOf(state["history"], isLegacyHistory, MAX_HISTORY_COUNT) &&
     arrayOf(state["rooms"], isRoom, MAX_ROOM_COUNT)
   );
 }
 
-function isTrigger(value: unknown): value is ZenXTrigger {
+function isTrigger(
+  value: unknown,
+  version: "v1" | "v2" | "v3",
+): value is ZenXTrigger {
   const trigger = record(value);
   if (
     trigger === null ||
-    !onlyKeys(trigger, TRIGGER_KEYS) ||
     !string(trigger["id"], MAX_ID_BYTES) ||
     !string(trigger["threadId"], MAX_ID_BYTES) ||
     !triggerKind(trigger["kind"]) ||
     !string(trigger["label"], MAX_TRIGGER_LABEL_BYTES) ||
     !string(trigger["prompt"], MAX_TRIGGER_PROMPT_BYTES) ||
     !finiteNumber(trigger["createdAt"]) ||
-    typeof trigger["active"] !== "boolean" ||
+    typeof trigger["active"] !== "boolean"
+  )
+    return false;
+  const variantKey =
+    trigger["kind"] === "timer"
+      ? "timer"
+      : trigger["kind"] === "thread"
+        ? "watch"
+        : trigger["kind"] === "roomMention"
+          ? "room"
+          : "signal";
+  if (
+    !exactKeys(
+      trigger,
+      version === "v3"
+        ? [...TRIGGER_BASE_KEYS, variantKey, "program"]
+        : [...TRIGGER_BASE_KEYS, variantKey],
+    ) ||
+    (version !== "v3" && trigger["program"] !== undefined) ||
     (trigger["program"] !== undefined && !isProgramConfig(trigger["program"]))
   )
     return false;
@@ -418,7 +514,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const timer = record(trigger["timer"]);
     return (
       timer !== null &&
-      onlyKeys(timer, TIMER_KEYS) &&
+      exactKeys(timer, TIMER_KEYS) &&
       finiteNumber(timer["nextRunAt"]) &&
       (timer["intervalMinutes"] === null ||
         (finiteNumber(timer["intervalMinutes"]) &&
@@ -429,7 +525,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const watch = record(trigger["watch"]);
     return (
       watch !== null &&
-      onlyKeys(watch, WATCH_KEYS) &&
+      exactKeys(watch, WATCH_KEYS) &&
       string(watch["threadId"], MAX_ID_BYTES) &&
       watch["event"] === "turn_completed"
     );
@@ -438,7 +534,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const room = record(trigger["room"]);
     return (
       room !== null &&
-      onlyKeys(room, ROOM_TRIGGER_KEYS) &&
+      exactKeys(room, ROOM_TRIGGER_KEYS) &&
       string(room["roomId"], MAX_ID_BYTES) &&
       string(room["mention"], MAX_MEMBER_NAME_BYTES)
     );
@@ -446,7 +542,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
   const signal = record(trigger["signal"]);
   return (
     signal !== null &&
-    onlyKeys(signal, SIGNAL_KEYS) &&
+    exactKeys(signal, SIGNAL_KEYS) &&
     string(signal["name"], MAX_ID_BYTES)
   );
 }
@@ -455,7 +551,7 @@ function isHistory(value: unknown): value is TriggerHistoryEntry {
   const entry = record(value);
   return (
     entry !== null &&
-    onlyKeys(entry, HISTORY_V3_KEYS) &&
+    exactKeys(entry, HISTORY_V3_KEYS) &&
     isHistoryBase(entry) &&
     entry !== null &&
     nullableString(entry["replyRoomId"], MAX_ID_BYTES) &&
@@ -473,7 +569,7 @@ function isVersion2History(
   const entry = record(value);
   return (
     entry !== null &&
-    onlyKeys(entry, HISTORY_V2_KEYS) &&
+    exactKeys(entry, HISTORY_V2_KEYS) &&
     isHistoryBase(entry) &&
     entry !== null &&
     nullableString(entry["sourceThreadId"], MAX_ID_BYTES) &&
@@ -488,7 +584,9 @@ function isLegacyHistory(
 ): value is LegacyStoredState["history"][number] {
   const entry = record(value);
   return (
-    entry !== null && onlyKeys(entry, HISTORY_BASE_KEYS) && isHistoryBase(entry)
+    entry !== null &&
+    exactKeys(entry, HISTORY_BASE_KEYS) &&
+    isHistoryBase(entry)
   );
 }
 
@@ -513,7 +611,7 @@ function isProgramConfig(value: unknown): value is TriggerProgramConfig {
   const config = record(value);
   return (
     config !== null &&
-    onlyKeys(config, PROGRAM_KEYS) &&
+    exactKeys(config, PROGRAM_KEYS) &&
     (config["predicate"] === undefined || isProgramSpec(config["predicate"])) &&
     (config["action"] === undefined || isProgramSpec(config["action"])) &&
     (config["match"] === undefined || isMatch(config["match"])) &&
@@ -527,7 +625,7 @@ function isProgramSpec(value: unknown): value is TriggerProgramSpec {
   const spec = record(value);
   if (
     spec === null ||
-    !onlyKeys(spec, PROGRAM_SPEC_KEYS) ||
+    !exactKeys(spec, PROGRAM_SPEC_KEYS) ||
     !string(spec["command"], MAX_PROGRAM_COMMAND_BYTES) ||
     (spec["args"] !== undefined &&
       !arrayOf(
@@ -573,7 +671,7 @@ function isMatch(value: unknown): boolean {
   const match = record(value);
   if (
     match === null ||
-    !onlyKeys(match, MATCH_KEYS) ||
+    !exactKeys(match, MATCH_KEYS) ||
     match["field"] !== "completedItemText" ||
     !string(match["regex"], MAX_PROGRAM_MATCH_REGEX_BYTES) ||
     (match["flags"] !== undefined &&
@@ -592,7 +690,7 @@ function isProgramOutcome(value: unknown): value is TriggerProgramOutcome {
   const outcome = record(value);
   return (
     outcome !== null &&
-    onlyKeys(outcome, OUTCOME_KEYS) &&
+    exactKeys(outcome, OUTCOME_KEYS) &&
     (outcome["stage"] === "predicate" || outcome["stage"] === "action") &&
     programStatus(outcome["status"]) &&
     string(outcome["invocationId"], MAX_ID_BYTES) &&
@@ -606,7 +704,7 @@ function isRoom(value: unknown): value is ZenXRoom {
   const room = record(value);
   if (
     room === null ||
-    !onlyKeys(room, ROOM_KEYS) ||
+    !exactKeys(room, ROOM_KEYS) ||
     !string(room["id"], MAX_ID_BYTES) ||
     !string(room["name"], MAX_ROOM_NAME_BYTES) ||
     !arrayOf(room["members"], isRoomMember, MAX_ROOM_MEMBERS) ||
@@ -629,7 +727,7 @@ function isRoomMember(value: unknown): value is RoomMember {
   const member = record(value);
   return (
     member !== null &&
-    onlyKeys(member, MEMBER_KEYS) &&
+    exactKeys(member, MEMBER_KEYS) &&
     string(member["name"], MAX_MEMBER_NAME_BYTES) &&
     string(member["threadId"], MAX_ID_BYTES)
   );
@@ -639,7 +737,7 @@ function isRoomMessage(value: unknown): value is RoomMessage {
   const message = record(value);
   return (
     message !== null &&
-    onlyKeys(message, MESSAGE_KEYS) &&
+    exactKeys(message, MESSAGE_KEYS) &&
     string(message["id"], MAX_ID_BYTES) &&
     string(message["roomId"], MAX_ID_BYTES) &&
     string(message["author"], MAX_MESSAGE_AUTHOR_BYTES) &&
@@ -659,12 +757,13 @@ function record(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function onlyKeys(
+function exactKeys(
   value: Record<string, unknown>,
   allowed: readonly string[],
 ): boolean {
   const keys = new Set(allowed);
-  return Object.keys(value).every((key) => keys.has(key));
+  const actual = Object.keys(value);
+  return actual.every((key) => keys.has(key));
 }
 
 function arrayOf<T>(

--- a/apps/zenx/src/main/trigger-store.ts
+++ b/apps/zenx/src/main/trigger-store.ts
@@ -30,6 +30,7 @@ import {
   MAX_PROGRAM_FLAGS_BYTES,
   MAX_PROGRAM_MATCH_REGEX_BYTES,
   MAX_PROGRAM_OUTCOMES,
+  MAX_PROGRAM_TIMEOUT_MS,
   MAX_REASON_BYTES,
   MAX_ROOM_COUNT,
   MAX_ROOM_MEMBERS,
@@ -73,9 +74,90 @@ interface LegacyStoredState extends Omit<TriggerSnapshot, "history"> {
       | "replyAuthor"
       | "programInvocationId"
       | "programOutcome"
+      | "programOutcomes"
     >
   >;
 }
+
+const STORED_STATE_KEYS = ["version", "triggers", "history", "rooms"] as const;
+const TRIGGER_KEYS = [
+  "id",
+  "threadId",
+  "kind",
+  "label",
+  "prompt",
+  "createdAt",
+  "active",
+  "timer",
+  "watch",
+  "room",
+  "signal",
+  "program",
+] as const;
+const TIMER_KEYS = ["nextRunAt", "intervalMinutes"] as const;
+const WATCH_KEYS = ["threadId", "event"] as const;
+const ROOM_TRIGGER_KEYS = ["roomId", "mention"] as const;
+const SIGNAL_KEYS = ["name"] as const;
+const PROGRAM_KEYS = ["predicate", "action", "match"] as const;
+const PROGRAM_SPEC_KEYS = [
+  "command",
+  "args",
+  "cwd",
+  "env",
+  "timeoutMs",
+  "maxOutputBytes",
+] as const;
+const MATCH_KEYS = ["field", "regex", "flags"] as const;
+const HISTORY_BASE_KEYS = [
+  "id",
+  "triggerId",
+  "threadId",
+  "kind",
+  "reason",
+  "prompt",
+  "clientUserMessageId",
+  "startedAt",
+  "completedAt",
+  "status",
+  "turnId",
+  "error",
+] as const;
+const HISTORY_SOURCE_KEYS = [
+  "sourceThreadId",
+  "sourceTurnId",
+  "sourceRoomId",
+  "sourceRoomMessageId",
+] as const;
+const HISTORY_V2_KEYS = [...HISTORY_BASE_KEYS, ...HISTORY_SOURCE_KEYS] as const;
+const HISTORY_V3_KEYS = [
+  ...HISTORY_BASE_KEYS,
+  ...HISTORY_SOURCE_KEYS,
+  "replyRoomId",
+  "replyAuthor",
+  "programInvocationId",
+  "programOutcome",
+  "programOutcomes",
+] as const;
+const OUTCOME_KEYS = [
+  "stage",
+  "invocationId",
+  "status",
+  "output",
+  "exitCode",
+  "error",
+] as const;
+const ROOM_KEYS = ["id", "name", "members", "messages", "createdAt"] as const;
+const MEMBER_KEYS = ["name", "threadId"] as const;
+const MESSAGE_KEYS = [
+  "id",
+  "roomId",
+  "author",
+  "text",
+  "createdAt",
+  "kind",
+  "originThreadId",
+  "originTurnId",
+] as const;
 
 export class ZenXTriggerStore {
   readonly #filePath: string;
@@ -98,23 +180,27 @@ export class ZenXTriggerStore {
       if (isStoredState(value)) return snapshotFrom(value);
       if (isVersion2StoredState(value)) {
         return {
-          triggers: value.triggers,
+          triggers: value.triggers.map(canonicalTrigger),
           history: value.history.map((entry) => ({
-            ...entry,
+            ...canonicalBaseHistory(entry),
+            sourceThreadId: entry.sourceThreadId,
+            sourceTurnId: entry.sourceTurnId,
+            sourceRoomId: entry.sourceRoomId,
+            sourceRoomMessageId: entry.sourceRoomMessageId,
             replyRoomId: null,
             replyAuthor: null,
             programInvocationId: null,
             programOutcome: null,
             programOutcomes: [],
           })),
-          rooms: value.rooms,
+          rooms: value.rooms.map(canonicalRoom),
         };
       }
       if (isLegacyStoredState(value)) {
         return {
-          triggers: value.triggers,
+          triggers: value.triggers.map(canonicalTrigger),
           history: value.history.map((entry) => ({
-            ...entry,
+            ...canonicalBaseHistory(entry),
             sourceThreadId: null,
             sourceTurnId: null,
             sourceRoomId: null,
@@ -125,7 +211,7 @@ export class ZenXTriggerStore {
             programOutcome: null,
             programOutcomes: [],
           })),
-          rooms: value.rooms,
+          rooms: value.rooms.map(canonicalRoom),
         };
       }
       throw new Error(
@@ -161,9 +247,119 @@ function emptySnapshot(): TriggerSnapshot {
 
 function snapshotFrom(value: StoredState): TriggerSnapshot {
   return {
-    triggers: value.triggers,
-    history: value.history,
-    rooms: value.rooms,
+    triggers: value.triggers.map(canonicalTrigger),
+    history: value.history.map(canonicalHistory),
+    rooms: value.rooms.map(canonicalRoom),
+  };
+}
+
+function canonicalTrigger(trigger: ZenXTrigger): ZenXTrigger {
+  return {
+    id: trigger.id,
+    threadId: trigger.threadId,
+    kind: trigger.kind,
+    label: trigger.label,
+    prompt: trigger.prompt,
+    createdAt: trigger.createdAt,
+    active: trigger.active,
+    ...(trigger.timer === undefined ? {} : { timer: { ...trigger.timer } }),
+    ...(trigger.watch === undefined ? {} : { watch: { ...trigger.watch } }),
+    ...(trigger.room === undefined ? {} : { room: { ...trigger.room } }),
+    ...(trigger.signal === undefined ? {} : { signal: { ...trigger.signal } }),
+    ...(trigger.program === undefined
+      ? {}
+      : { program: canonicalProgramConfig(trigger.program) }),
+  };
+}
+
+function canonicalBaseHistory(
+  entry: LegacyStoredState["history"][number],
+): Omit<
+  TriggerHistoryEntry,
+  | "sourceThreadId"
+  | "sourceTurnId"
+  | "sourceRoomId"
+  | "sourceRoomMessageId"
+  | "replyRoomId"
+  | "replyAuthor"
+  | "programInvocationId"
+  | "programOutcome"
+  | "programOutcomes"
+> {
+  return {
+    id: entry.id,
+    triggerId: entry.triggerId,
+    threadId: entry.threadId,
+    kind: entry.kind,
+    reason: entry.reason,
+    prompt: entry.prompt,
+    clientUserMessageId: entry.clientUserMessageId,
+    startedAt: entry.startedAt,
+    completedAt: entry.completedAt,
+    status: entry.status,
+    turnId: entry.turnId,
+    error: entry.error,
+  };
+}
+
+function canonicalHistory(entry: TriggerHistoryEntry): TriggerHistoryEntry {
+  return {
+    ...canonicalBaseHistory(entry),
+    sourceThreadId: entry.sourceThreadId,
+    sourceTurnId: entry.sourceTurnId,
+    sourceRoomId: entry.sourceRoomId,
+    sourceRoomMessageId: entry.sourceRoomMessageId,
+    replyRoomId: entry.replyRoomId,
+    replyAuthor: entry.replyAuthor,
+    programInvocationId: entry.programInvocationId,
+    programOutcome:
+      entry.programOutcome === null
+        ? null
+        : canonicalProgramOutcome(entry.programOutcome),
+    programOutcomes: entry.programOutcomes.map(canonicalProgramOutcome),
+  };
+}
+
+function canonicalProgramConfig(
+  config: TriggerProgramConfig,
+): TriggerProgramConfig {
+  return {
+    ...(config.predicate === undefined
+      ? {}
+      : { predicate: canonicalProgramSpec(config.predicate) }),
+    ...(config.action === undefined
+      ? {}
+      : { action: canonicalProgramSpec(config.action) }),
+    ...(config.match === undefined ? {} : { match: { ...config.match } }),
+  };
+}
+
+function canonicalProgramSpec(spec: TriggerProgramSpec): TriggerProgramSpec {
+  return {
+    command: spec.command,
+    ...(spec.args === undefined ? {} : { args: [...spec.args] }),
+    ...(spec.cwd === undefined ? {} : { cwd: spec.cwd }),
+    ...(spec.env === undefined ? {} : { env: { ...spec.env } }),
+    ...(spec.timeoutMs === undefined ? {} : { timeoutMs: spec.timeoutMs }),
+    ...(spec.maxOutputBytes === undefined
+      ? {}
+      : { maxOutputBytes: spec.maxOutputBytes }),
+  };
+}
+
+function canonicalProgramOutcome(
+  outcome: TriggerProgramOutcome,
+): TriggerProgramOutcome {
+  return { ...outcome };
+}
+
+function canonicalRoom(room: ZenXRoom): ZenXRoom {
+  return {
+    id: room.id,
+    name: room.name,
+    members: room.members.map((member) => ({ ...member })),
+    messages: room.messages.map((message) => ({ ...message })),
+    createdAt: room.createdAt,
   };
 }
 
@@ -171,6 +367,7 @@ function isStoredState(value: unknown): value is StoredState {
   const state = record(value);
   return (
     state !== null &&
+    onlyKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 3 &&
     arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
     arrayOf(state["history"], isHistory, MAX_HISTORY_COUNT) &&
@@ -182,6 +379,7 @@ function isVersion2StoredState(value: unknown): value is Version2StoredState {
   const state = record(value);
   return (
     state !== null &&
+    onlyKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 2 &&
     arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
     arrayOf(state["history"], isVersion2History, MAX_HISTORY_COUNT) &&
@@ -193,6 +391,7 @@ function isLegacyStoredState(value: unknown): value is LegacyStoredState {
   const state = record(value);
   return (
     state !== null &&
+    onlyKeys(state, STORED_STATE_KEYS) &&
     state["version"] === 1 &&
     arrayOf(state["triggers"], isTrigger, MAX_TRIGGER_COUNT) &&
     arrayOf(state["history"], isLegacyHistory, MAX_HISTORY_COUNT) &&
@@ -204,6 +403,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
   const trigger = record(value);
   if (
     trigger === null ||
+    !onlyKeys(trigger, TRIGGER_KEYS) ||
     !string(trigger["id"], MAX_ID_BYTES) ||
     !string(trigger["threadId"], MAX_ID_BYTES) ||
     !triggerKind(trigger["kind"]) ||
@@ -218,6 +418,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const timer = record(trigger["timer"]);
     return (
       timer !== null &&
+      onlyKeys(timer, TIMER_KEYS) &&
       finiteNumber(timer["nextRunAt"]) &&
       (timer["intervalMinutes"] === null ||
         (finiteNumber(timer["intervalMinutes"]) &&
@@ -228,6 +429,7 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const watch = record(trigger["watch"]);
     return (
       watch !== null &&
+      onlyKeys(watch, WATCH_KEYS) &&
       string(watch["threadId"], MAX_ID_BYTES) &&
       watch["event"] === "turn_completed"
     );
@@ -236,18 +438,25 @@ function isTrigger(value: unknown): value is ZenXTrigger {
     const room = record(trigger["room"]);
     return (
       room !== null &&
+      onlyKeys(room, ROOM_TRIGGER_KEYS) &&
       string(room["roomId"], MAX_ID_BYTES) &&
       string(room["mention"], MAX_MEMBER_NAME_BYTES)
     );
   }
   const signal = record(trigger["signal"]);
-  return signal !== null && string(signal["name"], MAX_ID_BYTES);
+  return (
+    signal !== null &&
+    onlyKeys(signal, SIGNAL_KEYS) &&
+    string(signal["name"], MAX_ID_BYTES)
+  );
 }
 
 function isHistory(value: unknown): value is TriggerHistoryEntry {
   const entry = record(value);
   return (
-    isVersion2History(value) &&
+    entry !== null &&
+    onlyKeys(entry, HISTORY_V3_KEYS) &&
+    isHistoryBase(entry) &&
     entry !== null &&
     nullableString(entry["replyRoomId"], MAX_ID_BYTES) &&
     nullableString(entry["replyAuthor"], MAX_MEMBER_NAME_BYTES) &&
@@ -263,7 +472,9 @@ function isVersion2History(
 ): value is Version2StoredState["history"][number] {
   const entry = record(value);
   return (
-    isLegacyHistory(value) &&
+    entry !== null &&
+    onlyKeys(entry, HISTORY_V2_KEYS) &&
+    isHistoryBase(entry) &&
     entry !== null &&
     nullableString(entry["sourceThreadId"], MAX_ID_BYTES) &&
     nullableString(entry["sourceTurnId"], MAX_ID_BYTES) &&
@@ -277,7 +488,12 @@ function isLegacyHistory(
 ): value is LegacyStoredState["history"][number] {
   const entry = record(value);
   return (
-    entry !== null &&
+    entry !== null && onlyKeys(entry, HISTORY_BASE_KEYS) && isHistoryBase(entry)
+  );
+}
+
+function isHistoryBase(entry: Record<string, unknown>): boolean {
+  return (
     string(entry["id"], MAX_ID_BYTES) &&
     string(entry["triggerId"], MAX_ID_BYTES) &&
     string(entry["threadId"], MAX_ID_BYTES) &&
@@ -297,6 +513,7 @@ function isProgramConfig(value: unknown): value is TriggerProgramConfig {
   const config = record(value);
   return (
     config !== null &&
+    onlyKeys(config, PROGRAM_KEYS) &&
     (config["predicate"] === undefined || isProgramSpec(config["predicate"])) &&
     (config["action"] === undefined || isProgramSpec(config["action"])) &&
     (config["match"] === undefined || isMatch(config["match"])) &&
@@ -310,6 +527,7 @@ function isProgramSpec(value: unknown): value is TriggerProgramSpec {
   const spec = record(value);
   if (
     spec === null ||
+    !onlyKeys(spec, PROGRAM_SPEC_KEYS) ||
     !string(spec["command"], MAX_PROGRAM_COMMAND_BYTES) ||
     (spec["args"] !== undefined &&
       !arrayOf(
@@ -339,7 +557,9 @@ function isProgramSpec(value: unknown): value is TriggerProgramSpec {
           0,
         ) > MAX_PROGRAM_ENV_BYTES)) ||
     (spec["timeoutMs"] !== undefined &&
-      (!finiteNumber(spec["timeoutMs"]) || spec["timeoutMs"] <= 0)) ||
+      (!finiteNumber(spec["timeoutMs"]) ||
+        spec["timeoutMs"] <= 0 ||
+        spec["timeoutMs"] > MAX_PROGRAM_TIMEOUT_MS)) ||
     (spec["maxOutputBytes"] !== undefined &&
       (!Number.isSafeInteger(spec["maxOutputBytes"]) ||
         (spec["maxOutputBytes"] as number) < 256 ||
@@ -353,6 +573,7 @@ function isMatch(value: unknown): boolean {
   const match = record(value);
   if (
     match === null ||
+    !onlyKeys(match, MATCH_KEYS) ||
     match["field"] !== "completedItemText" ||
     !string(match["regex"], MAX_PROGRAM_MATCH_REGEX_BYTES) ||
     (match["flags"] !== undefined &&
@@ -371,6 +592,7 @@ function isProgramOutcome(value: unknown): value is TriggerProgramOutcome {
   const outcome = record(value);
   return (
     outcome !== null &&
+    onlyKeys(outcome, OUTCOME_KEYS) &&
     (outcome["stage"] === "predicate" || outcome["stage"] === "action") &&
     programStatus(outcome["status"]) &&
     string(outcome["invocationId"], MAX_ID_BYTES) &&
@@ -384,6 +606,7 @@ function isRoom(value: unknown): value is ZenXRoom {
   const room = record(value);
   if (
     room === null ||
+    !onlyKeys(room, ROOM_KEYS) ||
     !string(room["id"], MAX_ID_BYTES) ||
     !string(room["name"], MAX_ROOM_NAME_BYTES) ||
     !arrayOf(room["members"], isRoomMember, MAX_ROOM_MEMBERS) ||
@@ -406,6 +629,7 @@ function isRoomMember(value: unknown): value is RoomMember {
   const member = record(value);
   return (
     member !== null &&
+    onlyKeys(member, MEMBER_KEYS) &&
     string(member["name"], MAX_MEMBER_NAME_BYTES) &&
     string(member["threadId"], MAX_ID_BYTES)
   );
@@ -415,6 +639,7 @@ function isRoomMessage(value: unknown): value is RoomMessage {
   const message = record(value);
   return (
     message !== null &&
+    onlyKeys(message, MESSAGE_KEYS) &&
     string(message["id"], MAX_ID_BYTES) &&
     string(message["roomId"], MAX_ID_BYTES) &&
     string(message["author"], MAX_MESSAGE_AUTHOR_BYTES) &&
@@ -432,6 +657,14 @@ function record(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function onlyKeys(
+  value: Record<string, unknown>,
+  allowed: readonly string[],
+): boolean {
+  const keys = new Set(allowed);
+  return Object.keys(value).every((key) => keys.has(key));
 }
 
 function arrayOf<T>(

--- a/apps/zenx/src/main/trigger-types.ts
+++ b/apps/zenx/src/main/trigger-types.ts
@@ -1,5 +1,54 @@
 export type TriggerKind = "timer" | "thread" | "roomMention" | "signal";
 
+export type TriggerProgramStage = "predicate" | "action";
+
+export interface TriggerProgramSpec {
+  command: string;
+  args?: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+}
+
+export interface TriggerMatchSpec {
+  field: "completedItemText";
+  regex: string;
+  flags?: string;
+}
+
+export interface TriggerProgramConfig {
+  predicate?: TriggerProgramSpec;
+  action?: TriggerProgramSpec;
+  match?: TriggerMatchSpec;
+}
+
+export interface TriggerProgramOutcome {
+  stage: TriggerProgramStage;
+  invocationId: string;
+  status:
+    | "matched"
+    | "non_match"
+    | "completed"
+    | "failed"
+    | "cancelled"
+    | "timed_out"
+    | "nonzero_exit"
+    | "malformed_output"
+    | "oversized_output"
+    | "uncertain";
+  output: string | null;
+  exitCode: number | null;
+  error: string | null;
+}
+
+export interface TriggerProgramInput {
+  program?: TriggerProgramConfig;
+  predicate?: TriggerProgramSpec;
+  action?: TriggerProgramSpec;
+  match?: TriggerMatchSpec;
+}
+
 export interface ZenXTrigger {
   id: string;
   threadId: string;
@@ -12,6 +61,7 @@ export interface ZenXTrigger {
   watch?: { threadId: string; event: "turn_completed" };
   room?: { roomId: string; mention: string };
   signal?: { name: string };
+  program?: TriggerProgramConfig;
 }
 
 export interface TriggerHistoryEntry {
@@ -31,6 +81,11 @@ export interface TriggerHistoryEntry {
   sourceTurnId: string | null;
   sourceRoomId: string | null;
   sourceRoomMessageId: string | null;
+  replyRoomId: string | null;
+  replyAuthor: string | null;
+  programInvocationId: string | null;
+  programOutcome: TriggerProgramOutcome | null;
+  programOutcomes: TriggerProgramOutcome[];
 }
 
 export interface RoomMember {
@@ -62,36 +117,38 @@ export interface TriggerSnapshot {
 }
 
 export type CreateTriggerInput =
-  | {
+  | ({
       threadId: string;
       kind: "timer";
       label: string;
       prompt: string;
       runAt: number;
       intervalMinutes?: number;
-    }
-  | {
+    } & TriggerProgramInput)
+  | ({
       threadId: string;
       kind: "thread";
       label: string;
       prompt: string;
       watchedThreadId: string;
-    }
-  | {
+    } & TriggerProgramInput)
+  | ({
       threadId: string;
       kind: "roomMention";
       label: string;
       prompt: string;
       roomId: string;
       mention: string;
-    }
-  | {
+    } & TriggerProgramInput)
+  | ({
       threadId: string;
       kind: "signal";
       label: string;
       prompt: string;
       signalName: string;
-    };
+    } & TriggerProgramInput);
+
+export type UpdateTriggerInput = CreateTriggerInput & { id: string };
 
 export interface CreateRoomInput {
   name: string;

--- a/apps/zenx/src/renderer/src/ScheduledView.tsx
+++ b/apps/zenx/src/renderer/src/ScheduledView.tsx
@@ -273,8 +273,8 @@ export function ScheduledView({
           <strong>Developer signal simulator</strong>
           <p>
             This local UI invokes ZenX renderer IPC for testing. A production
-            external ingress and Agent-callable trigger tools are follow-up
-            work.
+            external signal ingress remains follow-up work; Agents can manage
+            Triggers and Rooms through the granted automation capability.
           </p>
           <div>
             <input

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -9,6 +9,11 @@ import {
   type AppServerHostStatus,
 } from "../src/main/app-server-manager.js";
 import type { ZenXCapabilityHost } from "../src/main/capabilities/types.js";
+import { MemoryZenXCapabilityGrantStore } from "../src/main/capabilities/grant-store.js";
+import { ZenXCapabilityRegistry } from "../src/main/capabilities/registry.js";
+import { ZenXAutomationControlCapabilityPackage } from "../src/main/capabilities/automation-control-package.js";
+import { ZenXTriggerService } from "../src/main/trigger-service.js";
+import { ZenXTriggerStore } from "../src/main/trigger-store.js";
 
 function managerFor(directory: string): AppServerManager {
   return new AppServerManager({
@@ -182,6 +187,126 @@ test("bridges a granted structured capability through the real App Server host",
   }
 });
 
+test("bridges all Agent Room tools through the real child App Server", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-capability-host-"),
+  );
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    capabilityHost: registry,
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+  });
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  registry.register(new ZenXAutomationControlCapabilityPackage(triggers));
+  await registry.initialize();
+  await registry.grant("zenx-automation-control");
+  try {
+    await manager.start();
+    await triggers.start();
+    const thread = (await manager.request("thread/start", {})).thread;
+    const turns: string[] = [];
+    const dispose = manager.onNotification((method, params) => {
+      if (method === "turn/completed") {
+        turns.push((params as { turn: { id: string } }).turn.id);
+      }
+    });
+    const runTool = async (name: string, args: Record<string, unknown>) => {
+      const before = turns.length;
+      await manager.request("turn/start", {
+        threadId: thread.id,
+        input: [
+          { type: "text", text: `!tool ${name} ${JSON.stringify(args)}` },
+        ],
+      });
+      await waitFor(() => turns.length > before);
+    };
+    await runTool("zenx_rooms_create", {
+      name: "release",
+      members: [{ name: "Bot", threadId: thread.id }],
+    });
+    await runTool("zenx_rooms_list", {});
+    await runTool("zenx_rooms_rename", {
+      roomId: triggers.snapshot().rooms[0]!.id,
+      name: "ship",
+    });
+    await runTool("zenx_rooms_add_member", {
+      roomId: triggers.snapshot().rooms[0]!.id,
+      name: "Monitor",
+      threadId: "monitor-thread",
+    });
+    await runTool("zenx_rooms_remove_member", {
+      roomId: triggers.snapshot().rooms[0]!.id,
+      threadId: "monitor-thread",
+    });
+    await runTool("zenx_rooms_post_message", {
+      roomId: triggers.snapshot().rooms[0]!.id,
+      text: "agent note",
+    });
+    await runTool("zenx_rooms_delete", {
+      roomId: triggers.snapshot().rooms[0]!.id,
+    });
+    await runTool("zenx_triggers_create", {
+      threadId: thread.id,
+      kind: "signal",
+      label: "Deploy",
+      prompt: "Inspect deploy.",
+      signalName: "deploy",
+      program: {
+        match: { field: "completedItemText", regex: "deploy" },
+      },
+    });
+    const triggerId = triggers.snapshot().triggers[0]!.id;
+    await runTool("zenx_triggers_list", {});
+    await runTool("zenx_triggers_update", {
+      id: triggerId,
+      threadId: thread.id,
+      kind: "signal",
+      label: "Updated deploy",
+      prompt: "Inspect updated deploy.",
+      signalName: "deploy-updated",
+    });
+    await runTool("zenx_triggers_cancel", { triggerId });
+    await runTool("zenx_triggers_delete", { triggerId });
+    dispose();
+    assert.equal(triggers.snapshot().rooms.length, 0);
+    assert.equal(triggers.snapshot().triggers.length, 0);
+    const read = await manager.request("thread/read", {
+      threadId: thread.id,
+      includeTurns: true,
+    });
+    assert.equal(
+      read.thread.turns.filter((turn) =>
+        turn.items.some(
+          (item) =>
+            item.type === "commandExecution" &&
+            item.command.startsWith("zenx_"),
+        ),
+      ).length,
+      12,
+    );
+  } finally {
+    await triggers.stop();
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((resolvePromise) => {
@@ -207,5 +332,17 @@ async function within<T>(
     ]);
   } finally {
     if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  milliseconds = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + milliseconds;
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error("Timed out waiting for Room tool turn");
+    await new Promise((resolve) => setTimeout(resolve, 10));
   }
 }

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -307,6 +307,65 @@ test("bridges all Agent Room tools through the real child App Server", async () 
   }
 });
 
+test("real Room mention wakes one selected member and renders one sourceful reply", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-mention-host-"),
+  );
+  const manager = managerFor(directory);
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await manager.start();
+    await triggers.start();
+    const selected = (await manager.request("thread/start", {})).thread;
+    const unselected = (await manager.request("thread/start", {})).thread;
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [
+        { name: "Bot", threadId: selected.id },
+        { name: "Monitor", threadId: unselected.id },
+      ],
+    });
+    await triggers.create({
+      threadId: selected.id,
+      kind: "roomMention",
+      label: "Room answer",
+      prompt: "Answer the Room mention.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "Human", "@Bot status?");
+    await waitFor(() => triggers.snapshot().history[0]?.status === "completed");
+    const snapshot = triggers.snapshot();
+    const history = snapshot.history[0]!;
+    assert.equal(snapshot.history.length, 1);
+    assert.equal(history.threadId, selected.id);
+    assert.equal(history.sourceThreadId, null);
+    assert.equal(history.sourceRoomId, room.id);
+    assert.notEqual(history.sourceRoomMessageId, null);
+    assert.equal(
+      snapshot.rooms[0]!.messages.filter((message) => message.kind === "agent")
+        .length,
+      1,
+    );
+    const reply = snapshot.rooms[0]!.messages.at(-1)!;
+    assert.equal(reply.author, "Bot");
+    assert.equal(reply.originThreadId, selected.id);
+    assert.equal(reply.originTurnId, history.turnId);
+    assert.equal(
+      snapshot.history.filter((entry) => entry.threadId === unselected.id)
+        .length,
+      0,
+    );
+  } finally {
+    await triggers.stop();
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
   const promise = new Promise<T>((resolvePromise) => {

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ToolInvocation } from "../../../src/tool.js";
+import {
+  ZENX_AUTOMATION_READ_PERMISSION,
+  ZENX_AUTOMATION_WRITE_PERMISSION,
+  ZenXAutomationControlCapabilityPackage,
+  type ZenXAutomationControlPort,
+} from "../src/main/capabilities/automation-control-package.js";
+import type {
+  CreateRoomInput,
+  CreateTriggerInput,
+  RoomMember,
+  TriggerSnapshot,
+  UpdateTriggerInput,
+  ZenXRoom,
+  ZenXTrigger,
+} from "../src/main/trigger-types.js";
+
+test("automation tools have independent read and write grants", () => {
+  const capability = new ZenXAutomationControlCapabilityPackage(new FakePort());
+  assert.deepEqual(
+    capability.manifest.tools.find((tool) => tool.name === "zenx_triggers_list")
+      ?.permissions,
+    [ZENX_AUTOMATION_READ_PERMISSION],
+  );
+  assert.deepEqual(
+    capability.manifest.tools.find(
+      (tool) => tool.name === "zenx_triggers_create",
+    )?.permissions,
+    [ZENX_AUTOMATION_WRITE_PERMISSION],
+  );
+  assert.deepEqual(
+    capability.manifest.tools
+      .filter((tool) => tool.name.startsWith("zenx_rooms"))
+      .map((tool) => tool.name),
+    [
+      "zenx_rooms_list",
+      "zenx_rooms_create",
+      "zenx_rooms_rename",
+      "zenx_rooms_delete",
+      "zenx_rooms_add_member",
+      "zenx_rooms_remove_member",
+      "zenx_rooms_post_message",
+    ],
+  );
+});
+
+test("automation tools route Trigger CRUD and every Room operation", async () => {
+  const port = new FakePort();
+  const capability = new ZenXAutomationControlCapabilityPackage(port);
+  await invoke(capability, "zenx_triggers_list", {});
+  await invoke(capability, "zenx_triggers_create", {
+    threadId: "target",
+    kind: "signal",
+    label: "Deploy",
+    prompt: "Inspect deploy",
+    signalName: "deploy",
+    program: {
+      match: { field: "completedItemText", regex: "deploy" },
+    },
+  });
+  await invoke(capability, "zenx_triggers_update", {
+    id: "trigger-1",
+    threadId: "target",
+    kind: "thread",
+    label: "Review",
+    prompt: "Review it",
+    watchedThreadId: "source",
+  });
+  await invoke(capability, "zenx_triggers_cancel", { triggerId: "trigger-1" });
+  await invoke(capability, "zenx_triggers_delete", { triggerId: "trigger-1" });
+  await invoke(capability, "zenx_rooms_list", {});
+  await invoke(capability, "zenx_rooms_create", {
+    name: "release",
+    members: [{ name: "Reviewer", threadId: "target" }],
+  });
+  await invoke(capability, "zenx_rooms_rename", {
+    roomId: "room-1",
+    name: "ship",
+  });
+  await invoke(capability, "zenx_rooms_add_member", {
+    roomId: "room-1",
+    name: "Monitor",
+    threadId: "monitor",
+  });
+  await invoke(capability, "zenx_rooms_remove_member", {
+    roomId: "room-1",
+    threadId: "monitor",
+  });
+  await invoke(capability, "zenx_rooms_post_message", {
+    roomId: "room-1",
+    text: "Ready",
+  });
+  await invoke(capability, "zenx_rooms_delete", { roomId: "room-1" });
+  assert.deepEqual(
+    port.calls.map((call) => call[0]),
+    [
+      "create",
+      "update",
+      "cancel",
+      "delete",
+      "createRoom",
+      "renameRoom",
+      "addRoomMember",
+      "removeRoomMember",
+      "postAgentRoomMessage",
+      "deleteRoom",
+    ],
+  );
+});
+
+async function invoke(
+  capability: ZenXAutomationControlCapabilityPackage,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<unknown> {
+  const invocation: ToolInvocation = {
+    name,
+    arguments: args,
+    cwd: process.cwd(),
+    signal: new AbortController().signal,
+    callId: `call-${name}`,
+  };
+  return await capability.invoke(name, invocation);
+}
+
+class FakePort implements ZenXAutomationControlPort {
+  readonly calls: Array<[string, unknown]> = [];
+
+  snapshot(): TriggerSnapshot {
+    return { triggers: [], history: [], rooms: [] };
+  }
+  async create(input: CreateTriggerInput): Promise<ZenXTrigger> {
+    this.calls.push(["create", input]);
+    return { id: "trigger-1", createdAt: 1, active: true, ...input };
+  }
+  async update(input: UpdateTriggerInput): Promise<ZenXTrigger> {
+    this.calls.push(["update", input]);
+    return { createdAt: 1, active: true, ...input };
+  }
+  async cancel(id: string): Promise<void> {
+    this.calls.push(["cancel", id]);
+  }
+  async delete(id: string): Promise<void> {
+    this.calls.push(["delete", id]);
+  }
+  async createRoom(input: CreateRoomInput): Promise<ZenXRoom> {
+    this.calls.push(["createRoom", input]);
+    return { id: "room-1", createdAt: 1, messages: [], ...input };
+  }
+  async renameRoom(id: string, name: string): Promise<void> {
+    this.calls.push(["renameRoom", { id, name }]);
+  }
+  async deleteRoom(id: string): Promise<void> {
+    this.calls.push(["deleteRoom", id]);
+  }
+  async addRoomMember(id: string, member: RoomMember): Promise<void> {
+    this.calls.push(["addRoomMember", { id, member }]);
+  }
+  async removeRoomMember(id: string, threadId: string): Promise<void> {
+    this.calls.push(["removeRoomMember", { id, threadId }]);
+  }
+  async postAgentRoomMessage(id: string, text: string): Promise<void> {
+    this.calls.push(["postAgentRoomMessage", { id, text }]);
+  }
+}

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -111,6 +111,71 @@ test("automation tools route Trigger CRUD and every Room operation", async () =>
   );
 });
 
+test("read-only Trigger listing removes program environment and diagnostics", async () => {
+  const capability = new ZenXAutomationControlCapabilityPackage(
+    new SensitivePort(),
+  );
+  const listed = (await invoke(capability, "zenx_triggers_list", {})) as {
+    triggers: Array<{
+      program?: { action?: { env?: Record<string, string> } };
+    }>;
+    history: Array<{
+      programOutcome: { output: string | null; error: string | null } | null;
+      programOutcomes: Array<{ output: string | null; error: string | null }>;
+    }>;
+  };
+  assert.equal(listed.triggers[0]?.program?.action?.env, undefined);
+  assert.equal(listed.history[0]?.programOutcome?.output, null);
+  assert.equal(listed.history[0]?.programOutcome?.error, null);
+  assert.equal(listed.history[0]?.programOutcomes[0]?.output, null);
+  assert.doesNotMatch(JSON.stringify(listed), /do-not-leak/u);
+});
+
+test("Agent automation inputs enforce bounded strings, members, and program env", async () => {
+  const capability = new ZenXAutomationControlCapabilityPackage(new FakePort());
+  await assert.rejects(
+    invoke(capability, "zenx_triggers_create", {
+      threadId: "target",
+      kind: "signal",
+      label: "bounded",
+      prompt: "x".repeat(5_000),
+      signalName: "signal",
+    }),
+    /non-empty string/u,
+  );
+  await assert.rejects(
+    invoke(capability, "zenx_rooms_create", {
+      name: "too-many",
+      members: Array.from({ length: 65 }, (_, index) => ({
+        name: `member-${String(index)}`,
+        threadId: `thread-${String(index)}`,
+      })),
+    }),
+    /1-64/u,
+  );
+  await assert.rejects(
+    invoke(capability, "zenx_triggers_create", {
+      threadId: "target",
+      kind: "signal",
+      label: "bounded",
+      prompt: "prompt",
+      signalName: "signal",
+      program: {
+        action: {
+          command: "fixture",
+          env: Object.fromEntries(
+            Array.from({ length: 65 }, (_, index) => [
+              `KEY_${String(index)}`,
+              "value",
+            ]),
+          ),
+        },
+      },
+    }),
+    /too many entries/u,
+  );
+});
+
 async function invoke(
   capability: ZenXAutomationControlCapabilityPackage,
   name: string,
@@ -164,5 +229,72 @@ class FakePort implements ZenXAutomationControlPort {
   }
   async postAgentRoomMessage(id: string, text: string): Promise<void> {
     this.calls.push(["postAgentRoomMessage", { id, text }]);
+  }
+}
+
+class SensitivePort extends FakePort {
+  override snapshot(): TriggerSnapshot {
+    return {
+      triggers: [
+        {
+          id: "trigger-sensitive",
+          threadId: "target",
+          kind: "signal",
+          label: "Sensitive",
+          prompt: "Inspect",
+          signal: { name: "sensitive" },
+          createdAt: 1,
+          active: true,
+          program: {
+            action: {
+              command: "fixture",
+              env: { OPENAI_API_KEY: "do-not-leak" },
+            },
+          },
+        },
+      ],
+      history: [
+        {
+          id: "history-sensitive",
+          triggerId: "trigger-sensitive",
+          threadId: "target",
+          kind: "signal",
+          reason: "reason",
+          prompt: "Inspect",
+          clientUserMessageId: "wakeup",
+          startedAt: 1,
+          completedAt: 2,
+          status: "failed",
+          turnId: null,
+          error: "error",
+          sourceThreadId: null,
+          sourceTurnId: null,
+          sourceRoomId: null,
+          sourceRoomMessageId: null,
+          replyRoomId: null,
+          replyAuthor: null,
+          programInvocationId: null,
+          programOutcome: {
+            stage: "action",
+            invocationId: "invocation",
+            status: "failed",
+            output: "do-not-leak",
+            exitCode: 1,
+            error: "do-not-leak",
+          },
+          programOutcomes: [
+            {
+              stage: "action",
+              invocationId: "invocation",
+              status: "failed",
+              output: "do-not-leak",
+              exitCode: 1,
+              error: "do-not-leak",
+            },
+          ],
+        },
+      ],
+      rooms: [],
+    };
   }
 }

--- a/apps/zenx/test/automation-control-capability.test.ts
+++ b/apps/zenx/test/automation-control-capability.test.ts
@@ -174,6 +174,19 @@ test("Agent automation inputs enforce bounded strings, members, and program env"
     }),
     /too many entries/u,
   );
+  await assert.rejects(
+    invoke(capability, "zenx_triggers_create", {
+      threadId: "target",
+      kind: "signal",
+      label: "bounded",
+      prompt: "prompt",
+      signalName: "signal",
+      program: {
+        action: { command: "fixture", timeoutMs: 120_001 },
+      },
+    }),
+    /timeoutMs must be between/u,
+  );
 });
 
 async function invoke(

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -108,3 +108,59 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
   controller.abort(new Error("fixture cancellation"));
   assert.equal((await cancelled).status, "cancelled");
 });
+
+test("program runner contains a TERM-ignoring descendant after cancellation", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-kill-"));
+  const marker = path.join(directory, "late-marker");
+  const descendant = `const fs=require('node:fs');setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),400);`;
+  const parent = `const {spawn}=require('node:child_process');process.on('SIGTERM',()=>{});spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});setInterval(()=>process.stdout.write(JSON.stringify({ok:true})+'\\n'),50);`;
+  const controller = new AbortController();
+  try {
+    const running = runner.run(
+      {
+        command: process.execPath,
+        args: ["-e", parent],
+        maxOutputBytes: 64 * 1024,
+      },
+      { invocationId: "contained-cancel", stage: "action", event: {} },
+      controller.signal,
+    );
+    await delay(40);
+    controller.abort(new Error("cancel fixture"));
+    const result = await running;
+    assert.equal(result.status, "cancelled");
+    assert.equal(result.output, null);
+    await delay(600);
+    await assert.rejects(stat(marker), { code: "ENOENT" });
+  } finally {
+    await assert.rejects(stat(marker), { code: "ENOENT" });
+  }
+});
+
+test("program runner forces the tree when the direct child exits on TERM", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-program-tree-close-"),
+  );
+  const marker = path.join(directory, "late-marker");
+  const descendant = `const fs=require('node:fs');setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),400);`;
+  const parent = `const {spawn}=require('node:child_process');spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000);`;
+  const controller = new AbortController();
+  try {
+    const running = runner.run(
+      { command: process.execPath, args: ["-e", parent] },
+      { invocationId: "tree-close", stage: "action", event: {} },
+      controller.signal,
+    );
+    await delay(40);
+    controller.abort(new Error("tree close fixture"));
+    assert.equal((await running).status, "cancelled");
+    await delay(600);
+    await assert.rejects(stat(marker), { code: "ENOENT" });
+  } finally {
+    await assert.rejects(stat(marker), { code: "ENOENT" });
+  }
+});
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  ZenXTriggerProgramRunner,
+  type TriggerProgramRunInput,
+} from "../src/main/trigger-program-runner.js";
+
+const runner = new ZenXTriggerProgramRunner();
+
+test("program runner passes bounded JSON input, cwd, and env", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-"));
+  const input: TriggerProgramRunInput = {
+    invocationId: "invocation-stable",
+    stage: "action",
+    event: { completedItemText: "deploy" },
+  };
+  const result = await runner.run(
+    {
+      command: process.execPath,
+      args: [
+        "-e",
+        "process.stdin.on('data',d=>{const x=JSON.parse(d); console.log(JSON.stringify({ok:true, cwd:process.cwd(), env:process.env.ZENX_FIXTURE, invocationId:x.invocationId}))})",
+      ],
+      cwd: directory,
+      env: { ZENX_FIXTURE: "yes" },
+    },
+    input,
+    new AbortController().signal,
+  );
+  assert.equal(result.status, "completed");
+  assert.match(result.output ?? "", /invocation-stable/u);
+  assert.match(result.output ?? "", /"env":"yes"/u);
+  assert.match(result.output ?? "", /zenx-program-/u);
+});
+
+test("predicate output distinguishes match and non-match", async () => {
+  const make = (match: boolean) =>
+    runner.run(
+      {
+        command: process.execPath,
+        args: ["-e", `console.log(JSON.stringify({match:${String(match)}}))`],
+      },
+      {
+        invocationId: "predicate-id",
+        stage: "predicate",
+        event: {},
+      },
+      new AbortController().signal,
+    );
+  assert.equal((await make(true)).status, "matched");
+  assert.equal((await make(false)).status, "non_match");
+});
+
+test("program runner records malformed, nonzero, oversized, timeout, and cancellation outcomes", async () => {
+  const malformed = await runner.run(
+    { command: process.execPath, args: ["-e", "console.log('nope')"] },
+    { invocationId: "malformed", stage: "action", event: {} },
+    new AbortController().signal,
+  );
+  assert.equal(malformed.status, "malformed_output");
+
+  const nonzero = await runner.run(
+    {
+      command: process.execPath,
+      args: ["-e", "console.error('bad'); process.exit(3)"],
+    },
+    { invocationId: "nonzero", stage: "action", event: {} },
+    new AbortController().signal,
+  );
+  assert.equal(nonzero.status, "nonzero_exit");
+  assert.equal(nonzero.exitCode, 3);
+
+  const oversized = await runner.run(
+    {
+      command: process.execPath,
+      args: [
+        "-e",
+        "console.log(JSON.stringify({ok:true, x:'x'.repeat(1000)}))",
+      ],
+      maxOutputBytes: 256,
+    },
+    { invocationId: "oversized", stage: "action", event: {} },
+    new AbortController().signal,
+  );
+  assert.equal(oversized.status, "oversized_output");
+
+  const timedOut = await runner.run(
+    {
+      command: process.execPath,
+      args: ["-e", "setTimeout(()=>{},1000)"],
+      timeoutMs: 20,
+    },
+    { invocationId: "timeout", stage: "action", event: {} },
+    new AbortController().signal,
+  );
+  assert.equal(timedOut.status, "timed_out");
+
+  const controller = new AbortController();
+  const cancelled = runner.run(
+    { command: process.execPath, args: ["-e", "setTimeout(()=>{},1000)"] },
+    { invocationId: "cancel", stage: "action", event: {} },
+    controller.signal,
+  );
+  controller.abort(new Error("fixture cancellation"));
+  assert.equal((await cancelled).status, "cancelled");
+});

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -24,6 +24,7 @@ import type {
   ThreadItem,
   Turn,
 } from "../src/protocol-client/index.js";
+import type { TriggerSnapshot } from "../src/main/trigger-types.js";
 
 test("timer expiry creates one explicit App Server turn and auditable history", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-trigger-"));
@@ -497,6 +498,228 @@ test("completedItemText matching does not inspect signal or timer projections", 
       completed.history.map((entry) => entry.programOutcome?.status),
       ["non_match", "non_match"],
     );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("completedItemText only matches the selected completed Agent Item", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-match-item-"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const source = await triggers.createRoom({
+      name: "source",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Room predicate",
+      prompt: "Must not match the Room source text.",
+      roomId: source.id,
+      mention: "Bot",
+      program: {
+        match: { field: "completedItemText", regex: "go" },
+      },
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "thread",
+      label: "Thread predicate",
+      prompt: "Must inspect only the final Agent Item.",
+      watchedThreadId: "source-thread",
+      program: {
+        match: { field: "completedItemText", regex: "go" },
+      },
+    });
+    await triggers.postRoomMessage(source.id, "You", "@Bot go");
+    await snapshotWhen(triggers, (snapshot) =>
+      snapshot.history.some(
+        (entry) => entry.kind === "roomMention" && entry.status === "completed",
+      ),
+    );
+    const sourceTurn = completedTurn("source-turn", "go", [
+      {
+        type: "commandExecution",
+        id: "command-go",
+        pluginId: null,
+        scriptPath: null,
+        command: "echo go",
+        cwd: "/workspace",
+        processId: null,
+        source: "agent",
+        status: "completed",
+        commandActions: [],
+        aggregatedOutput: "go",
+        exitCode: 0,
+        durationMs: null,
+      },
+    ]);
+    const answer = sourceTurn.items.find(
+      (item): item is Extract<ThreadItem, { type: "agentMessage" }> =>
+        item.type === "agentMessage",
+    );
+    assert(answer);
+    answer.text = "finished";
+    manager.complete("source-thread", sourceTurn);
+    const finished = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.kind === "thread").length ===
+          1 &&
+        snapshot.history.some(
+          (entry) => entry.kind === "thread" && entry.status === "completed",
+        ),
+    );
+    assert.equal(manager.requests.length, 0);
+    assert.equal(
+      finished.history.find((entry) => entry.kind === "roomMention")
+        ?.programOutcome?.status,
+      "non_match",
+    );
+    assert.equal(
+      finished.history.find((entry) => entry.kind === "thread")?.status,
+      "completed",
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Unicode completion replies stay byte-bounded and persistence failures release the wakeup", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-unicode-complete-"),
+  );
+  const manager = new ControlledManager();
+  const store = new FailTerminalWriteStore(
+    path.join(directory, "triggers.json"),
+  );
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Unicode reply",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    const answer = "a".repeat(7_975) + "😀" + "trailing text";
+    const completed = completedTurn(running.history[0]!.turnId!, "status?");
+    const agent = completed.items.find(
+      (item): item is Extract<ThreadItem, { type: "agentMessage" }> =>
+        item.type === "agentMessage",
+    );
+    assert(agent);
+    agent.text = answer;
+    store.failNextTerminalWrite = true;
+    manager.complete("target", completed);
+    const failed = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "failed",
+    );
+    assert.equal(failed.history[0]?.programInvocationId, null);
+    assert.match(failed.history[0]?.error ?? "", /could not be persisted/u);
+    await triggers.postRoomMessage(room.id, "You", "@Bot again");
+    const secondRunning = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.kind === "roomMention")
+          .length === 2 && snapshot.history[0]?.status === "running",
+    );
+    const second = completedTurn(secondRunning.history[0]!.turnId!, "again");
+    const secondAgent = second.items.find(
+      (item): item is Extract<ThreadItem, { type: "agentMessage" }> =>
+        item.type === "agentMessage",
+    );
+    assert(secondAgent);
+    secondAgent.text = answer;
+    manager.complete("target", second);
+    await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history[0]?.status === "completed" &&
+        snapshot.rooms[0]?.messages.some(
+          (message) => message.kind === "agent",
+        ) === true,
+    );
+    const roomReply = triggers
+      .snapshot()
+      .rooms[0]?.messages.find((message) => message.kind === "agent");
+    assert(roomReply);
+    assert(Buffer.byteLength(roomReply.text, "utf8") <= 8_000);
+    assert(!roomReply.text.includes("\uFFFD"));
+    assert.equal(manager.requests.length, 2);
+    const signalDetail = "x".repeat(3_990) + "😀";
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Unicode signal",
+      prompt: "No dispatch needed.",
+      signalName: "unicode",
+    });
+    await triggers.signal("unicode", signalDetail);
+    const signalHistory = triggers
+      .snapshot()
+      .history.find((entry) => entry.kind === "signal");
+    assert(signalHistory);
+    assert(Buffer.byteLength(signalHistory.reason, "utf8") <= 4_000);
+    assert(!signalHistory.reason.includes("\uFFFD"));
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Unicode program output and errors are bounded without replacement characters", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-unicode-program-"),
+  );
+  const manager = new ControlledManager();
+  const runner = new UnicodeProgramRunner();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    { programs: runner },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Unicode program",
+      prompt: "Run bounded local work.",
+      signalName: "unicode-program",
+      program: { action: { command: "fixture" } },
+    });
+    await triggers.signal("unicode-program", "run");
+    const failed = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "failed",
+    );
+    const outcome = failed.history[0]?.programOutcome;
+    assert(outcome);
+    assert(Buffer.byteLength(outcome.output ?? "", "utf8") <= 8_000);
+    assert(Buffer.byteLength(outcome.error ?? "", "utf8") <= 4_000);
+    assert(!outcome.output?.includes("\uFFFD"));
+    assert(!outcome.error?.includes("\uFFFD"));
   } finally {
     await triggers.stop();
     await rm(directory, { recursive: true, force: true });
@@ -1115,6 +1338,36 @@ class MatchingProgramRunner implements TriggerProgramRunner {
       exitCode: 0,
       error: null,
     };
+  }
+}
+
+class UnicodeProgramRunner implements TriggerProgramRunner {
+  async run(
+    _spec: { command: string },
+    _input: TriggerProgramRunInput,
+    _signal: AbortSignal,
+  ): Promise<TriggerProgramRunResult> {
+    return {
+      status: "failed",
+      output: "😀".repeat(4_500),
+      exitCode: 7,
+      error: "💥".repeat(3_000),
+    };
+  }
+}
+
+class FailTerminalWriteStore extends ZenXTriggerStore {
+  failNextTerminalWrite = false;
+
+  override async write(snapshot: TriggerSnapshot): Promise<void> {
+    if (
+      this.failNextTerminalWrite &&
+      snapshot.history.some((entry) => entry.status === "completed")
+    ) {
+      this.failNextTerminalWrite = false;
+      throw new Error("fixture terminal persistence failure");
+    }
+    await super.write(snapshot);
   }
 }
 

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -10,6 +10,11 @@ import {
   ZenXTriggerService,
   type ZenXTriggerAppServerPort,
 } from "../src/main/trigger-service.js";
+import type {
+  TriggerProgramRunInput,
+  TriggerProgramRunResult,
+  TriggerProgramRunner,
+} from "../src/main/trigger-program-runner.js";
 import { ZenXTriggerStore } from "../src/main/trigger-store.js";
 import type {
   ClientRequestParams,
@@ -62,7 +67,7 @@ test("timer expiry creates one explicit App Server turn and auditable history", 
         wakeup.content[0]?.text ?? "",
         /\[ZenX trigger wakeup\].*Injected prompt/su,
       );
-    triggers.stop();
+    await triggers.stop();
   } finally {
     await manager.stop();
     await rm(directory, { recursive: true, force: true });
@@ -200,7 +205,7 @@ test("thread snapshots and two-member Room context route through target Threads"
         new RegExp(`Registered trigger: .*Room|${member}`, "u"),
       );
     }
-    triggers.stop();
+    await triggers.stop();
   } finally {
     await manager.stop();
     await rm(directory, { recursive: true, force: true });
@@ -272,7 +277,7 @@ test("explicit cyclic relay is stable, sourceful, auditable, and stops after can
     assert.equal(triggers.snapshot().history.length, 2);
     assert.equal(manager.requests.length, 2);
   } finally {
-    triggers.stop();
+    await triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -301,7 +306,7 @@ test("self-watch remains an explicit supported relay", async () => {
     assert.equal(snapshot.history[0]?.sourceThreadId, "thread-a");
     assert.equal(manager.requests[0]?.threadId, "thread-a");
   } finally {
-    triggers.stop();
+    await triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -351,7 +356,7 @@ test("Room membership enforces unique names and Threads and supports add/remove"
       { name: "Reviewer", threadId: "thread-b" },
     ]);
   } finally {
-    triggers.stop();
+    await triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -383,7 +388,241 @@ test("failed relay is terminal and is not hidden, queued, or retried", async () 
     assert.equal(manager.requests.length, 1);
     assert.equal(triggers.snapshot().history.length, 1);
   } finally {
-    triggers.stop();
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("admits exactly 64 nonterminal wakeups, rejects the 65th, then frees one slot on terminal completion", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-admission-"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Admission",
+      prompt: "Run once.",
+      signalName: "wake",
+    });
+    for (let index = 0; index < 64; index++)
+      await triggers.signal("wake", String(index));
+    await settle();
+    assert.equal(manager.requests.length, 64);
+    await triggers.signal("wake", "65");
+    const rejected = triggers
+      .snapshot()
+      .history.find((entry) => entry.reason.endsWith(": 65"));
+    assert.equal(manager.requests.length, 64);
+    assert.equal(rejected?.status, "failed");
+    assert.match(rejected?.error ?? "", /64 nonterminal/u);
+    const first = triggers
+      .snapshot()
+      .history.find((entry) => entry.status === "running");
+    assert(first?.turnId);
+    manager.complete("target", completedTurn(first.turnId, "release"));
+    await snapshotWhen(triggers, (snapshot) =>
+      snapshot.history.some(
+        (entry) => entry.id === first.id && entry.status === "completed",
+      ),
+    );
+    await triggers.signal("wake", "66");
+    await settle();
+    assert.equal(manager.requests.length, 65);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("early completion requires exact thread and client correlation and is applied once", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-completion-"),
+  );
+  const manager = new EarlyCompletionManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Early",
+      prompt: "Complete once.",
+      signalName: "wake",
+    });
+    await triggers.signal("wake", "early");
+    const completed = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(completed.history.length, 1);
+    assert.equal(manager.requests.length, 1);
+    assert.equal(manager.completions.length, 1);
+    manager.emitLate({
+      threadId: "other",
+      turn: completedTurn("same-turn", "wrong thread"),
+    });
+    manager.emitLate({
+      threadId: "target",
+      turn: completedTurn("different-turn", "late"),
+    });
+    await settle();
+    assert.equal(triggers.snapshot().history.length, 1);
+    assert.equal(triggers.snapshot().history[0]?.status, "completed");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("zero and conflicting early completion evidence stays rejected until the owned Turn completes", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-early-evidence-"),
+  );
+  const manager = new EarlyEvidenceManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Evidence",
+      prompt: "Complete only with owned evidence.",
+      signalName: "wake",
+    });
+    await triggers.signal("wake", "zero");
+    await triggers.signal("wake", "conflict");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "running")
+          .length === 2,
+    );
+    assert.equal(manager.requests.length, 2);
+    assert.equal(
+      running.history.filter((entry) => entry.status === "completed").length,
+      0,
+    );
+    for (const entry of running.history) {
+      assert(entry.turnId);
+      manager.complete("target", completedTurn(entry.turnId, "owned"));
+    }
+    const completed = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.filter((entry) => entry.status === "completed")
+          .length === 2,
+    );
+    assert.equal(completed.history.length, 2);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Room deletion is fenced by a nonterminal immutable reply route", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-delete-fence-"),
+  );
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    const trigger = await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer the Room.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    await triggers.postRoomMessage(room.id, "You", "@Bot status?");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    await assert.rejects(
+      async () => await triggers.deleteRoom(room.id),
+      /nonterminal wakeup owns/u,
+    );
+    await triggers.update({
+      id: trigger.id,
+      threadId: "target",
+      kind: "signal",
+      label: "Updated",
+      prompt: "Updated.",
+      signalName: "unused",
+    });
+    manager.complete(
+      "target",
+      completedTurn(running.history[0]!.turnId!, "answer"),
+    );
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(triggers.snapshot().rooms[0]?.messages.at(-1)?.author, "Bot");
+    await triggers.deleteRoom(room.id);
+    assert.equal(triggers.snapshot().rooms.length, 0);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("restart records uncertain local work once and never retries it", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-program-restart-"),
+  );
+  const manager = new ControlledManager();
+  const runner = new BlockingProgramRunner();
+  const store = new ZenXTriggerStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store, { programs: runner });
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Local action",
+      prompt: "Run local action.",
+      signalName: "local",
+      program: { action: { command: "fixture-action" } },
+    });
+    const firing = triggers.signal("local", "once");
+    await runner.started.promise;
+    await triggers.stop();
+    const stopped = triggers.snapshot().history[0];
+    assert.equal(stopped?.status, "failed");
+    assert.equal(stopped?.programOutcome?.status, "uncertain");
+    runner.release();
+    await firing;
+
+    const restarted = new ZenXTriggerService(manager, store, {
+      programs: runner,
+    });
+    await restarted.start();
+    assert.equal(runner.calls, 1);
+    assert.equal(restarted.snapshot().history[0]?.status, "failed");
+    await restarted.stop();
+  } finally {
+    await triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -436,7 +675,7 @@ test("long timers reschedule at the clamp boundary instead of firing early", asy
     );
     assert.equal(manager.requests.length, 1);
   } finally {
-    triggers.stop();
+    await triggers.stop();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -512,6 +751,162 @@ class ControlledManager implements ZenXTriggerAppServerPort {
   complete(threadId: string, turn: Turn): void {
     this.#listener?.("turn/completed", { threadId, turn });
   }
+}
+
+class EarlyCompletionManager implements ZenXTriggerAppServerPort {
+  readonly requests: ClientRequestParams["turn/start"][] = [];
+  readonly completions: ServerNotificationParams["turn/completed"][] = [];
+  #listener:
+    | ((
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ) => void)
+    | undefined;
+
+  async request(
+    _method: "turn/start",
+    params: ClientRequestParams["turn/start"],
+  ): Promise<ClientRequestResults["turn/start"]> {
+    this.requests.push(params);
+    const id = `early-turn-${this.requests.length}`;
+    const completed = completedTurn(id, "early", [
+      {
+        type: "userMessage",
+        id: `${id}-user`,
+        clientId: params.clientUserMessageId ?? null,
+        content: [{ type: "text", text: "early", text_elements: [] }],
+      },
+    ]);
+    const event = { threadId: params.threadId, turn: completed };
+    this.completions.push(event);
+    this.#listener?.("turn/completed", event);
+    return {
+      turn: {
+        ...completed,
+        status: "inProgress",
+        completedAt: null,
+        durationMs: null,
+      },
+    };
+  }
+
+  onNotification(
+    listener: (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void,
+  ): () => void {
+    this.#listener = listener;
+    return () => {
+      if (this.#listener === listener) this.#listener = undefined;
+    };
+  }
+
+  emitLate(event: ServerNotificationParams["turn/completed"]): void {
+    this.#listener?.("turn/completed", event);
+  }
+}
+
+class EarlyEvidenceManager implements ZenXTriggerAppServerPort {
+  readonly requests: ClientRequestParams["turn/start"][] = [];
+  #listener:
+    | ((
+        method: ServerNotificationMethod,
+        params: ServerNotificationParams[ServerNotificationMethod],
+      ) => void)
+    | undefined;
+
+  async request(
+    _method: "turn/start",
+    params: ClientRequestParams["turn/start"],
+  ): Promise<ClientRequestResults["turn/start"]> {
+    this.requests.push(params);
+    const id = `evidence-turn-${this.requests.length}`;
+    const items: ThreadItem[] =
+      this.requests.length === 1
+        ? []
+        : [
+            {
+              type: "userMessage" as const,
+              id: `${id}-wrong-a`,
+              clientId: "wrong-a",
+              content: [
+                { type: "text" as const, text: "wrong-a", text_elements: [] },
+              ],
+            },
+            {
+              type: "userMessage" as const,
+              id: `${id}-wrong-b`,
+              clientId: "wrong-b",
+              content: [
+                { type: "text" as const, text: "wrong-b", text_elements: [] },
+              ],
+            },
+          ];
+    this.#listener?.("turn/completed", {
+      threadId: params.threadId,
+      turn: completedTurn(id, "early", items),
+    });
+    return {
+      turn: {
+        ...completedTurn(id, "owned"),
+        status: "inProgress",
+        completedAt: null,
+        durationMs: null,
+      },
+    };
+  }
+
+  onNotification(
+    listener: (
+      method: ServerNotificationMethod,
+      params: ServerNotificationParams[ServerNotificationMethod],
+    ) => void,
+  ): () => void {
+    this.#listener = listener;
+    return () => {
+      if (this.#listener === listener) this.#listener = undefined;
+    };
+  }
+
+  complete(threadId: string, turn: Turn): void {
+    this.#listener?.("turn/completed", { threadId, turn });
+  }
+}
+
+class BlockingProgramRunner implements TriggerProgramRunner {
+  calls = 0;
+  readonly started = deferred<void>();
+  #resolve: ((result: TriggerProgramRunResult) => void) | undefined;
+
+  run(
+    _spec: { command: string },
+    _input: TriggerProgramRunInput,
+    _signal: AbortSignal,
+  ): Promise<TriggerProgramRunResult> {
+    this.calls += 1;
+    this.started.resolve();
+    return new Promise<TriggerProgramRunResult>((resolve) => {
+      this.#resolve = resolve;
+    });
+  }
+
+  release(): void {
+    this.#resolve?.({
+      status: "completed",
+      output: '{"ok":true}',
+      exitCode: 0,
+      error: null,
+    });
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 function completedTurn(

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -439,6 +439,117 @@ test("admits exactly 64 nonterminal wakeups, rejects the 65th, then frees one sl
   }
 });
 
+test("completedItemText matching does not inspect signal or timer projections", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-match-field-"));
+  const manager = new ControlledManager();
+  let now = 1_000;
+  const scheduled: Array<() => void> = [];
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+    {
+      now: () => now,
+      schedule: (callback) => {
+        scheduled.push(callback);
+        return callback;
+      },
+      cancelScheduled: () => undefined,
+    },
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Signal predicate",
+      prompt: "Must not run from signal projection.",
+      signalName: "probe",
+      program: {
+        match: { field: "completedItemText", regex: "Signal detail" },
+      },
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "timer",
+      label: "Timer predicate",
+      prompt: "Must not run from timer projection.",
+      runAt: now + 10,
+      program: {
+        match: { field: "completedItemText", regex: "Signal detail" },
+      },
+    });
+    await triggers.signal("probe", "Signal detail");
+    await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "completed",
+    );
+    assert.equal(manager.requests.length, 0);
+    now += 10;
+    scheduled.at(-1)?.();
+    const completed = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.length === 2 &&
+        snapshot.history.every((entry) => entry.status === "completed"),
+    );
+    assert.equal(manager.requests.length, 0);
+    assert.deepEqual(
+      completed.history.map((entry) => entry.programOutcome?.status),
+      ["non_match", "non_match"],
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("canonical Trigger history and Room messages use bounded retention", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-retention-"));
+  const manager = new ControlledManager();
+  const triggers = new ZenXTriggerService(
+    manager,
+    new ZenXTriggerStore(path.join(directory, "triggers.json")),
+  );
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Bounded",
+      prompt: "Keep the audit bounded.",
+      signalName: "bounded",
+    });
+    for (let index = 0; index < 65; index++)
+      await triggers.signal("bounded", String(index));
+    const admission = triggers.snapshot();
+    assert.equal(
+      admission.history.filter((entry) => entry.status === "failed").length,
+      1,
+    );
+    assert.match(admission.history[0]?.error ?? "", /64 nonterminal/u);
+    for (let index = 65; index < 300; index++)
+      await triggers.signal("bounded", String(index));
+    assert.equal(triggers.snapshot().history.length, 256);
+
+    const room = await triggers.createRoom({
+      name: "bounded-room",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    for (let index = 0; index < 300; index++)
+      await triggers.postRoomMessage(
+        room.id,
+        "Human",
+        `message-${String(index)}`,
+      );
+    const roomSnapshot = triggers.snapshot();
+    assert.equal(roomSnapshot.rooms[0]?.messages.length, 256);
+    assert.equal(roomSnapshot.rooms[0]?.messages.at(-1)?.text, "message-299");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("early completion requires exact thread and client correlation and is applied once", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-early-completion-"),
@@ -620,6 +731,94 @@ test("restart records uncertain local work once and never retries it", async () 
     await restarted.start();
     assert.equal(runner.calls, 1);
     assert.equal(restarted.snapshot().history[0]?.status, "failed");
+    await restarted.stop();
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("restart preserves completed predicate and match audits while a Turn remains nonterminal", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-program-audit-"),
+  );
+  const manager = new ControlledManager();
+  const store = new ZenXTriggerStore(path.join(directory, "triggers.json"));
+  const runner = new MatchingProgramRunner();
+  const triggers = new ZenXTriggerService(manager, store, { programs: runner });
+  try {
+    await triggers.start();
+    const predicate = await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Predicate",
+      prompt: "Keep the downstream Turn open.",
+      signalName: "restart",
+      program: { predicate: { command: "fixture-predicate" } },
+    });
+    const matchOnly = await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Match only",
+      prompt: "Must not match without completed Item text.",
+      signalName: "restart",
+      program: {
+        match: { field: "completedItemText", regex: "never-present" },
+      },
+    });
+    await triggers.signal("restart", "event");
+    const beforeStop = await snapshotWhen(
+      triggers,
+      (snapshot) =>
+        snapshot.history.some(
+          (entry) =>
+            entry.triggerId === predicate.id && entry.status === "running",
+        ) &&
+        snapshot.history.some(
+          (entry) =>
+            entry.triggerId === matchOnly.id && entry.status === "completed",
+        ),
+    );
+    assert.equal(runner.calls, 1);
+    const predicateBefore = beforeStop.history.find(
+      (entry) => entry.triggerId === predicate.id,
+    )!;
+    assert.equal(predicateBefore.programInvocationId, null);
+    assert.deepEqual(
+      predicateBefore.programOutcomes.map((outcome) => outcome.status),
+      ["matched"],
+    );
+    await triggers.stop();
+    const stopped = triggers.snapshot();
+    const predicateStopped = stopped.history.find(
+      (entry) => entry.triggerId === predicate.id,
+    )!;
+    const matchStopped = stopped.history.find(
+      (entry) => entry.triggerId === matchOnly.id,
+    )!;
+    assert.equal(predicateStopped.status, "failed");
+    assert.equal(predicateStopped.programInvocationId, null);
+    assert.deepEqual(
+      predicateStopped.programOutcomes.map((outcome) => outcome.status),
+      ["matched"],
+    );
+    assert.deepEqual(
+      matchStopped.programOutcomes.map((outcome) => outcome.status),
+      ["non_match"],
+    );
+
+    const restarted = new ZenXTriggerService(manager, store, {
+      programs: runner,
+    });
+    await restarted.start();
+    assert.equal(runner.calls, 1);
+    assert.deepEqual(
+      restarted
+        .snapshot()
+        .history.find((entry) => entry.triggerId === predicate.id)
+        ?.programOutcomes.map((outcome) => outcome.status),
+      ["matched"],
+    );
     await restarted.stop();
   } finally {
     await triggers.stop();
@@ -898,6 +1097,24 @@ class BlockingProgramRunner implements TriggerProgramRunner {
       exitCode: 0,
       error: null,
     });
+  }
+}
+
+class MatchingProgramRunner implements TriggerProgramRunner {
+  calls = 0;
+
+  async run(
+    _spec: { command: string },
+    _input: TriggerProgramRunInput,
+    _signal: AbortSignal,
+  ): Promise<TriggerProgramRunResult> {
+    this.calls += 1;
+    return {
+      status: "matched",
+      output: '{"match":true}',
+      exitCode: 0,
+      error: null,
+    };
   }
 }
 

--- a/apps/zenx/test/trigger-service.test.ts
+++ b/apps/zenx/test/trigger-service.test.ts
@@ -921,6 +921,173 @@ test("Room deletion is fenced by a nonterminal immutable reply route", async () 
   }
 });
 
+test("Room routing candidates are committed with the message before later trigger mutations", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-routing-atomic-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingWriteStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Original",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    store.blockNextWrite = true;
+    const posting = triggers.postRoomMessage(room.id, "You", "@Bot now");
+    await store.started.promise;
+    const added = triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Added late",
+      prompt: "Must not receive the old message.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    store.release();
+    await posting;
+    await added;
+    assert.equal(manager.requests.length, 1);
+    assert.equal(
+      triggers
+        .snapshot()
+        .history.filter((entry) => entry.kind === "roomMention").length,
+      1,
+    );
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Room deletion queued behind mention append sees the committed reply-route fence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-delete-race-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingWriteStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    store.blockNextWrite = true;
+    const posting = triggers.postRoomMessage(room.id, "You", "@Bot now");
+    await store.started.promise;
+    const deleting = triggers.deleteRoom(room.id);
+    const deletion = assert.rejects(deleting, /nonterminal wakeup owns/u);
+    store.release();
+    await posting;
+    await deletion;
+    assert.equal(triggers.snapshot().rooms.length, 1);
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("Room member removal queued behind mention append cannot alter its committed candidate", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-room-member-race-"),
+  );
+  const manager = new ControlledManager();
+  const store = new BlockingWriteStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    const room = await triggers.createRoom({
+      name: "release",
+      members: [{ name: "Bot", threadId: "target" }],
+    });
+    await triggers.create({
+      threadId: "target",
+      kind: "roomMention",
+      label: "Answer",
+      prompt: "Answer once.",
+      roomId: room.id,
+      mention: "Bot",
+    });
+    store.blockNextWrite = true;
+    const posting = triggers.postRoomMessage(room.id, "You", "@Bot now");
+    await store.started.promise;
+    const removing = triggers.removeRoomMember(room.id, "target");
+    store.release();
+    await posting;
+    await removing;
+    assert.equal(manager.requests.length, 1);
+    assert.equal(triggers.snapshot().rooms[0]?.members.length, 0);
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+  } finally {
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("terminal persistence failure fails closed without dispatching another wakeup, and listener errors are isolated", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-terminal-boundary-"),
+  );
+  const manager = new ControlledManager();
+  const store = new AlwaysFailWriteStore(path.join(directory, "triggers.json"));
+  const triggers = new ZenXTriggerService(manager, store);
+  try {
+    await triggers.start();
+    await triggers.create({
+      threadId: "target",
+      kind: "signal",
+      label: "Boundary",
+      prompt: "Run once.",
+      signalName: "boundary",
+    });
+    const listenerDispose = triggers.onChange(() => {
+      throw new Error("fixture listener failure");
+    });
+    store.failWrites = false;
+    await triggers.signal("boundary", "first");
+    const running = await snapshotWhen(
+      triggers,
+      (snapshot) => snapshot.history[0]?.status === "running",
+    );
+    store.failWrites = true;
+    manager.complete(
+      "target",
+      completedTurn(running.history[0]!.turnId!, "first"),
+    );
+    await settle();
+    assert.equal(triggers.snapshot().history[0]?.status, "running");
+    assert.equal(manager.requests.length, 1);
+    await assert.rejects(
+      async () => await triggers.signal("boundary", "second"),
+      /service is not running/u,
+    );
+    listenerDispose();
+    store.failWrites = false;
+  } finally {
+    store.failWrites = false;
+    await triggers.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("restart records uncertain local work once and never retries it", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-program-restart-"),
@@ -1368,6 +1535,38 @@ class FailTerminalWriteStore extends ZenXTriggerStore {
       throw new Error("fixture terminal persistence failure");
     }
     await super.write(snapshot);
+  }
+}
+
+class AlwaysFailWriteStore extends ZenXTriggerStore {
+  failWrites = false;
+
+  override async write(snapshot: TriggerSnapshot): Promise<void> {
+    if (this.failWrites)
+      throw new Error("fixture persistent store unavailable");
+    await super.write(snapshot);
+  }
+}
+
+class BlockingWriteStore extends ZenXTriggerStore {
+  blockNextWrite = false;
+  readonly started = deferred<void>();
+  #releaseWrite: (() => void) | undefined;
+
+  override async write(snapshot: TriggerSnapshot): Promise<void> {
+    if (this.blockNextWrite) {
+      this.blockNextWrite = false;
+      this.started.resolve();
+      await new Promise<void>((resolve) => {
+        this.#releaseWrite = resolve;
+      });
+    }
+    await super.write(snapshot);
+  }
+
+  release(): void {
+    this.#releaseWrite?.();
+    this.#releaseWrite = undefined;
   }
 }
 

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -76,6 +76,11 @@ test("migrates fully validated version 1 history to nullable source metadata", a
       sourceTurnId: _sourceTurnId,
       sourceRoomId: _sourceRoomId,
       sourceRoomMessageId: _sourceRoomMessageId,
+      replyRoomId: _replyRoomId,
+      replyAuthor: _replyAuthor,
+      programInvocationId: _programInvocationId,
+      programOutcome: _programOutcome,
+      programOutcomes: _programOutcomes,
       ...entry
     }) => entry,
   );
@@ -91,6 +96,60 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     assert.equal(migrated.history[0]?.sourceTurnId, null);
     await store.write(migrated);
     assert.equal(JSON.parse(await readFile(file, "utf8")).version, 3);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects unknown legacy and current fields before migration or safe projection", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-store-extra-"));
+  const file = path.join(directory, "triggers.json");
+  const base = validState();
+  const corruptions = [
+    {
+      ...base,
+      version: 1,
+      history: [{ ...base.history[0], secret: "x" }],
+    },
+    {
+      ...base,
+      version: 2,
+      history: [{ ...base.history[0], programOutput: "x" }],
+    },
+    {
+      ...base,
+      version: 3,
+      history: [{ ...base.history[0], diagnostic: "x" }],
+    },
+  ];
+  try {
+    for (const value of corruptions) {
+      await writeFile(file, JSON.stringify(value), "utf8");
+      await assert.rejects(
+        async () => await new ZenXTriggerStore(file).read(),
+        /unsupported version or invalid entry shape/u,
+      );
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects an oversized timeout at the legacy store boundary", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-store-timeout-"),
+  );
+  const file = path.join(directory, "triggers.json");
+  const state = validState();
+  state.triggers[0]!.program = {
+    action: { command: "fixture", timeoutMs: 120_001 },
+  };
+  try {
+    await writeFile(file, JSON.stringify({ ...state, version: 1 }), "utf8");
+    await assert.rejects(
+      async () => await new ZenXTriggerStore(file).read(),
+      /unsupported version or invalid entry shape/u,
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -67,7 +67,7 @@ test("migrates fully validated version 1 history to nullable source metadata", a
     assert.equal(migrated.history[0]?.sourceThreadId, null);
     assert.equal(migrated.history[0]?.sourceTurnId, null);
     await store.write(migrated);
-    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 2);
+    assert.equal(JSON.parse(await readFile(file, "utf8")).version, 3);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -106,6 +106,11 @@ function validState(): TriggerSnapshot & { version: 2 } {
         sourceTurnId: "turn-b",
         sourceRoomId: null,
         sourceRoomMessageId: null,
+        replyRoomId: null,
+        replyAuthor: null,
+        programInvocationId: null,
+        programOutcome: null,
+        programOutcomes: [],
       },
     ],
     rooms: [

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -28,6 +28,29 @@ test("rejects nested trigger registry corruption instead of admitting runtime ob
         },
       ],
     },
+    {
+      ...validState(),
+      history: Array.from({ length: 257 }, (_, index) => ({
+        ...validState().history[0]!,
+        id: `history-${String(index)}`,
+      })),
+    },
+    {
+      ...validState(),
+      rooms: [
+        {
+          ...validState().rooms[0]!,
+          messages: Array.from({ length: 257 }, (_, index) => ({
+            ...validState().rooms[0]!.messages[0]!,
+            id: `message-${String(index)}`,
+          })),
+        },
+      ],
+    },
+    {
+      ...validState(),
+      triggers: [{ ...validState().triggers[0]!, prompt: "x".repeat(5_000) }],
+    },
     { ...validState(), version: 999 },
   ];
   try {

--- a/apps/zenx/test/trigger-store.test.ts
+++ b/apps/zenx/test/trigger-store.test.ts
@@ -155,6 +155,77 @@ test("rejects an oversized timeout at the legacy store boundary", async () => {
   }
 });
 
+test("enforces version-specific and per-kind Trigger schemas", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-store-schema-"));
+  const file = path.join(directory, "triggers.json");
+  const state = validState();
+  const signal = {
+    id: "signal-trigger",
+    threadId: "thread-a",
+    kind: "signal" as const,
+    label: "Signal",
+    prompt: "Signal",
+    createdAt: 1,
+    active: true,
+    signal: { name: "deploy" },
+  };
+  const history = state.history.map(
+    ({
+      replyRoomId: _replyRoomId,
+      replyAuthor: _replyAuthor,
+      programInvocationId: _programInvocationId,
+      programOutcome: _programOutcome,
+      programOutcomes: _programOutcomes,
+      ...entry
+    }) => entry,
+  );
+  const invalid = [
+    {
+      version: 1,
+      triggers: [{ ...signal, program: { action: { command: "fixture" } } }],
+      history,
+      rooms: state.rooms,
+    },
+    {
+      version: 2,
+      triggers: [{ ...signal, program: { action: { command: "fixture" } } }],
+      history: state.history.map(
+        ({
+          replyRoomId: _replyRoomId,
+          replyAuthor: _replyAuthor,
+          programInvocationId: _programInvocationId,
+          programOutcome: _programOutcome,
+          programOutcomes: _programOutcomes,
+          ...entry
+        }) => entry,
+      ),
+      rooms: state.rooms,
+    },
+    {
+      version: 3,
+      triggers: [
+        {
+          ...signal,
+          watch: { threadId: "thread-b", event: "turn_completed" },
+        },
+      ],
+      history: state.history,
+      rooms: state.rooms,
+    },
+  ];
+  try {
+    for (const value of invalid) {
+      await writeFile(file, JSON.stringify(value), "utf8");
+      await assert.rejects(
+        async () => await new ZenXTriggerStore(file).read(),
+        /unsupported version or invalid entry shape/u,
+      );
+    }
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 function validState(): TriggerSnapshot & { version: 2 } {
   return {
     version: 2,


### PR DESCRIPTION
## Summary

- Closes #69
- Closes #52
- Adds separately permissioned Agent Trigger tools for list/create/update/cancel/delete and Agent Room tools for list/create/rename/delete/member management/message posting.
- Preserves existing timer, thread, roomMention, and signal Trigger UI/service paths.

## Final repair at exact head

- Exact base: `7f55bffe00596a2533508c4bf5f2e36d6a2deb31`
- Exact final repair head: `ab80f50b5805b124eb664ebc54e4d6cb9ab0d742`
- GitHub Actions run: [31569719683](https://github.com/albert-zen/zen/actions/runs/31569719683), all 6 jobs completed successfully.
- Local SHA = `ab80f50b5805b124eb664ebc54e4d6cb9ab0d742` = remote branch SHA = PR head SHA.

The final repair adds strict schema-version/per-kind persisted-state whitelists and canonical migration, explicit read-safe projections with program env/output/diagnostic redaction, identity-aware bounded OS process-tree termination with repeated quiescence proof and explicit containment failure, fail-closed Trigger persistence when both terminal writes fail, isolated change listeners, and atomic Room mention routing candidates captured with the message append/deletion fence.

## Design

- Durable canonical state remains in the existing Trigger/Room store (v3 migration); no Core Item or wire-protocol expansion.
- Wakeups use lifecycle generations, exact thread + Turn + client correlation, immutable `replyRoomId`/`replyAuthor`, serialized Room deletion fencing, duplicate/late evidence rejection, one terminal release, and a hard 64 nonterminal admission limit.
- `trigger-program-runner.ts` is a documented deep module for one-attempt bounded local predicate/action execution with explicit JSON input/output, timeout, cancellation, cwd/env, regex matching, stable invocation IDs, durable outcomes, and restart uncertainty without retry.
- Agent tools route through the existing capability/service/App Server Turn flow; no second runtime, coordinator, transcript, queue, or durable self-healing state machine.

## Verification

- Focused Trigger/Room/program/store/capability/App Server tests: 33/33 passed.
- Real child App Server bridge: all Agent Room tools and Trigger CRUD/update/cancel/delete passed.
- Real Room mention bridge: one selected member wakeup, one reply, source Room/message and reply-origin metadata passed.
- Root `npm run typecheck`, `npm run build`, and `npm run lint`: passed.
- ZenX typecheck, build, and targeted changed-file Prettier: passed.
- ZenX full Windows suite: 292/297 passed; five known Windows/POSIX baseline failures remain (printf shell expectation, POSIX `/tmp` path expectations, POSIX executable fixture, and streamed-tool baseline). No Trigger/Room/program/bridge test failed.
- Root Node suite: 86/93 passed; six known Windows/POSIX baseline failures. IMZen: 37/38 passed; one known Windows chmod-permission baseline failure.
- Repository-wide `npm run format:check` remains an existing CRLF/format baseline across unrelated files; all changed files pass targeted Prettier and `git diff --check`.
- Local Windows packaged capability smoke logs the existing macOS-only bundled computer-provider limitation; local real smoke passes. CI packaged capability, real Playwright, Windows WinApp, Windows attached-browser, and Core/CLI/IMZen jobs all passed for this exact head.

## Historical evidence

PRs #49, #59, #63, #66, and #70 were consulted as evidence only. They are superseded by this implementation upon merge; this PR does not close or revive those historical branches.

## Residual risks

- Programmable local commands are bounded and one-attempt but are not a sandbox; callers must grant the capability intentionally.
- OS process-table visibility and termination APIs are platform-dependent; inability to prove identity/quiescence fails the local outcome rather than claiming containment.
- Real authenticated provider/model smoke was not run; fake-provider child App Server and deterministic local fixtures were used for acceptance.