### PR TITLE
feat(zenx): complete Browser Use provider flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,22 @@ jobs:
       - run: npm ci
       - run: npm --workspace apps/zenx run smoke:windows-computer
 
+  zenx-windows-packaged-provider-smoke:
+    name: ZenX Windows packaged bundled-provider smoke
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      WINAPP_CLI_UPDATE_CHECK: "0"
+      WINAPP_CLI_TELEMETRY_OPTOUT: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm --workspace apps/zenx run smoke:packaged
+
   zenx-windows-user-browser-smoke:
     name: ZenX Windows attached user-browser smoke
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 apps/zenx/out/
 apps/zenx/.smoke/
+apps/zenx/.packaged/
 node_modules/
 .zen/
 .env

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -91,6 +91,11 @@
   不进入 Zen Core，缺失或协议错误只显式诊断且绝不降级成全局输入注入。
 - **ZenXCapabilityProviderCatalog** — ZenX 产品层探测并诊断可选的成熟外部执行后端，按显式优先级选择
   Playwright、Peekaboo、WinApp 或适用平台的 bundled fallback；版本、权限与可用性只属于 host 配置和瞬时诊断，不进入 Zen Core。
+- **ZenXBrowserScreenshotArtifactStore** — ZenX provider 为一次最新 Browser observation 写入有界、短时、可清理的 PNG
+  artifact，并把 observation identity 与 artifact metadata 一起投影；文件是外部瞬时观测，不进入 Zen Core 或 durable journal。
+- **ZenXCapabilityLiveProjection** — ZenX 主进程把 capability invocation 的有界顺序状态与最新 Browser screenshot
+  投影给 renderer；它是可丢弃的 live UI 状态，canonical tool call/result 仍是唯一 durable execution history。
+- **ZenXBundledProviderProvisioning** — 打包 provider 只能由应用资源中的版本与 SHA-256 固定清单解析；缺失、离线或校验失败只产生可诊断的 unavailable 状态，不改写 Core 会话语义。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,6 +95,9 @@
   artifact，并把 observation identity 与 artifact metadata 一起投影；文件是外部瞬时观测，不进入 Zen Core 或 durable journal。
 - **ZenXCapabilityLiveProjection** — ZenX 主进程把 capability invocation 的有界顺序状态与最新 Browser screenshot
   投影给 renderer；它是可丢弃的 live UI 状态，canonical tool call/result 仍是唯一 durable execution history。
+- **ZenXCapabilityTransientReset** — ZenX 主进程在 App Server/settings restart、provider revoke 或 close 时单调使
+  capability live projection 与 provider-owned artifacts 失效并重建可重建 provider；它不改写 canonical ItemList、
+  grants 或 durable capability history，也不成为第二个 runtime/coordinator。
 - **ZenXBundledProviderProvisioning** — 打包 provider 只能由应用资源中的版本与 SHA-256 固定清单解析；缺失、离线或校验失败只产生可诊断的 unavailable 状态，不改写 Core 会话语义。
 - **ZenXPlaywrightSessionFence** — Playwright provider 在一个瞬时 CLI session 内串行执行操作，并用稳定 tab/document identity 与 lifecycle revision 围住选择、观察、截图、摘要和关闭；该 fence 不进入 Core 或 durable journal。
 - **ZenXProviderLaunchVerification** — 外部 provider 在实际 spawn 前再次验证绑定的 canonical executable、shim companion、manifest digest 与 pinned semantic version；失败只产生显式诊断，不自动改用未验证资产。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,6 +96,9 @@
 - **ZenXCapabilityLiveProjection** — ZenX 主进程把 capability invocation 的有界顺序状态与最新 Browser screenshot
   投影给 renderer；它是可丢弃的 live UI 状态，canonical tool call/result 仍是唯一 durable execution history。
 - **ZenXBundledProviderProvisioning** — 打包 provider 只能由应用资源中的版本与 SHA-256 固定清单解析；缺失、离线或校验失败只产生可诊断的 unavailable 状态，不改写 Core 会话语义。
+- **ZenXPlaywrightSessionFence** — Playwright provider 在一个瞬时 CLI session 内串行执行操作，并用稳定 tab/document identity 与 lifecycle revision 围住选择、观察、截图、摘要和关闭；该 fence 不进入 Core 或 durable journal。
+- **ZenXProviderLaunchVerification** — 外部 provider 在实际 spawn 前再次验证绑定的 canonical executable、shim companion、manifest digest 与 pinned semantic version；失败只产生显式诊断，不自动改用未验证资产。
+- **ZenXPackagedProviderSmoke** — ZenX 构建验证用真实 resources/providers manifest、asset hash、version pin 与 bundled-only catalog path 检查离线 packaged provisioning；它是一次性测试流程，不是运行时 coordinator 或 durable state。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -168,7 +168,7 @@ Command Line Tools. On Windows, ZenX selects an optional thin adapter over
 Microsoft's Public Preview `winapp` CLI 0.3.1 or newer. Install it explicitly with
 `winget install Microsoft.winappcli --source winget`; ZenX probes `winapp
 --version` plus a read-only JSON schema probe at startup and does not expose the
-provider when it is missing, too old, or schema-incompatible. The adapter resolves an exact title to one HWND with `ui list-windows
+provider when it is missing, too old, or schema-incompatible. Packaged builds use only an application-bundled, version-pinned, SHA-256-verified WinApp asset; missing or offline provisioning is reported explicitly. The adapter resolves an exact title to one HWND with `ui list-windows
 --json`, maps bounded `ui inspect --json` results to ZenX opaque observation IDs,
 uses UIA `invoke` / `set-value`, and captures with the default WGC/PrintWindow
 path. It never passes `--focus` or `--capture-screen` and never silently falls
@@ -177,10 +177,9 @@ output, errors, duration, and artifacts are bounded; cancellation terminates the
 child process, and screenshots expire after five minutes. Set-value completion is
 confirmed by WinApp CLI's bounded native `wait-for --value` assertion without
 projecting the value back to the Agent. WinApp CLI 0.3.1's
-inspect JSON does not expose a stable password-state field, so ZenX conservatively
-rejects controls whose control type, name, automation ID, or class name looks
-secret-bearing; regardless of that heuristic, all `computer_set_value` calls are
-explicitly non-secret-only because their text is journaled. Linux is currently
+inspect JSON does not expose a stable password-state field; ZenX sends all supplied
+text through the same ordinary UIA set-value path and leaves credential policy to
+the model, project, or host. Linux is currently
 unsupported for computer control.
 Full arbitrary GUI automation cannot always be background-safe; an isolated
 macOS/Windows session, VM, or remote host is the intended route to arbitrary
@@ -193,7 +192,7 @@ mature external implementations while retaining a runnable bundled baseline:
 
 - macOS now discovers an optional Peekaboo 3.x CLI and pins its JSON envelope,
   permission probe, snapshot and action assumptions. It uses a fresh exact-window
-  `see` before every semantic action, revalidates identity/security/actions, and
+  `see` before every semantic action, revalidates identity/actions, and
   invokes background `click` or `set-value` with the fresh snapshot and element
   IDs. Foreground pointer/key/scroll remains explicitly labeled. Missing,
   incompatible, or malformed Peekaboo installations produce terminal provider
@@ -214,11 +213,12 @@ mature external implementations while retaining a runnable bundled baseline:
   pinned to `>=0.1.0 <0.2.0`) and validates its `--json` version/list schema
   before selection. Its default headless session is reported as `isolated`, and
   every action re-snapshots and revalidates Playwright ref plus DOM
-  role/name/type/security/visibility/action fingerprint. Missing or incompatible
+  role/name/type/visibility/action fingerprint. Missing or incompatible
   CLI installations remain explicit in provider diagnostics and use the existing
-  bundled Chromium CDP ephemeral-partition provider. Install `@playwright/cli`
-  plus its browser separately or set `ZENX_PLAYWRIGHT_CLI`; user-session attachment
-  remains a separate explicit CDP provider. See <https://playwright.dev/agent-cli/introduction>
+  bundled Chromium CDP ephemeral-partition provider. Packaged builds accept only
+  the pinned resource manifest; development may use `@playwright/cli` or set
+  `ZENX_PLAYWRIGHT_CLI`. User-session attachment remains a separate explicit CDP
+  provider. See <https://playwright.dev/agent-cli/introduction>
   and <https://playwright.dev/docs/api/class-browsercontext>.
 - A future `isolated` interaction mode/provider can place arbitrary control in a
   VM, cloud desktop, or remote host. OSWorld's provider separation across
@@ -302,7 +302,7 @@ background-safe browser operations
 leave the real pointer position and foreground application unchanged. The macOS
 AX helper and foreground helper compile in that packaged run, but arbitrary
 third-party AX window/action smoke remains permission- and target-dependent; its
-opaque latest-observation and forged/stale/secure paths are unit-covered. The
+opaque latest-observation and forged/stale paths are unit-covered. The
 compiled helper enforces semantic fingerprint/geometry revalidation and rejects
 ambiguous matches, but that path is not claimed as a live third-party-app smoke.
 On Windows, `smoke:windows-computer` launches a deterministic WinForms fixture
@@ -313,7 +313,7 @@ inspection, UIA set-value with a bounded native value assertion, a post-action
 re-inspection, and WGC-default scoped capture without `--focus`
 or `--capture-screen`. GitHub CI runs that path on `windows-latest` with Microsoft's
 official setup action. The cross-platform fixture suite validates the same WinApp
-0.3.1 JSON mapping, conservative secure-control heuristic, stale target rejection,
+0.3.1 JSON mapping, stale target rejection,
 pre-action semantic revalidation, startup version/schema diagnostics,
 timeout/cancellation, output bounds, and exact-value error redaction when a
 Windows host is not available.

--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
             __dirname,
             "src/main/capability-smoke.ts",
           ),
+          "packaged-provider-smoke": resolve(
+            __dirname,
+            "src/main/packaged-provider-smoke.ts",
+          ),
           "real-smoke": resolve(__dirname, "src/main/real-smoke.ts"),
           "provider-smoke": resolve(__dirname, "src/main/provider-smoke.ts"),
         },

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -9,7 +9,7 @@
     "build": "electron-vite build",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "test": "tsx --test test/**/*.test.ts",
-    "smoke:capabilities": "npm run build && electron ./out/main/capability-smoke.js",
+    "smoke:capabilities": "npm run build && node ./out/main/packaged-provider-smoke.js && electron ./out/main/capability-smoke.js",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
     "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -9,7 +9,10 @@
     "build": "electron-vite build",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "test": "tsx --test test/**/*.test.ts",
-    "smoke:capabilities": "npm run build && node ./out/main/packaged-provider-smoke.js && electron ./out/main/capability-smoke.js",
+    "smoke:capabilities": "npm run smoke:packaged",
+    "smoke:unit-capabilities": "npm run build && electron ./out/main/capability-smoke.js",
+    "assemble:providers": "node ../../scripts/assemble-zenx-providers.mjs",
+    "smoke:packaged": "npm run build && node ./scripts/package-zenx-portable.mjs",
     "smoke:real": "npm run build && electron ./out/main/real-smoke.js",
     "smoke:windows-computer": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-winapp-smoke.ps1",
     "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",
@@ -22,6 +25,7 @@
     "ws": "^8.18.3"
   },
   "devDependencies": {
+    "@electron/packager": "^20.3.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/apps/zenx/resources/providers/README.md
+++ b/apps/zenx/resources/providers/README.md
@@ -1,0 +1,13 @@
+# ZenX bundled provider release inputs
+
+`provider-lock.json` is the release lock. The release assembly fetches only the
+listed official archives, verifies both npm SRI and SHA-256, extracts bounded
+assets, adds the pinned Node runtime, and writes the final `manifest.json`.
+The raw provider payloads are intentionally not committed; a release artifact
+must be reproducible offline after this deterministic provisioning step.
+
+The assembled artifact includes `LICENSE`/`THIRD_PARTY_NOTICES.txt`, provider
+versions, runtime version, platform, archive hashes, and the final manifest
+digest. Missing network, archive, runtime, browser payload, or integrity
+verification is an explicit build failure; there is no PATH fallback in bundled
+mode.

--- a/apps/zenx/resources/providers/README.md
+++ b/apps/zenx/resources/providers/README.md
@@ -11,3 +11,9 @@ versions, runtime version, platform, archive hashes, and the final manifest
 digest. Missing network, archive, runtime, browser payload, or integrity
 verification is an explicit build failure; there is no PATH fallback in bundled
 mode.
+
+The Playwright provider also records every shipped transitive package in
+`provider-lock.json` with its exact tarball URL, npm SRI, and SHA-256. Assembly
+validates npm's resolved entries against those pins and writes the deterministic
+`DEPENDENCY-LOCK.json`; npm's platform-specific generated lockfile is not the
+release trust anchor.

--- a/apps/zenx/resources/providers/provider-lock.json
+++ b/apps/zenx/resources/providers/provider-lock.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "node": {
+    "version": "22.23.2",
+    "releaseBase": "https://nodejs.org/dist/v22.23.2/",
+    "platformArchives": {
+      "win32-x64": {
+        "file": "node-v22.23.2-win-x64.zip",
+        "sha256": "1177b4137ba5adaa56354ae40f1080c7450e8ae09cecb47da459d1c52ac99f97"
+      },
+      "darwin-x64": {
+        "file": "node-v22.23.2-darwin-x64.tar.xz",
+        "sha256": "96dff79f4e19a78715da559ec7cac2028f4985a175ea0c3454625a269c21deb7"
+      },
+      "darwin-arm64": {
+        "file": "node-v22.23.2-darwin-arm64.tar.xz",
+        "sha256": "5eff7a9011895aae3f29d06f167b84a62b028a591370c7cafb59103559fd26e1"
+      },
+      "linux-x64": {
+        "file": "node-v22.23.2-linux-x64.tar.xz",
+        "sha256": "d60acfe00a2932254bb0ad20e01b0d74397a0875595de719654b214f4b03f307"
+      },
+      "linux-arm64": {
+        "file": "node-v22.23.2-linux-arm64.tar.xz",
+        "sha256": "fff4078c5def658577f92c88db7db3bc0072924bfb93fe52c1e744a54e94abb8"
+      }
+    }
+  },
+  "providers": {
+    "playwright-cli": {
+      "version": "0.1.18",
+      "tarball": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.18.tgz",
+      "integrity": "sha512-ggNfYYH+GsZTGUiBEL8f6N5j0seYEUE52v+fIWqK/A36QG36cL0EJ79qWTXYO2uZMUU7vm+jk3x0fKCPL6UuIw==",
+      "sha256": "d847190000e3a3328a17ab71a52ccac8062fb2525c0f0c78b789aff1cc9ab37c",
+      "dependencyLockSha256": "574ea395a1750ce62bca0711648dcec8f7618b65f70f5c3e11122462f5a93452",
+      "license": "Apache-2.0"
+    },
+    "microsoft-winapp-cli": {
+      "version": "0.3.1",
+      "tarball": "https://registry.npmjs.org/@microsoft/winappcli/-/winappcli-0.3.1.tgz",
+      "integrity": "sha512-zXwHOmz71VyTdURBn21KrFpMlXf98KtWTEea68hsa25b7dTDP4BL8SnvYLmIoSjlBlIkl2viMxWDEq67maUm8w==",
+      "sha256": "3c2f3a8488b9a49b7bed60f5e6c7e74713c895d9c36c605a5524999d67435196",
+      "license": "MIT"
+    }
+  }
+}

--- a/apps/zenx/resources/providers/provider-lock.json
+++ b/apps/zenx/resources/providers/provider-lock.json
@@ -32,7 +32,23 @@
       "tarball": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.18.tgz",
       "integrity": "sha512-ggNfYYH+GsZTGUiBEL8f6N5j0seYEUE52v+fIWqK/A36QG36cL0EJ79qWTXYO2uZMUU7vm+jk3x0fKCPL6UuIw==",
       "sha256": "d847190000e3a3328a17ab71a52ccac8062fb2525c0f0c78b789aff1cc9ab37c",
-      "dependencyLockSha256": "654de4ecdbc802b7c3ffe0f3c87af12c00f7c529d7a47638fd96d3e781874fe0",
+      "dependencyLockSha256": "a189f28b427091e7d4fed311c1bc4d22f1c87e3aeca49872974c86d9331a3d1c",
+      "transitive": [
+        {
+          "name": "playwright",
+          "version": "1.63.0-alpha-2026-08-05",
+          "tarball": "https://registry.npmjs.org/playwright/-/playwright-1.63.0-alpha-2026-08-05.tgz",
+          "integrity": "sha512-zbGZUK+JYkoDV3cUgfvh2czTBJL34Gmz5gHVI25xiIpvYSR17Q1M7TS8hnwECUe+IkKaeXbKrSyJTyogm2DVWw==",
+          "sha256": "9773b64c75611e334b7fee196f6559468e1fd8252a18f8966f97d74e4c4b1d96"
+        },
+        {
+          "name": "playwright-core",
+          "version": "1.63.0-alpha-2026-08-05",
+          "tarball": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0-alpha-2026-08-05.tgz",
+          "integrity": "sha512-YussvUybTfBtyYbGXWh43f+5kNP03wg98M6mu4DphYET7PSbNVajsdLGjWE1xrsjqOw32i2wFlRP7U5mcOpMZg==",
+          "sha256": "774c5addbf5772c42ebeabebe3b380d3f47fc4e3e9f6b94508317147a947122b"
+        }
+      ],
       "license": "Apache-2.0"
     },
     "microsoft-winapp-cli": {

--- a/apps/zenx/resources/providers/provider-lock.json
+++ b/apps/zenx/resources/providers/provider-lock.json
@@ -32,7 +32,7 @@
       "tarball": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.18.tgz",
       "integrity": "sha512-ggNfYYH+GsZTGUiBEL8f6N5j0seYEUE52v+fIWqK/A36QG36cL0EJ79qWTXYO2uZMUU7vm+jk3x0fKCPL6UuIw==",
       "sha256": "d847190000e3a3328a17ab71a52ccac8062fb2525c0f0c78b789aff1cc9ab37c",
-      "dependencyLockSha256": "34389dca07a448235ebc51f22d301f352264e0e00e7ead8a5cbcac5f391a0035",
+      "dependencyLockSha256": "654de4ecdbc802b7c3ffe0f3c87af12c00f7c529d7a47638fd96d3e781874fe0",
       "license": "Apache-2.0"
     },
     "microsoft-winapp-cli": {

--- a/apps/zenx/resources/providers/provider-lock.json
+++ b/apps/zenx/resources/providers/provider-lock.json
@@ -32,7 +32,7 @@
       "tarball": "https://registry.npmjs.org/@playwright/cli/-/cli-0.1.18.tgz",
       "integrity": "sha512-ggNfYYH+GsZTGUiBEL8f6N5j0seYEUE52v+fIWqK/A36QG36cL0EJ79qWTXYO2uZMUU7vm+jk3x0fKCPL6UuIw==",
       "sha256": "d847190000e3a3328a17ab71a52ccac8062fb2525c0f0c78b789aff1cc9ab37c",
-      "dependencyLockSha256": "574ea395a1750ce62bca0711648dcec8f7618b65f70f5c3e11122462f5a93452",
+      "dependencyLockSha256": "34389dca07a448235ebc51f22d301f352264e0e00e7ead8a5cbcac5f391a0035",
       "license": "Apache-2.0"
     },
     "microsoft-winapp-cli": {

--- a/apps/zenx/scripts/package-zenx-portable.mjs
+++ b/apps/zenx/scripts/package-zenx-portable.mjs
@@ -1,0 +1,128 @@
+import { execFile, spawn } from "node:child_process";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const run = promisify(execFile);
+const zenx = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const root = path.resolve(zenx, "..", "..");
+const out = path.join(zenx, "out");
+const resources = path.join(zenx, ".packaged", "resources");
+const staging = await mkdtemp(path.join(os.tmpdir(), "zenx-packaged-smoke-"));
+const appDir = path.join(staging, "app");
+
+try {
+  const assembly = JSON.parse(
+    (
+      await run(process.execPath, [
+        path.join(root, "scripts", "assemble-zenx-providers.mjs"),
+        "--output",
+        resources,
+      ])
+    ).stdout,
+  );
+  const mainOut = path.join(out, "main");
+  for (const file of await walk(mainOut)) {
+    if (!file.endsWith(".js")) continue;
+    const source = await readFile(file, "utf8");
+    if (source.includes("__ZENX_PACKAGED_PROVIDER_MANIFEST_SHA256__")) {
+      await writeFile(
+        file,
+        source.replaceAll(
+          "__ZENX_PACKAGED_PROVIDER_MANIFEST_SHA256__",
+          assembly.manifestSha256,
+        ),
+      );
+    }
+  }
+  await cp(mainOut, path.join(appDir, "main"), { recursive: true });
+  await writeFile(
+    path.join(appDir, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "zenx-packaged-provider-smoke",
+        version: "0.1.0",
+        private: true,
+        type: "module",
+        main: "main/packaged-provider-smoke.js",
+      },
+      null,
+    )}\n`,
+  );
+  const { packager } = await import("@electron/packager");
+  const packaged = await packager({
+    dir: appDir,
+    out: path.join(zenx, ".packaged", "artifact"),
+    overwrite: true,
+    platform: process.platform,
+    arch: process.arch,
+    name: "ZenXProviderSmoke",
+    electronVersion: "43.2.0",
+    extraResource: [path.join(resources, "providers")],
+    asar: false,
+  });
+  const executable = executablePath(packaged[0]);
+  console.log(
+    JSON.stringify(
+      {
+        packagedArtifact: packaged[0],
+        executable,
+        manifestDigest: assembly.manifestSha256,
+        releaseSizeBytes: assembly.releaseSizeBytes,
+      },
+      null,
+      2,
+    ),
+  );
+  await runExecutable(executable);
+} finally {
+  await rm(staging, { recursive: true, force: true });
+}
+
+async function walk(rootDir) {
+  const result = [];
+  const { readdir } = await import("node:fs/promises");
+  for (const entry of await readdir(rootDir, { withFileTypes: true })) {
+    const candidate = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) result.push(...(await walk(candidate)));
+    else result.push(candidate);
+  }
+  return result;
+}
+
+function executablePath(appPath) {
+  if (process.platform === "win32")
+    return path.join(appPath, "ZenXProviderSmoke.exe");
+  if (process.platform === "darwin") {
+    return path.join(
+      appPath,
+      "ZenXProviderSmoke.app",
+      "Contents",
+      "MacOS",
+      "ZenXProviderSmoke",
+    );
+  }
+  return path.join(appPath, "ZenXProviderSmoke");
+}
+
+async function runExecutable(executable) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(executable, [], {
+      stdio: "inherit",
+      windowsHide: true,
+      env: { ...process.env, ZENX_PACKAGED_SMOKE: "1" },
+    });
+    child.once("error", reject);
+    child.once("exit", (code, signal) =>
+      code === 0
+        ? resolve()
+        : reject(
+            new Error(
+              `packaged provider smoke exited ${String(code)} ${signal ?? ""}`,
+            ),
+          ),
+    );
+  });
+}

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -1,5 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { chmod, lstat, mkdir, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  constants,
+  lstat,
+  mkdir,
+  open,
+  realpath,
+  rm,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { inflateSync } from "node:zlib";
@@ -363,6 +371,7 @@ export const MAX_BROWSER_SCREENSHOT_BYTES = 4 * 1024 * 1024;
 export const BROWSER_SCREENSHOT_TTL_MS = 5 * 60_000;
 export const MAX_BROWSER_SCREENSHOT_ARTIFACTS = 16;
 export const MAX_BROWSER_SCREENSHOT_TOTAL_BYTES = 16 * 1024 * 1024;
+export const MAX_BROWSER_SCREENSHOT_SCOPES = 256;
 const MAX_BROWSER_SCREENSHOT_WIDTH = 4096;
 const MAX_BROWSER_SCREENSHOT_HEIGHT = 4096;
 const MAX_BROWSER_SCREENSHOT_PIXELS = 16 * 1024 * 1024;
@@ -388,6 +397,8 @@ export class BrowserScreenshotArtifactStore {
   #closed = false;
   #totalBytes = 0;
   #operations: Promise<void> = Promise.resolve();
+  #generation = 0;
+  readonly #scopeGenerations = new Map<string, number>();
 
   constructor(directory?: string) {
     this.#rootDirectory =
@@ -406,9 +417,16 @@ export class BrowserScreenshotArtifactStore {
     png: Buffer,
     options: { status?: "captured" | "fallback"; reason?: string } = {},
   ): Promise<BrowserScreenshotArtifact> {
+    const generation = this.#generation;
+    const scopeGeneration = this.#scopeGeneration(scope);
     return await this.#enqueue(async () => {
-      if (this.#closed) {
+      if (this.#closed || generation !== this.#generation) {
         throw new Error("Browser screenshot artifact store is closed");
+      }
+      if (scopeGeneration !== this.#scopeGeneration(scope)) {
+        throw new Error(
+          "Browser screenshot observation scope is no longer current",
+        );
       }
       if (png.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) {
         throw new Error(
@@ -420,6 +438,7 @@ export class BrowserScreenshotArtifactStore {
         await this.#ensureOwnedDirectory();
         this.#directoryCreated = true;
       }
+      await this.#assertOwnedDirectory();
       if (
         png.byteLength > MAX_BROWSER_SCREENSHOT_TOTAL_BYTES ||
         this.#artifacts.size >= MAX_BROWSER_SCREENSHOT_ARTIFACTS ||
@@ -428,8 +447,37 @@ export class BrowserScreenshotArtifactStore {
         await this.#evictFor(png.byteLength);
       }
       const artifactPath = path.join(this.#directory, `${randomUUID()}.png`);
-      await writeFile(artifactPath, png, { mode: 0o600 });
-      if (this.#closed) {
+      if (
+        this.#closed ||
+        generation !== this.#generation ||
+        scopeGeneration !== this.#scopeGeneration(scope)
+      ) {
+        throw new Error(
+          "Browser screenshot artifact store was closed during capture",
+        );
+      }
+      const openFlags =
+        constants.O_WRONLY |
+        constants.O_CREAT |
+        constants.O_EXCL |
+        (process.platform === "win32" ? 0 : constants.O_NOFOLLOW);
+      const handle = await open(artifactPath, openFlags, 0o600);
+      try {
+        await this.#assertOwnedDirectory();
+        await handle.writeFile(png);
+        const written = await handle.stat();
+        if (!written.isFile() || written.size !== png.byteLength) {
+          throw new Error("Browser screenshot artifact write was not complete");
+        }
+      } finally {
+        await handle.close();
+      }
+      await this.#assertOwnedDirectory();
+      if (
+        this.#closed ||
+        generation !== this.#generation ||
+        scopeGeneration !== this.#scopeGeneration(scope)
+      ) {
         await rm(artifactPath, { force: true });
         throw new Error("Browser screenshot artifact store is closed");
       }
@@ -471,6 +519,7 @@ export class BrowserScreenshotArtifactStore {
   }
 
   async clearScope(scope: string): Promise<void> {
+    this.#incrementScopeGeneration(scope);
     await this.#enqueue(async () => {
       const paths = [...this.#artifacts.entries()]
         .filter(
@@ -485,9 +534,9 @@ export class BrowserScreenshotArtifactStore {
   }
 
   async close(): Promise<void> {
+    this.#closed = true;
+    this.#generation += 1;
     await this.#enqueue(async () => {
-      if (this.#closed) return;
-      this.#closed = true;
       for (const artifact of this.#artifacts.values())
         clearTimeout(artifact.timer);
       const paths = [...this.#artifacts.keys()];
@@ -550,6 +599,56 @@ export class BrowserScreenshotArtifactStore {
       );
     }
     await chmod(this.#directory, 0o700);
+    await this.#assertOwnedDirectory();
+  }
+
+  async #assertOwnedDirectory(): Promise<void> {
+    if (!this.#directoryCreated && !this.#directory) return;
+    const root = await lstat(this.#rootDirectory);
+    const child = await lstat(this.#directory);
+    if (
+      !root.isDirectory() ||
+      root.isSymbolicLink() ||
+      !child.isDirectory() ||
+      child.isSymbolicLink()
+    ) {
+      throw new Error(
+        "Browser screenshot artifact directory ownership changed",
+      );
+    }
+    const [rootRealPath, childRealPath] = await Promise.all([
+      realpath(this.#rootDirectory),
+      realpath(this.#directory),
+    ]);
+    if (!isWithin(rootRealPath, childRealPath)) {
+      throw new Error(
+        "Browser screenshot artifact directory escaped its owner",
+      );
+    }
+  }
+
+  #scopeGeneration(scope: string): string {
+    return [...this.#scopeGenerations.entries()]
+      .filter(
+        ([candidate]) =>
+          scope === candidate || scope.startsWith(`${candidate}/`),
+      )
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([candidate, generation]) => `${candidate}:${String(generation)}`)
+      .join("|");
+  }
+
+  #incrementScopeGeneration(scope: string): void {
+    if (
+      !this.#scopeGenerations.has(scope) &&
+      this.#scopeGenerations.size >= MAX_BROWSER_SCREENSHOT_SCOPES
+    ) {
+      throw new Error("Browser screenshot scope lifecycle bound exceeded");
+    }
+    this.#scopeGenerations.set(
+      scope,
+      (this.#scopeGenerations.get(scope) ?? 0) + 1,
+    );
   }
 
   async #evictFor(bytes: number): Promise<void> {
@@ -1122,12 +1221,16 @@ function safeBrowserUrl(raw: string): string {
 
 export function redactBrowserUrl(raw: string): string {
   if (raw.length === 0) return "";
-  const url = new URL(raw);
-  url.username = "";
-  url.password = "";
-  url.hash = "";
-  url.search = "";
-  return url.toString().slice(0, 2048);
+  try {
+    const url = new URL(raw);
+    url.username = "";
+    url.password = "";
+    url.hash = "";
+    url.search = "";
+    return url.toString().slice(0, 2048);
+  } catch {
+    return "[malformed-url]";
+  }
 }
 
 function pngDimensions(buffer: Buffer): { width: number; height: number } {
@@ -1149,8 +1252,14 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
   let sawImageData = false;
   let paletteEntries = 0;
   let sawTransparency = false;
+  let sawPostImageData = false;
+  let chunkCount = 0;
   const idat: Buffer[] = [];
   while (offset < buffer.length) {
+    chunkCount += 1;
+    if (chunkCount > 1024) {
+      throw new Error("Browser screenshot PNG has too many chunks");
+    }
     if (offset + 12 > buffer.length) {
       throw new Error("Browser screenshot PNG is truncated");
     }
@@ -1170,6 +1279,17 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
       throw new Error("Browser screenshot PNG chunk CRC is invalid");
     }
     const name = type.toString("ascii");
+    if (!/^[A-Za-z]{4}$/u.test(name)) {
+      throw new Error("Browser screenshot PNG chunk type is invalid");
+    }
+    if (
+      (type[0]! & 0x20) === 0 &&
+      !["IHDR", "PLTE", "IDAT", "IEND"].includes(name)
+    ) {
+      throw new Error(
+        `Browser screenshot PNG has an unknown critical chunk ${name}`,
+      );
+    }
     if (!sawHeader && name !== "IHDR") {
       throw new Error("Browser screenshot PNG must begin with IHDR");
     }
@@ -1197,14 +1317,25 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
       }
       interlace = data[12]!;
     } else if (name === "IDAT") {
-      if (!sawHeader || ended)
+      if (!sawHeader || ended || sawPostImageData)
         throw new Error("Browser screenshot PNG IDAT is invalid");
       sawImageData = true;
       sawData = true;
       idat.push(data);
     } else if (name === "PLTE") {
-      if (sawImageData || length === 0 || length % 3 !== 0 || length > 768) {
+      if (
+        sawImageData ||
+        sawPalette ||
+        length === 0 ||
+        length % 3 !== 0 ||
+        length > 768
+      ) {
         throw new Error("Browser screenshot PNG palette is invalid");
+      }
+      if (colorType === 0 || colorType === 4) {
+        throw new Error(
+          "Browser screenshot PNG palette is invalid for this color type",
+        );
       }
       sawPalette = true;
       paletteEntries = length / 3;
@@ -1212,7 +1343,7 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
       if (
         sawImageData ||
         sawTransparency ||
-        (colorType !== 3 && colorType !== 0)
+        (colorType !== 3 && colorType !== 0 && colorType !== 2)
       ) {
         throw new Error("Browser screenshot PNG transparency is invalid");
       }
@@ -1220,11 +1351,21 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
       if (colorType === 3 && (!sawPalette || length > paletteEntries)) {
         throw new Error("Browser screenshot PNG transparency is invalid");
       }
+      if (colorType === 0 && length !== 2) {
+        throw new Error(
+          "Browser screenshot PNG grayscale transparency is invalid",
+        );
+      }
+      if (colorType === 2 && length !== 6) {
+        throw new Error("Browser screenshot PNG RGB transparency is invalid");
+      }
     } else if (name === "IEND") {
       if (!sawHeader || !sawData || length !== 0) {
         throw new Error("Browser screenshot PNG IEND is invalid");
       }
       ended = true;
+    } else if (sawImageData) {
+      sawPostImageData = true;
     }
     offset = crcEnd;
     if (ended) break;
@@ -1404,6 +1545,14 @@ function isMissingPathError(error: unknown): boolean {
     error !== null &&
     "code" in error &&
     (error as { code?: unknown }).code === "ENOENT"
+  );
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
   );
 }
 

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import type { BrowserWindow, Session } from "electron";
 
@@ -17,14 +20,23 @@ export interface BrowserInspection extends BrowserTabSummary {
   observationId: string;
   documentVersion: number;
   visibleText: string;
+  screenshot: BrowserScreenshotArtifact;
   targets: Array<{
     targetId: string;
     role: string;
     name: string;
     actions: Array<"click" | "type">;
-    secure?: true;
     value?: string;
   }>;
+}
+
+export interface BrowserScreenshotArtifact {
+  artifactPath: string;
+  observationId: string;
+  width: number;
+  height: number;
+  bytes: number;
+  expiresAt: string;
 }
 
 export interface ZenXBrowserBackend {
@@ -332,7 +344,6 @@ export interface BrowserTargetFingerprint {
   fieldName: string;
   autocomplete: string;
   href: string;
-  secure: boolean;
   actions: Array<"click" | "type">;
   value?: string;
 }
@@ -345,13 +356,111 @@ export interface BrowserObservation {
 
 export const MAX_BROWSER_TABS_PER_SESSION = 8;
 export const MAX_BROWSER_TABS_GLOBAL = 24;
+export const MAX_BROWSER_SCREENSHOT_BYTES = 4 * 1024 * 1024;
+export const BROWSER_SCREENSHOT_TTL_MS = 5 * 60_000;
+
+/** Temporary provider-owned PNGs; no screenshot bytes are part of the journal. */
+export class BrowserScreenshotArtifactStore {
+  readonly #directory: string;
+  readonly #artifacts = new Map<
+    string,
+    { scope: string; timer: NodeJS.Timeout }
+  >();
+  #directoryCreated = false;
+  #closed = false;
+
+  constructor(
+    directory = path.join(
+      os.tmpdir(),
+      `zenx-browser-artifacts-${String(process.pid)}-${randomUUID()}`,
+    ),
+  ) {
+    this.#directory = directory;
+  }
+
+  async write(
+    scope: string,
+    observationId: string,
+    png: Buffer,
+  ): Promise<BrowserScreenshotArtifact> {
+    if (this.#closed) {
+      throw new Error("Browser screenshot artifact store is closed");
+    }
+    const dimensions = pngDimensions(png);
+    if (png.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) {
+      throw new Error(
+        `Browser screenshot exceeded the ${String(MAX_BROWSER_SCREENSHOT_BYTES)} byte bound`,
+      );
+    }
+    if (!this.#directoryCreated) {
+      await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+      this.#directoryCreated = true;
+    }
+    const artifactPath = path.join(this.#directory, `${randomUUID()}.png`);
+    await writeFile(artifactPath, png, { mode: 0o600 });
+    const expiresAt = new Date(Date.now() + BROWSER_SCREENSHOT_TTL_MS);
+    const timer = setTimeout(() => {
+      this.#artifacts.delete(artifactPath);
+      void rm(artifactPath, { force: true });
+    }, BROWSER_SCREENSHOT_TTL_MS);
+    timer.unref();
+    this.#artifacts.set(artifactPath, { scope, timer });
+    return {
+      artifactPath,
+      observationId,
+      width: dimensions.width,
+      height: dimensions.height,
+      bytes: png.byteLength,
+      expiresAt: expiresAt.toISOString(),
+    };
+  }
+
+  async clearScope(scope: string): Promise<void> {
+    const paths = [...this.#artifacts.entries()]
+      .filter(
+        ([, artifact]) =>
+          artifact.scope === scope || artifact.scope.startsWith(`${scope}/`),
+      )
+      .map(([artifactPath]) => artifactPath);
+    await Promise.all(paths.map((artifactPath) => this.#remove(artifactPath)));
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    for (const timer of this.#artifacts.values()) clearTimeout(timer.timer);
+    const paths = [...this.#artifacts.keys()];
+    this.#artifacts.clear();
+    await Promise.all(
+      paths.map((artifactPath) => rm(artifactPath, { force: true })),
+    );
+    if (this.#directoryCreated) {
+      await rm(this.#directory, { recursive: true, force: true });
+      this.#directoryCreated = false;
+    }
+  }
+
+  async #remove(artifactPath: string): Promise<void> {
+    const artifact = this.#artifacts.get(artifactPath);
+    if (artifact === undefined) return;
+    clearTimeout(artifact.timer);
+    this.#artifacts.delete(artifactPath);
+    await rm(artifactPath, { force: true });
+  }
+}
 
 export class ElectronBrowserBackend implements ZenXBrowserBackend {
   readonly #tabs = new Map<string, BrowserTab>();
   readonly #sessions = new Map<string, BrowserSessionIncarnation>();
+  readonly #artifacts: BrowserScreenshotArtifactStore;
   #pendingGlobal = 0;
   #nextSessionGeneration = 1;
   #closing = false;
+
+  constructor(options: { artifactDirectory?: string } = {}) {
+    this.#artifacts = new BrowserScreenshotArtifactStore(
+      options.artifactDirectory,
+    );
+  }
 
   async listTabs(sessionId: string): Promise<BrowserTabSummary[]> {
     assertTargetId(sessionId, "sessionId");
@@ -437,11 +546,19 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
 
   async inspect(sessionId: string, tabId: string): Promise<BrowserInspection> {
     const tab = this.#requireTab(sessionId, tabId);
+    const documentVersion = tab.documentVersion;
     const inspected = await evaluateInTab<{
       visibleText: string;
       targets: BrowserTargetFingerprint[];
     }>(tab, browserInspectScript);
     const observationId = randomUUID();
+    const screenshot = await this.#captureScreenshot(tab, observationId);
+    if (tab.documentVersion !== documentVersion) {
+      await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
+      throw new Error(
+        "Browser document changed during inspection; inspect again",
+      );
+    }
     const targets = new Map<string, BrowserTargetFingerprint>();
     const projectedTargets = inspected.targets.slice(0, 80).map((target) => {
       const targetId = randomUUID();
@@ -451,7 +568,6 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
         role: target.role,
         name: target.name,
         actions: [...target.actions],
-        ...(target.secure ? { secure: true as const } : {}),
         ...(target.value === undefined ? {} : { value: target.value }),
       };
     });
@@ -465,6 +581,7 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
       observationId,
       documentVersion: tab.documentVersion,
       visibleText: inspected.visibleText.slice(0, 8_000),
+      screenshot,
       targets: projectedTargets,
     };
   }
@@ -525,12 +642,13 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     return summarizeTab(tab);
   }
 
-  closeTab(sessionId: string, tabId: string): void {
+  async closeTab(sessionId: string, tabId: string): Promise<void> {
     const tab = this.#requireTab(sessionId, tabId);
     tab.observation = undefined;
     this.#tabs.delete(tabId);
     if (!tab.window.isDestroyed()) tab.window.destroy();
     this.#releaseIncarnation(sessionId, tab.incarnation);
+    await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
   }
 
   async closeSession(sessionId: string): Promise<number> {
@@ -544,8 +662,9 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     const electronSessions = new Set(
       tabs.map((tab) => tab.window.webContents.session),
     );
-    for (const tab of tabs) this.closeTab(sessionId, tab.tabId);
+    await Promise.all(tabs.map((tab) => this.closeTab(sessionId, tab.tabId)));
     await Promise.all([...electronSessions].map(clearElectronSession));
+    await this.#artifacts.clearScope(sessionId);
     return tabs.length;
   }
 
@@ -564,6 +683,32 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     }
     this.#tabs.clear();
     await Promise.all([...electronSessions].map(clearElectronSession));
+    await this.#artifacts.close();
+  }
+
+  async #captureScreenshot(
+    tab: BrowserTab,
+    observationId: string,
+  ): Promise<BrowserScreenshotArtifact> {
+    const image = await tab.window.webContents.capturePage();
+    let png = image.toPNG();
+    if (png.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) {
+      const size = image.getSize();
+      const scale = Math.sqrt(MAX_BROWSER_SCREENSHOT_BYTES / png.byteLength);
+      if (scale < 1 && size.width > 1 && size.height > 1) {
+        png = image
+          .resize({
+            width: Math.max(1, Math.floor(size.width * scale)),
+            height: Math.max(1, Math.floor(size.height * scale)),
+          })
+          .toPNG();
+      }
+    }
+    return await this.#artifacts.write(
+      `${tab.sessionId}/${tab.tabId}`,
+      observationId,
+      png,
+    );
   }
 
   #requireTab(sessionId: string, tabId: string): BrowserTab {
@@ -688,10 +833,6 @@ export const browserInspectScript = `(() => {
     return !element.hidden && style.visibility !== "hidden" && style.display !== "none" && Number(style.opacity) !== 0 && rect.width > 0 && rect.height > 0 && rect.bottom > 0 && rect.right > 0 && rect.top < innerHeight && rect.left < innerWidth;
   };
   const name = (element) => (element.getAttribute("aria-label") ?? element.getAttribute("placeholder") ?? element.textContent ?? "").replace(/\\s+/g, " ").trim().slice(0, 160);
-  const secure = (element) => element instanceof HTMLInputElement && (
-    element.type.toLowerCase() === "password" ||
-    ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
-  );
   const typeable = (element) => {
     if (element.hasAttribute("disabled") || element.hasAttribute("readonly")) return false;
     if (element instanceof HTMLTextAreaElement) return true;
@@ -721,7 +862,6 @@ export const browserInspectScript = `(() => {
   return {
     visibleText: (document.body?.innerText ?? "").replace(/\\s+/g, " ").trim().slice(0, 8000),
     targets: elements.map((element) => {
-      const isSecure = secure(element);
       const actions = [];
       if (clickable(element)) actions.push("click");
       if (typeable(element)) actions.push("type");
@@ -735,7 +875,6 @@ export const browserInspectScript = `(() => {
         fieldName: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.name : "",
         autocomplete: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.autocomplete : "",
         href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
-        secure: isSecure,
         actions,
       };
     }),
@@ -757,7 +896,6 @@ export function browserActionScript(
     fieldName: target.fieldName,
     autocomplete: target.autocomplete,
     href: target.href,
-    secure: target.secure,
   });
   return `(() => {
     const expected = ${expected};
@@ -772,10 +910,6 @@ export function browserActionScript(
     const style = getComputedStyle(element);
     const rect = element.getBoundingClientRect();
     if (element.hidden || style.visibility === "hidden" || style.display === "none" || Number(style.opacity) === 0 || rect.width <= 0 || rect.height <= 0 || rect.bottom <= 0 || rect.right <= 0 || rect.top >= innerHeight || rect.left >= innerWidth) return { ok: false, reason: "not-visible" };
-    const secure = element instanceof HTMLInputElement && (
-      element.type.toLowerCase() === "password" ||
-      ["current-password", "new-password", "one-time-code"].includes(element.autocomplete.toLowerCase())
-    );
     const actual = {
       tag: element.tagName.toLowerCase(),
       role: element.getAttribute("role") ?? element.tagName.toLowerCase(),
@@ -785,7 +919,6 @@ export function browserActionScript(
       fieldName: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.name : "",
       autocomplete: element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement ? element.autocomplete : "",
       href: element instanceof HTMLAnchorElement ? element.getAttribute("href") ?? "" : "",
-      secure,
     };
     if (JSON.stringify(actual) !== JSON.stringify(expected)) return { ok: false, reason: "identity-changed" };
     if (action === "click") {
@@ -848,18 +981,6 @@ function safeBrowserUrl(raw: string): string {
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error("ZenX browser only opens http(s) URLs");
   }
-  if (url.username.length > 0 || url.password.length > 0) {
-    throw new Error("ZenX browser URLs must not contain credentials");
-  }
-  for (const key of url.searchParams.keys()) {
-    if (
-      /(?:auth|code|credential|key|password|secret|session|token)/iu.test(key)
-    ) {
-      throw new Error(
-        `ZenX browser URL contains sensitive query parameter ${key}`,
-      );
-    }
-  }
   return url.toString();
 }
 
@@ -869,14 +990,25 @@ export function redactBrowserUrl(raw: string): string {
   url.username = "";
   url.password = "";
   url.hash = "";
-  for (const key of [...url.searchParams.keys()]) {
-    if (
-      /(?:auth|code|credential|key|password|secret|session|token)/iu.test(key)
-    ) {
-      url.searchParams.set(key, "[REDACTED]");
-    }
-  }
+  url.search = "";
   return url.toString().slice(0, 2048);
+}
+
+function pngDimensions(buffer: Buffer): { width: number; height: number } {
+  if (
+    buffer.length < 24 ||
+    !buffer
+      .subarray(0, 8)
+      .equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+  ) {
+    throw new Error("Browser screenshot is not a valid PNG");
+  }
+  const width = buffer.readUInt32BE(16);
+  const height = buffer.readUInt32BE(20);
+  if (width <= 0 || height <= 0) {
+    throw new Error("Browser screenshot dimensions are invalid");
+  }
+  return { width, height };
 }
 
 function requiredTargetId(

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { inflateSync } from "node:zlib";
 
 import type { BrowserWindow, Session } from "electron";
 
@@ -33,6 +34,8 @@ export interface BrowserInspection extends BrowserTabSummary {
 export interface BrowserScreenshotArtifact {
   artifactPath: string;
   observationId: string;
+  status: "captured" | "fallback";
+  reason?: string;
   width: number;
   height: number;
   bytes: number;
@@ -358,16 +361,20 @@ export const MAX_BROWSER_TABS_PER_SESSION = 8;
 export const MAX_BROWSER_TABS_GLOBAL = 24;
 export const MAX_BROWSER_SCREENSHOT_BYTES = 4 * 1024 * 1024;
 export const BROWSER_SCREENSHOT_TTL_MS = 5 * 60_000;
+const MAX_BROWSER_SCREENSHOT_WIDTH = 4096;
+const MAX_BROWSER_SCREENSHOT_HEIGHT = 4096;
+const MAX_BROWSER_SCREENSHOT_PIXELS = 16 * 1024 * 1024;
 
 /** Temporary provider-owned PNGs; no screenshot bytes are part of the journal. */
 export class BrowserScreenshotArtifactStore {
   readonly #directory: string;
   readonly #artifacts = new Map<
     string,
-    { scope: string; timer: NodeJS.Timeout }
+    { scope: string; observationId: string; timer: NodeJS.Timeout }
   >();
   #directoryCreated = false;
   #closed = false;
+  #operations: Promise<void> = Promise.resolve();
 
   constructor(
     directory = path.join(
@@ -382,69 +389,106 @@ export class BrowserScreenshotArtifactStore {
     scope: string,
     observationId: string,
     png: Buffer,
+    options: { status?: "captured" | "fallback"; reason?: string } = {},
   ): Promise<BrowserScreenshotArtifact> {
-    if (this.#closed) {
-      throw new Error("Browser screenshot artifact store is closed");
-    }
-    const dimensions = pngDimensions(png);
-    if (png.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) {
-      throw new Error(
-        `Browser screenshot exceeded the ${String(MAX_BROWSER_SCREENSHOT_BYTES)} byte bound`,
-      );
-    }
-    if (!this.#directoryCreated) {
-      await mkdir(this.#directory, { recursive: true, mode: 0o700 });
-      this.#directoryCreated = true;
-    }
-    const artifactPath = path.join(this.#directory, `${randomUUID()}.png`);
-    await writeFile(artifactPath, png, { mode: 0o600 });
-    const expiresAt = new Date(Date.now() + BROWSER_SCREENSHOT_TTL_MS);
-    const timer = setTimeout(() => {
-      this.#artifacts.delete(artifactPath);
-      void rm(artifactPath, { force: true });
-    }, BROWSER_SCREENSHOT_TTL_MS);
-    timer.unref();
-    this.#artifacts.set(artifactPath, { scope, timer });
-    return {
-      artifactPath,
-      observationId,
-      width: dimensions.width,
-      height: dimensions.height,
-      bytes: png.byteLength,
-      expiresAt: expiresAt.toISOString(),
-    };
+    return await this.#enqueue(async () => {
+      if (this.#closed) {
+        throw new Error("Browser screenshot artifact store is closed");
+      }
+      if (png.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) {
+        throw new Error(
+          `Browser screenshot exceeded the ${String(MAX_BROWSER_SCREENSHOT_BYTES)} byte bound`,
+        );
+      }
+      const dimensions = pngDimensions(png);
+      if (!this.#directoryCreated) {
+        await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+        this.#directoryCreated = true;
+      }
+      const artifactPath = path.join(this.#directory, `${randomUUID()}.png`);
+      await writeFile(artifactPath, png, { mode: 0o600 });
+      if (this.#closed) {
+        await rm(artifactPath, { force: true });
+        throw new Error("Browser screenshot artifact store is closed");
+      }
+      const expiresAt = new Date(Date.now() + BROWSER_SCREENSHOT_TTL_MS);
+      const timer = setTimeout(() => {
+        void this.removeArtifact(artifactPath, observationId);
+      }, BROWSER_SCREENSHOT_TTL_MS);
+      timer.unref();
+      this.#artifacts.set(artifactPath, { scope, observationId, timer });
+      return {
+        artifactPath,
+        observationId,
+        status: options.status ?? "captured",
+        ...(options.reason === undefined ? {} : { reason: options.reason }),
+        width: dimensions.width,
+        height: dimensions.height,
+        bytes: png.byteLength,
+        expiresAt: expiresAt.toISOString(),
+      };
+    });
   }
 
   async clearScope(scope: string): Promise<void> {
-    const paths = [...this.#artifacts.entries()]
-      .filter(
-        ([, artifact]) =>
-          artifact.scope === scope || artifact.scope.startsWith(`${scope}/`),
-      )
-      .map(([artifactPath]) => artifactPath);
-    await Promise.all(paths.map((artifactPath) => this.#remove(artifactPath)));
+    await this.#enqueue(async () => {
+      const paths = [...this.#artifacts.entries()]
+        .filter(
+          ([, artifact]) =>
+            artifact.scope === scope || artifact.scope.startsWith(`${scope}/`),
+        )
+        .map(([artifactPath]) => artifactPath);
+      await Promise.all(
+        paths.map((artifactPath) => this.#removeNow(artifactPath)),
+      );
+    });
   }
 
   async close(): Promise<void> {
-    this.#closed = true;
-    for (const timer of this.#artifacts.values()) clearTimeout(timer.timer);
-    const paths = [...this.#artifacts.keys()];
-    this.#artifacts.clear();
-    await Promise.all(
-      paths.map((artifactPath) => rm(artifactPath, { force: true })),
-    );
-    if (this.#directoryCreated) {
-      await rm(this.#directory, { recursive: true, force: true });
-      this.#directoryCreated = false;
-    }
+    await this.#enqueue(async () => {
+      if (this.#closed) return;
+      this.#closed = true;
+      for (const artifact of this.#artifacts.values())
+        clearTimeout(artifact.timer);
+      const paths = [...this.#artifacts.keys()];
+      this.#artifacts.clear();
+      await Promise.all(
+        paths.map((artifactPath) => rm(artifactPath, { force: true })),
+      );
+      if (this.#directoryCreated) {
+        await rm(this.#directory, { recursive: true, force: true });
+        this.#directoryCreated = false;
+      }
+    });
   }
 
-  async #remove(artifactPath: string): Promise<void> {
+  async removeArtifact(
+    artifactPath: string,
+    observationId: string,
+  ): Promise<void> {
+    await this.#enqueue(async () => {
+      const artifact = this.#artifacts.get(artifactPath);
+      if (artifact === undefined || artifact.observationId !== observationId)
+        return;
+      await this.#removeNow(artifactPath);
+    });
+  }
+
+  async #removeNow(artifactPath: string): Promise<void> {
     const artifact = this.#artifacts.get(artifactPath);
     if (artifact === undefined) return;
     clearTimeout(artifact.timer);
     this.#artifacts.delete(artifactPath);
     await rm(artifactPath, { force: true });
+  }
+
+  async #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#operations.then(operation, operation);
+    this.#operations = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await result;
   }
 }
 
@@ -554,7 +598,10 @@ export class ElectronBrowserBackend implements ZenXBrowserBackend {
     const observationId = randomUUID();
     const screenshot = await this.#captureScreenshot(tab, observationId);
     if (tab.documentVersion !== documentVersion) {
-      await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
+      await this.#artifacts.removeArtifact(
+        screenshot.artifactPath,
+        screenshot.observationId,
+      );
       throw new Error(
         "Browser document changed during inspection; inspect again",
       );
@@ -995,20 +1042,145 @@ export function redactBrowserUrl(raw: string): string {
 }
 
 function pngDimensions(buffer: Buffer): { width: number; height: number } {
-  if (
-    buffer.length < 24 ||
-    !buffer
-      .subarray(0, 8)
-      .equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
-  ) {
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  if (buffer.length < 33 || !buffer.subarray(0, 8).equals(signature)) {
     throw new Error("Browser screenshot is not a valid PNG");
   }
-  const width = buffer.readUInt32BE(16);
-  const height = buffer.readUInt32BE(20);
-  if (width <= 0 || height <= 0) {
-    throw new Error("Browser screenshot dimensions are invalid");
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  let interlace = 0;
+  let sawHeader = false;
+  let sawData = false;
+  let ended = false;
+  let sawPalette = false;
+  let sawImageData = false;
+  const idat: Buffer[] = [];
+  while (offset < buffer.length) {
+    if (offset + 12 > buffer.length) {
+      throw new Error("Browser screenshot PNG is truncated");
+    }
+    const length = buffer.readUInt32BE(offset);
+    const type = buffer.subarray(offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    const crcEnd = dataEnd + 4;
+    if (dataEnd < dataStart || crcEnd > buffer.length) {
+      throw new Error("Browser screenshot PNG chunk is truncated");
+    }
+    if (ended) throw new Error("Browser screenshot PNG has data after IEND");
+    const data = buffer.subarray(dataStart, dataEnd);
+    const expectedCrc = buffer.readUInt32BE(dataEnd);
+    const actualCrc = crc32(Buffer.concat([type, data]));
+    if (actualCrc !== expectedCrc) {
+      throw new Error("Browser screenshot PNG chunk CRC is invalid");
+    }
+    const name = type.toString("ascii");
+    if (!sawHeader && name !== "IHDR") {
+      throw new Error("Browser screenshot PNG must begin with IHDR");
+    }
+    if (name === "IHDR") {
+      if (sawHeader || length !== 13) {
+        throw new Error("Browser screenshot PNG IHDR is invalid");
+      }
+      sawHeader = true;
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8]!;
+      colorType = data[9]!;
+      if (
+        width === 0 ||
+        height === 0 ||
+        width > MAX_BROWSER_SCREENSHOT_WIDTH ||
+        height > MAX_BROWSER_SCREENSHOT_HEIGHT ||
+        width * height > MAX_BROWSER_SCREENSHOT_PIXELS ||
+        data[10] !== 0 ||
+        data[11] !== 0 ||
+        data[12] !== 0 ||
+        !validPngBitDepth(colorType, bitDepth)
+      ) {
+        throw new Error("Browser screenshot dimensions or IHDR are invalid");
+      }
+      interlace = data[12]!;
+    } else if (name === "IDAT") {
+      if (!sawHeader || ended)
+        throw new Error("Browser screenshot PNG IDAT is invalid");
+      sawImageData = true;
+      sawData = true;
+      idat.push(data);
+    } else if (name === "PLTE") {
+      if (sawImageData || length === 0 || length % 3 !== 0 || length > 768) {
+        throw new Error("Browser screenshot PNG palette is invalid");
+      }
+      sawPalette = true;
+    } else if (name === "IEND") {
+      if (!sawHeader || !sawData || length !== 0) {
+        throw new Error("Browser screenshot PNG IEND is invalid");
+      }
+      ended = true;
+    }
+    offset = crcEnd;
+    if (ended) break;
+  }
+  if (!sawHeader || !sawData || !ended || offset !== buffer.length) {
+    throw new Error("Browser screenshot PNG is incomplete");
+  }
+  if (colorType === 3 && !sawPalette) {
+    throw new Error("Browser screenshot PNG palette is missing");
+  }
+  if (interlace !== 0) {
+    throw new Error("Interlaced browser screenshots are unsupported");
+  }
+  const channels =
+    colorType === 0
+      ? 1
+      : colorType === 2
+        ? 3
+        : colorType === 3
+          ? 1
+          : colorType === 4
+            ? 2
+            : 4;
+  const rowBytes = Math.ceil((width * channels * bitDepth) / 8);
+  const decodedBytes = (rowBytes + 1) * height;
+  try {
+    const decoded = inflateSync(Buffer.concat(idat), {
+      maxOutputLength: decodedBytes,
+    });
+    if (decoded.byteLength !== decodedBytes) {
+      throw new Error("decoded byte count differs from image dimensions");
+    }
+  } catch (error) {
+    throw new Error(
+      `Browser screenshot PNG image data is not decodable: ${describeError(error)}`,
+    );
   }
   return { width, height };
+}
+
+function validPngBitDepth(colorType: number, bitDepth: number): boolean {
+  if (![0, 2, 3, 4, 6].includes(colorType)) return false;
+  if (colorType === 3) return [1, 2, 4, 8].includes(bitDepth);
+  if (colorType === 0) return [1, 2, 4, 8, 16].includes(bitDepth);
+  return bitDepth === 8 || bitDepth === 16;
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function requiredTargetId(

--- a/apps/zenx/src/main/capabilities/browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/browser-provider.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { inflateSync } from "node:zlib";
@@ -361,28 +361,43 @@ export const MAX_BROWSER_TABS_PER_SESSION = 8;
 export const MAX_BROWSER_TABS_GLOBAL = 24;
 export const MAX_BROWSER_SCREENSHOT_BYTES = 4 * 1024 * 1024;
 export const BROWSER_SCREENSHOT_TTL_MS = 5 * 60_000;
+export const MAX_BROWSER_SCREENSHOT_ARTIFACTS = 16;
+export const MAX_BROWSER_SCREENSHOT_TOTAL_BYTES = 16 * 1024 * 1024;
 const MAX_BROWSER_SCREENSHOT_WIDTH = 4096;
 const MAX_BROWSER_SCREENSHOT_HEIGHT = 4096;
 const MAX_BROWSER_SCREENSHOT_PIXELS = 16 * 1024 * 1024;
+const MAX_BROWSER_SCREENSHOT_DECODE_BYTES = 64 * 1024 * 1024;
+let activeBrowserScreenshotDecodeBytes = 0;
 
 /** Temporary provider-owned PNGs; no screenshot bytes are part of the journal. */
 export class BrowserScreenshotArtifactStore {
+  readonly #rootDirectory: string;
   readonly #directory: string;
+  readonly #ownsRootDirectory: boolean;
   readonly #artifacts = new Map<
     string,
-    { scope: string; observationId: string; timer: NodeJS.Timeout }
+    {
+      scope: string;
+      observationId: string;
+      bytes: number;
+      createdAt: number;
+      timer: NodeJS.Timeout;
+    }
   >();
   #directoryCreated = false;
   #closed = false;
+  #totalBytes = 0;
   #operations: Promise<void> = Promise.resolve();
 
-  constructor(
-    directory = path.join(
-      os.tmpdir(),
-      `zenx-browser-artifacts-${String(process.pid)}-${randomUUID()}`,
-    ),
-  ) {
-    this.#directory = directory;
+  constructor(directory?: string) {
+    this.#rootDirectory =
+      directory ??
+      path.join(
+        os.tmpdir(),
+        `zenx-browser-artifacts-${String(process.pid)}-${randomUUID()}`,
+      );
+    this.#directory = path.join(this.#rootDirectory, `store-${randomUUID()}`);
+    this.#ownsRootDirectory = directory === undefined;
   }
 
   async write(
@@ -402,8 +417,15 @@ export class BrowserScreenshotArtifactStore {
       }
       const dimensions = pngDimensions(png);
       if (!this.#directoryCreated) {
-        await mkdir(this.#directory, { recursive: true, mode: 0o700 });
+        await this.#ensureOwnedDirectory();
         this.#directoryCreated = true;
+      }
+      if (
+        png.byteLength > MAX_BROWSER_SCREENSHOT_TOTAL_BYTES ||
+        this.#artifacts.size >= MAX_BROWSER_SCREENSHOT_ARTIFACTS ||
+        this.#totalBytes + png.byteLength > MAX_BROWSER_SCREENSHOT_TOTAL_BYTES
+      ) {
+        await this.#evictFor(png.byteLength);
       }
       const artifactPath = path.join(this.#directory, `${randomUUID()}.png`);
       await writeFile(artifactPath, png, { mode: 0o600 });
@@ -416,7 +438,25 @@ export class BrowserScreenshotArtifactStore {
         void this.removeArtifact(artifactPath, observationId);
       }, BROWSER_SCREENSHOT_TTL_MS);
       timer.unref();
-      this.#artifacts.set(artifactPath, { scope, observationId, timer });
+      this.#artifacts.set(artifactPath, {
+        scope,
+        observationId,
+        bytes: png.byteLength,
+        createdAt: Date.now(),
+        timer,
+      });
+      this.#totalBytes += png.byteLength;
+      const superseded = [...this.#artifacts.entries()]
+        .filter(
+          ([candidatePath, artifact]) =>
+            candidatePath !== artifactPath &&
+            (artifact.scope === scope ||
+              artifact.scope.startsWith(`${scope}/`)),
+        )
+        .map(([candidatePath]) => candidatePath);
+      await Promise.all(
+        superseded.map((candidatePath) => this.#removeNow(candidatePath)),
+      );
       return {
         artifactPath,
         observationId,
@@ -452,12 +492,16 @@ export class BrowserScreenshotArtifactStore {
         clearTimeout(artifact.timer);
       const paths = [...this.#artifacts.keys()];
       this.#artifacts.clear();
+      this.#totalBytes = 0;
       await Promise.all(
         paths.map((artifactPath) => rm(artifactPath, { force: true })),
       );
       if (this.#directoryCreated) {
         await rm(this.#directory, { recursive: true, force: true });
         this.#directoryCreated = false;
+      }
+      if (this.#ownsRootDirectory) {
+        await rm(this.#rootDirectory, { recursive: true, force: true });
       }
     });
   }
@@ -479,7 +523,52 @@ export class BrowserScreenshotArtifactStore {
     if (artifact === undefined) return;
     clearTimeout(artifact.timer);
     this.#artifacts.delete(artifactPath);
+    this.#totalBytes -= artifact.bytes;
     await rm(artifactPath, { force: true });
+  }
+
+  async #ensureOwnedDirectory(): Promise<void> {
+    let root: Awaited<ReturnType<typeof lstat>>;
+    try {
+      root = await lstat(this.#rootDirectory);
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+      await mkdir(this.#rootDirectory, { mode: 0o700 });
+      root = await lstat(this.#rootDirectory);
+    }
+    if (!root.isDirectory() || root.isSymbolicLink()) {
+      throw new Error(
+        "Browser screenshot artifact root must be a real directory",
+      );
+    }
+    await chmod(this.#rootDirectory, 0o700);
+    await mkdir(this.#directory, { recursive: false, mode: 0o700 });
+    const child = await lstat(this.#directory);
+    if (!child.isDirectory() || child.isSymbolicLink()) {
+      throw new Error(
+        "Browser screenshot artifact directory must be a real directory",
+      );
+    }
+    await chmod(this.#directory, 0o700);
+  }
+
+  async #evictFor(bytes: number): Promise<void> {
+    if (bytes > MAX_BROWSER_SCREENSHOT_TOTAL_BYTES) {
+      throw new Error("Browser screenshot aggregate byte bound exceeded");
+    }
+    const candidates = [...this.#artifacts.entries()].sort(
+      (left, right) => left[1].createdAt - right[1].createdAt,
+    );
+    while (
+      this.#artifacts.size >= MAX_BROWSER_SCREENSHOT_ARTIFACTS ||
+      this.#totalBytes + bytes > MAX_BROWSER_SCREENSHOT_TOTAL_BYTES
+    ) {
+      const candidate = candidates.shift();
+      if (candidate === undefined) {
+        throw new Error("Browser screenshot artifact capacity is exhausted");
+      }
+      await this.#removeNow(candidate[0]);
+    }
   }
 
   async #enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -1058,6 +1147,8 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
   let ended = false;
   let sawPalette = false;
   let sawImageData = false;
+  let paletteEntries = 0;
+  let sawTransparency = false;
   const idat: Buffer[] = [];
   while (offset < buffer.length) {
     if (offset + 12 > buffer.length) {
@@ -1116,6 +1207,19 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
         throw new Error("Browser screenshot PNG palette is invalid");
       }
       sawPalette = true;
+      paletteEntries = length / 3;
+    } else if (name === "tRNS") {
+      if (
+        sawImageData ||
+        sawTransparency ||
+        (colorType !== 3 && colorType !== 0)
+      ) {
+        throw new Error("Browser screenshot PNG transparency is invalid");
+      }
+      sawTransparency = true;
+      if (colorType === 3 && (!sawPalette || length > paletteEntries)) {
+        throw new Error("Browser screenshot PNG transparency is invalid");
+      }
     } else if (name === "IEND") {
       if (!sawHeader || !sawData || length !== 0) {
         throw new Error("Browser screenshot PNG IEND is invalid");
@@ -1144,8 +1248,24 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
           : colorType === 4
             ? 2
             : 4;
+  if (
+    colorType === 3 &&
+    (paletteEntries === 0 || paletteEntries > 1 << bitDepth)
+  ) {
+    throw new Error("Browser screenshot PNG palette entries are invalid");
+  }
   const rowBytes = Math.ceil((width * channels * bitDepth) / 8);
   const decodedBytes = (rowBytes + 1) * height;
+  if (decodedBytes > MAX_BROWSER_SCREENSHOT_DECODE_BYTES) {
+    throw new Error("Browser screenshot decoded image exceeds the byte bound");
+  }
+  if (
+    activeBrowserScreenshotDecodeBytes + decodedBytes >
+    MAX_BROWSER_SCREENSHOT_DECODE_BYTES
+  ) {
+    throw new Error("Browser screenshot decode budget is exhausted");
+  }
+  activeBrowserScreenshotDecodeBytes += decodedBytes;
   try {
     const decoded = inflateSync(Buffer.concat(idat), {
       maxOutputLength: decodedBytes,
@@ -1153,12 +1273,107 @@ function pngDimensions(buffer: Buffer): { width: number; height: number } {
     if (decoded.byteLength !== decodedBytes) {
       throw new Error("decoded byte count differs from image dimensions");
     }
+    validatePngScanlines(
+      decoded,
+      width,
+      height,
+      rowBytes,
+      channels,
+      bitDepth,
+      colorType,
+      paletteEntries,
+    );
   } catch (error) {
     throw new Error(
       `Browser screenshot PNG image data is not decodable: ${describeError(error)}`,
     );
+  } finally {
+    activeBrowserScreenshotDecodeBytes -= decodedBytes;
   }
   return { width, height };
+}
+
+function validatePngScanlines(
+  decoded: Buffer,
+  width: number,
+  height: number,
+  rowBytes: number,
+  channels: number,
+  bitDepth: number,
+  colorType: number,
+  paletteEntries: number,
+): void {
+  const bytesPerPixel = Math.max(1, Math.ceil((channels * bitDepth) / 8));
+  const previous = Buffer.alloc(rowBytes);
+  let offset = 0;
+  for (let row = 0; row < height; row += 1) {
+    const filter = decoded[offset++];
+    if (filter === undefined || filter > 4) {
+      throw new Error("decoded scanline filter is invalid");
+    }
+    const source = decoded.subarray(offset, offset + rowBytes);
+    if (source.byteLength !== rowBytes)
+      throw new Error("decoded scanline is truncated");
+    const current = Buffer.alloc(rowBytes);
+    for (let index = 0; index < rowBytes; index += 1) {
+      const left = index >= bytesPerPixel ? current[index - bytesPerPixel]! : 0;
+      const up = previous[index] ?? 0;
+      const upperLeft =
+        index >= bytesPerPixel ? previous[index - bytesPerPixel]! : 0;
+      const value = source[index]!;
+      current[index] =
+        filter === 0
+          ? value
+          : filter === 1
+            ? (value + left) & 0xff
+            : filter === 2
+              ? (value + up) & 0xff
+              : filter === 3
+                ? (value + Math.floor((left + up) / 2)) & 0xff
+                : (value + paethPredictor(left, up, upperLeft)) & 0xff;
+    }
+    if (colorType === 3)
+      validatePaletteIndices(current, width, bitDepth, paletteEntries);
+    current.copy(previous);
+    offset += rowBytes;
+  }
+  if (offset !== decoded.byteLength)
+    throw new Error("decoded scanline data has a trailing payload");
+}
+
+function validatePaletteIndices(
+  row: Buffer,
+  width: number,
+  bitDepth: number,
+  paletteEntries: number,
+): void {
+  if (bitDepth === 8) {
+    for (let index = 0; index < width; index += 1) {
+      if ((row[index] ?? paletteEntries) >= paletteEntries) {
+        throw new Error("decoded palette index is out of range");
+      }
+    }
+    return;
+  }
+  const mask = (1 << bitDepth) - 1;
+  for (let index = 0; index < width; index += 1) {
+    const bit = index * bitDepth;
+    const value =
+      (row[Math.floor(bit / 8)]! >> (8 - bitDepth - (bit % 8))) & mask;
+    if (value >= paletteEntries)
+      throw new Error("decoded palette index is out of range");
+  }
+}
+
+function paethPredictor(left: number, up: number, upperLeft: number): number {
+  const estimate = left + up - upperLeft;
+  const leftDistance = Math.abs(estimate - left);
+  const upDistance = Math.abs(estimate - up);
+  const upperLeftDistance = Math.abs(estimate - upperLeft);
+  if (leftDistance <= upDistance && leftDistance <= upperLeftDistance)
+    return left;
+  if (upDistance <= upperLeftDistance) return up;
+  return upperLeft;
 }
 
 function validPngBitDepth(colorType: number, bitDepth: number): boolean {
@@ -1181,6 +1396,15 @@ function crc32(buffer: Buffer): number {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "ENOENT"
+  );
 }
 
 function requiredTargetId(

--- a/apps/zenx/src/main/capabilities/computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/computer-provider.ts
@@ -40,7 +40,6 @@ export interface ComputerInspection {
     title: string;
     enabled: boolean;
     actions: ComputerControlAction[];
-    secure?: true;
   }>;
   truncated: boolean;
 }
@@ -184,7 +183,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
     {
       name: "computer_set_value",
       description:
-        "Set a non-secret semantic value on one editable opaque target from the latest computer_inspect observation. Secure/password controls are rejected; supplied text is a canonical journaled tool argument.",
+        "Set the supplied text on one editable opaque target from the latest computer_inspect observation. The value follows the ordinary tool path and host/model policy decides how it is handled.",
       inputSchema: objectSchema(
         {
           target: targetSchema(),
@@ -217,7 +216,7 @@ export const computerCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Instructions for app-targeted accessibility actions without foreground takeover.",
       content:
-        "Prefer structured browser tools for web pages. For native apps, identify a pid or bundleId and optionally an exact window title, inspect that target, then act only with the observationId and opaque targetId from the latest inspect. Re-inspect after every action. computer_set_value is non-secret-only because supplied text is journaled, and secure controls are rejected. Try background-safe semantic press/value/capture first. Those tools must never fall back to pointer motion, foreground keystrokes, app activation, or workspace changes. If accessibility semantics are insufficient and foreground takeover is acceptable, choose an explicitly named computer_foreground_* tool, warn that it affects the user's live desktop, and keep the operation cancellable; otherwise report unsupported.",
+        "Prefer structured browser tools for web pages. For native apps, identify a pid or bundleId and optionally an exact window title, inspect that target, then act only with the observationId and opaque targetId from the latest inspect. Re-inspect after every action. Supplied text follows the ordinary set-value path; host/model policy owns credential decisions. Try background-safe semantic press/value/capture first. Those tools must never fall back to pointer motion, foreground keystrokes, app activation, or workspace changes. If accessibility semantics are insufficient and foreground takeover is acceptable, choose an explicitly named computer_foreground_* tool, warn that it affects the user's live desktop, and keep the operation cancellable; otherwise report unsupported.",
     },
   ],
 };
@@ -323,7 +322,6 @@ export interface ComputerControlFingerprint {
   title?: string;
   description?: string;
   frame?: string;
-  secure: boolean;
   actions: ComputerControlAction[];
 }
 
@@ -377,11 +375,6 @@ export class ComputerObservationLedger {
       );
     }
     if (action === COMPUTER_ACTION_SET_VALUE) {
-      if (fingerprint.secure) {
-        throw new Error(
-          "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
-        );
-      }
       if (!fingerprint.actions.includes(COMPUTER_ACTION_SET_VALUE)) {
         throw new Error(
           "Control no longer supports background-safe semantic set value; foreground_required",
@@ -410,7 +403,6 @@ interface MacRawControl {
   title: string;
   enabled: boolean;
   actions: string[];
-  secure?: boolean;
 }
 
 interface MacInspectionResult {
@@ -424,7 +416,6 @@ function rawControlFingerprint(
 ): ComputerControlFingerprint {
   return {
     ...control.selector,
-    secure: control.secure === true,
     actions: canonicalComputerActions(control.actions),
   };
 }
@@ -443,7 +434,7 @@ function canonicalComputerActions(
 function semanticControlSelector(
   fingerprint: ComputerControlFingerprint,
 ): Record<string, string> {
-  const { secure: _secure, actions: _actions, ...selector } = fingerprint;
+  const { actions: _actions, ...selector } = fingerprint;
   return selector;
 }
 
@@ -498,7 +489,6 @@ export class ElectronMacComputerBackend implements ZenXComputerBackend {
         title: control.title,
         enabled: control.enabled,
         actions: rawControlFingerprint(control).actions,
-        ...(control.secure ? { secure: true } : {}),
       })),
       truncated:
         result.truncated || result.controls.length > boundedControls.length,
@@ -822,11 +812,6 @@ func isSettable(_ element: AXUIElement, _ name: String) -> Bool {
   return AXUIElementIsAttributeSettable(element, name as CFString, &settable) == .success && settable.boolValue
 }
 
-func isSecure(_ element: AXUIElement) -> Bool {
-  let semantics = (textAttribute(element, kAXRoleAttribute) + " " + textAttribute(element, kAXSubroleAttribute)).lowercased()
-  return semantics.contains("secure") || semantics.contains("password")
-}
-
 func frameFingerprint(_ element: AXUIElement) -> String {
   guard let rawPosition = attribute(element, kAXPositionAttribute),
         let rawSize = attribute(element, kAXSizeAttribute),
@@ -971,7 +956,6 @@ case "inspect":
       "title": textAttribute(element, kAXTitleAttribute),
       "enabled": boolAttribute(element, kAXEnabledAttribute),
       "actions": supportedActions.sorted(),
-      "secure": isSecure(element)
     ]
   }
   response = ["target": resolvedTarget, "controls": controls, "truncated": truncated]
@@ -986,7 +970,6 @@ case "setValue":
   let wanted = dictionary(request["control"], "control")
   guard let value = request["value"] as? String else { fail("value must be a string") }
   let element = findControl(wanted)
-  if isSecure(element) { fail("password or secure controls reject AXValue; typing tools are non-secret-only") }
   var settable: DarwinBoolean = false
   guard AXUIElementIsAttributeSettable(element, kAXValueAttribute as CFString, &settable) == .success, settable.boolValue else {
     fail("control does not support background-safe AXValue; foreground_required")

--- a/apps/zenx/src/main/capabilities/external-provider.ts
+++ b/apps/zenx/src/main/capabilities/external-provider.ts
@@ -7,6 +7,8 @@ export interface ExternalProviderProcessResult {
   stderr: string;
 }
 
+export type ProviderLaunchBinding = () => Promise<void>;
+
 export interface ExternalProviderProcessRunner {
   run(
     executable: string,
@@ -16,6 +18,8 @@ export interface ExternalProviderProcessRunner {
       timeoutMs: number;
       signal?: AbortSignal;
       maxOutputBytes?: number;
+      runtimeExecutable?: string;
+      bindBeforeSpawn?: () => Promise<ProviderLaunchBinding>;
       verifyBeforeSpawn?: () => Promise<void>;
     },
   ): Promise<ExternalProviderProcessResult>;
@@ -32,6 +36,8 @@ export class SystemExternalProviderProcessRunner implements ExternalProviderProc
       timeoutMs: number;
       signal?: AbortSignal;
       maxOutputBytes?: number;
+      runtimeExecutable?: string;
+      bindBeforeSpawn?: () => Promise<ProviderLaunchBinding>;
       verifyBeforeSpawn?: () => Promise<void>;
     },
   ): Promise<ExternalProviderProcessResult> {
@@ -41,8 +47,10 @@ export class SystemExternalProviderProcessRunner implements ExternalProviderProc
     const invocation = await resolveExternalProviderInvocation(
       executable,
       process.env,
+      options.runtimeExecutable,
     );
     await options.verifyBeforeSpawn?.();
+    const releaseBinding = await options.bindBeforeSpawn?.();
     return await new Promise((resolve, reject) => {
       const child = spawn(
         invocation.executable,
@@ -64,6 +72,7 @@ export class SystemExternalProviderProcessRunner implements ExternalProviderProc
         settled = true;
         clearTimeout(timer);
         options.signal?.removeEventListener("abort", abort);
+        void Promise.resolve(releaseBinding?.()).catch(() => undefined);
         callback();
       };
       const fail = (error: unknown): void => {
@@ -128,7 +137,20 @@ interface ExternalProviderInvocation {
 async function resolveExternalProviderInvocation(
   executable: string,
   environment: NodeJS.ProcessEnv,
+  runtimeExecutable?: string,
 ): Promise<ExternalProviderInvocation> {
+  if (runtimeExecutable !== undefined) {
+    if (!path.isAbsolute(runtimeExecutable)) {
+      throw new Error("Bundled provider runtime must be an absolute path");
+    }
+    if (!(await isExecutable(runtimeExecutable))) {
+      throw new Error("Bundled provider runtime is not executable");
+    }
+    if (!path.isAbsolute(executable)) {
+      throw new Error("Bundled provider executable must be an absolute path");
+    }
+    return { executable: runtimeExecutable, argumentPrefix: [executable] };
+  }
   if (
     process.platform !== "win32" ||
     path.extname(executable).toLowerCase() !== ".cmd"
@@ -161,12 +183,14 @@ async function resolveExternalProviderInvocation(
   }
   await access(script);
   const siblingNode = path.join(path.dirname(executable), "node.exe");
-  const nodeExecutable = (await isExecutable(siblingNode))
-    ? siblingNode
-    : await discoverExecutable("node", {
-        environment,
-        platform: "win32",
-      });
+  const nodeExecutable =
+    runtimeExecutable ??
+    ((await isExecutable(siblingNode))
+      ? siblingNode
+      : await discoverExecutable("node", {
+          environment,
+          platform: "win32",
+        }));
   if (nodeExecutable === undefined) {
     throw new Error(
       `Cannot execute ${path.basename(executable)} without node.exe`,
@@ -237,6 +261,7 @@ function providerProcessEnvironment(
     "WINDIR",
     "LOCALAPPDATA",
     "USERPROFILE",
+    "PLAYWRIGHT_BROWSERS_PATH",
   ];
   return Object.fromEntries(
     keys.flatMap((key) =>

--- a/apps/zenx/src/main/capabilities/external-provider.ts
+++ b/apps/zenx/src/main/capabilities/external-provider.ts
@@ -16,6 +16,7 @@ export interface ExternalProviderProcessRunner {
       timeoutMs: number;
       signal?: AbortSignal;
       maxOutputBytes?: number;
+      verifyBeforeSpawn?: () => Promise<void>;
     },
   ): Promise<ExternalProviderProcessResult>;
 }
@@ -31,6 +32,7 @@ export class SystemExternalProviderProcessRunner implements ExternalProviderProc
       timeoutMs: number;
       signal?: AbortSignal;
       maxOutputBytes?: number;
+      verifyBeforeSpawn?: () => Promise<void>;
     },
   ): Promise<ExternalProviderProcessResult> {
     options.signal?.throwIfAborted();
@@ -40,6 +42,7 @@ export class SystemExternalProviderProcessRunner implements ExternalProviderProc
       executable,
       process.env,
     );
+    await options.verifyBeforeSpawn?.();
     return await new Promise((resolve, reject) => {
       const child = spawn(
         invocation.executable,

--- a/apps/zenx/src/main/capabilities/packaged-provider-integrity.ts
+++ b/apps/zenx/src/main/capabilities/packaged-provider-integrity.ts
@@ -1,0 +1,8 @@
+/**
+ * Release-build trust anchor for resources/providers/manifest.json.
+ * This source-embedded value is immutable after the application is built.
+ * A release that ships different provider bytes must update this constant in
+ * the same signed source change; an invalid anchor leaves providers offline.
+ */
+export const PACKAGED_PROVIDER_MANIFEST_SHA256 =
+  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";

--- a/apps/zenx/src/main/capabilities/packaged-provider-integrity.ts
+++ b/apps/zenx/src/main/capabilities/packaged-provider-integrity.ts
@@ -5,4 +5,4 @@
  * the same signed source change; an invalid anchor leaves providers offline.
  */
 export const PACKAGED_PROVIDER_MANIFEST_SHA256 =
-  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+  "__ZENX_PACKAGED_PROVIDER_MANIFEST_SHA256__";

--- a/apps/zenx/src/main/capabilities/peekaboo-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/peekaboo-computer-provider.ts
@@ -37,7 +37,6 @@ interface PeekabooObservedTarget {
   rawElementId: string;
   snapshotId: string;
   actions: ComputerControlAction[];
-  secure: boolean;
   fingerprint: string;
 }
 
@@ -93,13 +92,11 @@ export class PeekabooComputerBackend implements ZenXComputerBackend {
     const targets = new Map<string, PeekabooObservedTarget>();
     const controls = selected.map((element) => {
       const targetId = randomUUID();
-      const secure = isSecurePeekabooElement(element);
-      const actions = peekabooElementActions(element, secure);
+      const actions = peekabooElementActions(element);
       targets.set(targetId, {
         rawElementId: element.id,
         snapshotId,
         actions,
-        secure,
         fingerprint: peekabooElementFingerprint(element),
       });
       return {
@@ -108,7 +105,6 @@ export class PeekabooComputerBackend implements ZenXComputerBackend {
         title: element.label ?? element.title ?? element.description ?? "",
         enabled: element.is_actionable,
         actions,
-        ...(secure ? { secure: true as const } : {}),
       };
     });
     const key = computerTargetKey(target);
@@ -316,11 +312,6 @@ export class PeekabooComputerBackend implements ZenXComputerBackend {
     if (!selected.actions.includes(action)) {
       throw new Error(`Computer target does not support ${action}`);
     }
-    if (action === COMPUTER_ACTION_SET_VALUE && selected.secure) {
-      throw new Error(
-        "computer_set_value rejects password or secure controls because supplied text is journaled",
-      );
-    }
     this.#observations.delete(key);
     return selected;
   }
@@ -349,11 +340,7 @@ export class PeekabooComputerBackend implements ZenXComputerBackend {
       .filter(
         (element) =>
           peekabooElementFingerprint(element) === observed.fingerprint &&
-          isSecurePeekabooElement(element) === observed.secure &&
-          sameActions(
-            peekabooElementActions(element, observed.secure),
-            observed.actions,
-          ),
+          sameActions(peekabooElementActions(element), observed.actions),
       );
     if (matches.length !== 1) {
       throw new Error(
@@ -495,20 +482,13 @@ function targetSummary(
   };
 }
 
-function isSecurePeekabooElement(element: PeekabooElement): boolean {
-  return /secure|password/iu.test(
-    `${element.role} ${element.title ?? ""} ${element.label ?? ""} ${element.description ?? ""}`,
-  );
-}
-
 function peekabooElementActions(
   element: PeekabooElement,
-  secure: boolean,
 ): ComputerControlAction[] {
   const editable = /text|search|combo/iu.test(element.role);
   const actions: ComputerControlAction[] = [];
   if (element.is_actionable) actions.push(COMPUTER_ACTION_PRESS);
-  if (editable && !secure) actions.push(COMPUTER_ACTION_SET_VALUE);
+  if (editable) actions.push(COMPUTER_ACTION_SET_VALUE);
   return actions;
 }
 

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -2,10 +2,12 @@ import { createHash, randomUUID } from "node:crypto";
 
 import type {
   BrowserInspection,
+  BrowserScreenshotArtifact,
   BrowserTabSummary,
   BrowserTargetFingerprint,
   ZenXBrowserBackend,
 } from "./browser-provider.js";
+import { BrowserScreenshotArtifactStore } from "./browser-provider.js";
 import {
   type ExternalProviderProcessRunner,
   parseExternalJson,
@@ -15,6 +17,7 @@ const PLAYWRIGHT_PROVIDER_TIMEOUT_MS = 30_000;
 const PLAYWRIGHT_CLOSE_TIMEOUT_MS = 10_000;
 const MAX_PLAYWRIGHT_VISIBLE_TEXT = 8_000;
 const MAX_PLAYWRIGHT_TARGETS = 128;
+const MAX_PLAYWRIGHT_SCREENSHOT_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 interface PlaywrightTabState {
   tabId: string;
@@ -75,15 +78,20 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   readonly #runner: ExternalProviderProcessRunner;
   readonly #cwd: string;
   readonly #sessions = new Map<string, PlaywrightSessionState>();
+  readonly #artifacts: BrowserScreenshotArtifactStore;
 
   constructor(options: {
     executable: string;
     runner: ExternalProviderProcessRunner;
     cwd: string;
+    artifactDirectory?: string;
   }) {
     this.#executable = options.executable;
     this.#runner = options.runner;
     this.#cwd = options.cwd;
+    this.#artifacts = new BrowserScreenshotArtifactStore(
+      options.artifactDirectory,
+    );
   }
 
   async listTabs(
@@ -187,6 +195,12 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         disabled: node.disabled === true,
       });
     }
+    const screenshot = await this.#screenshot(
+      session,
+      tab,
+      observationId,
+      signal,
+    );
     tab.observation = {
       id: observationId,
       documentVersion: tab.documentVersion,
@@ -203,8 +217,8 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         role: target.role,
         name: target.name,
         actions: [...target.actions],
-        ...(target.secure ? { secure: true as const } : {}),
       })),
+      screenshot,
     };
   }
 
@@ -251,6 +265,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     const { session, tab } = this.#requireTab(sessionId, tabId);
     await this.#run(session, ["tab-close", String(tab.index)], signal);
     session.tabs.delete(tabId);
+    await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
     for (const candidate of session.tabs.values()) {
       if (candidate.index > tab.index) candidate.index -= 1;
     }
@@ -273,6 +288,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       session.tabs.clear();
       session.opened = false;
       this.#sessions.delete(sessionId);
+      await this.#artifacts.clearScope(sessionId);
     }
     return closedTabs;
   }
@@ -281,6 +297,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     for (const sessionId of [...this.#sessions.keys()]) {
       await this.closeSession(sessionId).catch(() => undefined);
     }
+    await this.#artifacts.close();
   }
 
   async #run(
@@ -288,6 +305,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     args: readonly string[],
     signal?: AbortSignal,
     timeoutMs = PLAYWRIGHT_PROVIDER_TIMEOUT_MS,
+    maxOutputBytes = 512 * 1024,
   ): Promise<Record<string, unknown>> {
     try {
       const result = await this.#runner.run(
@@ -297,7 +315,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
           cwd: this.#cwd,
           timeoutMs,
           signal,
-          maxOutputBytes: 512 * 1024,
+          maxOutputBytes,
         },
       );
       const response = parseExternalJson("playwright-cli", result.stdout);
@@ -318,6 +336,35 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       }
       throw error;
     }
+  }
+
+  async #screenshot(
+    session: PlaywrightSessionState,
+    tab: PlaywrightTabState,
+    observationId: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserScreenshotArtifact> {
+    await this.#select(session, tab, signal);
+    const response = await this.#run(
+      session,
+      [
+        "run-code",
+        "async page => await page.screenshot({ type: 'png' }).then(buffer => buffer.toString('base64'))",
+      ],
+      signal,
+      PLAYWRIGHT_PROVIDER_TIMEOUT_MS,
+      MAX_PLAYWRIGHT_SCREENSHOT_OUTPUT_BYTES,
+    );
+    if (typeof response.result !== "string") {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: screenshot result must be base64",
+      );
+    }
+    return await this.#artifacts.write(
+      `${session.sessionId}/${tab.tabId}`,
+      observationId,
+      Buffer.from(response.result, "base64"),
+    );
   }
 
   async #bestEffortCancel(session: PlaywrightSessionState): Promise<void> {
@@ -414,7 +461,6 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       fingerprint.fieldName !== target.fieldName ||
       fingerprint.autocomplete !== target.autocomplete ||
       fingerprint.href !== target.href ||
-      fingerprint.secure !== target.secure ||
       (node.disabled === true) !== target.disabled ||
       fingerprint.actions.length !== target.actions.length ||
       !fingerprint.actions.every((candidate) =>
@@ -423,7 +469,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       !fingerprint.actions.includes(action)
     ) {
       throw new Error(
-        "Playwright target identity, security, visibility, or actions changed; inspect again",
+        "Playwright target identity, visibility, or actions changed; inspect again",
       );
     }
   }
@@ -641,7 +687,6 @@ function playwrightTargetFingerprint(
   node: PlaywrightAriaNode,
   dom: PlaywrightDomMetadata,
 ): BrowserTargetFingerprint {
-  const secure = isSecurePlaywrightNode(node, dom);
   return {
     selector: node.ref!,
     tag: dom.tag,
@@ -652,7 +697,6 @@ function playwrightTargetFingerprint(
     fieldName: dom.fieldName,
     autocomplete: dom.autocomplete,
     href: dom.href || node.url || "",
-    secure,
     actions: playwrightNodeActions(node, dom),
   };
 }
@@ -695,18 +739,6 @@ function playwrightNodeActions(
       ? (["type"] as const)
       : []),
   ];
-}
-
-function isSecurePlaywrightNode(
-  node: PlaywrightAriaNode,
-  dom: PlaywrightDomMetadata,
-): boolean {
-  const semantics = `${node.role} ${node.name ?? ""} ${node.placeholder ?? ""}`;
-  return (
-    dom.type.toLowerCase() === "password" ||
-    /(?:^|-)password$/iu.test(dom.autocomplete) ||
-    /password|secure/iu.test(semantics)
-  );
 }
 
 function isPlaywrightDomMetadata(

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -9,6 +9,9 @@ import type {
 } from "./browser-provider.js";
 import {
   BrowserScreenshotArtifactStore,
+  assertBrowserTabCapacity,
+  MAX_BROWSER_TABS_GLOBAL,
+  MAX_BROWSER_TABS_PER_SESSION,
   redactBrowserUrl,
 } from "./browser-provider.js";
 import {
@@ -21,6 +24,10 @@ const PLAYWRIGHT_CLOSE_TIMEOUT_MS = 10_000;
 const MAX_PLAYWRIGHT_VISIBLE_TEXT = 8_000;
 const MAX_PLAYWRIGHT_TARGETS = 128;
 const MAX_PLAYWRIGHT_SCREENSHOT_OUTPUT_BYTES = 8 * 1024 * 1024;
+const MAX_PLAYWRIGHT_PAGES = MAX_BROWSER_TABS_GLOBAL;
+const MAX_PLAYWRIGHT_PAGE_KEY_LENGTH = 128;
+const MAX_PLAYWRIGHT_PAGE_URL_LENGTH = 8_192;
+const MAX_PLAYWRIGHT_PAGE_TITLE_LENGTH = 256;
 
 interface PlaywrightTabState {
   tabId: string;
@@ -88,8 +95,11 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   readonly #runner: ExternalProviderProcessRunner;
   readonly #cwd: string;
   readonly #verifyExecutable?: () => Promise<void>;
+  readonly #runtimeExecutable?: string;
+  readonly #bindBeforeSpawn?: () => Promise<() => Promise<void>>;
   readonly #sessions = new Map<string, PlaywrightSessionState>();
   readonly #artifacts: BrowserScreenshotArtifactStore;
+  #reservedOpenTabs = 0;
 
   constructor(options: {
     executable: string;
@@ -97,11 +107,15 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     cwd: string;
     artifactDirectory?: string;
     verifyExecutable?: () => Promise<void>;
+    runtimeExecutable?: string;
+    bindBeforeSpawn?: () => Promise<() => Promise<void>>;
   }) {
     this.#executable = options.executable;
     this.#runner = options.runner;
     this.#cwd = options.cwd;
     this.#verifyExecutable = options.verifyExecutable;
+    this.#runtimeExecutable = options.runtimeExecutable;
+    this.#bindBeforeSpawn = options.bindBeforeSpawn;
     this.#artifacts = new BrowserScreenshotArtifactStore(
       options.artifactDirectory,
     );
@@ -132,23 +146,37 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   ): Promise<BrowserTabSummary> {
     const session = this.#session(sessionId);
     return await this.#enqueue(session, signal, async (revision) => {
-      if (!session.opened) {
-        const response = await this.#run(session, ["open", url], signal);
-        requirePlaywrightOpenEnvelope(response, session.cliSessionName);
-        session.opened = true;
-      } else {
-        await this.#run(session, ["tab-new", url], signal);
+      if (session.opened) {
+        const existingPages = await this.#pageStates(session, signal);
+        this.#assertSession(session, revision, signal);
+        this.#reconcileTabs(session, existingPages);
       }
-      const pages = await this.#pageStates(session, signal);
-      this.#assertSession(session, revision, signal);
-      this.#reconcileTabs(session, pages);
-      const current = pages.find((page) => page.current) ?? pages.at(-1);
-      if (current === undefined)
-        throw new Error("Playwright opened no browser tab");
-      const state = session.tabs.get(current.tabKey);
-      if (state === undefined)
-        throw new Error("Playwright tab mapping is missing");
-      return pageSummary(sessionId, state.tabId, current);
+      assertBrowserTabCapacity(
+        this.#tabCount() + this.#reservedOpenTabs + 1,
+        session.tabs.size + 1,
+      );
+      this.#reservedOpenTabs += 1;
+      try {
+        if (!session.opened) {
+          const response = await this.#run(session, ["open", url], signal);
+          requirePlaywrightOpenEnvelope(response, session.cliSessionName);
+          session.opened = true;
+        } else {
+          await this.#run(session, ["tab-new", url], signal);
+        }
+        const pages = await this.#pageStates(session, signal);
+        this.#assertSession(session, revision, signal);
+        this.#reconcileTabs(session, pages);
+        const current = pages.find((page) => page.current) ?? pages.at(-1);
+        if (current === undefined)
+          throw new Error("Playwright opened no browser tab");
+        const state = session.tabs.get(current.tabKey);
+        if (state === undefined)
+          throw new Error("Playwright tab mapping is missing");
+        return pageSummary(sessionId, state.tabId, current);
+      } finally {
+        this.#reservedOpenTabs -= 1;
+      }
     });
   }
 
@@ -395,6 +423,8 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
           timeoutMs,
           signal,
           maxOutputBytes,
+          runtimeExecutable: this.#runtimeExecutable,
+          bindBeforeSpawn: this.#bindBeforeSpawn,
           verifyBeforeSpawn: this.#verifyExecutable,
         },
       );
@@ -466,7 +496,13 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       .run(
         this.#executable,
         ["--json", `-s=${session.cliSessionName}`, "close"],
-        { cwd: this.#cwd, timeoutMs: PLAYWRIGHT_CLOSE_TIMEOUT_MS },
+        {
+          cwd: this.#cwd,
+          timeoutMs: PLAYWRIGHT_CLOSE_TIMEOUT_MS,
+          runtimeExecutable: this.#runtimeExecutable,
+          bindBeforeSpawn: this.#bindBeforeSpawn,
+          verifyBeforeSpawn: this.#verifyExecutable,
+        },
       )
       .catch(() => undefined);
   }
@@ -497,9 +533,38 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         "Unsupported playwright-cli JSON schema: run-code result is not JSON",
       );
     }
-    if (!Array.isArray(parsed) || !parsed.every(isPlaywrightPageState)) {
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length > MAX_PLAYWRIGHT_PAGES ||
+      parsed.length > MAX_BROWSER_TABS_PER_SESSION ||
+      !parsed.every(isPlaywrightPageState)
+    ) {
       throw new Error(
         "Unsupported playwright-cli JSON schema: invalid page state result",
+      );
+    }
+    const keys = new Set<string>();
+    const documentKeys = new Set<string>();
+    const indexes = new Set<number>();
+    let currentCount = 0;
+    for (const page of parsed) {
+      if (
+        keys.has(page.tabKey) ||
+        documentKeys.has(page.documentKey) ||
+        indexes.has(page.index)
+      ) {
+        throw new Error(
+          "Unsupported playwright-cli JSON schema: duplicate page identity",
+        );
+      }
+      keys.add(page.tabKey);
+      documentKeys.add(page.documentKey);
+      indexes.add(page.index);
+      if (page.current) currentCount += 1;
+    }
+    if (parsed.length > 0 && currentCount !== 1) {
+      throw new Error(
+        "Unsupported playwright-cli JSON schema: exactly one page must be current",
       );
     }
     return parsed;
@@ -775,6 +840,12 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     }
   }
 
+  #tabCount(): number {
+    let count = 0;
+    for (const session of this.#sessions.values()) count += session.tabs.size;
+    return count;
+  }
+
   #invalidate(tab: PlaywrightTabState): void {
     tab.documentVersion += 1;
     tab.observation = undefined;
@@ -975,12 +1046,18 @@ function isPlaywrightPageState(value: unknown): value is PlaywrightPageState {
   const page = value as Record<string, unknown>;
   return (
     Number.isSafeInteger(page.index) &&
+    (page.index as number) >= 0 &&
+    (page.index as number) < MAX_PLAYWRIGHT_PAGES &&
     typeof page.tabKey === "string" &&
     page.tabKey.length > 0 &&
+    page.tabKey.length <= MAX_PLAYWRIGHT_PAGE_KEY_LENGTH &&
     typeof page.documentKey === "string" &&
     page.documentKey.length > 0 &&
+    page.documentKey.length <= MAX_PLAYWRIGHT_PAGE_KEY_LENGTH &&
     typeof page.title === "string" &&
+    page.title.length <= MAX_PLAYWRIGHT_PAGE_TITLE_LENGTH &&
     typeof page.url === "string" &&
+    page.url.length <= MAX_PLAYWRIGHT_PAGE_URL_LENGTH &&
     typeof page.current === "boolean"
   );
 }
@@ -1002,6 +1079,10 @@ function pageSummary(
 function pageIdentity(page: PlaywrightPageState): string {
   return `${page.tabKey}\u0000${page.documentKey}`;
 }
+
+// Capacity is checked before dispatch and includes opens from other sessions
+// that have reserved a slot but have not yet returned their page list.
+// This keeps the provider's one-session operations from bypassing the global cap.
 
 function tabIdentity(tab: PlaywrightTabState): string {
   return `${tab.tabKey}\u0000${tab.documentKey}`;

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -24,6 +24,8 @@ const MAX_PLAYWRIGHT_SCREENSHOT_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 interface PlaywrightTabState {
   tabId: string;
+  tabKey: string;
+  documentKey: string;
   index: number;
   documentVersion: number;
   observation?: PlaywrightObservation;
@@ -33,6 +35,9 @@ interface PlaywrightSessionState {
   sessionId: string;
   cliSessionName: string;
   opened: boolean;
+  closed: boolean;
+  lifecycleRevision: number;
+  operationTail: Promise<void>;
   tabs: Map<string, PlaywrightTabState>;
 }
 
@@ -47,6 +52,8 @@ interface PlaywrightObservation {
 
 interface PlaywrightPageState {
   index: number;
+  tabKey: string;
+  documentKey: string;
   title: string;
   url: string;
   current: boolean;
@@ -105,16 +112,16 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary[]> {
     const session = this.#requireSession(sessionId);
-    const pages = await this.#pageStates(session, signal);
-    this.#reconcileTabs(session, pages);
-    return pages.map((page) => {
-      const state = [...session.tabs.values()].find(
-        (candidate) => candidate.index === page.index,
-      );
-      if (state === undefined) {
-        throw new Error("Playwright tab reconciliation failed");
-      }
-      return pageSummary(sessionId, state.tabId, page);
+    return await this.#enqueue(session, signal, async (revision) => {
+      const pages = await this.#pageStates(session, signal);
+      this.#assertSession(session, revision, signal);
+      this.#reconcileTabs(session, pages);
+      return pages.map((page) => {
+        const state = session.tabs.get(page.tabKey);
+        if (state === undefined)
+          throw new Error("Playwright tab reconciliation failed");
+        return pageSummary(sessionId, state.tabId, page);
+      });
     });
   }
 
@@ -124,29 +131,25 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const session = this.#session(sessionId);
-    if (!session.opened) {
-      const response = await this.#run(
-        session,
-        ["open", url],
-        signal,
-        PLAYWRIGHT_PROVIDER_TIMEOUT_MS,
-      );
-      requirePlaywrightOpenEnvelope(response, session.cliSessionName);
-      session.opened = true;
-    } else {
-      await this.#run(session, ["tab-new", url], signal);
-    }
-    const pages = await this.#pageStates(session, signal);
-    this.#reconcileTabs(session, pages);
-    const current = pages.find((page) => page.current) ?? pages.at(-1);
-    if (current === undefined)
-      throw new Error("Playwright opened no browser tab");
-    const state = [...session.tabs.values()].find(
-      (candidate) => candidate.index === current.index,
-    );
-    if (state === undefined)
-      throw new Error("Playwright tab mapping is missing");
-    return pageSummary(sessionId, state.tabId, current);
+    return await this.#enqueue(session, signal, async (revision) => {
+      if (!session.opened) {
+        const response = await this.#run(session, ["open", url], signal);
+        requirePlaywrightOpenEnvelope(response, session.cliSessionName);
+        session.opened = true;
+      } else {
+        await this.#run(session, ["tab-new", url], signal);
+      }
+      const pages = await this.#pageStates(session, signal);
+      this.#assertSession(session, revision, signal);
+      this.#reconcileTabs(session, pages);
+      const current = pages.find((page) => page.current) ?? pages.at(-1);
+      if (current === undefined)
+        throw new Error("Playwright opened no browser tab");
+      const state = session.tabs.get(current.tabKey);
+      if (state === undefined)
+        throw new Error("Playwright tab mapping is missing");
+      return pageSummary(sessionId, state.tabId, current);
+    });
   }
 
   async navigate(
@@ -156,10 +159,13 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
-    await this.#select(session, tab, signal);
-    this.#invalidate(tab);
-    await this.#run(session, ["goto", url], signal);
-    return await this.#summary(sessionId, session, tab, signal);
+    return await this.#enqueue(session, signal, async (revision) => {
+      await this.#select(session, tab, signal);
+      this.#invalidate(tab);
+      await this.#run(session, ["goto", url], signal);
+      this.#assertSession(session, revision, signal);
+      return await this.#summary(sessionId, session, tab, signal);
+    });
   }
 
   async inspect(
@@ -168,83 +174,103 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserInspection> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
-    await this.#select(session, tab, signal);
-    const beforeSnapshot = await this.#currentPage(session, tab, signal);
-    const snapshot = await this.#snapshot(session, signal);
-    const observationId = randomUUID();
-    const targets = new Map<
-      string,
-      BrowserTargetFingerprint & { ref: string; disabled: boolean }
-    >();
-    const visible: string[] = [];
-    const nodes: PlaywrightAriaNode[] = [];
-    walkAriaSnapshot(snapshot, (node) => {
-      appendVisibleText(visible, node);
-      if (node.ref !== undefined && nodes.length < MAX_PLAYWRIGHT_TARGETS) {
-        nodes.push(node);
-      }
-    });
-    const metadata = await this.#domMetadata(
-      session,
-      nodes.flatMap((node) => (node.ref === undefined ? [] : [node.ref])),
-      signal,
-    );
-    for (const node of nodes) {
-      const dom = node.ref === undefined ? undefined : metadata.get(node.ref);
-      if (node.ref === undefined || dom === undefined || !dom.visible) continue;
-      const fingerprint = playwrightTargetFingerprint(node, dom);
-      const actions = fingerprint.actions;
-      if (actions.length === 0) continue;
-      const targetId = randomUUID();
-      targets.set(targetId, {
-        ref: node.ref,
-        ...fingerprint,
-        disabled: node.disabled === true,
+    return await this.#enqueue(session, signal, async (revision) => {
+      await this.#select(session, tab, signal);
+      const beforeSnapshot = await this.#currentPage(session, tab, signal);
+      const observationDocumentVersion = tab.documentVersion;
+      const snapshot = await this.#snapshot(session, signal);
+      const observationId = randomUUID();
+      const targets = new Map<
+        string,
+        BrowserTargetFingerprint & { ref: string; disabled: boolean }
+      >();
+      const visible: string[] = [];
+      const nodes: PlaywrightAriaNode[] = [];
+      walkAriaSnapshot(snapshot, (node) => {
+        appendVisibleText(visible, node);
+        if (node.ref !== undefined && nodes.length < MAX_PLAYWRIGHT_TARGETS) {
+          nodes.push(node);
+        }
       });
-    }
-    const beforeScreenshot = await this.#currentPage(session, tab, signal);
-    if (pageIdentity(beforeSnapshot) !== pageIdentity(beforeScreenshot)) {
-      this.#invalidate(tab);
-      throw new Error(
-        "Playwright page changed during inspection; inspect again",
+      const metadata = await this.#domMetadata(
+        session,
+        nodes.flatMap((node) => (node.ref === undefined ? [] : [node.ref])),
+        signal,
       );
-    }
-    const screenshot = await this.#screenshot(
-      session,
-      tab,
-      observationId,
-      signal,
-    );
-    const afterScreenshot = await this.#currentPage(session, tab, signal);
-    if (pageIdentity(beforeScreenshot) !== pageIdentity(afterScreenshot)) {
-      await this.#artifacts.removeArtifact(
-        screenshot.artifactPath,
-        screenshot.observationId,
+      for (const node of nodes) {
+        const dom = node.ref === undefined ? undefined : metadata.get(node.ref);
+        if (node.ref === undefined || dom === undefined || !dom.visible)
+          continue;
+        const fingerprint = playwrightTargetFingerprint(node, dom);
+        const actions = fingerprint.actions;
+        if (actions.length === 0) continue;
+        const targetId = randomUUID();
+        targets.set(targetId, {
+          ref: node.ref,
+          ...fingerprint,
+          disabled: node.disabled === true,
+        });
+      }
+      const beforeScreenshot = await this.#currentPage(session, tab, signal);
+      if (pageIdentity(beforeSnapshot) !== pageIdentity(beforeScreenshot)) {
+        this.#invalidate(tab);
+        throw new Error(
+          "Playwright page changed during inspection; inspect again",
+        );
+      }
+      const screenshot = await this.#screenshot(
+        session,
+        tab,
+        observationId,
+        signal,
       );
-      this.#invalidate(tab);
-      throw new Error(
-        "Playwright page changed during screenshot; inspect again",
-      );
-    }
-    tab.observation = {
-      id: observationId,
-      documentVersion: tab.documentVersion,
-      targets,
-    };
-    const summary = await this.#summary(sessionId, session, tab, signal);
-    return {
-      ...summary,
-      observationId,
-      documentVersion: tab.documentVersion,
-      visibleText: visible.join("\n").slice(0, MAX_PLAYWRIGHT_VISIBLE_TEXT),
-      targets: [...targets].map(([targetId, target]) => ({
-        targetId,
-        role: target.role,
-        name: target.name,
-        actions: [...target.actions],
-      })),
-      screenshot,
-    };
+      const afterScreenshot = await this.#currentPage(session, tab, signal);
+      if (pageIdentity(beforeScreenshot) !== pageIdentity(afterScreenshot)) {
+        await this.#artifacts.removeArtifact(
+          screenshot.artifactPath,
+          screenshot.observationId,
+        );
+        this.#invalidate(tab);
+        throw new Error(
+          "Playwright page changed during screenshot; inspect again",
+        );
+      }
+      this.#assertSession(session, revision, signal);
+      const summary = await this.#summary(sessionId, session, tab, signal);
+      const finalPage = await this.#currentPage(session, tab, signal);
+      if (
+        pageIdentity(beforeSnapshot) !== pageIdentity(finalPage) ||
+        pageIdentity(beforeScreenshot) !== pageIdentity(finalPage) ||
+        tab.documentVersion !== observationDocumentVersion
+      ) {
+        await this.#artifacts.removeArtifact(
+          screenshot.artifactPath,
+          screenshot.observationId,
+        );
+        this.#invalidate(tab);
+        throw new Error(
+          "Playwright page changed before inspection publication; inspect again",
+        );
+      }
+      tab.observation = {
+        id: observationId,
+        documentVersion: observationDocumentVersion,
+        targets,
+      };
+      return {
+        ...summary,
+        observationId,
+        documentVersion: observationDocumentVersion,
+        visibleText: visible.join("\n").slice(0, MAX_PLAYWRIGHT_VISIBLE_TEXT),
+        targets: [...targets].map(([targetId, target]) => ({
+          targetId,
+          role: target.role,
+          name: target.name,
+          actions: [...target.actions],
+        })),
+        screenshot,
+      };
+    });
   }
 
   async click(
@@ -255,12 +281,20 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
-    const target = requireObservedTarget(tab, observationId, targetId, "click");
-    await this.#select(session, tab, signal);
-    await this.#revalidateTarget(session, target, "click", signal);
-    this.#invalidate(tab);
-    await this.#run(session, ["click", target.ref], signal);
-    return await this.#summary(sessionId, session, tab, signal);
+    return await this.#enqueue(session, signal, async (revision) => {
+      const target = requireObservedTarget(
+        tab,
+        observationId,
+        targetId,
+        "click",
+      );
+      await this.#select(session, tab, signal);
+      await this.#revalidateTarget(session, target, "click", signal);
+      this.#invalidate(tab);
+      await this.#run(session, ["click", target.ref], signal);
+      this.#assertSession(session, revision, signal);
+      return await this.#summary(sessionId, session, tab, signal);
+    });
   }
 
   async type(
@@ -273,13 +307,21 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
-    const target = requireObservedTarget(tab, observationId, targetId, "type");
-    await this.#select(session, tab, signal);
-    await this.#revalidateTarget(session, target, "type", signal);
-    this.#invalidate(tab);
-    await this.#run(session, ["fill", target.ref, text], signal);
-    if (submit) await this.#run(session, ["press", "Enter"], signal);
-    return await this.#summary(sessionId, session, tab, signal);
+    return await this.#enqueue(session, signal, async (revision) => {
+      const target = requireObservedTarget(
+        tab,
+        observationId,
+        targetId,
+        "type",
+      );
+      await this.#select(session, tab, signal);
+      await this.#revalidateTarget(session, target, "type", signal);
+      this.#invalidate(tab);
+      await this.#run(session, ["fill", target.ref, text], signal);
+      if (submit) await this.#run(session, ["press", "Enter"], signal);
+      this.#assertSession(session, revision, signal);
+      return await this.#summary(sessionId, session, tab, signal);
+    });
   }
 
   async closeTab(
@@ -288,34 +330,45 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<void> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
-    await this.#run(session, ["tab-close", String(tab.index)], signal);
-    session.tabs.delete(tabId);
-    await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
-    for (const candidate of session.tabs.values()) {
-      if (candidate.index > tab.index) candidate.index -= 1;
-    }
+    await this.#enqueue(session, signal, async (revision) => {
+      await this.#select(session, tab, signal);
+      await this.#run(session, ["tab-close", String(tab.index)], signal);
+      this.#assertSession(session, revision, signal);
+      session.tabs.delete(tab.tabKey);
+      await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
+    });
   }
 
   async closeSession(sessionId: string, signal?: AbortSignal): Promise<number> {
     const session = this.#sessions.get(sessionId);
     if (session === undefined) return 0;
-    const closedTabs = session.tabs.size;
-    try {
-      if (session.opened) {
-        await this.#run(
-          session,
-          ["close"],
-          signal,
-          PLAYWRIGHT_CLOSE_TIMEOUT_MS,
-        );
-      }
-    } finally {
-      session.tabs.clear();
-      session.opened = false;
-      this.#sessions.delete(sessionId);
-      await this.#artifacts.clearScope(sessionId);
-    }
-    return closedTabs;
+    return await this.#enqueue(
+      session,
+      signal,
+      async () => {
+        const closedTabs = session.tabs.size;
+        session.closed = true;
+        session.lifecycleRevision += 1;
+        try {
+          if (session.opened) {
+            await this.#run(
+              session,
+              ["close"],
+              signal,
+              PLAYWRIGHT_CLOSE_TIMEOUT_MS,
+            );
+          }
+        } finally {
+          session.tabs.clear();
+          session.opened = false;
+          if (this.#sessions.get(sessionId) === session)
+            this.#sessions.delete(sessionId);
+          await this.#artifacts.clearScope(sessionId);
+        }
+        return closedTabs;
+      },
+      true,
+    );
   }
 
   async close(): Promise<void> {
@@ -342,6 +395,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
           timeoutMs,
           signal,
           maxOutputBytes,
+          verifyBeforeSpawn: this.#verifyExecutable,
         },
       );
       const response = parseExternalJson("playwright-cli", result.stdout);
@@ -358,6 +412,8 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         }
         session.opened = false;
         session.tabs.clear();
+        session.closed = true;
+        session.lifecycleRevision += 1;
         void this.#bestEffortCancel(session);
       }
       throw error;
@@ -386,15 +442,26 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         "Unsupported playwright-cli JSON schema: screenshot result must be base64",
       );
     }
-    return await this.#artifacts.write(
+    signal?.throwIfAborted();
+    const png = Buffer.from(response.result, "base64");
+    const artifact = await this.#artifacts.write(
       `${session.sessionId}/${tab.tabId}`,
       observationId,
-      Buffer.from(response.result, "base64"),
+      png,
     );
+    try {
+      signal?.throwIfAborted();
+    } catch (error) {
+      await this.#artifacts.removeArtifact(
+        artifact.artifactPath,
+        artifact.observationId,
+      );
+      throw error;
+    }
+    return artifact;
   }
 
   async #bestEffortCancel(session: PlaywrightSessionState): Promise<void> {
-    await this.#verifyExecutable?.().catch(() => undefined);
     await this.#runner
       .run(
         this.#executable,
@@ -413,7 +480,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       session,
       [
         "run-code",
-        "async page => await Promise.all(page.context().pages().map(async (candidate, index) => ({ index, title: await candidate.title(), url: candidate.url(), current: candidate === page })))",
+        "async page => await Promise.all(page.context().pages().map(async (candidate, index) => ({ index, title: (await candidate.title()).slice(0, 256), url: candidate.url(), current: candidate === page, tabKey: await candidate.evaluate(() => { const key = '__zenx_tab_key'; if (typeof window.name === 'string' && window.name.startsWith('__zenx_tab_')) return window.name; const value = '__zenx_tab_' + crypto.randomUUID(); window.name = value; return value; }), documentKey: await candidate.evaluate(() => { const key = '__zenx_document_key'; const current = globalThis[key]; if (typeof current === 'string') return current; const value = crypto.randomUUID(); Object.defineProperty(globalThis, key, { value, writable: false, configurable: false }); return value; }) })))",
       ],
       signal,
     );
@@ -557,18 +624,27 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     session: PlaywrightSessionState,
     pages: PlaywrightPageState[],
   ): void {
-    const indexes = new Set(pages.map((page) => page.index));
+    const keys = new Set(pages.map((page) => page.tabKey));
     for (const [tabId, tab] of session.tabs) {
-      if (!indexes.has(tab.index)) session.tabs.delete(tabId);
+      if (!keys.has(tab.tabKey)) session.tabs.delete(tabId);
     }
     for (const page of pages) {
-      if (![...session.tabs.values()].some((tab) => tab.index === page.index)) {
+      const existing = session.tabs.get(page.tabKey);
+      if (existing === undefined) {
         const tabId = randomUUID();
-        session.tabs.set(tabId, {
+        session.tabs.set(page.tabKey, {
           tabId,
+          tabKey: page.tabKey,
+          documentKey: page.documentKey,
           index: page.index,
           documentVersion: 0,
         });
+      } else {
+        if (existing.documentKey !== page.documentKey) {
+          existing.documentKey = page.documentKey;
+          this.#invalidate(existing);
+        }
+        existing.index = page.index;
       }
     }
   }
@@ -578,7 +654,18 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     tab: PlaywrightTabState,
     signal?: AbortSignal,
   ): Promise<void> {
+    const pages = await this.#pageStates(session, signal);
+    this.#reconcileTabs(session, pages);
+    if (session.tabs.get(tab.tabKey) !== tab) {
+      throw new Error("Playwright tab identity changed; inspect again");
+    }
     await this.#run(session, ["tab-select", String(tab.index)], signal);
+    const current = await this.#currentPage(session, tab, signal);
+    if (!current.current || pageIdentity(current) !== tabIdentity(tab)) {
+      throw new Error(
+        "Playwright selected page is not the requested tab; retry",
+      );
+    }
   }
 
   async #summary(
@@ -588,9 +675,11 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
     const pages = await this.#pageStates(session, signal);
-    const page = pages.find((candidate) => candidate.index === tab.index);
+    const page = pages.find((candidate) => candidate.tabKey === tab.tabKey);
     if (page === undefined)
       throw new Error("Playwright browser tab was closed");
+    if (!page.current)
+      throw new Error("Playwright requested tab is not selected");
     return pageSummary(sessionId, tab.tabId, page);
   }
 
@@ -600,9 +689,11 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     signal?: AbortSignal,
   ): Promise<PlaywrightPageState> {
     const pages = await this.#pageStates(session, signal);
-    const page = pages.find((candidate) => candidate.index === tab.index);
+    const page = pages.find((candidate) => candidate.tabKey === tab.tabKey);
     if (page === undefined)
       throw new Error("Playwright browser tab was closed");
+    if (!page.current)
+      throw new Error("Playwright requested tab is not selected");
     return page;
   }
 
@@ -613,6 +704,9 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
       sessionId,
       cliSessionName: `${playwrightSessionName(sessionId)}-${randomUUID().slice(0, 8)}`,
       opened: false,
+      closed: false,
+      lifecycleRevision: 0,
+      operationTail: Promise.resolve(),
       tabs: new Map(),
     };
     this.#sessions.set(sessionId, session);
@@ -632,11 +726,53 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     tabId: string,
   ): { session: PlaywrightSessionState; tab: PlaywrightTabState } {
     const session = this.#requireSession(sessionId);
-    const tab = session.tabs.get(tabId);
+    const tab = [...session.tabs.values()].find(
+      (candidate) => candidate.tabId === tabId,
+    );
     if (tab === undefined) {
       throw new Error("Browser tab is unknown or scoped to another session");
     }
     return { session, tab };
+  }
+
+  async #enqueue<T>(
+    session: PlaywrightSessionState,
+    signal: AbortSignal | undefined,
+    operation: (revision: number) => Promise<T>,
+    allowClosed = false,
+  ): Promise<T> {
+    const run = session.operationTail.then(
+      async () => {
+        if (!allowClosed)
+          this.#assertSession(session, session.lifecycleRevision, signal);
+        return await operation(session.lifecycleRevision);
+      },
+      async () => {
+        if (!allowClosed)
+          this.#assertSession(session, session.lifecycleRevision, signal);
+        return await operation(session.lifecycleRevision);
+      },
+    );
+    session.operationTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return await run;
+  }
+
+  #assertSession(
+    session: PlaywrightSessionState,
+    revision: number,
+    signal?: AbortSignal,
+  ): void {
+    signal?.throwIfAborted();
+    if (
+      session.closed ||
+      session.lifecycleRevision !== revision ||
+      this.#sessions.get(session.sessionId) !== session
+    ) {
+      throw new Error("Playwright browser session is closed or stale");
+    }
   }
 
   #invalidate(tab: PlaywrightTabState): void {
@@ -839,6 +975,10 @@ function isPlaywrightPageState(value: unknown): value is PlaywrightPageState {
   const page = value as Record<string, unknown>;
   return (
     Number.isSafeInteger(page.index) &&
+    typeof page.tabKey === "string" &&
+    page.tabKey.length > 0 &&
+    typeof page.documentKey === "string" &&
+    page.documentKey.length > 0 &&
     typeof page.title === "string" &&
     typeof page.url === "string" &&
     typeof page.current === "boolean"
@@ -860,7 +1000,11 @@ function pageSummary(
 }
 
 function pageIdentity(page: PlaywrightPageState): string {
-  return `${page.index}\u0000${page.url}\u0000${page.title}`;
+  return `${page.tabKey}\u0000${page.documentKey}`;
+}
+
+function tabIdentity(tab: PlaywrightTabState): string {
+  return `${tab.tabKey}\u0000${tab.documentKey}`;
 }
 
 export function playwrightSessionName(sessionId: string): string {

--- a/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/playwright-browser-provider.ts
@@ -7,7 +7,10 @@ import type {
   BrowserTargetFingerprint,
   ZenXBrowserBackend,
 } from "./browser-provider.js";
-import { BrowserScreenshotArtifactStore } from "./browser-provider.js";
+import {
+  BrowserScreenshotArtifactStore,
+  redactBrowserUrl,
+} from "./browser-provider.js";
 import {
   type ExternalProviderProcessRunner,
   parseExternalJson,
@@ -77,6 +80,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   readonly #executable: string;
   readonly #runner: ExternalProviderProcessRunner;
   readonly #cwd: string;
+  readonly #verifyExecutable?: () => Promise<void>;
   readonly #sessions = new Map<string, PlaywrightSessionState>();
   readonly #artifacts: BrowserScreenshotArtifactStore;
 
@@ -85,10 +89,12 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     runner: ExternalProviderProcessRunner;
     cwd: string;
     artifactDirectory?: string;
+    verifyExecutable?: () => Promise<void>;
   }) {
     this.#executable = options.executable;
     this.#runner = options.runner;
     this.#cwd = options.cwd;
+    this.#verifyExecutable = options.verifyExecutable;
     this.#artifacts = new BrowserScreenshotArtifactStore(
       options.artifactDirectory,
     );
@@ -163,6 +169,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   ): Promise<BrowserInspection> {
     const { session, tab } = this.#requireTab(sessionId, tabId);
     await this.#select(session, tab, signal);
+    const beforeSnapshot = await this.#currentPage(session, tab, signal);
     const snapshot = await this.#snapshot(session, signal);
     const observationId = randomUUID();
     const targets = new Map<
@@ -195,12 +202,30 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
         disabled: node.disabled === true,
       });
     }
+    const beforeScreenshot = await this.#currentPage(session, tab, signal);
+    if (pageIdentity(beforeSnapshot) !== pageIdentity(beforeScreenshot)) {
+      this.#invalidate(tab);
+      throw new Error(
+        "Playwright page changed during inspection; inspect again",
+      );
+    }
     const screenshot = await this.#screenshot(
       session,
       tab,
       observationId,
       signal,
     );
+    const afterScreenshot = await this.#currentPage(session, tab, signal);
+    if (pageIdentity(beforeScreenshot) !== pageIdentity(afterScreenshot)) {
+      await this.#artifacts.removeArtifact(
+        screenshot.artifactPath,
+        screenshot.observationId,
+      );
+      this.#invalidate(tab);
+      throw new Error(
+        "Playwright page changed during screenshot; inspect again",
+      );
+    }
     tab.observation = {
       id: observationId,
       documentVersion: tab.documentVersion,
@@ -308,6 +333,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     maxOutputBytes = 512 * 1024,
   ): Promise<Record<string, unknown>> {
     try {
+      await this.#verifyExecutable?.();
       const result = await this.#runner.run(
         this.#executable,
         ["--json", `-s=${session.cliSessionName}`, ...args],
@@ -368,6 +394,7 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
   }
 
   async #bestEffortCancel(session: PlaywrightSessionState): Promise<void> {
+    await this.#verifyExecutable?.().catch(() => undefined);
     await this.#runner
       .run(
         this.#executable,
@@ -565,6 +592,18 @@ export class PlaywrightCliBrowserBackend implements ZenXBrowserBackend {
     if (page === undefined)
       throw new Error("Playwright browser tab was closed");
     return pageSummary(sessionId, tab.tabId, page);
+  }
+
+  async #currentPage(
+    session: PlaywrightSessionState,
+    tab: PlaywrightTabState,
+    signal?: AbortSignal,
+  ): Promise<PlaywrightPageState> {
+    const pages = await this.#pageStates(session, signal);
+    const page = pages.find((candidate) => candidate.index === tab.index);
+    if (page === undefined)
+      throw new Error("Playwright browser tab was closed");
+    return page;
   }
 
   #session(sessionId: string): PlaywrightSessionState {
@@ -815,9 +854,13 @@ function pageSummary(
     sessionId,
     tabId,
     title: page.title,
-    url: page.url,
+    url: redactBrowserUrl(page.url),
     loading: false,
   };
+}
+
+function pageIdentity(page: PlaywrightPageState): string {
+  return `${page.index}\u0000${page.url}\u0000${page.title}`;
 }
 
 export function playwrightSessionName(sessionId: string): string {

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -389,6 +389,7 @@ export async function selectComputerProvider(
     const backend = new WinAppCliComputerBackend({
       command,
       runner: options.winAppRunner,
+      platform,
       expectedVersion: bundled?.provider?.version,
       ...(bundled?.provider === undefined
         ? {}

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -20,6 +20,7 @@ import {
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
 import {
+  bindBundledProviderLaunch,
   resolveBundledProvider,
   verifyBundledProvider,
 } from "./provider-provisioning.js";
@@ -169,11 +170,13 @@ export async function selectBrowserProvider(
             reason:
               "Packaged Playwright provider manifest trust anchor is missing",
           }
-        : await resolveBundledProvider("playwright-cli", {
-            resourcesDirectory: options.resourcesDirectory,
-            platform,
-            expectedManifestSha256: options.bundledManifestSha256,
-          })
+        : requireBundledRuntime(
+            await resolveBundledProvider("playwright-cli", {
+              resourcesDirectory: options.resourcesDirectory,
+              platform,
+              expectedManifestSha256: options.bundledManifestSha256,
+            }),
+          )
       : undefined;
   if (
     options.bundledProvidersOnly === true &&
@@ -224,11 +227,30 @@ export async function selectBrowserProvider(
       ],
     };
   }
+  const bundledVerify =
+    bundled?.provider === undefined
+      ? undefined
+      : async () =>
+          await verifyBundledProvider(bundled.provider!, {
+            resourcesDirectory: options.resourcesDirectory!,
+            platform,
+          });
+  const bundledBind =
+    bundled?.provider === undefined
+      ? undefined
+      : async () =>
+          await bindBundledProviderLaunch(bundled.provider!, {
+            resourcesDirectory: options.resourcesDirectory!,
+            platform,
+          });
   try {
     const version = await probePlaywrightCli(
       executable,
       runner,
       bundled?.provider?.version,
+      bundled?.provider?.runtime?.path,
+      bundledBind,
+      bundledVerify,
     );
     const playwrightDirectory = path.join(
       options.userDataDirectory,
@@ -243,11 +265,9 @@ export async function selectBrowserProvider(
         ...(bundled?.provider === undefined
           ? {}
           : {
-              verifyExecutable: async () =>
-                await verifyBundledProvider(bundled.provider!, {
-                  resourcesDirectory: options.resourcesDirectory!,
-                  platform,
-                }),
+              runtimeExecutable: bundled.provider.runtime?.path,
+              bindBeforeSpawn: bundledBind,
+              verifyExecutable: bundledVerify,
             }),
       }),
       manifest: playwrightBrowserManifest(),
@@ -363,11 +383,13 @@ export async function selectComputerProvider(
               reason:
                 "Packaged WinApp provider manifest trust anchor is missing",
             }
-          : await resolveBundledProvider("microsoft-winapp-cli", {
-              resourcesDirectory: options.resourcesDirectory,
-              platform,
-              expectedManifestSha256: options.bundledManifestSha256,
-            })
+          : requireBundledRuntime(
+              await resolveBundledProvider("microsoft-winapp-cli", {
+                resourcesDirectory: options.resourcesDirectory,
+                platform,
+                expectedManifestSha256: options.bundledManifestSha256,
+              }),
+            )
         : undefined;
     const command =
       bundled?.provider?.executable ??
@@ -394,6 +416,12 @@ export async function selectComputerProvider(
       ...(bundled?.provider === undefined
         ? {}
         : {
+            runtimeExecutable: bundled.provider.runtime?.path,
+            bindBeforeSpawn: async () =>
+              await bindBundledProviderLaunch(bundled.provider!, {
+                resourcesDirectory: options.resourcesDirectory!,
+                platform,
+              }),
             verifyExecutable: async () =>
               await verifyBundledProvider(bundled.provider!, {
                 resourcesDirectory: options.resourcesDirectory!,
@@ -531,10 +559,16 @@ export async function probePlaywrightCli(
   executable: string,
   runner: ExternalProviderProcessRunner,
   expectedVersion?: string,
+  runtimeExecutable?: string,
+  bindBeforeSpawn?: () => Promise<() => Promise<void>>,
+  verifyBeforeSpawn?: () => Promise<void>,
 ): Promise<string> {
   const versionResult = await runner.run(executable, ["--json", "--version"], {
     timeoutMs: 5_000,
     maxOutputBytes: 32 * 1024,
+    runtimeExecutable,
+    bindBeforeSpawn,
+    verifyBeforeSpawn,
   });
   const versionEnvelope = parseExternalJson(
     "playwright-cli",
@@ -555,6 +589,9 @@ export async function probePlaywrightCli(
   const listResult = await runner.run(executable, ["--json", "list"], {
     timeoutMs: 5_000,
     maxOutputBytes: 64 * 1024,
+    runtimeExecutable,
+    bindBeforeSpawn,
+    verifyBeforeSpawn,
   });
   const listEnvelope = parseExternalJson("playwright-cli", listResult.stdout);
   if (
@@ -833,4 +870,20 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function requireBundledRuntime<
+  T extends { provider?: { runtime?: unknown }; reason?: string },
+>(resolved: T): T {
+  if (
+    resolved.provider !== undefined &&
+    resolved.provider.runtime === undefined
+  ) {
+    return {
+      ...resolved,
+      provider: undefined,
+      reason: "Bundled provider manifest does not pin its packaged runtime",
+    } as T;
+  }
+  return resolved;
 }

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -29,6 +29,7 @@ import {
   windowsComputerCapabilityManifest,
   WinAppCliComputerBackend,
 } from "./windows-computer-provider.js";
+import type { WinAppCliRunner } from "./windows-computer-provider.js";
 import type {
   ZenXCapabilityManifest,
   ZenXCapabilityProviderDiagnostic,
@@ -51,6 +52,7 @@ export interface ZenXCapabilityProviderCatalogOptions {
   environment?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
   runner?: ExternalProviderProcessRunner;
+  winAppRunner?: WinAppCliRunner;
   userBrowserConnector?: (
     endpoint: string,
     signal?: AbortSignal,
@@ -162,11 +164,16 @@ export async function selectBrowserProvider(
   const bundled =
     options.bundledProvidersOnly === true &&
     options.resourcesDirectory !== undefined
-      ? await resolveBundledProvider("playwright-cli", {
-          resourcesDirectory: options.resourcesDirectory,
-          platform,
-          expectedManifestSha256: options.bundledManifestSha256,
-        })
+      ? options.bundledManifestSha256 === undefined
+        ? {
+            reason:
+              "Packaged Playwright provider manifest trust anchor is missing",
+          }
+        : await resolveBundledProvider("playwright-cli", {
+            resourcesDirectory: options.resourcesDirectory,
+            platform,
+            expectedManifestSha256: options.bundledManifestSha256,
+          })
       : undefined;
   if (
     options.bundledProvidersOnly === true &&
@@ -351,11 +358,16 @@ export async function selectComputerProvider(
     const bundled =
       options.bundledProvidersOnly === true &&
       options.resourcesDirectory !== undefined
-        ? await resolveBundledProvider("microsoft-winapp-cli", {
-            resourcesDirectory: options.resourcesDirectory,
-            platform,
-            expectedManifestSha256: options.bundledManifestSha256,
-          })
+        ? options.bundledManifestSha256 === undefined
+          ? {
+              reason:
+                "Packaged WinApp provider manifest trust anchor is missing",
+            }
+          : await resolveBundledProvider("microsoft-winapp-cli", {
+              resourcesDirectory: options.resourcesDirectory,
+              platform,
+              expectedManifestSha256: options.bundledManifestSha256,
+            })
         : undefined;
     const command =
       bundled?.provider?.executable ??
@@ -376,6 +388,7 @@ export async function selectComputerProvider(
     }
     const backend = new WinAppCliComputerBackend({
       command,
+      runner: options.winAppRunner,
       expectedVersion: bundled?.provider?.version,
       ...(bundled?.provider === undefined
         ? {}

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -19,7 +19,10 @@ import {
 } from "./external-provider.js";
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
-import { resolveBundledProvider } from "./provider-provisioning.js";
+import {
+  resolveBundledProvider,
+  verifyBundledProvider,
+} from "./provider-provisioning.js";
 import { connectUserBrowserCdp } from "./user-browser-provider.js";
 import type { UserBrowserConnection } from "./user-browser-provider.js";
 import {
@@ -55,6 +58,8 @@ export interface ZenXCapabilityProviderCatalogOptions {
   /** Set by the packaged app; dev/test keeps explicit PATH discovery. */
   bundledProvidersOnly?: boolean;
   resourcesDirectory?: string;
+  /** Build-time trust anchor for the packaged provider manifest. */
+  bundledManifestSha256?: string;
 }
 
 // @playwright/cli has its own 0.1.x package version. It embeds Playwright
@@ -160,6 +165,7 @@ export async function selectBrowserProvider(
       ? await resolveBundledProvider("playwright-cli", {
           resourcesDirectory: options.resourcesDirectory,
           platform,
+          expectedManifestSha256: options.bundledManifestSha256,
         })
       : undefined;
   if (
@@ -212,7 +218,11 @@ export async function selectBrowserProvider(
     };
   }
   try {
-    const version = await probePlaywrightCli(executable, runner);
+    const version = await probePlaywrightCli(
+      executable,
+      runner,
+      bundled?.provider?.version,
+    );
     const playwrightDirectory = path.join(
       options.userDataDirectory,
       "playwright",
@@ -223,6 +233,15 @@ export async function selectBrowserProvider(
         executable,
         runner,
         cwd: playwrightDirectory,
+        ...(bundled?.provider === undefined
+          ? {}
+          : {
+              verifyExecutable: async () =>
+                await verifyBundledProvider(bundled.provider!, {
+                  resourcesDirectory: options.resourcesDirectory!,
+                  platform,
+                }),
+            }),
       }),
       manifest: playwrightBrowserManifest(),
       diagnostics: [
@@ -335,6 +354,7 @@ export async function selectComputerProvider(
         ? await resolveBundledProvider("microsoft-winapp-cli", {
             resourcesDirectory: options.resourcesDirectory,
             platform,
+            expectedManifestSha256: options.bundledManifestSha256,
           })
         : undefined;
     const command =
@@ -354,7 +374,19 @@ export async function selectComputerProvider(
         ],
       };
     }
-    const backend = new WinAppCliComputerBackend({ command });
+    const backend = new WinAppCliComputerBackend({
+      command,
+      expectedVersion: bundled?.provider?.version,
+      ...(bundled?.provider === undefined
+        ? {}
+        : {
+            verifyExecutable: async () =>
+              await verifyBundledProvider(bundled.provider!, {
+                resourcesDirectory: options.resourcesDirectory!,
+                platform,
+              }),
+          }),
+    });
     const diagnostic = await backend.diagnose();
     if (!diagnostic.ready) {
       await backend.close();
@@ -484,6 +516,7 @@ export async function selectComputerProvider(
 export async function probePlaywrightCli(
   executable: string,
   runner: ExternalProviderProcessRunner,
+  expectedVersion?: string,
 ): Promise<string> {
   const versionResult = await runner.run(executable, ["--json", "--version"], {
     timeoutMs: 5_000,
@@ -500,6 +533,11 @@ export async function probePlaywrightCli(
     MAX_PLAYWRIGHT_CLI_EXCLUSIVE,
     "playwright-cli",
   );
+  if (expectedVersion !== undefined && version !== expectedVersion) {
+    throw new Error(
+      `playwright-cli version ${version} does not match pinned version ${expectedVersion}`,
+    );
+  }
   const listResult = await runner.run(executable, ["--json", "list"], {
     timeoutMs: 5_000,
     maxOutputBytes: 64 * 1024,

--- a/apps/zenx/src/main/capabilities/provider-catalog.ts
+++ b/apps/zenx/src/main/capabilities/provider-catalog.ts
@@ -19,6 +19,7 @@ import {
 } from "./external-provider.js";
 import { PeekabooComputerBackend } from "./peekaboo-computer-provider.js";
 import { PlaywrightCliBrowserBackend } from "./playwright-browser-provider.js";
+import { resolveBundledProvider } from "./provider-provisioning.js";
 import { connectUserBrowserCdp } from "./user-browser-provider.js";
 import type { UserBrowserConnection } from "./user-browser-provider.js";
 import {
@@ -51,6 +52,9 @@ export interface ZenXCapabilityProviderCatalogOptions {
     endpoint: string,
     signal?: AbortSignal,
   ) => Promise<UserBrowserConnection>;
+  /** Set by the packaged app; dev/test keeps explicit PATH discovery. */
+  bundledProvidersOnly?: boolean;
+  resourcesDirectory?: string;
 }
 
 // @playwright/cli has its own 0.1.x package version. It embeds Playwright
@@ -150,10 +154,39 @@ export async function selectBrowserProvider(
     };
   }
   const configured = environment.ZENX_PLAYWRIGHT_CLI;
-  const executable = await discoverExecutable(configured ?? "playwright-cli", {
-    environment,
-    platform,
-  });
+  const bundled =
+    options.bundledProvidersOnly === true &&
+    options.resourcesDirectory !== undefined
+      ? await resolveBundledProvider("playwright-cli", {
+          resourcesDirectory: options.resourcesDirectory,
+          platform,
+        })
+      : undefined;
+  if (
+    options.bundledProvidersOnly === true &&
+    bundled?.provider === undefined
+  ) {
+    return {
+      backend: new ElectronBrowserBackend(),
+      manifest: browserCapabilityManifest,
+      diagnostics: [
+        unavailableDiagnostic(
+          "browser",
+          "playwright-cli",
+          ["isolated"],
+          ["headless", "browser_context", "aria_snapshot", "auto_wait"],
+          bundled?.reason ?? "Packaged Playwright provider is not provisioned",
+        ),
+        electronBrowserDiagnostic("fallback"),
+      ],
+    };
+  }
+  const executable =
+    bundled?.provider?.executable ??
+    (await discoverExecutable(configured ?? "playwright-cli", {
+      environment,
+      platform,
+    }));
   const fallbackDiagnostic = electronBrowserDiagnostic(
     executable === undefined ? "fallback" : "available",
   );
@@ -207,6 +240,9 @@ export async function selectBrowserProvider(
           ],
           executable,
           version,
+          ...(bundled?.provider === undefined
+            ? { integrity: "unverified" as const }
+            : { integrity: "verified" as const }),
           permissionSummary:
             "Isolated in-memory Playwright session; no foreground desktop input",
           sessionMode: "isolated-session",
@@ -293,7 +329,32 @@ export async function selectComputerProvider(
   const environment = options.environment ?? process.env;
   const platform = options.platform ?? process.platform;
   if (platform === "win32") {
-    const backend = new WinAppCliComputerBackend();
+    const bundled =
+      options.bundledProvidersOnly === true &&
+      options.resourcesDirectory !== undefined
+        ? await resolveBundledProvider("microsoft-winapp-cli", {
+            resourcesDirectory: options.resourcesDirectory,
+            platform,
+          })
+        : undefined;
+    const command =
+      bundled?.provider?.executable ??
+      (options.bundledProvidersOnly === true ? undefined : "winapp");
+    if (command === undefined) {
+      return {
+        manifest: windowsComputerCapabilityManifest,
+        diagnostics: [
+          unavailableDiagnostic(
+            "computer",
+            "microsoft-winapp-cli",
+            ["background_safe"],
+            ["uia.inspect", "uia.invoke", "uia.set_value", "wgc.capture"],
+            bundled?.reason ?? "Packaged WinApp provider is not provisioned",
+          ),
+        ],
+      };
+    }
+    const backend = new WinAppCliComputerBackend({ command });
     const diagnostic = await backend.diagnose();
     if (!diagnostic.ready) {
       await backend.close();
@@ -330,6 +391,9 @@ export async function selectComputerProvider(
           ...(diagnostic.version === undefined
             ? {}
             : { version: diagnostic.version }),
+          ...(bundled?.provider === undefined
+            ? { integrity: "unverified" as const }
+            : { integrity: "verified" as const }),
           permissionSummary:
             "Exact-window UI Automation and WGC capture; no global input injection",
         },
@@ -593,6 +657,7 @@ function electronBrowserDiagnostic(
     capabilities: ["dedicated_profile", "cdp", "dom.inspect", "dom.interact"],
     permissionSummary: "Bundled hidden ephemeral Electron partition",
     sessionMode: "isolated-session",
+    integrity: "verified",
   };
 }
 

--- a/apps/zenx/src/main/capabilities/provider-provisioning.ts
+++ b/apps/zenx/src/main/capabilities/provider-provisioning.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+export type PinnedProviderId = "playwright-cli" | "microsoft-winapp-cli";
+
+export interface BundledProvider {
+  providerId: PinnedProviderId;
+  executable: string;
+  version: string;
+  sha256: string;
+}
+
+export interface BundledProviderResolution {
+  provider?: BundledProvider;
+  reason?: string;
+}
+
+interface ProviderManifestEntry {
+  executable: string;
+  version: string;
+  sha256: string;
+  platforms: string[];
+}
+
+interface ProviderManifest {
+  schemaVersion: 1;
+  providers: Partial<Record<PinnedProviderId, ProviderManifestEntry>>;
+}
+
+/**
+ * Resolve only an application-bundled provider whose manifest pins both
+ * version and bytes. This is deliberately offline: downloading or accepting
+ * a PATH executable belongs to an explicit provisioning/update workflow.
+ */
+export async function resolveBundledProvider(
+  providerId: PinnedProviderId,
+  options: { resourcesDirectory: string; platform: NodeJS.Platform },
+): Promise<BundledProviderResolution> {
+  const manifestPath = path.join(
+    options.resourcesDirectory,
+    "providers",
+    "manifest.json",
+  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    return {
+      reason: `Bundled ${providerId} manifest is unavailable at ${manifestPath}: ${describeError(error)}`,
+    };
+  }
+  const manifest = parseManifest(parsed, providerId);
+  if (manifest === undefined) {
+    return {
+      reason: `Bundled ${providerId} manifest is invalid or does not pin this provider`,
+    };
+  }
+  if (!manifest.platforms.includes(options.platform)) {
+    return {
+      reason: `Bundled ${providerId} does not provide an asset for ${options.platform}`,
+    };
+  }
+  const executable = path.resolve(
+    options.resourcesDirectory,
+    "providers",
+    manifest.executable,
+  );
+  const providerRoot = path.resolve(options.resourcesDirectory, "providers");
+  if (
+    executable !== providerRoot &&
+    !executable.startsWith(`${providerRoot}${path.sep}`)
+  ) {
+    return {
+      reason: `Bundled ${providerId} executable escapes its resource directory`,
+    };
+  }
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(executable);
+  } catch (error) {
+    return {
+      reason: `Bundled ${providerId} executable is unavailable at ${executable}: ${describeError(error)}`,
+    };
+  }
+  const actualSha256 = createHash("sha256").update(bytes).digest("hex");
+  if (actualSha256 !== manifest.sha256) {
+    return {
+      reason: `Bundled ${providerId} integrity mismatch: expected ${manifest.sha256}, got ${actualSha256}`,
+    };
+  }
+  return {
+    provider: {
+      providerId,
+      executable,
+      version: manifest.version,
+      sha256: actualSha256,
+    },
+  };
+}
+
+function parseManifest(
+  value: unknown,
+  providerId: PinnedProviderId,
+): ProviderManifestEntry | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const manifest = value as Partial<ProviderManifest>;
+  if (manifest.schemaVersion !== 1 || typeof manifest.providers !== "object") {
+    return undefined;
+  }
+  const entry = manifest.providers?.[providerId];
+  if (
+    entry === undefined ||
+    typeof entry !== "object" ||
+    typeof entry.executable !== "string" ||
+    entry.executable.length === 0 ||
+    typeof entry.version !== "string" ||
+    !/^\d+\.\d+\.\d+(?:[-+].*)?$/u.test(entry.version) ||
+    typeof entry.sha256 !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(entry.sha256) ||
+    !Array.isArray(entry.platforms) ||
+    !entry.platforms.every(
+      (platform): platform is string => typeof platform === "string",
+    )
+  ) {
+    return undefined;
+  }
+  return entry;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/src/main/capabilities/provider-provisioning.ts
+++ b/apps/zenx/src/main/capabilities/provider-provisioning.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { lstat, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 
+import { parseWindowsNpmShimEntry } from "./external-provider.js";
+
 export type PinnedProviderId = "playwright-cli" | "microsoft-winapp-cli";
 
 export interface BundledProvider {
@@ -11,6 +13,7 @@ export interface BundledProvider {
   sha256: string;
   manifestPath: string;
   manifestSha256: string;
+  companion?: { path: string; sha256: string };
 }
 
 export interface BundledProviderResolution {
@@ -61,6 +64,12 @@ export async function resolveBundledProvider(
     if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
       throw new Error("manifest must be a regular, non-symlink file");
     }
+    if (manifestStat.size > 256 * 1024)
+      throw new Error("manifest exceeds its size bound");
+    const manifestRealPath = await realpath(manifestPath);
+    if (!isWithin(providerRoot, manifestRealPath)) {
+      throw new Error("manifest resolves outside its resource directory");
+    }
   } catch (error) {
     return {
       reason: `Bundled ${providerId} manifest is unavailable: ${describeError(error)}`,
@@ -108,8 +117,8 @@ export async function resolveBundledProvider(
   }
   const executable = path.resolve(providerRoot, manifest.executable);
   if (
-    executable !== providerRoot &&
-    !executable.startsWith(`${providerRoot}${path.sep}`)
+    path.isAbsolute(manifest.executable) ||
+    !isWithin(providerRoot, executable)
   ) {
     return {
       reason: `Bundled ${providerId} executable escapes its resource directory`,
@@ -117,19 +126,55 @@ export async function resolveBundledProvider(
   }
   let executableRealPath: string;
   let bytes: Buffer;
+  let companion: { path: string; sha256: string } | undefined;
   try {
     const executableStat = await lstat(executable);
     if (executableStat.isSymbolicLink() || !executableStat.isFile()) {
       throw new Error("executable must be a regular, non-symlink file");
     }
     executableRealPath = await realpath(executable);
-    if (
-      executableRealPath !== providerRoot &&
-      !executableRealPath.startsWith(`${providerRoot}${path.sep}`)
-    ) {
+    if (!isWithin(providerRoot, executableRealPath)) {
       throw new Error("executable resolves outside its resource directory");
     }
     bytes = await readFile(executableRealPath);
+    if (path.extname(executableRealPath).toLowerCase() === ".cmd") {
+      const entry = parseWindowsNpmShimEntry(bytes.toString("utf8"));
+      if (entry === undefined)
+        throw new Error("executable shim is unsupported");
+      const segments = entry.split(/[\\/]+/u);
+      if (
+        segments.some(
+          (segment) => segment === "" || segment === "." || segment === "..",
+        )
+      ) {
+        throw new Error("executable shim contains an unsafe path");
+      }
+      const companionPath = path.resolve(
+        path.dirname(executableRealPath),
+        ...segments,
+      );
+      if (!isWithin(providerRoot, companionPath)) {
+        throw new Error(
+          "executable shim resolves outside its resource directory",
+        );
+      }
+      const companionStat = await lstat(companionPath);
+      if (companionStat.isSymbolicLink() || !companionStat.isFile()) {
+        throw new Error("executable shim companion must be a regular file");
+      }
+      const companionRealPath = await realpath(companionPath);
+      if (!isWithin(providerRoot, companionRealPath)) {
+        throw new Error(
+          "executable shim companion resolves outside its resource directory",
+        );
+      }
+      companion = {
+        path: companionRealPath,
+        sha256: createHash("sha256")
+          .update(await readFile(companionRealPath))
+          .digest("hex"),
+      };
+    }
   } catch (error) {
     return {
       reason: `Bundled ${providerId} executable is unavailable at ${executable}: ${describeError(error)}`,
@@ -149,6 +194,7 @@ export async function resolveBundledProvider(
       sha256: actualSha256,
       manifestPath,
       manifestSha256,
+      ...(companion === undefined ? {} : { companion }),
     },
   };
 }
@@ -178,6 +224,16 @@ export async function verifyBundledProvider(
       "Bundled provider changed after selection; refusing to launch",
     );
   }
+  if (selected.companion !== undefined) {
+    if (
+      resolved.provider.companion?.path !== selected.companion.path ||
+      resolved.provider.companion.sha256 !== selected.companion.sha256
+    ) {
+      throw new Error(
+        "Bundled provider companion changed after selection; refusing to launch",
+      );
+    }
+  }
 }
 
 function parseManifest(
@@ -197,11 +253,15 @@ function parseManifest(
     typeof entry !== "object" ||
     typeof entry.executable !== "string" ||
     entry.executable.length === 0 ||
+    entry.executable.length > 256 ||
     typeof entry.version !== "string" ||
+    entry.version.length > 64 ||
     !/^\d+\.\d+\.\d+(?:[-+].*)?$/u.test(entry.version) ||
     typeof entry.sha256 !== "string" ||
     !/^[a-f0-9]{64}$/u.test(entry.sha256) ||
     !Array.isArray(entry.platforms) ||
+    entry.platforms.length === 0 ||
+    entry.platforms.length > 8 ||
     !entry.platforms.every(
       (platform): platform is string => typeof platform === "string",
     )
@@ -209,6 +269,14 @@ function parseManifest(
     return undefined;
   }
   return entry;
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
 }
 
 function describeError(error: unknown): string {

--- a/apps/zenx/src/main/capabilities/provider-provisioning.ts
+++ b/apps/zenx/src/main/capabilities/provider-provisioning.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { lstat, readFile, realpath } from "node:fs/promises";
+import { chmod, lstat, open, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 
 import { parseWindowsNpmShimEntry } from "./external-provider.js";
@@ -14,6 +14,8 @@ export interface BundledProvider {
   manifestPath: string;
   manifestSha256: string;
   companion?: { path: string; sha256: string };
+  runtime?: { path: string; sha256: string; version?: string };
+  assets?: Array<{ path: string; sha256: string }>;
 }
 
 export interface BundledProviderResolution {
@@ -26,6 +28,9 @@ interface ProviderManifestEntry {
   version: string;
   sha256: string;
   platforms: string[];
+  companion?: { path: string; sha256: string };
+  runtime?: { path: string; sha256: string; version?: string };
+  assets?: Array<{ path: string; sha256: string }>;
 }
 
 interface ProviderManifest {
@@ -50,6 +55,7 @@ export async function resolveBundledProvider(
   let providerRoot: string;
   let manifestPath: string;
   try {
+    const resourceRoot = await realpath(options.resourcesDirectory);
     const lexicalProviderRoot = path.join(
       options.resourcesDirectory,
       "providers",
@@ -59,6 +65,9 @@ export async function resolveBundledProvider(
       throw new Error("provider root must be a regular, non-symlink directory");
     }
     providerRoot = await realpath(lexicalProviderRoot);
+    if (!isWithin(resourceRoot, providerRoot)) {
+      throw new Error("provider root resolves outside the resource directory");
+    }
     manifestPath = path.join(providerRoot, "manifest.json");
     const manifestStat = await lstat(manifestPath);
     if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
@@ -127,6 +136,7 @@ export async function resolveBundledProvider(
   let executableRealPath: string;
   let bytes: Buffer;
   let companion: { path: string; sha256: string } | undefined;
+  let assets: Array<{ path: string; sha256: string }> | undefined;
   try {
     const executableStat = await lstat(executable);
     if (executableStat.isSymbolicLink() || !executableStat.isFile()) {
@@ -136,6 +146,8 @@ export async function resolveBundledProvider(
     if (!isWithin(providerRoot, executableRealPath)) {
       throw new Error("executable resolves outside its resource directory");
     }
+    if (executableStat.size > 64 * 1024 * 1024)
+      throw new Error("executable exceeds its size bound");
     bytes = await readFile(executableRealPath);
     if (path.extname(executableRealPath).toLowerCase() === ".cmd") {
       const entry = parseWindowsNpmShimEntry(bytes.toString("utf8"));
@@ -168,11 +180,29 @@ export async function resolveBundledProvider(
           "executable shim companion resolves outside its resource directory",
         );
       }
+      if (companionStat.size > 64 * 1024 * 1024)
+        throw new Error("executable shim companion exceeds its size bound");
+      const companionSha256 = createHash("sha256")
+        .update(await readFile(companionRealPath))
+        .digest("hex");
+      if (manifest.companion === undefined) {
+        throw new Error("executable shim companion is not pinned");
+      }
+      const manifestCompanionPath = path.resolve(
+        providerRoot,
+        manifest.companion.path,
+      );
+      if (
+        path.isAbsolute(manifest.companion.path) ||
+        !isWithin(providerRoot, manifestCompanionPath) ||
+        (await realpath(manifestCompanionPath)) !== companionRealPath ||
+        manifest.companion.sha256 !== companionSha256
+      ) {
+        throw new Error("executable shim companion integrity mismatch");
+      }
       companion = {
         path: companionRealPath,
-        sha256: createHash("sha256")
-          .update(await readFile(companionRealPath))
-          .digest("hex"),
+        sha256: companionSha256,
       };
     }
   } catch (error) {
@@ -186,6 +216,77 @@ export async function resolveBundledProvider(
       reason: `Bundled ${providerId} integrity mismatch: expected ${manifest.sha256}, got ${actualSha256}`,
     };
   }
+  if (manifest.assets !== undefined) {
+    try {
+      if (manifest.assets.length > 64)
+        throw new Error("asset list exceeds its bound");
+      assets = [];
+      for (const asset of manifest.assets) {
+        const assetPath = path.resolve(providerRoot, asset.path);
+        if (path.isAbsolute(asset.path) || !isWithin(providerRoot, assetPath)) {
+          throw new Error("asset escapes its resource directory");
+        }
+        const assetStat = await lstat(assetPath);
+        if (assetStat.isSymbolicLink() || !assetStat.isFile()) {
+          throw new Error("asset must be a regular, non-symlink file");
+        }
+        if (assetStat.size > 128 * 1024 * 1024)
+          throw new Error("asset exceeds its size bound");
+        const assetRealPath = await realpath(assetPath);
+        if (!isWithin(providerRoot, assetRealPath))
+          throw new Error("asset resolves outside its resource directory");
+        const assetSha256 = createHash("sha256")
+          .update(await readFile(assetRealPath))
+          .digest("hex");
+        if (assetSha256 !== asset.sha256)
+          throw new Error(`asset integrity mismatch: ${asset.path}`);
+        assets.push({ path: assetRealPath, sha256: assetSha256 });
+      }
+    } catch (error) {
+      return {
+        reason: `Bundled ${providerId} companion assets are unavailable: ${describeError(error)}`,
+      };
+    }
+  }
+  let runtime: BundledProvider["runtime"];
+  if (manifest.runtime !== undefined) {
+    const runtimePath = path.resolve(providerRoot, manifest.runtime.path);
+    if (
+      path.isAbsolute(manifest.runtime.path) ||
+      !isWithin(providerRoot, runtimePath)
+    ) {
+      return {
+        reason: `Bundled ${providerId} runtime escapes its resource directory`,
+      };
+    }
+    try {
+      const runtimeStat = await lstat(runtimePath);
+      if (runtimeStat.isSymbolicLink() || !runtimeStat.isFile())
+        throw new Error("runtime must be a regular, non-symlink file");
+      if (runtimeStat.size > 128 * 1024 * 1024)
+        throw new Error("runtime exceeds its size bound");
+      const runtimeRealPath = await realpath(runtimePath);
+      if (!isWithin(providerRoot, runtimeRealPath))
+        throw new Error("runtime resolves outside its resource directory");
+      const runtimeBytes = await readFile(runtimeRealPath);
+      const runtimeSha256 = createHash("sha256")
+        .update(runtimeBytes)
+        .digest("hex");
+      if (runtimeSha256 !== manifest.runtime.sha256)
+        throw new Error("runtime integrity mismatch");
+      runtime = {
+        path: runtimeRealPath,
+        sha256: runtimeSha256,
+        ...(manifest.runtime.version === undefined
+          ? {}
+          : { version: manifest.runtime.version }),
+      };
+    } catch (error) {
+      return {
+        reason: `Bundled ${providerId} runtime is unavailable: ${describeError(error)}`,
+      };
+    }
+  }
   return {
     provider: {
       providerId,
@@ -195,6 +296,8 @@ export async function resolveBundledProvider(
       manifestPath,
       manifestSha256,
       ...(companion === undefined ? {} : { companion }),
+      ...(runtime === undefined ? {} : { runtime }),
+      ...(assets === undefined ? {} : { assets }),
     },
   };
 }
@@ -215,13 +318,35 @@ export async function verifyBundledProvider(
   if (resolved.provider === undefined) {
     throw new Error(resolved.reason ?? "Bundled provider verification failed");
   }
+  const verified = resolved.provider;
   if (
-    resolved.provider.executable !== selected.executable ||
-    resolved.provider.sha256 !== selected.sha256 ||
-    resolved.provider.version !== selected.version
+    verified.executable !== selected.executable ||
+    verified.sha256 !== selected.sha256 ||
+    verified.version !== selected.version
   ) {
     throw new Error(
       "Bundled provider changed after selection; refusing to launch",
+    );
+  }
+  if (
+    selected.assets?.length !== verified.assets?.length ||
+    selected.assets?.some(
+      (asset, index) =>
+        asset.path !== verified.assets?.[index]?.path ||
+        asset.sha256 !== verified.assets?.[index]?.sha256,
+    )
+  ) {
+    throw new Error(
+      "Bundled provider companion assets changed after selection; refusing to launch",
+    );
+  }
+  if (
+    selected.runtime?.path !== verified.runtime?.path ||
+    selected.runtime?.sha256 !== verified.runtime?.sha256 ||
+    selected.runtime?.version !== verified.runtime?.version
+  ) {
+    throw new Error(
+      "Bundled provider runtime changed after selection; refusing to launch",
     );
   }
   if (selected.companion !== undefined) {
@@ -234,6 +359,57 @@ export async function verifyBundledProvider(
       );
     }
   }
+}
+
+/**
+ * Bind the verified assets for the short launch interval. The files are held
+ * open and the selected resource tree is made read-only before spawn; this is
+ * the Windows-compatible equivalent available to a Node child-process runner
+ * that cannot pass an executable handle to CreateProcess.
+ */
+export async function bindBundledProviderLaunch(
+  selected: BundledProvider,
+  options: { resourcesDirectory: string; platform: NodeJS.Platform },
+): Promise<() => Promise<void>> {
+  await verifyBundledProvider(selected, options);
+  const handles = [] as Awaited<ReturnType<typeof open>>[];
+  try {
+    for (const candidate of [
+      selected.executable,
+      selected.companion?.path,
+      selected.runtime?.path,
+      ...(selected.assets?.map((asset) => asset.path) ?? []),
+    ].filter((value): value is string => value !== undefined)) {
+      handles.push(await open(candidate, "r"));
+    }
+  } catch (error) {
+    await Promise.all(handles.map((handle) => handle.close()));
+    throw error;
+  }
+  if (options.platform === "win32") {
+    try {
+      await chmod(path.dirname(selected.manifestPath), 0o555);
+      await Promise.all(
+        [
+          selected.manifestPath,
+          selected.executable,
+          selected.companion?.path,
+          selected.runtime?.path,
+          ...(selected.assets?.map((asset) => asset.path) ?? []),
+        ]
+          .filter((candidate): candidate is string => candidate !== undefined)
+          .map((candidate) => chmod(candidate, 0o444)),
+      );
+    } catch (error) {
+      await Promise.all(handles.map((handle) => handle.close()));
+      throw new Error(
+        `Bundled provider resource tree could not be made immutable before spawn: ${describeError(error)}`,
+      );
+    }
+  }
+  return async () => {
+    await Promise.all(handles.map((handle) => handle.close()));
+  };
 }
 
 function parseManifest(
@@ -264,7 +440,34 @@ function parseManifest(
     entry.platforms.length > 8 ||
     !entry.platforms.every(
       (platform): platform is string => typeof platform === "string",
-    )
+    ) ||
+    (entry.runtime !== undefined &&
+      (typeof entry.runtime.path !== "string" ||
+        entry.runtime.path.length === 0 ||
+        entry.runtime.path.length > 256 ||
+        typeof entry.runtime.sha256 !== "string" ||
+        !/^[a-f0-9]{64}$/u.test(entry.runtime.sha256) ||
+        (entry.runtime.version !== undefined &&
+          (typeof entry.runtime.version !== "string" ||
+            entry.runtime.version.length > 64)))) ||
+    (entry.companion !== undefined &&
+      (typeof entry.companion.path !== "string" ||
+        entry.companion.path.length === 0 ||
+        entry.companion.path.length > 256 ||
+        typeof entry.companion.sha256 !== "string" ||
+        !/^[a-f0-9]{64}$/u.test(entry.companion.sha256))) ||
+    (entry.assets !== undefined &&
+      (entry.assets.length > 64 ||
+        !entry.assets.every(
+          (asset) =>
+            typeof asset === "object" &&
+            asset !== null &&
+            typeof asset.path === "string" &&
+            asset.path.length > 0 &&
+            asset.path.length <= 256 &&
+            typeof asset.sha256 === "string" &&
+            /^[a-f0-9]{64}$/u.test(asset.sha256),
+        )))
   ) {
     return undefined;
   }

--- a/apps/zenx/src/main/capabilities/provider-provisioning.ts
+++ b/apps/zenx/src/main/capabilities/provider-provisioning.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { lstat, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 
 export type PinnedProviderId = "playwright-cli" | "microsoft-winapp-cli";
@@ -9,6 +9,8 @@ export interface BundledProvider {
   executable: string;
   version: string;
   sha256: string;
+  manifestPath: string;
+  manifestSha256: string;
 }
 
 export interface BundledProviderResolution {
@@ -35,19 +37,54 @@ interface ProviderManifest {
  */
 export async function resolveBundledProvider(
   providerId: PinnedProviderId,
-  options: { resourcesDirectory: string; platform: NodeJS.Platform },
+  options: {
+    resourcesDirectory: string;
+    platform: NodeJS.Platform;
+    expectedVersion?: string;
+    expectedManifestSha256?: string;
+  },
 ): Promise<BundledProviderResolution> {
-  const manifestPath = path.join(
-    options.resourcesDirectory,
-    "providers",
-    "manifest.json",
-  );
-  let parsed: unknown;
+  let providerRoot: string;
+  let manifestPath: string;
   try {
-    parsed = JSON.parse(await readFile(manifestPath, "utf8"));
+    const lexicalProviderRoot = path.join(
+      options.resourcesDirectory,
+      "providers",
+    );
+    const rootStat = await lstat(lexicalProviderRoot);
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) {
+      throw new Error("provider root must be a regular, non-symlink directory");
+    }
+    providerRoot = await realpath(lexicalProviderRoot);
+    manifestPath = path.join(providerRoot, "manifest.json");
+    const manifestStat = await lstat(manifestPath);
+    if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
+      throw new Error("manifest must be a regular, non-symlink file");
+    }
+  } catch (error) {
+    return {
+      reason: `Bundled ${providerId} manifest is unavailable: ${describeError(error)}`,
+    };
+  }
+  let parsed: unknown;
+  let manifestBytes: Buffer;
+  try {
+    manifestBytes = await readFile(manifestPath);
+    parsed = JSON.parse(manifestBytes.toString("utf8"));
   } catch (error) {
     return {
       reason: `Bundled ${providerId} manifest is unavailable at ${manifestPath}: ${describeError(error)}`,
+    };
+  }
+  const manifestSha256 = createHash("sha256")
+    .update(manifestBytes)
+    .digest("hex");
+  if (
+    options.expectedManifestSha256 !== undefined &&
+    manifestSha256 !== options.expectedManifestSha256
+  ) {
+    return {
+      reason: `Bundled ${providerId} manifest integrity mismatch: expected ${options.expectedManifestSha256}, got ${manifestSha256}`,
     };
   }
   const manifest = parseManifest(parsed, providerId);
@@ -61,12 +98,15 @@ export async function resolveBundledProvider(
       reason: `Bundled ${providerId} does not provide an asset for ${options.platform}`,
     };
   }
-  const executable = path.resolve(
-    options.resourcesDirectory,
-    "providers",
-    manifest.executable,
-  );
-  const providerRoot = path.resolve(options.resourcesDirectory, "providers");
+  if (
+    options.expectedVersion !== undefined &&
+    manifest.version !== options.expectedVersion
+  ) {
+    return {
+      reason: `Bundled ${providerId} version mismatch: expected ${options.expectedVersion}, got ${manifest.version}`,
+    };
+  }
+  const executable = path.resolve(providerRoot, manifest.executable);
   if (
     executable !== providerRoot &&
     !executable.startsWith(`${providerRoot}${path.sep}`)
@@ -75,9 +115,21 @@ export async function resolveBundledProvider(
       reason: `Bundled ${providerId} executable escapes its resource directory`,
     };
   }
+  let executableRealPath: string;
   let bytes: Buffer;
   try {
-    bytes = await readFile(executable);
+    const executableStat = await lstat(executable);
+    if (executableStat.isSymbolicLink() || !executableStat.isFile()) {
+      throw new Error("executable must be a regular, non-symlink file");
+    }
+    executableRealPath = await realpath(executable);
+    if (
+      executableRealPath !== providerRoot &&
+      !executableRealPath.startsWith(`${providerRoot}${path.sep}`)
+    ) {
+      throw new Error("executable resolves outside its resource directory");
+    }
+    bytes = await readFile(executableRealPath);
   } catch (error) {
     return {
       reason: `Bundled ${providerId} executable is unavailable at ${executable}: ${describeError(error)}`,
@@ -92,11 +144,40 @@ export async function resolveBundledProvider(
   return {
     provider: {
       providerId,
-      executable,
+      executable: executableRealPath,
       version: manifest.version,
       sha256: actualSha256,
+      manifestPath,
+      manifestSha256,
     },
   };
+}
+
+/** Re-read and re-hash a selected asset immediately before provider use. */
+export async function verifyBundledProvider(
+  selected: BundledProvider,
+  options: {
+    resourcesDirectory: string;
+    platform: NodeJS.Platform;
+  },
+): Promise<void> {
+  const resolved = await resolveBundledProvider(selected.providerId, {
+    ...options,
+    expectedVersion: selected.version,
+    expectedManifestSha256: selected.manifestSha256,
+  });
+  if (resolved.provider === undefined) {
+    throw new Error(resolved.reason ?? "Bundled provider verification failed");
+  }
+  if (
+    resolved.provider.executable !== selected.executable ||
+    resolved.provider.sha256 !== selected.sha256 ||
+    resolved.provider.version !== selected.version
+  ) {
+    throw new Error(
+      "Bundled provider changed after selection; refusing to launch",
+    );
+  }
 }
 
 function parseManifest(

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -45,6 +45,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   readonly #audit: ZenXCapabilityAuditRecord[] = [];
   #currentScreenshot: ZenXCapabilityScreenshotArtifact | undefined;
   #browserProjectionSequence = 0;
+  readonly #browserInvocationSequences = new Map<string, number>();
   readonly #providerDiagnostics: ZenXCapabilityProviderDiagnostic[] = [];
   readonly #discoveryErrors: string[] = [];
   readonly #options: ZenXCapabilityRegistryOptions;
@@ -107,6 +108,12 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   }
 
   recordProviderDiagnostic(diagnostic: ZenXCapabilityProviderDiagnostic): void {
+    if (
+      diagnostic.capabilityId === "browser" &&
+      diagnostic.status !== "selected"
+    ) {
+      this.#clearBrowserProjection();
+    }
     const index = this.#providerDiagnostics.findIndex(
       (candidate) =>
         candidate.capabilityId === diagnostic.capabilityId &&
@@ -288,12 +295,20 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
       return { output: result, exitCode: 0 };
     } catch (error) {
       const cancelled = invocation.signal.aborted || isAbortError(error);
+      const owner = this.#toolOwners.get(invocation.name);
+      if (owner?.capabilityId === "browser") {
+        this.#clearBrowserProjection(
+          this.#browserInvocationSequences.get(invocation.callId),
+        );
+      }
       this.#finishAudit(
         audit,
         cancelled ? "cancelled" : "failed",
         describeError(error),
       );
       throw error;
+    } finally {
+      this.#browserInvocationSequences.delete(invocation.callId);
     }
   }
 
@@ -356,10 +371,14 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   ): Promise<unknown> {
     const isBrowser = capabilityPackage.manifest.id === "browser";
     const sequence = isBrowser ? ++this.#browserProjectionSequence : undefined;
-    if (isBrowser) this.#currentScreenshot = undefined;
+    if (isBrowser) {
+      this.#currentScreenshot = undefined;
+      this.#browserInvocationSequences.set(invocation.callId, sequence!);
+    }
     try {
       const value = await capabilityPackage.invoke(invocation.name, invocation);
       if (isBrowser && sequence === this.#browserProjectionSequence) {
+        invocation.signal.throwIfAborted();
         const screenshot = browserScreenshotFrom(value);
         if (screenshot !== undefined) this.#currentScreenshot = screenshot;
       }
@@ -372,7 +391,9 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     }
   }
 
-  #clearBrowserProjection(): void {
+  #clearBrowserProjection(sequence?: number): void {
+    if (sequence !== undefined && sequence !== this.#browserProjectionSequence)
+      return;
     this.#browserProjectionSequence += 1;
     this.#currentScreenshot = undefined;
   }

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -16,6 +16,7 @@ import type {
   ZenXCapabilityPackage,
   ZenXCapabilityProviderDiagnostic,
   ZenXCapabilitySnapshot,
+  ZenXCapabilityScreenshotArtifact,
   ZenXCapabilityTool,
   ZenXCapabilityInteractionMode,
 } from "./types.js";
@@ -27,8 +28,6 @@ import {
 export const CAPABILITY_RESOURCE_TOOL = "zenx_capability_resource";
 const DEFAULT_MAX_OUTPUT_BYTES = 16 * 1024;
 const MAX_AUDIT_RECORDS = 100;
-const SENSITIVE_KEY =
-  /(?:authorization|cookie|credential|password|secret|sessionMaterial|storageState|token)/iu;
 
 export interface ZenXCapabilityRegistryOptions {
   allowForegroundRequired: boolean;
@@ -44,6 +43,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   >();
   readonly #listeners = new Set<(snapshot: ZenXCapabilitySnapshot) => void>();
   readonly #audit: ZenXCapabilityAuditRecord[] = [];
+  #currentScreenshot: ZenXCapabilityScreenshotArtifact | undefined;
   readonly #providerDiagnostics: ZenXCapabilityProviderDiagnostic[] = [];
   readonly #discoveryErrors: string[] = [];
   readonly #options: ZenXCapabilityRegistryOptions;
@@ -208,6 +208,9 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
         };
       }),
       recentInvocations: structuredClone(this.#audit),
+      ...(this.#currentScreenshot === undefined
+        ? {}
+        : { currentScreenshot: structuredClone(this.#currentScreenshot) }),
       providerDiagnostics: structuredClone(this.#providerDiagnostics),
       discoveryErrors: [...this.#discoveryErrors],
     };
@@ -332,7 +335,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     }
     invocation.signal.throwIfAborted();
     return {
-      value: await registered.package.invoke(invocation.name, invocation),
+      value: await this.#invokeProvider(registered.package, invocation),
       maxOutputBytes: owner.tool.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
       capabilityId: owner.capabilityId,
       provider: {
@@ -342,6 +345,23 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
       interactionMode: owner.tool.interactionMode,
       capabilities: [...owner.tool.capabilities],
     };
+  }
+
+  async #invokeProvider(
+    capabilityPackage: ZenXCapabilityPackage,
+    invocation: ToolInvocation,
+  ): Promise<unknown> {
+    if (capabilityPackage.manifest.id === "browser") {
+      // Any non-published Browser result makes the previous observation stale;
+      // only this invocation's inspect may publish a new screenshot.
+      this.#currentScreenshot = undefined;
+    }
+    const value = await capabilityPackage.invoke(invocation.name, invocation);
+    if (capabilityPackage.manifest.id === "browser") {
+      const screenshot = browserScreenshotFrom(value);
+      if (screenshot !== undefined) this.#currentScreenshot = screenshot;
+    }
+    return value;
   }
 
   #readResource(arguments_: Record<string, unknown>): {
@@ -551,18 +571,17 @@ function boundedResult(
   interactionMode: ZenXCapabilityInteractionMode,
   capabilities: readonly string[],
 ): string {
-  const safe = redactSensitive(value);
   const envelope = {
     capabilityId,
     provider,
     tool: toolName,
     interactionMode,
     capabilities,
-    result: safe,
+    result: value,
   };
   const serialized = JSON.stringify(envelope);
   if (Buffer.byteLength(serialized, "utf8") <= maxBytes) return serialized;
-  let preview = JSON.stringify(safe);
+  let preview = JSON.stringify(value);
   const truncated = (): string =>
     JSON.stringify({
       capabilityId,
@@ -588,28 +607,6 @@ function boundedResult(
   });
 }
 
-function redactSensitive(value: unknown, key = ""): unknown {
-  if (SENSITIVE_KEY.test(key)) return "[REDACTED]";
-  if (typeof value === "string") {
-    return value
-      .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/giu, "Bearer [REDACTED]")
-      .replace(
-        /\b((?:api[_-]?key|access[_-]?token|password|secret))=[^&\s]+/giu,
-        "$1=[REDACTED]",
-      );
-  }
-  if (Array.isArray(value)) return value.map((entry) => redactSensitive(entry));
-  if (typeof value === "object" && value !== null) {
-    return Object.fromEntries(
-      Object.entries(value).map(([childKey, child]) => [
-        childKey,
-        redactSensitive(child, childKey),
-      ]),
-    );
-  }
-  return value;
-}
-
 function requiredString(value: Record<string, unknown>, key: string): string {
   const candidate = value[key];
   if (typeof candidate !== "string" || candidate.length === 0) {
@@ -628,4 +625,40 @@ function describeError(error: unknown): string {
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === "AbortError";
+}
+
+function browserScreenshotFrom(
+  value: unknown,
+): ZenXCapabilityScreenshotArtifact | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const screenshot = (value as Record<string, unknown>).screenshot;
+  if (
+    typeof screenshot !== "object" ||
+    screenshot === null ||
+    Array.isArray(screenshot)
+  ) {
+    return undefined;
+  }
+  const record = screenshot as Record<string, unknown>;
+  if (
+    typeof record.artifactPath !== "string" ||
+    typeof record.width !== "number" ||
+    typeof record.height !== "number" ||
+    typeof record.bytes !== "number" ||
+    typeof record.expiresAt !== "string"
+  ) {
+    return undefined;
+  }
+  return {
+    artifactPath: record.artifactPath,
+    ...(typeof record.observationId === "string"
+      ? { observationId: record.observationId }
+      : {}),
+    width: record.width,
+    height: record.height,
+    bytes: record.bytes,
+    expiresAt: record.expiresAt,
+  };
 }

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -323,6 +323,11 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     }
   }
 
+  async resetTransient(): Promise<void> {
+    this.#clearBrowserProjection();
+    this.#emit();
+  }
+
   async #executeProvider(invocation: ToolInvocation): Promise<{
     value: unknown;
     maxOutputBytes: number;

--- a/apps/zenx/src/main/capabilities/registry.ts
+++ b/apps/zenx/src/main/capabilities/registry.ts
@@ -44,6 +44,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
   readonly #listeners = new Set<(snapshot: ZenXCapabilitySnapshot) => void>();
   readonly #audit: ZenXCapabilityAuditRecord[] = [];
   #currentScreenshot: ZenXCapabilityScreenshotArtifact | undefined;
+  #browserProjectionSequence = 0;
   readonly #providerDiagnostics: ZenXCapabilityProviderDiagnostic[] = [];
   readonly #discoveryErrors: string[] = [];
   readonly #options: ZenXCapabilityRegistryOptions;
@@ -92,6 +93,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     const registered = this.#registered.get(capabilityId);
     if (registered === undefined) return;
     this.#registered.delete(capabilityId);
+    if (capabilityId === "browser") this.#clearBrowserProjection();
     for (const tool of registered.package.manifest.tools) {
       this.#toolOwners.delete(tool.name);
     }
@@ -173,6 +175,7 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
       };
     }
     await this.#grantStore.save(this.#grants);
+    if (capabilityId === "browser") this.#clearBrowserProjection();
     this.#emit();
   }
 
@@ -351,17 +354,27 @@ export class ZenXCapabilityRegistry implements ZenXCapabilityHost {
     capabilityPackage: ZenXCapabilityPackage,
     invocation: ToolInvocation,
   ): Promise<unknown> {
-    if (capabilityPackage.manifest.id === "browser") {
-      // Any non-published Browser result makes the previous observation stale;
-      // only this invocation's inspect may publish a new screenshot.
-      this.#currentScreenshot = undefined;
+    const isBrowser = capabilityPackage.manifest.id === "browser";
+    const sequence = isBrowser ? ++this.#browserProjectionSequence : undefined;
+    if (isBrowser) this.#currentScreenshot = undefined;
+    try {
+      const value = await capabilityPackage.invoke(invocation.name, invocation);
+      if (isBrowser && sequence === this.#browserProjectionSequence) {
+        const screenshot = browserScreenshotFrom(value);
+        if (screenshot !== undefined) this.#currentScreenshot = screenshot;
+      }
+      return value;
+    } catch (error) {
+      if (isBrowser && sequence === this.#browserProjectionSequence) {
+        this.#currentScreenshot = undefined;
+      }
+      throw error;
     }
-    const value = await capabilityPackage.invoke(invocation.name, invocation);
-    if (capabilityPackage.manifest.id === "browser") {
-      const screenshot = browserScreenshotFrom(value);
-      if (screenshot !== undefined) this.#currentScreenshot = screenshot;
-    }
-    return value;
+  }
+
+  #clearBrowserProjection(): void {
+    this.#browserProjectionSequence += 1;
+    this.#currentScreenshot = undefined;
   }
 
   #readResource(arguments_: Record<string, unknown>): {
@@ -647,7 +660,8 @@ function browserScreenshotFrom(
     typeof record.width !== "number" ||
     typeof record.height !== "number" ||
     typeof record.bytes !== "number" ||
-    typeof record.expiresAt !== "string"
+    typeof record.expiresAt !== "string" ||
+    (record.status !== "captured" && record.status !== "fallback")
   ) {
     return undefined;
   }
@@ -656,6 +670,8 @@ function browserScreenshotFrom(
     ...(typeof record.observationId === "string"
       ? { observationId: record.observationId }
       : {}),
+    status: record.status,
+    ...(typeof record.reason === "string" ? { reason: record.reason } : {}),
     width: record.width,
     height: record.height,
     bytes: record.bytes,

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -79,6 +79,15 @@ export interface ZenXCapabilityAuditRecord {
   summary?: string;
 }
 
+export interface ZenXCapabilityScreenshotArtifact {
+  artifactPath: string;
+  observationId?: string;
+  width: number;
+  height: number;
+  bytes: number;
+  expiresAt: string;
+}
+
 export interface ZenXCapabilityProviderDiagnostic {
   capabilityId: string;
   providerId: string;
@@ -87,6 +96,7 @@ export interface ZenXCapabilityProviderDiagnostic {
   capabilities: string[];
   executable?: string;
   version?: string;
+  integrity?: "verified" | "unverified" | "failed";
   permissionSummary?: string;
   reason?: string;
   sessionMode?: "isolated-session" | "user-session" | "invalid";
@@ -107,6 +117,8 @@ export interface ZenXCapabilitySummary {
 export interface ZenXCapabilitySnapshot {
   capabilities: ZenXCapabilitySummary[];
   recentInvocations: ZenXCapabilityAuditRecord[];
+  /** Renderer-only live projection; it is intentionally absent from canonical Items. */
+  currentScreenshot?: ZenXCapabilityScreenshotArtifact;
   providerDiagnostics: ZenXCapabilityProviderDiagnostic[];
   discoveryErrors: string[];
 }

--- a/apps/zenx/src/main/capabilities/types.ts
+++ b/apps/zenx/src/main/capabilities/types.ts
@@ -82,6 +82,8 @@ export interface ZenXCapabilityAuditRecord {
 export interface ZenXCapabilityScreenshotArtifact {
   artifactPath: string;
   observationId?: string;
+  status: "captured" | "fallback";
+  reason?: string;
   width: number;
   height: number;
   bytes: number;

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -18,6 +18,7 @@ import {
 } from "./browser-provider.js";
 
 const USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS = 2_000;
+const USER_BROWSER_SCREENSHOT_TIMEOUT_MS = 10_000;
 const USER_BROWSER_MAX_TARGET_EVIDENCE = 128;
 const USER_BROWSER_MAX_DISCOVERED_TARGETS = 512;
 const USER_BROWSER_MAX_OPERATION_EVIDENCE = 32;
@@ -1704,10 +1705,10 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     const response = asRecord(
       await this.#send(
         "Page.captureScreenshot",
-        { format: "png" },
+        { format: "png", fromSurface: false, captureBeyondViewport: false },
         before.sessionId,
         signal,
-        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+        USER_BROWSER_SCREENSHOT_TIMEOUT_MS,
         undefined,
         undefined,
         () => this.#assertDocumentFence(before, true),

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -262,7 +262,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     throwIfAborted(signal);
     const session = this.#session(sessionId);
     const operation = this.#startSessionOperation(session, async () => {
-      const listed = await this.#client.listTargets();
+      const listed = await this.#client.listTargets(signal);
       const targets = listed.filter(
         (target) =>
           target.type === "page" &&
@@ -361,22 +361,23 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     const session = this.#session(sessionId);
     const operation = this.#startSessionOperation(session, async () => {
       const pendingUrl = `about:blank#zenx-pending-${randomUUID()}`;
-      const beforeTargets = await this.#client.listTargets();
+      const beforeTargets = await this.#client.listTargets(signal);
       const beforeTargetIds = new Set(
         beforeTargets.map((target) => target.targetId),
       );
       if (beforeTargets.some((target) => target.url === pendingUrl)) {
         throw new Error("User browser create marker already exists");
       }
-      let targetId: string;
+      let targetId: string | undefined;
       try {
-        targetId = await this.#client.createTarget(pendingUrl);
+        targetId = await this.#client.createTarget(pendingUrl, signal);
       } catch (error) {
         this.#recordUnresolvedCreate(session, pendingUrl, beforeTargetIds);
         const recovered = await this.#reconcileCreate(
           session,
           pendingUrl,
           beforeTargetIds,
+          signal,
         );
         if (recovered === undefined) {
           throw new Error(
@@ -407,8 +408,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       }
       this.#accountTarget(session, targetId, pendingUrl, false);
       const matches = await this.#client
-        .findTargetsByUrl(pendingUrl)
-        .catch(() => []);
+        .findTargetsByUrl(pendingUrl, signal)
+        .catch((error) => {
+          if (signal?.aborted === true) throw error;
+          return [];
+        });
       const createdMatches = matches.filter(
         (target) => !beforeTargetIds.has(target.targetId),
       );
@@ -431,6 +435,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         );
       }
       this.#assertSessionCurrent(session);
+      throwIfAborted(signal);
       const tab = this.#tabs.get(targetId);
       let dispatched = false;
       try {
@@ -438,13 +443,15 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
           targetId,
           url,
           this.#attachmentOwner(session),
-          undefined,
+          signal,
           () => (dispatched = true),
         );
         if (tab !== undefined) tab.url = url;
         this.#assertSessionCurrent(session);
+        throwIfAborted(signal);
         const summary = await this.#summary(sessionId, targetId);
         this.#assertSessionCurrent(session);
+        throwIfAborted(signal);
         return summary;
       } catch (error) {
         if (
@@ -453,6 +460,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
             error instanceof UserBrowserDocumentChangedAfterDispatchError)
         ) {
           tab.tainted = describeError(error);
+        }
+        if (signal?.aborted === true && tab !== undefined) {
+          await this.#compensateCancelledCreate(session, targetId, tab);
         }
         throw error;
       }
@@ -1349,10 +1359,14 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     session: UserBrowserSession,
     markerUrl: string,
     beforeTargetIds: Set<string>,
+    signal?: AbortSignal,
   ): Promise<UserBrowserCdpTarget | undefined> {
     const matches = await this.#client
-      .findTargetsByUrl(markerUrl)
-      .catch(() => []);
+      .findTargetsByUrl(markerUrl, signal)
+      .catch((error) => {
+        if (signal?.aborted === true) throw error;
+        return [];
+      });
     const candidates = matches.filter(
       (target) => !beforeTargetIds.has(target.targetId),
     );
@@ -1379,6 +1393,24 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     for (const [markerUrl, beforeTargetIds] of session.unresolvedCreates) {
       await this.#reconcileCreate(session, markerUrl, beforeTargetIds);
     }
+  }
+
+  async #compensateCancelledCreate(
+    session: UserBrowserSession,
+    targetId: string,
+    tab: UserBrowserTabState,
+  ): Promise<void> {
+    tab.detaching = true;
+    try {
+      await this.#detachTarget(session, targetId);
+    } catch (error) {
+      tab.tainted = `cancelled create cleanup is unknown (${describeError(error)})`;
+      this.#taintSession(session, `target ${targetId}: ${tab.tainted}`);
+      return;
+    }
+    session.targetIds.delete(targetId);
+    this.#ignoreTarget(session, targetId);
+    if (this.#tabs.get(targetId) === tab) this.#tabs.delete(targetId);
   }
 }
 

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -100,7 +100,12 @@ export interface UserBrowserCdpClient {
     owner: UserBrowserAttachmentOwner,
     expectedDocumentIdentity: string,
     signal?: AbortSignal,
-  ): Promise<{ data: string; documentIdentity: string }>;
+  ): Promise<{
+    data: string;
+    documentIdentity: string;
+    status?: "captured" | "fallback";
+    reason?: string;
+  }>;
   detachTarget(
     targetId: string,
     owner: UserBrowserAttachmentOwner,
@@ -545,6 +550,9 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
           ? {
               data: FALLBACK_SCREENSHOT_PNG_BASE64,
               documentIdentity: evaluation.documentIdentity,
+              status: "fallback" as const,
+              reason:
+                "Screenshot capture is not supported by the attached browser client",
             }
           : await this.#client.captureScreenshot(
               tabId,
@@ -555,10 +563,27 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       if (screenshotCapture.documentIdentity !== evaluation.documentIdentity) {
         throw new Error("User browser document changed during inspection");
       }
+      const normalizedScreenshot =
+        typeof screenshotCapture.data === "string" &&
+        screenshotCapture.data.length > 0
+          ? screenshotCapture
+          : {
+              data: FALLBACK_SCREENSHOT_PNG_BASE64,
+              documentIdentity: screenshotCapture.documentIdentity,
+              status: "fallback" as const,
+              reason:
+                "Attached browser screenshot response was empty or malformed",
+            };
       const screenshot: BrowserScreenshotArtifact = await this.#artifacts.write(
         `${sessionId}/${tabId}`,
         observationId,
-        Buffer.from(screenshotCapture.data, "base64"),
+        Buffer.from(normalizedScreenshot.data, "base64"),
+        {
+          status: normalizedScreenshot.status ?? "captured",
+          ...(normalizedScreenshot.reason === undefined
+            ? {}
+            : { reason: normalizedScreenshot.reason }),
+        },
       );
       const projected = fingerprints.map((fingerprint) => {
         const targetId = randomUUID();
@@ -1697,7 +1722,12 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     owner: UserBrowserAttachmentOwner,
     expectedDocumentIdentity: string,
     signal?: AbortSignal,
-  ): Promise<{ data: string; documentIdentity: string }> {
+  ): Promise<{
+    data: string;
+    documentIdentity: string;
+    status: "captured" | "fallback";
+    reason?: string;
+  }> {
     const before = await this.#executionDocument(targetId, owner, signal);
     if (before.identity !== expectedDocumentIdentity) {
       throw new UserBrowserDocumentChangedBeforeDispatchError();
@@ -1718,9 +1748,9 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       );
     } catch (error) {
       if (!(error instanceof UserBrowserCdpOutcomeUnknownError)) throw error;
-      // Screenshot is read-only. Some hidden Windows Chrome surfaces never
-      // answer Page.captureScreenshot; retain a valid bounded artifact while
-      // rechecking the document fence before publishing the observation.
+      // A read-only capture can have an unknown settlement on hidden browser
+      // surfaces. Keep this narrowly scoped fallback explicit and publish it
+      // only after rechecking the document fence.
       const afterTimeout = await this.#executionDocument(
         targetId,
         owner,
@@ -1732,18 +1762,26 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       return {
         data: FALLBACK_SCREENSHOT_PNG_BASE64,
         documentIdentity: afterTimeout.identity,
+        status: "fallback",
+        reason: "Attached browser screenshot capture outcome was unknown",
       };
     }
     const after = await this.#executionDocument(targetId, owner, signal);
     if (after.identity !== before.identity) {
       throw new UserBrowserDocumentChangedAfterDispatchError();
     }
+    if (typeof response?.data !== "string" || response.data.length === 0) {
+      return {
+        data: FALLBACK_SCREENSHOT_PNG_BASE64,
+        documentIdentity: after.identity,
+        status: "fallback",
+        reason: "Attached browser screenshot response was empty or malformed",
+      };
+    }
     return {
-      data:
-        typeof response?.data === "string" && response.data.length > 0
-          ? response.data
-          : FALLBACK_SCREENSHOT_PNG_BASE64,
+      data: response.data,
       documentIdentity: after.identity,
+      status: "captured",
     };
   }
 

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -8,7 +8,9 @@ import {
   browserInspectScript,
   redactBrowserUrl,
   resolveBrowserObservedTarget,
+  BrowserScreenshotArtifactStore,
   type BrowserInspection,
+  type BrowserScreenshotArtifact,
   type BrowserObservation,
   type BrowserTabSummary,
   type BrowserTargetFingerprint,
@@ -24,6 +26,8 @@ const USER_BROWSER_MAX_PENDING_CDP_REQUESTS = 128;
 const USER_BROWSER_MAX_ACTIVE_SESSIONS = 32;
 const USER_BROWSER_LATE_RESPONSE_RETENTION_MS = 5_000;
 const USER_BROWSER_DOCUMENT_WORLD_NAME = "__zenx_user_browser_document__";
+const FALLBACK_SCREENSHOT_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
 type UserBrowserCdpOutcome =
   "known-success" | "known-failure" | "outcome-unknown";
@@ -90,6 +94,12 @@ export interface UserBrowserCdpClient {
     signal?: AbortSignal,
     onDispatched?: () => void,
   ): Promise<{ value: unknown; documentIdentity: string }>;
+  captureScreenshot?(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    expectedDocumentIdentity: string,
+    signal?: AbortSignal,
+  ): Promise<{ data: string; documentIdentity: string }>;
   detachTarget(
     targetId: string,
     owner: UserBrowserAttachmentOwner,
@@ -211,13 +221,20 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
   readonly #detachOperations = new Map<string, Promise<void>>();
   readonly #sessionCloseOperations = new Map<string, Promise<number>>();
   readonly #closure = new ZenXUserBrowserAttachmentEpochBoundary();
+  readonly #artifacts: BrowserScreenshotArtifactStore;
   #closeOperation?: Promise<void>;
   #backendCloseQueued = false;
   #closing = false;
   #nextSessionIncarnation = 1;
 
-  constructor(client: UserBrowserCdpClient) {
+  constructor(
+    client: UserBrowserCdpClient,
+    options: { artifactDirectory?: string } = {},
+  ) {
     this.#client = client;
+    this.#artifacts = new BrowserScreenshotArtifactStore(
+      options.artifactDirectory,
+    );
   }
 
   async listTabs(
@@ -425,7 +442,18 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     return await raceAbort(operation, signal);
   }
 
-  async navigate(
+  navigate(
+    sessionId: string,
+    tabId: string,
+    url: string,
+    signal?: AbortSignal,
+  ): Promise<BrowserTabSummary> {
+    const operation = this.#navigate(sessionId, tabId, url, signal);
+    observeRejection(operation);
+    return operation;
+  }
+
+  async #navigate(
     sessionId: string,
     tabId: string,
     url: string,
@@ -510,6 +538,27 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       }
       const fingerprints = raw.targets.map(requireFingerprint).slice(0, 80);
       const targets = new Map<string, BrowserTargetFingerprint>();
+      const observationId = randomUUID();
+      const screenshotCapture =
+        this.#client.captureScreenshot === undefined
+          ? {
+              data: FALLBACK_SCREENSHOT_PNG_BASE64,
+              documentIdentity: evaluation.documentIdentity,
+            }
+          : await this.#client.captureScreenshot(
+              tabId,
+              this.#attachmentOwner(session),
+              evaluation.documentIdentity,
+              signal,
+            );
+      if (screenshotCapture.documentIdentity !== evaluation.documentIdentity) {
+        throw new Error("User browser document changed during inspection");
+      }
+      const screenshot: BrowserScreenshotArtifact = await this.#artifacts.write(
+        `${sessionId}/${tabId}`,
+        observationId,
+        Buffer.from(screenshotCapture.data, "base64"),
+      );
       const projected = fingerprints.map((fingerprint) => {
         const targetId = randomUUID();
         targets.set(targetId, fingerprint);
@@ -518,13 +567,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
           role: fingerprint.role,
           name: fingerprint.name,
           actions: [...fingerprint.actions],
-          ...(fingerprint.secure ? { secure: true as const } : {}),
           ...(fingerprint.value === undefined
             ? {}
             : { value: fingerprint.value }),
         };
       });
-      const observationId = randomUUID();
       const summary = await this.#summary(sessionId, tabId);
       this.#assertSessionCurrent(session);
       tab.documentIdentity = evaluation.documentIdentity;
@@ -538,20 +585,21 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
         observationId,
         documentVersion: tab.documentVersion,
         visibleText: raw.visibleText.slice(0, 8_000),
+        screenshot,
         targets: projected,
       };
     });
     return await raceAbort(operation, signal);
   }
 
-  async click(
+  click(
     sessionId: string,
     tabId: string,
     observationId: string,
     targetId: string,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
-    return await this.#act(
+    const operation = this.#act(
       sessionId,
       tabId,
       observationId,
@@ -561,9 +609,11 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       false,
       signal,
     );
+    observeRejection(operation);
+    return operation;
   }
 
-  async type(
+  type(
     sessionId: string,
     tabId: string,
     observationId: string,
@@ -572,7 +622,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     submit: boolean,
     signal?: AbortSignal,
   ): Promise<BrowserTabSummary> {
-    return await this.#act(
+    const operation = this.#act(
       sessionId,
       tabId,
       observationId,
@@ -582,6 +632,8 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       submit,
       signal,
     );
+    observeRejection(operation);
+    return operation;
   }
 
   async closeTab(sessionId: string, tabId: string): Promise<void> {
@@ -643,6 +695,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       true,
     );
     await operation;
+    await this.#artifacts.clearScope(`${sessionId}/${tabId}`);
   }
 
   async closeSession(sessionId: string): Promise<number> {
@@ -713,6 +766,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
             this.#taintBackend(session.id, taint);
         }
         this.#sessions.delete(sessionId);
+        await this.#artifacts.clearScope(sessionId);
         this.#throwIfSessionTainted(session, "session close");
         return count;
       },
@@ -747,6 +801,7 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       }
       this.#sessions.clear();
       this.#tabs.clear();
+      await this.#artifacts.close();
       const operationFailure = sessionClosures.find(
         (result): result is PromiseRejectedResult =>
           result.status === "rejected",
@@ -865,6 +920,10 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
     );
     if (targetId === undefined) throw new Error("User browser tab was closed");
     const outward = promiseCapability<T>();
+    // A queued operation can be fail-closed by a later detach before its
+    // caller reaches the assertion. Keep that expected rejection observed
+    // without changing the promise delivered to the caller.
+    void outward.promise.catch(() => undefined);
     let operationStarted = false;
     const retained = this.#startSessionOperation(session, async () => {
       operationStarted = true;
@@ -1630,6 +1689,41 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
       }
       throw error;
     }
+  }
+
+  async captureScreenshot(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    expectedDocumentIdentity: string,
+    signal?: AbortSignal,
+  ): Promise<{ data: string; documentIdentity: string }> {
+    const before = await this.#executionDocument(targetId, owner, signal);
+    if (before.identity !== expectedDocumentIdentity) {
+      throw new UserBrowserDocumentChangedBeforeDispatchError();
+    }
+    const response = asRecord(
+      await this.#send(
+        "Page.captureScreenshot",
+        { format: "png" },
+        before.sessionId,
+        signal,
+        USER_BROWSER_CDP_OUTCOME_TIMEOUT_MS,
+        undefined,
+        undefined,
+        () => this.#assertDocumentFence(before, true),
+      ),
+    );
+    const after = await this.#executionDocument(targetId, owner, signal);
+    if (after.identity !== before.identity) {
+      throw new UserBrowserDocumentChangedAfterDispatchError();
+    }
+    return {
+      data:
+        typeof response?.data === "string" && response.data.length > 0
+          ? response.data
+          : FALLBACK_SCREENSHOT_PNG_BASE64,
+      documentIdentity: after.identity,
+    };
   }
 
   async #sendDocumentRuntimeEvaluate(
@@ -2873,6 +2967,10 @@ function promiseCapability<T>(): {
   return { promise, resolve, reject };
 }
 
+function observeRejection<T>(promise: Promise<T>): void {
+  void promise.catch(() => undefined);
+}
+
 async function raceAbort<T>(
   operation: Promise<T>,
   signal?: AbortSignal,
@@ -2959,7 +3057,6 @@ function requireFingerprint(value: unknown): BrowserTargetFingerprint {
       "autocomplete",
       "href",
     ].every((key) => typeof target[key] === "string") ||
-    typeof target.secure !== "boolean" ||
     !Array.isArray(actions) ||
     !actions.every((action) => action === "click" || action === "type") ||
     (target.value !== undefined && typeof target.value !== "string")
@@ -2976,7 +3073,6 @@ function requireFingerprint(value: unknown): BrowserTargetFingerprint {
     fieldName: target.fieldName as string,
     autocomplete: target.autocomplete as string,
     href: target.href as string,
-    secure: target.secure,
     actions: [...actions],
     ...(target.value === undefined ? {} : { value: target.value }),
   };

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -30,6 +30,13 @@ const USER_BROWSER_DOCUMENT_WORLD_NAME = "__zenx_user_browser_document__";
 const FALLBACK_SCREENSHOT_PNG_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
+export class UserBrowserScreenshotMalformedError extends Error {
+  constructor(message = "Attached browser screenshot response was malformed") {
+    super(message);
+    this.name = "UserBrowserScreenshotMalformedError";
+  }
+}
+
 type UserBrowserCdpOutcome =
   "known-success" | "known-failure" | "outcome-unknown";
 
@@ -106,6 +113,11 @@ export interface UserBrowserCdpClient {
     status?: "captured" | "fallback";
     reason?: string;
   }>;
+  getDocumentIdentity(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+  ): Promise<string>;
   detachTarget(
     targetId: string,
     owner: UserBrowserAttachmentOwner,
@@ -563,6 +575,17 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       if (screenshotCapture.documentIdentity !== evaluation.documentIdentity) {
         throw new Error("User browser document changed during inspection");
       }
+      const finalIdentity = await this.#freshDocumentIdentity(
+        tabId,
+        session,
+        evaluation.documentIdentity,
+        signal,
+      );
+      if (finalIdentity !== evaluation.documentIdentity) {
+        throw new Error(
+          "User browser document changed before screenshot publication",
+        );
+      }
       const normalizedScreenshot =
         typeof screenshotCapture.data === "string" &&
         screenshotCapture.data.length > 0
@@ -574,10 +597,14 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
               reason:
                 "Attached browser screenshot response was empty or malformed",
             };
+      const screenshotBytes = decodeUserBrowserScreenshot(
+        normalizedScreenshot.data,
+      );
+      throwIfAborted(signal);
       const screenshot: BrowserScreenshotArtifact = await this.#artifacts.write(
         `${sessionId}/${tabId}`,
         observationId,
-        Buffer.from(normalizedScreenshot.data, "base64"),
+        screenshotBytes,
         {
           status: normalizedScreenshot.status ?? "captured",
           ...(normalizedScreenshot.reason === undefined
@@ -585,6 +612,15 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
             : { reason: normalizedScreenshot.reason }),
         },
       );
+      try {
+        throwIfAborted(signal);
+      } catch (error) {
+        await this.#artifacts.removeArtifact(
+          screenshot.artifactPath,
+          screenshot.observationId,
+        );
+        throw error;
+      }
       const projected = fingerprints.map((fingerprint) => {
         const targetId = randomUUID();
         targets.set(targetId, fingerprint);
@@ -600,6 +636,21 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       });
       const summary = await this.#summary(sessionId, tabId);
       this.#assertSessionCurrent(session);
+      const publishIdentity = await this.#freshDocumentIdentity(
+        tabId,
+        session,
+        evaluation.documentIdentity,
+        signal,
+      );
+      if (publishIdentity !== evaluation.documentIdentity) {
+        await this.#artifacts.removeArtifact(
+          screenshot.artifactPath,
+          screenshot.observationId,
+        );
+        throw new Error(
+          "User browser document changed before inspection publication",
+        );
+      }
       tab.documentIdentity = evaluation.documentIdentity;
       tab.observation = {
         id: observationId,
@@ -616,6 +667,19 @@ export class UserBrowserCdpBackend implements ZenXBrowserBackend {
       };
     });
     return await raceAbort(operation, signal);
+  }
+
+  async #freshDocumentIdentity(
+    tabId: string,
+    session: UserBrowserSession,
+    _expected: string,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    return await this.#client.getDocumentIdentity(
+      tabId,
+      this.#attachmentOwner(session),
+      signal,
+    );
   }
 
   click(
@@ -1778,11 +1842,20 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
         reason: "Attached browser screenshot response was empty or malformed",
       };
     }
+    decodeUserBrowserScreenshot(response.data);
     return {
       data: response.data,
       documentIdentity: after.identity,
       status: "captured",
     };
+  }
+
+  async getDocumentIdentity(
+    targetId: string,
+    owner: UserBrowserAttachmentOwner,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    return (await this.#executionDocument(targetId, owner, signal)).identity;
   }
 
   async #sendDocumentRuntimeEvaluate(
@@ -2965,6 +3038,24 @@ export function windowsBrowserExecutableCandidates(
 
 function describeError(error: unknown): string {
   return (error instanceof Error ? error.message : String(error)).slice(0, 512);
+}
+
+function decodeUserBrowserScreenshot(data: string): Buffer {
+  if (
+    data.length === 0 ||
+    data.length % 4 === 1 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(
+      data,
+    )
+  ) {
+    throw new UserBrowserScreenshotMalformedError();
+  }
+  const decoded = Buffer.from(data, "base64");
+  const normalized = decoded.toString("base64").replace(/=+$/u, "");
+  if (normalized !== data.replace(/=+$/u, "")) {
+    throw new UserBrowserScreenshotMalformedError();
+  }
+  return decoded;
 }
 
 function sameAttachmentOwner(

--- a/apps/zenx/src/main/capabilities/user-browser-provider.ts
+++ b/apps/zenx/src/main/capabilities/user-browser-provider.ts
@@ -1702,18 +1702,38 @@ class JsonRpcUserBrowserCdpClient implements UserBrowserCdpClient {
     if (before.identity !== expectedDocumentIdentity) {
       throw new UserBrowserDocumentChangedBeforeDispatchError();
     }
-    const response = asRecord(
-      await this.#send(
-        "Page.captureScreenshot",
-        { format: "png", fromSurface: false, captureBeyondViewport: false },
-        before.sessionId,
+    let response: Record<string, unknown> | undefined;
+    try {
+      response = asRecord(
+        await this.#send(
+          "Page.captureScreenshot",
+          { format: "png", fromSurface: false, captureBeyondViewport: false },
+          before.sessionId,
+          signal,
+          USER_BROWSER_SCREENSHOT_TIMEOUT_MS,
+          undefined,
+          undefined,
+          () => this.#assertDocumentFence(before, true),
+        ),
+      );
+    } catch (error) {
+      if (!(error instanceof UserBrowserCdpOutcomeUnknownError)) throw error;
+      // Screenshot is read-only. Some hidden Windows Chrome surfaces never
+      // answer Page.captureScreenshot; retain a valid bounded artifact while
+      // rechecking the document fence before publishing the observation.
+      const afterTimeout = await this.#executionDocument(
+        targetId,
+        owner,
         signal,
-        USER_BROWSER_SCREENSHOT_TIMEOUT_MS,
-        undefined,
-        undefined,
-        () => this.#assertDocumentFence(before, true),
-      ),
-    );
+      );
+      if (afterTimeout.identity !== before.identity) {
+        throw new UserBrowserDocumentChangedAfterDispatchError();
+      }
+      return {
+        data: FALLBACK_SCREENSHOT_PNG_BASE64,
+        documentIdentity: afterTimeout.identity,
+      };
+    }
     const after = await this.#executionDocument(targetId, owner, signal);
     if (after.identity !== before.identity) {
       throw new UserBrowserDocumentChangedAfterDispatchError();

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -218,6 +218,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
   readonly #observations = new ComputerObservationLedger();
   readonly #platform: NodeJS.Platform;
   readonly #runner: WinAppCliRunner;
+  readonly #expectedVersion?: string;
+  readonly #verifyExecutable?: () => Promise<void>;
 
   constructor(
     options: {
@@ -225,6 +227,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       command?: string;
       platform?: NodeJS.Platform;
       runner?: WinAppCliRunner;
+      expectedVersion?: string;
+      verifyExecutable?: () => Promise<void>;
     } = {},
   ) {
     this.#artifactDirectory =
@@ -233,6 +237,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     this.#command = options.command ?? "winapp";
     this.#platform = options.platform ?? process.platform;
     this.#runner = options.runner ?? new SpawnWinAppCliRunner();
+    this.#expectedVersion = options.expectedVersion;
+    this.#verifyExecutable = options.verifyExecutable;
   }
 
   async diagnose(signal?: AbortSignal): Promise<WinAppCliDiagnostic> {
@@ -249,7 +255,7 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     }
     let detectedVersion: string | undefined;
     try {
-      const result = await this.#runner.run(this.#command, ["--version"], {
+      const result = await this.#run(["--version"], {
         timeoutMs: 5_000,
         signal,
         maxStdoutBytes: 4 * 1024,
@@ -279,28 +285,35 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
           message: `Microsoft WinApp CLI ${version} is incompatible; ${MINIMUM_WINAPP_CLI_VERSION} or newer is required`,
         };
       }
+      if (
+        this.#expectedVersion !== undefined &&
+        version !== this.#expectedVersion
+      ) {
+        return {
+          ready: false,
+          platform: this.#platform,
+          executable: this.#command,
+          version,
+          requiredVersion: this.#expectedVersion,
+          schemaCompatible: false,
+          installCommand: WINAPP_INSTALL_COMMAND,
+          message: `Microsoft WinApp CLI ${version} does not match pinned version ${this.#expectedVersion}`,
+        };
+      }
       detectedVersion = version;
-      const cliSchemaResult = await this.#runner.run(
-        this.#command,
-        ["--cli-schema"],
-        {
-          timeoutMs: 5_000,
-          signal,
-          maxStdoutBytes: 512 * 1024,
-          maxStderrBytes: 4 * 1024,
-        },
-      );
+      const cliSchemaResult = await this.#run(["--cli-schema"], {
+        timeoutMs: 5_000,
+        signal,
+        maxStdoutBytes: 512 * 1024,
+        maxStderrBytes: 4 * 1024,
+      });
       validateCliSchema(cliSchemaResult.stdout, version);
-      const probe = await this.#runner.run(
-        this.#command,
-        ["ui", "list-windows", "--json"],
-        {
-          timeoutMs: 5_000,
-          signal,
-          maxStdoutBytes: 256 * 1024,
-          maxStderrBytes: 4 * 1024,
-        },
-      );
+      const probe = await this.#run(["ui", "list-windows", "--json"], {
+        timeoutMs: 5_000,
+        signal,
+        maxStdoutBytes: 256 * 1024,
+        maxStderrBytes: 4 * 1024,
+      });
       validateWindowListProbe(probe.stdout);
       return {
         ready: true,
@@ -676,13 +689,21 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     }
   }
 
+  async #run(
+    args: readonly string[],
+    options: WinAppCliRunOptions,
+  ): Promise<WinAppCliRunResult> {
+    await this.#verifyExecutable?.();
+    return await this.#runner.run(this.#command, args, options);
+  }
+
   async #json<T>(
     args: readonly string[],
     timeoutMs: number,
     signal?: AbortSignal,
     redactions?: readonly string[],
   ): Promise<T> {
-    const result = await this.#runner.run(this.#command, args, {
+    const result = await this.#run(args, {
       timeoutMs,
       signal,
       maxStdoutBytes: MAX_WINAPP_STDOUT_BYTES,

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -78,14 +78,14 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
           return {
             ...tool,
             description:
-              "Invoke one opaque control from the latest computer_inspect through Windows UI Automation. The provider revalidates selector, semantics, geometry, secure state, and action immediately before invoking.",
+              "Invoke one opaque control from the latest computer_inspect through Windows UI Automation. The provider revalidates selector, semantics, geometry, and action immediately before invoking.",
             capabilities: ["uia.invoke", "app_targeted", "no_global_input"],
           };
         case "computer_set_value":
           return {
             ...tool,
             description:
-              "Set a non-secret value on one opaque editable control through Windows UI Automation. The provider revalidates selector, semantics, geometry, secure state, and action; supplied text is a canonical journaled tool argument.",
+              "Set the supplied text on one opaque editable control through Windows UI Automation. The provider revalidates selector, semantics, geometry, and action; host/model policy owns credential decisions.",
             capabilities: ["uia.set_value", "app_targeted", "no_global_input"],
           };
         default:
@@ -105,7 +105,7 @@ export const windowsComputerCapabilityManifest: ZenXCapabilityManifest = {
       description:
         "Use Microsoft WinApp CLI UI Automation through ZenX's opaque observe-before-act contract.",
       content:
-        "Target one Windows application by pid or applicationId plus an exact windowTitle. Inspect first, then use only the observationId and targetId returned by the latest computer_inspect. Re-inspect after every action. Semantic invoke and set-value use UI Automation and do not inject global input. computer_set_value is non-secret-only because tool arguments are journaled; secure-looking controls are rejected. Window capture uses WinApp CLI's default WGC/PrintWindow path and never opts into --capture-screen or --focus. If UIA semantics are insufficient, report foreground_required; this provider does not silently inject pointer or keyboard input.",
+        "Target one Windows application by pid or applicationId plus an exact windowTitle. Inspect first, then use only the observationId and targetId returned by the latest computer_inspect. Re-inspect after every action. Semantic invoke and set-value use UI Automation and do not inject global input. Supplied text follows the ordinary set-value path and host/model policy owns credential decisions. Window capture uses WinApp CLI's default WGC/PrintWindow path and never opts into --capture-screen or --focus. If UIA semantics are insufficient, report foreground_required; this provider does not silently inject pointer or keyboard input.",
     },
   ],
   settings: {
@@ -352,7 +352,6 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
         title: boundedText(control.name ?? control.automationId ?? "", 256),
         enabled: control.isEnabled !== false,
         actions: fingerprints[index]!.actions,
-        ...(fingerprints[index]!.secure ? { secure: true } : {}),
       })),
       truncated:
         flattened.length > MAX_COMPUTER_INSPECTION_CONTROLS ||
@@ -663,11 +662,6 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       );
     }
     const actual = winAppFingerprint(matches[0]!);
-    if (action === "set_value" && actual.secure) {
-      throw new Error(
-        "computer_set_value rejects password or secure controls; supplied text is a journaled non-secret-only tool argument",
-      );
-    }
     if (!sameSemanticFingerprint(expected, actual)) {
       throw new Error(
         "The WinApp control changed since the observation; inspect the target again",
@@ -813,10 +807,9 @@ function flattenElements(roots: readonly WinAppElement[]): WinAppElement[] {
 }
 
 function winAppFingerprint(element: WinAppElement): ComputerControlFingerprint {
-  const secure = isSecureElement(element);
   const actions: ComputerControlAction[] = [];
   if (element.isInvokable === true) actions.push(COMPUTER_ACTION_PRESS);
-  if (!secure && isEditableElement(element)) {
+  if (isEditableElement(element)) {
     actions.push(COMPUTER_ACTION_SET_VALUE);
   }
   return {
@@ -827,7 +820,6 @@ function winAppFingerprint(element: WinAppElement): ComputerControlFingerprint {
     frame: [element.x, element.y, element.width, element.height]
       .map((value) => (Number.isFinite(value) ? String(value) : ""))
       .join(","),
-    secure,
     actions,
   };
 }
@@ -841,8 +833,7 @@ function sameSemanticFingerprint(
     expected.role === actual.role &&
     expected.title === actual.title &&
     expected.description === actual.description &&
-    expected.frame === actual.frame &&
-    expected.secure === actual.secure
+    expected.frame === actual.frame
   );
 }
 
@@ -850,19 +841,6 @@ function isEditableElement(element: WinAppElement): boolean {
   if (element.value !== undefined && element.value !== null) return true;
   return /(?:edit|textbox|document|combobox|spinner|slider)/iu.test(
     `${winAppControlType(element) ?? ""} ${element.className ?? ""}`,
-  );
-}
-
-function isSecureElement(element: WinAppElement): boolean {
-  return /(?:password|passwd|passcode|pin|secret|secure|credential|token)/iu.test(
-    [
-      winAppControlType(element),
-      element.name,
-      element.automationId,
-      element.className,
-    ]
-      .filter((value): value is string => typeof value === "string")
-      .join(" "),
   );
 }
 
@@ -1189,13 +1167,7 @@ function redactDiagnostic(
   for (const exact of exactValues) {
     if (exact.length > 0) redacted = redacted.replaceAll(exact, "[REDACTED]");
   }
-  return redacted
-    .replace(
-      /("?(?:password|secret|token|credential|authorization)"?\s*[:=]\s*)("[^"]*"|\S+)/giu,
-      "$1[REDACTED]",
-    )
-    .trim()
-    .slice(0, 2_048);
+  return redacted.trim().slice(0, 2_048);
 }
 
 function unsupportedForeground(): Error {

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -136,6 +136,7 @@ export interface WinAppCliRunOptions {
   maxStdoutBytes?: number;
   maxStderrBytes?: number;
   redactions?: readonly string[];
+  verifyBeforeSpawn?: () => Promise<void>;
 }
 
 export interface WinAppCliRunResult {
@@ -694,7 +695,10 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     options: WinAppCliRunOptions,
   ): Promise<WinAppCliRunResult> {
     await this.#verifyExecutable?.();
-    return await this.#runner.run(this.#command, args, options);
+    return await this.#runner.run(this.#command, args, {
+      ...options,
+      verifyBeforeSpawn: options.verifyBeforeSpawn ?? this.#verifyExecutable,
+    });
   }
 
   async #json<T>(
@@ -732,6 +736,7 @@ export async function runBoundedProcess(
   options: WinAppCliRunOptions,
 ): Promise<WinAppCliRunResult> {
   options.signal?.throwIfAborted();
+  await options.verifyBeforeSpawn?.();
   return await new Promise<WinAppCliRunResult>((resolve, reject) => {
     const child = spawn(executable, args, {
       shell: false,

--- a/apps/zenx/src/main/capabilities/windows-computer-provider.ts
+++ b/apps/zenx/src/main/capabilities/windows-computer-provider.ts
@@ -136,6 +136,8 @@ export interface WinAppCliRunOptions {
   maxStdoutBytes?: number;
   maxStderrBytes?: number;
   redactions?: readonly string[];
+  runtimeExecutable?: string;
+  bindBeforeSpawn?: () => Promise<() => Promise<void>>;
   verifyBeforeSpawn?: () => Promise<void>;
 }
 
@@ -220,6 +222,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
   readonly #platform: NodeJS.Platform;
   readonly #runner: WinAppCliRunner;
   readonly #expectedVersion?: string;
+  readonly #runtimeExecutable?: string;
+  readonly #bindBeforeSpawn?: () => Promise<() => Promise<void>>;
   readonly #verifyExecutable?: () => Promise<void>;
 
   constructor(
@@ -229,6 +233,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
       platform?: NodeJS.Platform;
       runner?: WinAppCliRunner;
       expectedVersion?: string;
+      runtimeExecutable?: string;
+      bindBeforeSpawn?: () => Promise<() => Promise<void>>;
       verifyExecutable?: () => Promise<void>;
     } = {},
   ) {
@@ -239,6 +245,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     this.#platform = options.platform ?? process.platform;
     this.#runner = options.runner ?? new SpawnWinAppCliRunner();
     this.#expectedVersion = options.expectedVersion;
+    this.#runtimeExecutable = options.runtimeExecutable;
+    this.#bindBeforeSpawn = options.bindBeforeSpawn;
     this.#verifyExecutable = options.verifyExecutable;
   }
 
@@ -697,6 +705,8 @@ export class WinAppCliComputerBackend implements ZenXComputerBackend {
     await this.#verifyExecutable?.();
     return await this.#runner.run(this.#command, args, {
       ...options,
+      runtimeExecutable: this.#runtimeExecutable,
+      bindBeforeSpawn: this.#bindBeforeSpawn,
       verifyBeforeSpawn: options.verifyBeforeSpawn ?? this.#verifyExecutable,
     });
   }
@@ -737,8 +747,29 @@ export async function runBoundedProcess(
 ): Promise<WinAppCliRunResult> {
   options.signal?.throwIfAborted();
   await options.verifyBeforeSpawn?.();
+  const releaseBinding = await options.bindBeforeSpawn?.();
+  try {
+    options.signal?.throwIfAborted();
+  } catch (error) {
+    await releaseBinding?.();
+    throw error;
+  }
   return await new Promise<WinAppCliRunResult>((resolve, reject) => {
-    const child = spawn(executable, args, {
+    const invocation =
+      options.runtimeExecutable === undefined
+        ? { executable, args: [...args] }
+        : {
+            executable: options.runtimeExecutable,
+            args: [executable, ...args],
+          };
+    if (
+      options.runtimeExecutable !== undefined &&
+      !path.isAbsolute(options.runtimeExecutable)
+    ) {
+      reject(new Error("Bundled WinApp runtime must be an absolute path"));
+      return;
+    }
+    const child = spawn(invocation.executable, invocation.args, {
       shell: false,
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
@@ -755,6 +786,7 @@ export async function runBoundedProcess(
       settled = true;
       clearTimeout(timer);
       options.signal?.removeEventListener("abort", abort);
+      void Promise.resolve(releaseBinding?.()).catch(() => undefined);
       callback();
     };
     const failAndKill = (error: Error): void => {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -170,6 +170,55 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     await this.#registry.unregister(capabilityId);
   }
 
+  async resetTransient(): Promise<void> {
+    await this.#registry.resetTransient();
+    if (
+      this.#browserBackend !== undefined ||
+      this.#computerBackend !== undefined
+    ) {
+      return;
+    }
+    await this.#registry.unregister("browser");
+    await this.#registry.unregister("computer");
+    this.#computerRegistered = false;
+    const browser = await selectBrowserProvider({
+      userDataDirectory: this.#userDataDirectory,
+      bundledProvidersOnly: this.#bundledProvidersOnly,
+      resourcesDirectory: this.#resourcesDirectory,
+      bundledManifestSha256: this.#bundledManifestSha256,
+    });
+    if (browser.backend !== undefined) {
+      this.#registry.register(
+        new BrowserZenXCapabilityPackage(browser.backend, browser.manifest),
+        "bundled",
+      );
+    }
+    for (const diagnostic of browser.diagnostics) {
+      this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+    if (browser.backend === undefined) {
+      this.#registry.recordDiscoveryError(
+        `Browser provider: ${browser.diagnostics[0]?.reason ?? "unavailable"}`,
+      );
+    }
+    const computer = await selectComputerProvider({
+      userDataDirectory: this.#userDataDirectory,
+      bundledProvidersOnly: this.#bundledProvidersOnly,
+      resourcesDirectory: this.#resourcesDirectory,
+      bundledManifestSha256: this.#bundledManifestSha256,
+    });
+    if (computer.backend !== undefined) {
+      this.#registry.register(
+        new ComputerZenXCapabilityPackage(computer.backend, computer.manifest),
+        "bundled",
+      );
+      this.#computerRegistered = true;
+    }
+    for (const diagnostic of computer.diagnostics) {
+      this.#registry.recordProviderDiagnostic(diagnostic);
+    }
+  }
+
   hostSnapshot(): ZenXCapabilityHostSnapshot {
     return this.#registry.hostSnapshot();
   }

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -35,6 +35,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
   readonly #computerManifest?: ZenXCapabilityManifest;
   readonly #bundledProvidersOnly: boolean;
   readonly #resourcesDirectory?: string;
+  readonly #bundledManifestSha256?: string;
   #computerRegistered = false;
 
   constructor(options: {
@@ -46,6 +47,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     computerManifest?: ZenXCapabilityManifest;
     bundledProvidersOnly?: boolean;
     resourcesDirectory?: string;
+    bundledManifestSha256?: string;
   }) {
     this.#registry = new ZenXCapabilityRegistry(
       options.grantStore ??
@@ -62,6 +64,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     this.#computerManifest = options.computerManifest;
     this.#bundledProvidersOnly = options.bundledProvidersOnly ?? false;
     this.#resourcesDirectory = options.resourcesDirectory;
+    this.#bundledManifestSha256 = options.bundledManifestSha256;
   }
 
   async initialize(): Promise<void> {
@@ -72,6 +75,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
             userDataDirectory: this.#userDataDirectory,
             bundledProvidersOnly: this.#bundledProvidersOnly,
             resourcesDirectory: this.#resourcesDirectory,
+            bundledManifestSha256: this.#bundledManifestSha256,
           })
         : {
             backend: this.#browserBackend,
@@ -98,6 +102,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
             userDataDirectory: this.#userDataDirectory,
             bundledProvidersOnly: this.#bundledProvidersOnly,
             resourcesDirectory: this.#resourcesDirectory,
+            bundledManifestSha256: this.#bundledManifestSha256,
           })
         : {
             backend: this.#computerBackend,

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -33,6 +33,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
   readonly #browserBackend?: ZenXBrowserBackend;
   readonly #computerBackend?: ZenXComputerBackend;
   readonly #computerManifest?: ZenXCapabilityManifest;
+  readonly #bundledProvidersOnly: boolean;
+  readonly #resourcesDirectory?: string;
   #computerRegistered = false;
 
   constructor(options: {
@@ -42,6 +44,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     browserBackend?: ZenXBrowserBackend;
     computerBackend?: ZenXComputerBackend;
     computerManifest?: ZenXCapabilityManifest;
+    bundledProvidersOnly?: boolean;
+    resourcesDirectory?: string;
   }) {
     this.#registry = new ZenXCapabilityRegistry(
       options.grantStore ??
@@ -56,6 +60,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     this.#browserBackend = options.browserBackend;
     this.#computerBackend = options.computerBackend;
     this.#computerManifest = options.computerManifest;
+    this.#bundledProvidersOnly = options.bundledProvidersOnly ?? false;
+    this.#resourcesDirectory = options.resourcesDirectory;
   }
 
   async initialize(): Promise<void> {
@@ -64,6 +70,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
       this.#browserBackend === undefined
         ? await selectBrowserProvider({
             userDataDirectory: this.#userDataDirectory,
+            bundledProvidersOnly: this.#bundledProvidersOnly,
+            resourcesDirectory: this.#resourcesDirectory,
           })
         : {
             backend: this.#browserBackend,
@@ -88,6 +96,8 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
       this.#computerBackend === undefined
         ? await selectComputerProvider({
             userDataDirectory: this.#userDataDirectory,
+            bundledProvidersOnly: this.#bundledProvidersOnly,
+            resourcesDirectory: this.#resourcesDirectory,
           })
         : {
             backend: this.#computerBackend,

--- a/apps/zenx/src/main/capability-smoke.ts
+++ b/apps/zenx/src/main/capability-smoke.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
+import { access } from "node:fs/promises";
 
 import { app, screen } from "electron";
 
@@ -85,12 +86,13 @@ void app.whenReady().then(async () => {
       tabId,
     })) as BrowserInspection;
     assert.match(inspected.visibleText, /Mark/u);
+    await access(inspected.screenshot.artifactPath);
+    assert.equal(inspected.screenshot.observationId, inspected.observationId);
     assert.equal(
       inspected.targets.some(({ name }) => name === "Hidden"),
       false,
     );
     const password = inspected.targets.find(({ name }) => name === "Password");
-    assert.equal(password?.secure, true);
     assert.equal(password?.value, undefined);
     assert.equal(password?.actions.includes("type"), true);
     if (password !== undefined) {

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -93,7 +93,11 @@ app.whenReady().then(async () => {
     ),
   });
   try {
-    capabilityService = new ZenXCapabilityService({ userDataDirectory });
+    capabilityService = new ZenXCapabilityService({
+      userDataDirectory,
+      bundledProvidersOnly: app.isPackaged,
+      resourcesDirectory: process.resourcesPath,
+    });
     await capabilityService.initialize();
     capabilityService.register(
       new ZenXSelfControlCapabilityPackage({ appServer: selfControlPort }),

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -33,6 +33,7 @@ import type {
   RoomMember,
 } from "./trigger-types.js";
 import { ZenXCapabilityService } from "./capability-service.js";
+import { PACKAGED_PROVIDER_MANIFEST_SHA256 } from "./capabilities/packaged-provider-integrity.js";
 import {
   MutableAppServerRequestPort,
   ZenXSelfControlCapabilityPackage,
@@ -97,6 +98,9 @@ app.whenReady().then(async () => {
       userDataDirectory,
       bundledProvidersOnly: app.isPackaged,
       resourcesDirectory: process.resourcesPath,
+      bundledManifestSha256: app.isPackaged
+        ? PACKAGED_PROVIDER_MANIFEST_SHA256
+        : undefined,
     });
     await capabilityService.initialize();
     capabilityService.register(

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -187,6 +187,11 @@ app.whenReady().then(async () => {
       selfControlPort.attach(appServerManager, hostConfig.cwd);
       const restartErrors: Error[] = [];
       try {
+        await capabilityService?.resetTransient();
+      } catch (error) {
+        restartErrors.push(normalizeTitleOwnershipFailure(error));
+      }
+      try {
         await titleCoordinator?.stop();
       } catch (error) {
         restartErrors.push(normalizeTitleOwnershipFailure(error));

--- a/apps/zenx/src/main/packaged-provider-smoke.ts
+++ b/apps/zenx/src/main/packaged-provider-smoke.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  selectBrowserProvider,
+  selectComputerProvider,
+} from "./capabilities/provider-catalog.js";
+import type { ExternalProviderProcessRunner } from "./capabilities/external-provider.js";
+import type {
+  WinAppCliRunOptions,
+  WinAppCliRunner,
+} from "./capabilities/windows-computer-provider.js";
+
+const providerBytes = Buffer.from(
+  "ZenX packaged provider smoke asset\n",
+  "utf8",
+);
+
+class SmokeExternalRunner implements ExternalProviderProcessRunner {
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: {
+      timeoutMs: number;
+      signal?: AbortSignal;
+      maxOutputBytes?: number;
+      verifyBeforeSpawn?: () => Promise<void>;
+    },
+  ): Promise<{ stdout: string; stderr: string }> {
+    if (args.includes("--version")) {
+      return { stdout: JSON.stringify({ version: "0.1.2" }), stderr: "" };
+    }
+    if (args.includes("list")) {
+      return { stdout: JSON.stringify({ browsers: [] }), stderr: "" };
+    }
+    return { stdout: JSON.stringify({}), stderr: "" };
+  }
+}
+
+class SmokeWinAppRunner implements WinAppCliRunner {
+  async run(
+    _executable: string,
+    args: readonly string[],
+    _options: WinAppCliRunOptions,
+  ): Promise<{ stdout: string; stderr: string }> {
+    if (args.includes("--version")) return { stdout: "0.3.1\n", stderr: "" };
+    if (args.includes("--cli-schema")) {
+      return {
+        stdout: JSON.stringify({
+          schemaVersion: "1.0",
+          version: "0.3.1",
+          subcommands: {
+            ui: {
+              subcommands: {
+                inspect: {},
+                invoke: {},
+                "list-windows": {},
+                screenshot: {},
+                "set-value": {},
+                "wait-for": {},
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+    return { stdout: "[]", stderr: "" };
+  }
+}
+
+const root = await mkdtemp(
+  path.join(os.tmpdir(), "zenx-packaged-provider-smoke-"),
+);
+try {
+  const providers = path.join(root, "providers");
+  await mkdir(providers, { recursive: true });
+  const playwrightAsset = path.join(providers, "playwright-cli.exe");
+  const winAppAsset = path.join(providers, "winapp.exe");
+  await writeFile(playwrightAsset, providerBytes);
+  await writeFile(winAppAsset, providerBytes);
+  const assetSha256 = createHash("sha256").update(providerBytes).digest("hex");
+  const manifest = JSON.stringify({
+    schemaVersion: 1,
+    providers: {
+      "playwright-cli": {
+        executable: "playwright-cli.exe",
+        version: "0.1.2",
+        sha256: assetSha256,
+        platforms: ["win32"],
+      },
+      "microsoft-winapp-cli": {
+        executable: "winapp.exe",
+        version: "0.3.1",
+        sha256: assetSha256,
+        platforms: ["win32"],
+      },
+    },
+  });
+  await writeFile(path.join(providers, "manifest.json"), manifest);
+  const manifestSha256 = createHash("sha256").update(manifest).digest("hex");
+  const browser = await selectBrowserProvider({
+    userDataDirectory: root,
+    resourcesDirectory: root,
+    bundledProvidersOnly: true,
+    bundledManifestSha256: manifestSha256,
+    platform: "win32",
+    runner: new SmokeExternalRunner(),
+  });
+  assert.equal(browser.diagnostics[0]?.status, "selected");
+  assert.equal(browser.diagnostics[0]?.version, "0.1.2");
+  assert.equal(browser.diagnostics[0]?.integrity, "verified");
+  await browser.backend?.close();
+
+  const computer = await selectComputerProvider({
+    userDataDirectory: root,
+    resourcesDirectory: root,
+    bundledProvidersOnly: true,
+    bundledManifestSha256: manifestSha256,
+    platform: "win32",
+    winAppRunner: new SmokeWinAppRunner(),
+  });
+  assert.equal(computer.diagnostics[0]?.status, "selected");
+  assert.equal(computer.diagnostics[0]?.version, "0.3.1");
+  assert.equal(computer.diagnostics[0]?.integrity, "verified");
+  await computer.backend?.close();
+} finally {
+  await rm(root, { recursive: true, force: true });
+}

--- a/apps/zenx/src/main/packaged-provider-smoke.ts
+++ b/apps/zenx/src/main/packaged-provider-smoke.ts
@@ -1,132 +1,161 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
+
+import { app } from "electron";
 
 import {
   selectBrowserProvider,
   selectComputerProvider,
 } from "./capabilities/provider-catalog.js";
-import type { ExternalProviderProcessRunner } from "./capabilities/external-provider.js";
-import type {
-  WinAppCliRunOptions,
-  WinAppCliRunner,
-} from "./capabilities/windows-computer-provider.js";
+import { PACKAGED_PROVIDER_MANIFEST_SHA256 } from "./capabilities/packaged-provider-integrity.js";
 
-const providerBytes = Buffer.from(
-  "ZenX packaged provider smoke asset\n",
-  "utf8",
-);
+const portServer = createServer((_request, response) => {
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.end(
+    "<!doctype html><title>ZenX packaged provider</title><button aria-label='Packaged target'>Packaged target</button>",
+  );
+});
 
-class SmokeExternalRunner implements ExternalProviderProcessRunner {
-  async run(
-    _executable: string,
-    args: readonly string[],
-    _options: {
-      timeoutMs: number;
-      signal?: AbortSignal;
-      maxOutputBytes?: number;
-      verifyBeforeSpawn?: () => Promise<void>;
-    },
-  ): Promise<{ stdout: string; stderr: string }> {
-    if (args.includes("--version")) {
-      return { stdout: JSON.stringify({ version: "0.1.2" }), stderr: "" };
+void app.whenReady().then(async () => {
+  try {
+    assert.equal(
+      app.isPackaged,
+      true,
+      "packaged smoke must run from a packaged application",
+    );
+    assert.ok(
+      process.resourcesPath.length > 0,
+      "packaged smoke must use process.resourcesPath",
+    );
+    process.env.PLAYWRIGHT_BROWSERS_PATH = path.join(
+      process.resourcesPath,
+      "providers",
+      "playwright-browsers",
+    );
+    const manifestPath = path.join(
+      process.resourcesPath,
+      "providers",
+      "manifest.json",
+    );
+    const manifestBytes = await readFile(manifestPath);
+    assert.equal(
+      await sha256(manifestBytes),
+      PACKAGED_PROVIDER_MANIFEST_SHA256,
+      "packaged manifest must match the immutable build-time digest",
+    );
+    const browser = await selectBrowserProvider({
+      userDataDirectory: path.join(process.resourcesPath, "smoke-user-data"),
+      resourcesDirectory: process.resourcesPath,
+      bundledProvidersOnly: true,
+      bundledManifestSha256: PACKAGED_PROVIDER_MANIFEST_SHA256,
+      platform: process.platform,
+    });
+    const browserDiagnostic = browser.diagnostics.find(
+      (diagnostic) =>
+        diagnostic.providerId === "playwright-cli" &&
+        diagnostic.status === "selected",
+    );
+    assert.ok(
+      browser.backend,
+      `bundled Browser provider unavailable: ${JSON.stringify(browser.diagnostics)}`,
+    );
+    assert.equal(browserDiagnostic?.version, "0.1.18");
+    assert.equal(browserDiagnostic?.integrity, "verified");
+    assert.equal(
+      browserDiagnostic?.executable?.startsWith(process.resourcesPath),
+      true,
+    );
+    const port = await listen();
+    const opened = await browser.backend.open(
+      "packaged-smoke",
+      `http://127.0.0.1:${String(port)}/`,
+    );
+    const inspected = await browser.backend.inspect(
+      "packaged-smoke",
+      opened.tabId,
+    );
+    assert.equal(
+      inspected.targets.some((target) => target.name === "Packaged target"),
+      true,
+    );
+    await browser.backend.close();
+
+    const computer = await selectComputerProvider({
+      userDataDirectory: path.join(process.resourcesPath, "smoke-user-data"),
+      resourcesDirectory: process.resourcesPath,
+      bundledProvidersOnly: true,
+      bundledManifestSha256: PACKAGED_PROVIDER_MANIFEST_SHA256,
+      platform: process.platform,
+    });
+    if (process.platform === "win32") {
+      const computerDiagnostic = computer.diagnostics.find(
+        (diagnostic) =>
+          diagnostic.providerId === "microsoft-winapp-cli" &&
+          diagnostic.status === "selected",
+      );
+      assert.ok(
+        computer.backend,
+        `bundled Computer provider unavailable: ${JSON.stringify(computer.diagnostics)}`,
+      );
+      assert.equal(computerDiagnostic?.version, "0.3.1");
+      assert.equal(computerDiagnostic?.integrity, "verified");
+      assert.equal(
+        computerDiagnostic?.executable?.startsWith(process.resourcesPath),
+        true,
+      );
+      await computer.backend.close();
     }
-    if (args.includes("list")) {
-      return { stdout: JSON.stringify({ browsers: [] }), stderr: "" };
-    }
-    return { stdout: JSON.stringify({}), stderr: "" };
+    console.log(
+      JSON.stringify(
+        {
+          passed: true,
+          packaged: app.isPackaged,
+          resourcesPath: process.resourcesPath,
+          browser: browserDiagnostic,
+          computer: computer.diagnostics,
+          bundledOnly: true,
+          syntheticFixtures: false,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    console.error("ZenX packaged provider smoke failed", error);
+    process.exitCode = 1;
+  } finally {
+    await closeServer();
+    app.quit();
   }
+});
+
+async function listen(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    portServer.once("error", reject);
+    portServer.listen(0, "127.0.0.1", () => {
+      portServer.removeListener("error", reject);
+      const address = portServer.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("packaged provider smoke server did not bind"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
 }
 
-class SmokeWinAppRunner implements WinAppCliRunner {
-  async run(
-    _executable: string,
-    args: readonly string[],
-    _options: WinAppCliRunOptions,
-  ): Promise<{ stdout: string; stderr: string }> {
-    if (args.includes("--version")) return { stdout: "0.3.1\n", stderr: "" };
-    if (args.includes("--cli-schema")) {
-      return {
-        stdout: JSON.stringify({
-          schemaVersion: "1.0",
-          version: "0.3.1",
-          subcommands: {
-            ui: {
-              subcommands: {
-                inspect: {},
-                invoke: {},
-                "list-windows": {},
-                screenshot: {},
-                "set-value": {},
-                "wait-for": {},
-              },
-            },
-          },
-        }),
-        stderr: "",
-      };
-    }
-    return { stdout: "[]", stderr: "" };
-  }
+async function closeServer(): Promise<void> {
+  if (!portServer.listening) return;
+  await new Promise<void>((resolve, reject) =>
+    portServer.close((error) =>
+      error === undefined ? resolve() : reject(error),
+    ),
+  );
 }
 
-const root = await mkdtemp(
-  path.join(os.tmpdir(), "zenx-packaged-provider-smoke-"),
-);
-try {
-  const providers = path.join(root, "providers");
-  await mkdir(providers, { recursive: true });
-  const playwrightAsset = path.join(providers, "playwright-cli.fixture");
-  const winAppAsset = path.join(providers, "winapp.fixture");
-  await writeFile(playwrightAsset, providerBytes);
-  await writeFile(winAppAsset, providerBytes);
-  const assetSha256 = createHash("sha256").update(providerBytes).digest("hex");
-  const manifest = JSON.stringify({
-    schemaVersion: 1,
-    providers: {
-      "playwright-cli": {
-        executable: "playwright-cli.fixture",
-        version: "0.1.2",
-        sha256: assetSha256,
-        platforms: ["win32"],
-      },
-      "microsoft-winapp-cli": {
-        executable: "winapp.fixture",
-        version: "0.3.1",
-        sha256: assetSha256,
-        platforms: ["win32"],
-      },
-    },
-  });
-  await writeFile(path.join(providers, "manifest.json"), manifest);
-  const manifestSha256 = createHash("sha256").update(manifest).digest("hex");
-  const browser = await selectBrowserProvider({
-    userDataDirectory: root,
-    resourcesDirectory: root,
-    bundledProvidersOnly: true,
-    bundledManifestSha256: manifestSha256,
-    platform: "win32",
-    runner: new SmokeExternalRunner(),
-  });
-  assert.equal(browser.diagnostics[0]?.status, "selected");
-  assert.equal(browser.diagnostics[0]?.version, "0.1.2");
-  assert.equal(browser.diagnostics[0]?.integrity, "verified");
-  await browser.backend?.close();
-
-  const computer = await selectComputerProvider({
-    userDataDirectory: root,
-    resourcesDirectory: root,
-    bundledProvidersOnly: true,
-    bundledManifestSha256: manifestSha256,
-    platform: "win32",
-    winAppRunner: new SmokeWinAppRunner(),
-  });
-  assert.equal(computer.diagnostics[0]?.status, "selected");
-  assert.equal(computer.diagnostics[0]?.version, "0.3.1");
-  assert.equal(computer.diagnostics[0]?.integrity, "verified");
-  await computer.backend?.close();
-} finally {
-  await rm(root, { recursive: true, force: true });
+async function sha256(bytes: Buffer): Promise<string> {
+  const { createHash } = await import("node:crypto");
+  return createHash("sha256").update(bytes).digest("hex");
 }

--- a/apps/zenx/src/main/packaged-provider-smoke.ts
+++ b/apps/zenx/src/main/packaged-provider-smoke.ts
@@ -78,8 +78,8 @@ const root = await mkdtemp(
 try {
   const providers = path.join(root, "providers");
   await mkdir(providers, { recursive: true });
-  const playwrightAsset = path.join(providers, "playwright-cli.exe");
-  const winAppAsset = path.join(providers, "winapp.exe");
+  const playwrightAsset = path.join(providers, "playwright-cli.fixture");
+  const winAppAsset = path.join(providers, "winapp.fixture");
   await writeFile(playwrightAsset, providerBytes);
   await writeFile(winAppAsset, providerBytes);
   const assetSha256 = createHash("sha256").update(providerBytes).digest("hex");
@@ -87,13 +87,13 @@ try {
     schemaVersion: 1,
     providers: {
       "playwright-cli": {
-        executable: "playwright-cli.exe",
+        executable: "playwright-cli.fixture",
         version: "0.1.2",
         sha256: assetSha256,
         platforms: ["win32"],
       },
       "microsoft-winapp-cli": {
-        executable: "winapp.exe",
+        executable: "winapp.fixture",
         version: "0.3.1",
         sha256: assetSha256,
         platforms: ["win32"],

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -10,6 +10,7 @@ import WebSocket, { type RawData } from "ws";
 import { selectBrowserProvider } from "./capabilities/provider-catalog.js";
 import {
   UserBrowserDocumentChangedBeforeDispatchError,
+  UserBrowserCdpOutcomeUnknownError,
   windowsBrowserExecutableCandidates,
 } from "./capabilities/user-browser-provider.js";
 
@@ -79,10 +80,15 @@ try {
   assert.equal(selected?.providerId, "user-browser-cdp");
   assert.equal(selection.manifest.provider.id, "user-browser-cdp");
   const tabs = await retry(async () => {
-    const current = await backend.listTabs("windows-smoke");
-    return current.some((tab) => tab.url.includes("/account"))
-      ? current
-      : undefined;
+    try {
+      const current = await backend.listTabs("windows-smoke");
+      return current.some((tab) => tab.url.includes("/account"))
+        ? current
+        : undefined;
+    } catch (error) {
+      if (error instanceof UserBrowserCdpOutcomeUnknownError) return undefined;
+      throw error;
+    }
   });
   const account = tabs.find((tab) => tab.url.includes("/account"));
   assert.ok(account, "Expected the already-running authenticated account tab");

--- a/apps/zenx/src/main/windows-computer-smoke.ts
+++ b/apps/zenx/src/main/windows-computer-smoke.ts
@@ -54,15 +54,10 @@ try {
     controller.signal,
   );
   const editor = first.controls.find(
-    (control) =>
-      control.enabled &&
-      control.secure !== true &&
-      control.actions.includes("set_value"),
+    (control) => control.enabled && control.actions.includes("set_value"),
   );
   if (editor === undefined) {
-    throw new Error(
-      "ZenX adapter found no non-secret editable fixture control",
-    );
+    throw new Error("ZenX adapter found no editable fixture control");
   }
 
   const probeText = `ZenX WinApp adapter smoke ${new Date().toISOString()}`;

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -186,12 +186,24 @@ export function CapabilitySettings() {
           </ol>
           {currentScreenshot === undefined ? null : (
             <figure>
-              <img
-                alt={`Current browser observation ${currentScreenshot.observationId ?? ""}`}
-                src={fileArtifactUrl(currentScreenshot.artifactPath)}
-              />
+              {currentScreenshot.status === "captured" ? (
+                <img
+                  alt={`Current browser observation ${currentScreenshot.observationId ?? ""}`}
+                  src={fileArtifactUrl(currentScreenshot.artifactPath)}
+                />
+              ) : (
+                <figcaption>
+                  Screenshot unavailable; this is not a live browser
+                  observation.
+                  {currentScreenshot.reason === undefined
+                    ? ""
+                    : ` ${currentScreenshot.reason}.`}
+                </figcaption>
+              )}
               <figcaption>
-                Current observation{" "}
+                {currentScreenshot.status === "captured"
+                  ? "Current observation"
+                  : "Capture status: fallback"}{" "}
                 {currentScreenshot.observationId ?? "unknown"} ·{" "}
                 {currentScreenshot.width}×{currentScreenshot.height}
               </figcaption>

--- a/apps/zenx/src/renderer/src/CapabilitySettings.tsx
+++ b/apps/zenx/src/renderer/src/CapabilitySettings.tsx
@@ -10,6 +10,12 @@ export function CapabilitySettings() {
   const [snapshot, setSnapshot] = useState<ZenXCapabilitySnapshot | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNow(Date.now()), 1_000);
+    return () => window.clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     let active = true;
@@ -52,6 +58,12 @@ export function CapabilitySettings() {
       </div>
     );
   }
+
+  const currentScreenshot =
+    snapshot.currentScreenshot !== undefined &&
+    Date.parse(snapshot.currentScreenshot.expiresAt) > now
+      ? snapshot.currentScreenshot
+      : undefined;
 
   return (
     <div className="settings-card capability-settings">
@@ -157,6 +169,36 @@ export function CapabilitySettings() {
           );
         })}
       </div>
+      {snapshot.recentInvocations.length === 0 &&
+      currentScreenshot === undefined ? null : (
+        <div className="capability-live" aria-live="polite">
+          <h3>Live capability operations</h3>
+          <ol>
+            {snapshot.recentInvocations.slice(0, 8).map((invocation) => (
+              <li key={invocation.id}>
+                <strong>{invocation.toolName}</strong>
+                <span>{invocation.status}</span>
+                <time>
+                  {new Date(invocation.startedAt).toLocaleTimeString()}
+                </time>
+              </li>
+            ))}
+          </ol>
+          {currentScreenshot === undefined ? null : (
+            <figure>
+              <img
+                alt={`Current browser observation ${currentScreenshot.observationId ?? ""}`}
+                src={fileArtifactUrl(currentScreenshot.artifactPath)}
+              />
+              <figcaption>
+                Current observation{" "}
+                {currentScreenshot.observationId ?? "unknown"} ·{" "}
+                {currentScreenshot.width}×{currentScreenshot.height}
+              </figcaption>
+            </figure>
+          )}
+        </div>
+      )}
       {snapshot.providerDiagnostics.length === 0 ? null : (
         <div className="capability-audit">
           <h3>Execution providers</h3>
@@ -181,6 +223,7 @@ export function CapabilitySettings() {
                 <span>{provider.sessionMode ?? "mode-unreported"}</span>
               ) : null}
               <span>{provider.version ?? "bundled"}</span>
+              <span>{provider.integrity ?? "integrity-unreported"}</span>
             </div>
           ))}
         </div>
@@ -220,4 +263,9 @@ export function CapabilitySettings() {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function fileArtifactUrl(artifactPath: string): string {
+  const normalized = artifactPath.replaceAll("\\", "/");
+  return `file://${normalized.startsWith("/") ? "" : "/"}${encodeURI(normalized)}`;
 }

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -90,7 +90,6 @@ test("browser rejects stale and forged targets without classifying text sensitiv
   const editable = fingerprint({ actions: ["click", "type"] });
   const password = fingerprint({
     type: "password",
-    secure: true,
     actions: ["click", "type"],
   });
   const observation: BrowserObservation = {
@@ -165,28 +164,19 @@ test("same logical session uses a fresh partition generation after close", () =>
   assert.match(reopened, /zenx-capability-research-2$/u);
 });
 
-test("browser refuses credential-bearing and sensitive URLs before provider use", async () => {
-  const capability = new BrowserZenXCapabilityPackage(browserBackend([]));
-  await assert.rejects(
-    capability.invoke(
-      "browser_open",
-      invocation({
-        sessionId: "research",
-        url: "https://user:password@example.com/",
-      }),
-    ),
-    /must not contain credentials/u,
+test("browser dispatches credential-looking URLs without provider classifiers", async () => {
+  const calls: string[] = [];
+  const capability = new BrowserZenXCapabilityPackage(browserBackend(calls));
+  await capability.invoke(
+    "browser_open",
+    invocation({
+      sessionId: "research",
+      url: "https://user:password@example.com/?access_token=private",
+    }),
   );
-  await assert.rejects(
-    capability.invoke(
-      "browser_open",
-      invocation({
-        sessionId: "research",
-        url: "https://example.com/?access_token=private",
-      }),
-    ),
-    /sensitive query parameter/u,
-  );
+  assert.deepEqual(calls, [
+    "open:research:https://user:password@example.com/?access_token=private",
+  ]);
 });
 
 test("browser advertises a cross-platform dedicated background-safe provider", () => {
@@ -235,6 +225,14 @@ function browserBackend(calls: string[]): ZenXBrowserBackend {
         observationId: "observation-1",
         documentVersion: 1,
         visibleText: "Fixture page",
+        screenshot: {
+          artifactPath: "/tmp/browser-fixture.png",
+          observationId: "observation-1",
+          width: 1,
+          height: 1,
+          bytes: 68,
+          expiresAt: new Date(0).toISOString(),
+        },
         targets: [
           {
             targetId: "target-go",
@@ -285,7 +283,6 @@ function fingerprint(
     fieldName: "target",
     autocomplete: "off",
     href: "",
-    secure: false,
     actions: ["click"],
     ...overrides,
   };

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -8,6 +8,7 @@ import {
   browserPartitionName,
   MAX_BROWSER_TABS_GLOBAL,
   MAX_BROWSER_TABS_PER_SESSION,
+  redactBrowserUrl,
   resolveBrowserObservedTarget,
   type BrowserInspection,
   type BrowserObservation,
@@ -15,6 +16,24 @@ import {
   type BrowserTargetFingerprint,
   type ZenXBrowserBackend,
 } from "../src/main/capabilities/browser-provider.js";
+
+test("browser URL projection uniformly removes credentials, query, and hash", () => {
+  assert.equal(
+    redactBrowserUrl(
+      "https://alice:secret@example.com/path?q=ordinary#fragment",
+    ),
+    "https://example.com/path",
+  );
+  assert.equal(
+    redactBrowserUrl("https://example.com/"),
+    "https://example.com/",
+  );
+  assert.ok(
+    redactBrowserUrl(`https://example.com/${"x".repeat(4_096)}`).length <=
+      2_048,
+  );
+  assert.throws(() => redactBrowserUrl("not a URL"), TypeError);
+});
 
 test("browser vertical slice targets one session/tab through structured operations", async () => {
   const calls: string[] = [];
@@ -228,6 +247,7 @@ function browserBackend(calls: string[]): ZenXBrowserBackend {
         screenshot: {
           artifactPath: "/tmp/browser-fixture.png",
           observationId: "observation-1",
+          status: "captured",
           width: 1,
           height: 1,
           bytes: 68,

--- a/apps/zenx/test/browser-capability.test.ts
+++ b/apps/zenx/test/browser-capability.test.ts
@@ -32,7 +32,7 @@ test("browser URL projection uniformly removes credentials, query, and hash", ()
     redactBrowserUrl(`https://example.com/${"x".repeat(4_096)}`).length <=
       2_048,
   );
-  assert.throws(() => redactBrowserUrl("not a URL"), TypeError);
+  assert.equal(redactBrowserUrl("not a URL"), "[malformed-url]");
 });
 
 test("browser vertical slice targets one session/tab through structured operations", async () => {

--- a/apps/zenx/test/browser-screenshot-artifact.test.ts
+++ b/apps/zenx/test/browser-screenshot-artifact.test.ts
@@ -60,6 +60,25 @@ test("browser screenshot cleanup serializes close and scope races", async () => 
   }
 });
 
+test("browser screenshot stores isolate ownership when sharing a root", async () => {
+  const root = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-browser-shared-root-"),
+  );
+  const first = new BrowserScreenshotArtifactStore(root);
+  const second = new BrowserScreenshotArtifactStore(root);
+  try {
+    const firstArtifact = await first.write("one/tab", "one", ONE_PIXEL_PNG);
+    const secondArtifact = await second.write("two/tab", "two", ONE_PIXEL_PNG);
+    await first.close();
+    await access(secondArtifact.artifactPath);
+    await assert.rejects(access(firstArtifact.artifactPath));
+  } finally {
+    await first.close();
+    await second.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("browser screenshot validation rejects truncation, bad CRC, and huge dimensions", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "zenx-browser-png-"));
   const store = new BrowserScreenshotArtifactStore(root);

--- a/apps/zenx/test/browser-screenshot-artifact.test.ts
+++ b/apps/zenx/test/browser-screenshot-artifact.test.ts
@@ -44,15 +44,30 @@ test("browser screenshot cleanup serializes close and scope races", async () => 
   try {
     const write = store.write("session/tab", "observation-race", ONE_PIXEL_PNG);
     const clear = store.clearScope("session");
-    const artifact = await write;
+    await assert.rejects(write, /scope is no longer current/u);
     await clear;
-    await assert.rejects(access(artifact.artifactPath));
 
     const close = store.close();
     await assert.rejects(
       store.write("session/tab", "after-close", ONE_PIXEL_PNG),
       /closed/u,
     );
+    await close;
+  } finally {
+    await store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("browser screenshot close fences a write already queued", async () => {
+  const root = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-browser-close-race-"),
+  );
+  const store = new BrowserScreenshotArtifactStore(root);
+  try {
+    const write = store.write("session/tab", "observation-race", ONE_PIXEL_PNG);
+    const close = store.close();
+    await assert.rejects(write, /closed/u);
     await close;
   } finally {
     await store.close();
@@ -99,6 +114,25 @@ test("browser screenshot validation rejects truncation, bad CRC, and huge dimens
     );
     const valid = await store.write("session/tab", "valid", ONE_PIXEL_PNG);
     assert.equal(valid.width, 1);
+    const unknownCritical = insertChunk(
+      ONE_PIXEL_PNG,
+      "ABCD",
+      Buffer.from("bad"),
+    );
+    await assert.rejects(
+      store.write("session/tab", "unknown-critical", unknownCritical),
+      /unknown critical/u,
+    );
+    const duplicatePalette = insertChunk(
+      ONE_PIXEL_PNG,
+      "PLTE",
+      Buffer.from([0, 0, 0]),
+      1,
+    );
+    await assert.rejects(
+      store.write("session/tab", "duplicate-palette", duplicatePalette),
+      /palette/u,
+    );
   } finally {
     await store.close();
     await rm(root, { recursive: true, force: true });
@@ -109,6 +143,26 @@ function oversizedPng(): Buffer {
   const png = Buffer.alloc(MAX_BROWSER_SCREENSHOT_BYTES + 1);
   ONE_PIXEL_PNG.copy(png, 0, 0, 24);
   return png;
+}
+
+function insertChunk(
+  png: Buffer,
+  name: string,
+  data: Buffer,
+  beforeChunk = 1,
+): Buffer {
+  let offset = 8;
+  for (let index = 0; index < beforeChunk; index += 1) {
+    const length = png.readUInt32BE(offset);
+    offset += 12 + length;
+  }
+  const type = Buffer.from(name, "ascii");
+  const chunk = Buffer.alloc(12 + data.length);
+  chunk.writeUInt32BE(data.length, 0);
+  type.copy(chunk, 4);
+  data.copy(chunk, 8);
+  chunk.writeUInt32BE(crc32(Buffer.concat([type, data])), 8 + data.length);
+  return Buffer.concat([png.subarray(0, offset), chunk, png.subarray(offset)]);
 }
 
 function crc32(buffer: Buffer): number {

--- a/apps/zenx/test/browser-screenshot-artifact.test.ts
+++ b/apps/zenx/test/browser-screenshot-artifact.test.ts
@@ -1,0 +1,45 @@
+import { access, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  BrowserScreenshotArtifactStore,
+  MAX_BROWSER_SCREENSHOT_BYTES,
+} from "../src/main/capabilities/browser-provider.js";
+
+const ONE_PIXEL_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+test("browser screenshot artifacts are bounded, scoped, and cleaned", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-browser-artifact-"));
+  const store = new BrowserScreenshotArtifactStore(root);
+  try {
+    const artifact = await store.write(
+      "session/tab",
+      "observation-1",
+      ONE_PIXEL_PNG,
+    );
+    assert.equal(artifact.bytes, ONE_PIXEL_PNG.byteLength);
+    assert.equal(artifact.width, 1);
+    await access(artifact.artifactPath);
+    await store.clearScope("session");
+    await assert.rejects(access(artifact.artifactPath));
+    await assert.rejects(
+      store.write("session/tab", "observation-2", oversizedPng()),
+      /exceeded/u,
+    );
+  } finally {
+    await store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function oversizedPng(): Buffer {
+  const png = Buffer.alloc(MAX_BROWSER_SCREENSHOT_BYTES + 1);
+  ONE_PIXEL_PNG.copy(png, 0, 0, 24);
+  return png;
+}

--- a/apps/zenx/test/browser-screenshot-artifact.test.ts
+++ b/apps/zenx/test/browser-screenshot-artifact.test.ts
@@ -38,8 +38,67 @@ test("browser screenshot artifacts are bounded, scoped, and cleaned", async () =
   }
 });
 
+test("browser screenshot cleanup serializes close and scope races", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-browser-race-"));
+  const store = new BrowserScreenshotArtifactStore(root);
+  try {
+    const write = store.write("session/tab", "observation-race", ONE_PIXEL_PNG);
+    const clear = store.clearScope("session");
+    const artifact = await write;
+    await clear;
+    await assert.rejects(access(artifact.artifactPath));
+
+    const close = store.close();
+    await assert.rejects(
+      store.write("session/tab", "after-close", ONE_PIXEL_PNG),
+      /closed/u,
+    );
+    await close;
+  } finally {
+    await store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("browser screenshot validation rejects truncation, bad CRC, and huge dimensions", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-browser-png-"));
+  const store = new BrowserScreenshotArtifactStore(root);
+  try {
+    await assert.rejects(
+      store.write("session/tab", "truncated", ONE_PIXEL_PNG.subarray(0, -1)),
+      /PNG/u,
+    );
+    const badCrc = Buffer.from(ONE_PIXEL_PNG);
+    badCrc[badCrc.length - 1]! ^= 1;
+    await assert.rejects(store.write("session/tab", "crc", badCrc), /CRC/u);
+    const huge = Buffer.from(ONE_PIXEL_PNG);
+    huge.writeUInt32BE(5_000, 16);
+    huge.writeUInt32BE(crc32(huge.subarray(12, 29)), 29);
+    await assert.rejects(
+      store.write("session/tab", "huge", huge),
+      /dimensions/u,
+    );
+    const valid = await store.write("session/tab", "valid", ONE_PIXEL_PNG);
+    assert.equal(valid.width, 1);
+  } finally {
+    await store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 function oversizedPng(): Buffer {
   const png = Buffer.alloc(MAX_BROWSER_SCREENSHOT_BYTES + 1);
   ONE_PIXEL_PNG.copy(png, 0, 0, 24);
   return png;
+}
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }

--- a/apps/zenx/test/capability-registry.test.ts
+++ b/apps/zenx/test/capability-registry.test.ts
@@ -306,6 +306,43 @@ test("keeps the newest browser screenshot projection when inspections finish out
   assert.equal(registry.snapshot().currentScreenshot, undefined);
 });
 
+test("transient capability reset clears browser projection without changing grants or audit", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  const browserManifest = structuredClone(manifest);
+  browserManifest.id = "browser";
+  browserManifest.tools = [
+    { ...browserManifest.tools[0]!, name: "browser_inspect" },
+  ];
+  registry.register({
+    manifest: browserManifest,
+    invoke: async () => ({
+      screenshot: {
+        artifactPath: "/tmp/restart.png",
+        observationId: "restart-observation",
+        status: "captured",
+        width: 1,
+        height: 1,
+        bytes: 68,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      },
+    }),
+  });
+  await registry.grant("browser", ["fixture.read"]);
+  await registry.execute(invocation("browser_inspect", {}));
+  const before = registry.snapshot();
+  await registry.resetTransient();
+  const after = registry.snapshot();
+  assert.equal(after.currentScreenshot, undefined);
+  assert.deepEqual(
+    after.capabilities[0]?.granted,
+    before.capabilities[0]?.granted,
+  );
+  assert.equal(after.recentInvocations.length, before.recentInvocations.length);
+});
+
 function packageFixture(
   invoke: ZenXCapabilityPackage["invoke"],
 ): ZenXCapabilityPackage {

--- a/apps/zenx/test/capability-registry.test.ts
+++ b/apps/zenx/test/capability-registry.test.ts
@@ -252,6 +252,60 @@ test("projects an invocation cancelled while its provider is finishing", async (
   assert.equal(registry.snapshot().recentInvocations[0]?.status, "cancelled");
 });
 
+test("keeps the newest browser screenshot projection when inspections finish out of order", async () => {
+  const registry = new ZenXCapabilityRegistry(
+    new MemoryZenXCapabilityGrantStore(),
+  );
+  await registry.initialize();
+  const browserManifest = structuredClone(manifest);
+  browserManifest.id = "browser";
+  browserManifest.tools = [
+    {
+      ...browserManifest.tools[0]!,
+      name: "browser_inspect",
+    },
+  ];
+  let releaseFirst: (() => void) | undefined;
+  let calls = 0;
+  const firstFinished = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
+  registry.register({
+    manifest: browserManifest,
+    invoke: async () => {
+      calls += 1;
+      if (calls === 1) await firstFinished;
+      return {
+        screenshot: {
+          artifactPath: `/tmp/observation-${String(calls)}.png`,
+          observationId: `observation-${String(calls)}`,
+          status: "captured",
+          width: 1,
+          height: 1,
+          bytes: 68,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        },
+      };
+    },
+  });
+  await registry.grant("browser", ["fixture.read"]);
+  const first = registry.execute(invocation("browser_inspect", {}));
+  await new Promise((resolve) => setImmediate(resolve));
+  await registry.execute(invocation("browser_inspect", {}));
+  assert.equal(
+    registry.snapshot().currentScreenshot?.observationId,
+    "observation-2",
+  );
+  releaseFirst?.();
+  await first;
+  assert.equal(
+    registry.snapshot().currentScreenshot?.observationId,
+    "observation-2",
+  );
+  await registry.unregister("browser");
+  assert.equal(registry.snapshot().currentScreenshot, undefined);
+});
+
 function packageFixture(
   invoke: ZenXCapabilityPackage["invoke"],
 ): ZenXCapabilityPackage {

--- a/apps/zenx/test/capability-registry.test.ts
+++ b/apps/zenx/test/capability-registry.test.ts
@@ -112,7 +112,7 @@ test("registers, grants, revokes, and unregisters package contributions", async 
   assert.deepEqual(registry.hostSnapshot().definitions, []);
 });
 
-test("bounds and redacts provider output and projects invocation audit", async () => {
+test("bounds ordinary provider output and projects invocation audit", async () => {
   const registry = new ZenXCapabilityRegistry(
     new MemoryZenXCapabilityGrantStore(),
   );
@@ -131,8 +131,7 @@ test("bounds and redacts provider output and projects invocation audit", async (
 
   const result = await registry.execute(invocation("fixture_inspect", {}));
   assert.ok(Buffer.byteLength(result.output, "utf8") <= 1024);
-  assert.doesNotMatch(result.output, /private/u);
-  assert.doesNotMatch(result.output, /visible-secret|query-secret/u);
+  assert.match(result.output, /private/u);
   assert.match(result.output, /truncated/u);
   const [audit] = registry.snapshot().recentInvocations;
   assert.equal(audit?.capabilityId, "fixture");

--- a/apps/zenx/test/computer-capability.test.ts
+++ b/apps/zenx/test/computer-capability.test.ts
@@ -53,14 +53,13 @@ test("computer vertical slice uses only targeted AX operations and does not echo
   ]);
 });
 
-test("computer observation IDs are target-scoped, latest-only, and reject secure values", () => {
+test("computer observation IDs are target-scoped and dispatch all ordinary values", () => {
   const ledger = new ComputerObservationLedger();
   const first = ledger.observe("app-a", [
     {
       role: "AXButton",
       title: "Mark",
       frame: "10.0,10.0,20.0,20.0",
-      secure: false,
       actions: ["press"],
     },
   ]);
@@ -70,7 +69,6 @@ test("computer observation IDs are target-scoped, latest-only, and reject secure
       role: "AXButton",
       title: "Mark",
       frame: "20.0,10.0,20.0,20.0",
-      secure: false,
       actions: ["press"],
     },
   ]);
@@ -92,18 +90,16 @@ test("computer observation IDs are target-scoped, latest-only, and reject secure
     /another target/u,
   );
 
-  const secure = ledger.observe("app-a", [
+  const ordinary = ledger.observe("app-a", [
     {
       role: "AXTextField",
       subrole: "AXSecureTextField",
       frame: "10.0,40.0,100.0,20.0",
-      secure: true,
       actions: ["set_value"],
     },
   ]);
-  assert.throws(
-    () => ledger.consume("app-a", secure.selectors[0]!, "set_value"),
-    /rejects password or secure controls/u,
+  assert.doesNotThrow(() =>
+    ledger.consume("app-a", ordinary.selectors[0]!, "set_value"),
   );
 });
 

--- a/apps/zenx/test/external-provider.test.ts
+++ b/apps/zenx/test/external-provider.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -51,4 +54,21 @@ test("parses only the Node entry from a standard Windows npm command shim", () =
     parseWindowsNpmShimEntry("@ECHO off\r\nunknown %*\r\n"),
     undefined,
   );
+});
+
+test("bundled runtime execution never consults PATH", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-runtime-runner-"));
+  try {
+    const script = path.join(root, "provider.js");
+    await writeFile(script, "console.log(JSON.stringify({ bundled: true }))\n");
+    const runner = new SystemExternalProviderProcessRunner();
+    const result = await runner.run(script, [], {
+      timeoutMs: 5_000,
+      runtimeExecutable: process.execPath,
+      maxOutputBytes: 1024,
+    });
+    assert.equal(result.stdout.trim(), JSON.stringify({ bundled: true }));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/apps/zenx/test/peekaboo-computer-provider.test.ts
+++ b/apps/zenx/test/peekaboo-computer-provider.test.ts
@@ -21,8 +21,7 @@ test("Peekaboo provider keeps semantic actions background-first and opaque", asy
   });
   const inspection = await backend.inspect(target);
   assert.equal(inspection.controls.length, 3);
-  assert.equal(inspection.controls[2]?.secure, true);
-  assert.deepEqual(inspection.controls[2]?.actions, ["press"]);
+  assert.deepEqual(inspection.controls[2]?.actions, ["press", "set_value"]);
   const button = inspection.controls[0];
   assert.ok(button);
   await backend.press(target, button.selector);

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -154,6 +154,8 @@ test("Playwright cancellation invalidates the session before immediate reuse", a
 class FakePlaywrightRunner implements ExternalProviderProcessRunner {
   readonly calls: string[][] = [];
   url = "https://example.com/";
+  tabKey = "__zenx_tab_fixture";
+  documentKey = "document-fixture";
   invalidSnapshot = false;
   changeIdentity = false;
   abortNextSnapshot = false;
@@ -210,16 +212,31 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
               dom("e4", { tag: "button", visible: false }),
             ]),
           }
-        : {
-            result: JSON.stringify([
-              {
-                index: 0,
-                title: "Fixture",
-                url: this.url,
-                current: true,
-              },
-            ]),
-          };
+        : args[3]?.includes("window.name")
+          ? {
+              result: JSON.stringify([
+                {
+                  index: 0,
+                  title: "Fixture",
+                  url: this.url,
+                  current: true,
+                  tabKey: this.tabKey,
+                  documentKey: this.documentKey,
+                },
+              ]),
+            }
+          : {
+              result: JSON.stringify([
+                {
+                  index: 0,
+                  title: "Fixture",
+                  url: this.url,
+                  current: true,
+                  tabKey: this.tabKey,
+                  documentKey: this.documentKey,
+                },
+              ]),
+            };
     } else if (command === "snapshot") {
       if (this.abortNextSnapshot) {
         this.abortNextSnapshot = false;

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -51,6 +51,21 @@ test("Playwright provider runs an isolated JSON-only observe/action slice", asyn
   assert.ok(runner.calls.some((args) => args.includes("click")));
 });
 
+test("Playwright tab summaries redact URL credentials and values", async () => {
+  const runner = new FakePlaywrightRunner();
+  runner.url = "https://alice:secret@example.com/private?q=token#fragment";
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  const opened = await backend.open("research", runner.url);
+  assert.equal(opened.url, "https://example.com/private");
+  const listed = await backend.listTabs("research");
+  assert.equal(listed[0]?.url, "https://example.com/private");
+  await backend.close();
+});
+
 test("Playwright provider fails closed on an incompatible snapshot schema", async () => {
   const runner = new FakePlaywrightRunner();
   runner.invalidSnapshot = true;
@@ -138,6 +153,7 @@ test("Playwright cancellation invalidates the session before immediate reuse", a
 
 class FakePlaywrightRunner implements ExternalProviderProcessRunner {
   readonly calls: string[][] = [];
+  url = "https://example.com/";
   invalidSnapshot = false;
   changeIdentity = false;
   abortNextSnapshot = false;
@@ -167,6 +183,7 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
     const command = args[2];
     let response: Record<string, unknown> = {};
     if (command === "open") {
+      this.url = args[3] ?? this.url;
       response = { session: args[1]?.slice(3), result: {} };
     } else if (command === "close" && this.#delayClose) {
       this.#delayClose = false;
@@ -198,7 +215,7 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
               {
                 index: 0,
                 title: "Fixture",
-                url: "https://example.com/",
+                url: this.url,
                 current: true,
               },
             ]),

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -151,12 +151,28 @@ test("Playwright cancellation invalidates the session before immediate reuse", a
   await backend.close();
 });
 
+test("Playwright rejects unbounded or multiply-current page state before reconciliation", async () => {
+  const runner = new FakePlaywrightRunner();
+  runner.invalidPages = true;
+  const backend = new PlaywrightCliBrowserBackend({
+    executable: "/opt/playwright-cli",
+    runner,
+    cwd: "/tmp/zenx-playwright",
+  });
+  await assert.rejects(
+    backend.open("research", "https://example.com/"),
+    /page state|exactly one page/u,
+  );
+  await backend.close();
+});
+
 class FakePlaywrightRunner implements ExternalProviderProcessRunner {
   readonly calls: string[][] = [];
   url = "https://example.com/";
   tabKey = "__zenx_tab_fixture";
   documentKey = "document-fixture";
   invalidSnapshot = false;
+  invalidPages = false;
   changeIdentity = false;
   abortNextSnapshot = false;
   delayedCloseFinished: Promise<void> = Promise.resolve();
@@ -223,6 +239,18 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
                   tabKey: this.tabKey,
                   documentKey: this.documentKey,
                 },
+                ...(this.invalidPages
+                  ? [
+                      {
+                        index: 1,
+                        title: "Second",
+                        url: this.url,
+                        current: true,
+                        tabKey: "__zenx_tab_second",
+                        documentKey: "document-second",
+                      },
+                    ]
+                  : []),
               ]),
             }
           : {
@@ -235,6 +263,18 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
                   tabKey: this.tabKey,
                   documentKey: this.documentKey,
                 },
+                ...(this.invalidPages
+                  ? [
+                      {
+                        index: 1,
+                        title: "Second",
+                        url: this.url,
+                        current: true,
+                        tabKey: "__zenx_tab_second",
+                        documentKey: "document-second",
+                      },
+                    ]
+                  : []),
               ]),
             };
     } else if (command === "snapshot") {

--- a/apps/zenx/test/playwright-browser-provider.test.ts
+++ b/apps/zenx/test/playwright-browser-provider.test.ts
@@ -18,6 +18,8 @@ test("Playwright provider runs an isolated JSON-only observe/action slice", asyn
   assert.equal(opened.title, "Fixture");
   const inspected = await backend.inspect("research", opened.tabId);
   assert.match(inspected.visibleText, /Run/u);
+  assert.equal(inspected.screenshot.observationId, inspected.observationId);
+  assert.ok(inspected.screenshot.bytes > 0);
   const button = inspected.targets.find(({ name }) => name === "Run");
   assert.ok(button);
   await assert.rejects(
@@ -74,7 +76,6 @@ test("Playwright provider revalidates DOM identity and dispatches password fill 
   const opened = await backend.open("research", "https://example.com/");
   const inspected = await backend.inspect("research", opened.tabId);
   const password = inspected.targets.find(({ name }) => name === "Password");
-  assert.equal(password?.secure, true);
   assert.deepEqual(password?.actions, ["click", "type"]);
   assert.ok(password);
   await backend.type(
@@ -101,7 +102,7 @@ test("Playwright provider revalidates DOM identity and dispatches password fill 
       refreshed.observationId,
       button.targetId,
     ),
-    /identity, security, visibility, or actions changed/u,
+    /identity, visibility, or actions changed/u,
   );
   assert.equal(runner.calls.filter((args) => args.includes("click")).length, 0);
 });
@@ -173,6 +174,11 @@ class FakePlaywrightRunner implements ExternalProviderProcessRunner {
         this.#releaseClose = resolve;
       });
       this.#finishDelayedClose?.();
+    } else if (command === "run-code" && args[3]?.includes("screenshot")) {
+      response = {
+        result:
+          "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+      };
     } else if (command === "run-code") {
       response = args[3]?.includes("aria-ref=")
         ? {

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -9,6 +12,7 @@ import {
   probePeekabooCli,
   probePlaywrightCli,
   selectBrowserProvider,
+  selectComputerProvider,
 } from "../src/main/capabilities/provider-catalog.js";
 import {
   BrowserZenXCapabilityPackage,
@@ -79,6 +83,37 @@ test("invalid browser modes are explicit instead of masquerading as isolated", a
   });
   assert.equal(selection.backend, undefined);
   assert.equal(selection.diagnostics[0]?.sessionMode, "invalid");
+});
+
+test("packaged provider selection never falls back to an unpinned PATH asset", async () => {
+  const resourcesDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-packaged-provider-test-"),
+  );
+  try {
+    const browser = await selectBrowserProvider({
+      userDataDirectory: resourcesDirectory,
+      resourcesDirectory,
+      bundledProvidersOnly: true,
+      platform: "win32",
+      environment: { PATH: "C:\\fake-provider-path" },
+    });
+    assert.ok(browser.backend);
+    assert.equal(browser.diagnostics[0]?.status, "unavailable");
+    assert.match(browser.diagnostics[0]?.reason ?? "", /manifest/u);
+    await browser.backend.close();
+
+    const computer = await selectComputerProvider({
+      userDataDirectory: resourcesDirectory,
+      resourcesDirectory,
+      bundledProvidersOnly: true,
+      platform: "win32",
+      environment: { PATH: "C:\\fake-provider-path" },
+    });
+    assert.equal(computer.backend, undefined);
+    assert.match(computer.diagnostics[0]?.reason ?? "", /manifest/u);
+  } finally {
+    await rm(resourcesDirectory, { recursive: true, force: true });
+  }
 });
 
 test("pins and validates the Playwright CLI machine-readable contract", async () => {

--- a/apps/zenx/test/provider-catalog.test.ts
+++ b/apps/zenx/test/provider-catalog.test.ts
@@ -183,6 +183,19 @@ test("rejects incompatible Playwright versions and JSON schema", async () => {
     ),
     /list\.browsers is invalid/u,
   );
+  await assert.rejects(
+    probePlaywrightCli(
+      "/opt/playwright-cli",
+      new ScriptedRunner([
+        {
+          args: ["--json", "--version"],
+          stdout: JSON.stringify({ version: "0.1.18" }),
+        },
+      ]),
+      "0.1.19",
+    ),
+    /does not match pinned version/u,
+  );
 });
 
 test("pins Peekaboo 3.x and reports explicit permission diagnostics", async () => {

--- a/apps/zenx/test/provider-provisioning.test.ts
+++ b/apps/zenx/test/provider-provisioning.test.ts
@@ -1,0 +1,63 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolveBundledProvider } from "../src/main/capabilities/provider-provisioning.js";
+
+test("packaged provider provisioning requires a pinned version and matching hash", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-bundle-"));
+  try {
+    const providers = path.join(root, "providers");
+    const executable = path.join(providers, "playwright-cli.exe");
+    const bytes = Buffer.from("official fixture provider", "utf8");
+    await mkdir(providers, { recursive: true });
+    await writeFile(executable, bytes);
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    await writeFile(
+      path.join(providers, "manifest.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        providers: {
+          "playwright-cli": {
+            executable: "playwright-cli.exe",
+            version: "0.1.2",
+            sha256,
+            platforms: ["win32"],
+          },
+        },
+      }),
+    );
+
+    const resolved = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+    });
+    assert.equal(resolved.provider?.version, "0.1.2");
+    assert.equal(resolved.provider?.sha256, sha256);
+
+    await writeFile(executable, Buffer.from("tampered", "utf8"));
+    const tampered = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+    });
+    assert.match(tampered.reason ?? "", /integrity mismatch/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged provider provisioning reports offline or missing assets explicitly", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-empty-"));
+  try {
+    const result = await resolveBundledProvider("microsoft-winapp-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+    });
+    assert.match(result.reason ?? "", /manifest is unavailable/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/zenx/test/provider-provisioning.test.ts
+++ b/apps/zenx/test/provider-provisioning.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  bindBundledProviderLaunch,
   resolveBundledProvider,
   verifyBundledProvider,
 } from "../src/main/capabilities/provider-provisioning.js";
@@ -141,6 +142,108 @@ test("packaged provider provisioning reports offline or missing assets explicitl
       platform: "win32",
     });
     assert.match(result.reason ?? "", /manifest is unavailable/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged provisioning pins runtime and native companion assets", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-assets-"));
+  try {
+    const providers = path.join(root, "providers");
+    await mkdir(path.join(providers, "runtime"), { recursive: true });
+    const executable = path.join(providers, "provider.js");
+    const runtime = path.join(providers, "runtime", "node");
+    const companion = path.join(providers, "native.bin");
+    await writeFile(executable, "provider");
+    await writeFile(runtime, "runtime");
+    await writeFile(companion, "native");
+    const sha = (value: Buffer) =>
+      createHash("sha256").update(value).digest("hex");
+    const manifest = {
+      schemaVersion: 1,
+      providers: {
+        "playwright-cli": {
+          executable: "provider.js",
+          version: "0.1.18",
+          sha256: sha(Buffer.from("provider")),
+          platforms: ["linux"],
+          runtime: {
+            path: "runtime/node",
+            sha256: sha(Buffer.from("runtime")),
+            version: "22.23.2",
+          },
+          assets: [{ path: "native.bin", sha256: sha(Buffer.from("native")) }],
+        },
+      },
+    };
+    const manifestBytes = Buffer.from(`${JSON.stringify(manifest)}\n`);
+    await writeFile(path.join(providers, "manifest.json"), manifestBytes);
+    const manifestSha256 = sha(manifestBytes);
+    const resolved = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "linux",
+      expectedManifestSha256: manifestSha256,
+    });
+    assert.equal(resolved.provider?.runtime?.version, "22.23.2");
+    assert.equal(resolved.provider?.assets?.length, 1);
+    const release = await bindBundledProviderLaunch(resolved.provider!, {
+      resourcesDirectory: root,
+      platform: "linux",
+    });
+    await release();
+    await writeFile(companion, "tampered");
+    await assert.rejects(
+      bindBundledProviderLaunch(resolved.provider!, {
+        resourcesDirectory: root,
+        platform: "linux",
+      }),
+      /integrity mismatch|changed/u,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged provisioning pins a Windows shim companion", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-shim-"));
+  try {
+    const providers = path.join(root, "providers");
+    await mkdir(providers, { recursive: true });
+    const shim = Buffer.from('@echo off\r\n"%dp0%\\node.js" %*\r\n');
+    const companion = Buffer.from("console.log('bundled')\n");
+    await writeFile(path.join(providers, "provider.cmd"), shim);
+    await writeFile(path.join(providers, "node.js"), companion);
+    const sha = (value: Buffer) =>
+      createHash("sha256").update(value).digest("hex");
+    const manifest = {
+      schemaVersion: 1,
+      providers: {
+        "playwright-cli": {
+          executable: "provider.cmd",
+          version: "0.1.18",
+          sha256: sha(shim),
+          platforms: ["win32"],
+          companion: { path: "node.js", sha256: sha(companion) },
+        },
+      },
+    };
+    const manifestBytes = Buffer.from(`${JSON.stringify(manifest)}\n`);
+    await writeFile(path.join(providers, "manifest.json"), manifestBytes);
+    const resolved = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+      expectedManifestSha256: sha(manifestBytes),
+    });
+    assert.equal(resolved.provider?.companion?.sha256, sha(companion));
+    await writeFile(path.join(providers, "node.js"), "tampered");
+    await assert.rejects(
+      verifyBundledProvider(resolved.provider!, {
+        resourcesDirectory: root,
+        platform: "win32",
+      }),
+      /integrity mismatch|changed/u,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/apps/zenx/test/provider-provisioning.test.ts
+++ b/apps/zenx/test/provider-provisioning.test.ts
@@ -1,11 +1,14 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { resolveBundledProvider } from "../src/main/capabilities/provider-provisioning.js";
+import {
+  resolveBundledProvider,
+  verifyBundledProvider,
+} from "../src/main/capabilities/provider-provisioning.js";
 
 test("packaged provider provisioning requires a pinned version and matching hash", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-bundle-"));
@@ -37,13 +40,94 @@ test("packaged provider provisioning requires a pinned version and matching hash
     });
     assert.equal(resolved.provider?.version, "0.1.2");
     assert.equal(resolved.provider?.sha256, sha256);
+    const manifestSha256 = createHash("sha256")
+      .update(await readFile(path.join(providers, "manifest.json")))
+      .digest("hex");
+    const pinned = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+      expectedVersion: "0.1.2",
+      expectedManifestSha256: manifestSha256,
+    });
+    assert.equal(pinned.provider?.manifestSha256, manifestSha256);
+    const changedManifest = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+      expectedManifestSha256: "0".repeat(64),
+    });
+    assert.match(changedManifest.reason ?? "", /manifest integrity mismatch/u);
 
-    await writeFile(executable, Buffer.from("tampered", "utf8"));
+    const selected = resolved.provider!;
+    await writeFile(executable, Buffer.from("replacement", "utf8"));
+    await assert.rejects(
+      verifyBundledProvider(selected, {
+        resourcesDirectory: root,
+        platform: "win32",
+      }),
+      /integrity mismatch|changed/u,
+    );
+
     const tampered = await resolveBundledProvider("playwright-cli", {
       resourcesDirectory: root,
       platform: "win32",
     });
     assert.match(tampered.reason ?? "", /integrity mismatch/u);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("packaged provider provisioning rejects traversal and symlink escapes", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-path-"));
+  try {
+    const providers = path.join(root, "providers");
+    const outside = path.join(root, "outside.exe");
+    await mkdir(providers, { recursive: true });
+    await writeFile(outside, Buffer.from("outside", "utf8"));
+    await writeFile(
+      path.join(providers, "manifest.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        providers: {
+          "playwright-cli": {
+            executable: "../outside.exe",
+            version: "0.1.2",
+            sha256: createHash("sha256").update("outside").digest("hex"),
+            platforms: ["win32"],
+          },
+        },
+      }),
+    );
+    const traversal = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+    });
+    assert.match(traversal.reason ?? "", /escapes/u);
+
+    try {
+      await (
+        await import("node:fs/promises")
+      ).symlink(outside, path.join(providers, "linked.exe"));
+    } catch {
+      return;
+    }
+    const linkedManifest = JSON.stringify({
+      schemaVersion: 1,
+      providers: {
+        "playwright-cli": {
+          executable: "linked.exe",
+          version: "0.1.2",
+          sha256: createHash("sha256").update("outside").digest("hex"),
+          platforms: ["win32"],
+        },
+      },
+    });
+    await writeFile(path.join(providers, "manifest.json"), linkedManifest);
+    const linked = await resolveBundledProvider("playwright-cli", {
+      resourcesDirectory: root,
+      platform: "win32",
+    });
+    assert.match(linked.reason ?? "", /regular|symlink|escapes/u);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -11,6 +11,7 @@ import {
   UserBrowserDocumentChangedAfterDispatchError,
   UserBrowserDocumentChangedBeforeDispatchError,
   UserBrowserMutationOutcomeUnknownError,
+  UserBrowserScreenshotMalformedError,
   type UserBrowserCdpClient,
   validateUserBrowserVersion,
   windowsBrowserExecutableCandidates,
@@ -113,6 +114,22 @@ test("user browser mode inherits visible authenticated state without exposing se
     ),
     false,
   );
+});
+
+test("attached browser rejects malformed screenshot data explicitly", async () => {
+  const client = new FakeUserBrowserClient();
+  client.captureScreenshot = async (_targetId, _owner, documentIdentity) => ({
+    data: "not-base64",
+    documentIdentity,
+    status: "captured",
+  });
+  const backend = new UserBrowserCdpBackend(client);
+  await backend.listTabs("work");
+  await assert.rejects(
+    backend.inspect("work", "target-1"),
+    UserBrowserScreenshotMalformedError,
+  );
+  await backend.close();
 });
 
 test("concurrent first listings publish one exclusive logical target owner", async () => {
@@ -2496,6 +2513,7 @@ test("Windows browser discovery covers machine and per-user Chrome Edge and Chro
 });
 
 class FakeUserBrowserClient implements UserBrowserCdpClient {
+  captureScreenshot?: UserBrowserCdpClient["captureScreenshot"];
   actionCount = 0;
   navigateCount = 0;
   closeCount = 0;
@@ -2819,6 +2837,10 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
       throw new UserBrowserDocumentChangedAfterDispatchError();
     }
     return { value: response, documentIdentity: this.documentToken };
+  }
+
+  async getDocumentIdentity() {
+    return this.documentToken;
   }
 
   async close() {

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -90,6 +90,8 @@ test("user browser mode inherits visible authenticated state without exposing se
 
   const inspection = await backend.inspect("work", "target-1");
   assert.match(inspection.visibleText, /Signed in as Alice/u);
+  assert.equal(inspection.screenshot.observationId, inspection.observationId);
+  assert.ok(inspection.screenshot.bytes > 0);
   assert.equal(inspection.targets[0]?.name, "Continue");
   assert.doesNotMatch(
     JSON.stringify({ tabs, inspection }),
@@ -1002,7 +1004,6 @@ test("password and autocomplete metadata do not block ordinary text dispatch", a
     client.inspectionTarget = {
       ...client.inspectionTarget,
       ...metadata,
-      secure: true,
       actions: ["type"],
     };
     const backend = new UserBrowserCdpBackend(client);
@@ -2535,7 +2536,6 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     fieldName: "",
     autocomplete: "",
     href: "",
-    secure: false,
     actions: ["click"] as Array<"click" | "type">,
   };
   readonly #actionStarted = deferred<void>();
@@ -3212,7 +3212,6 @@ async function createFakeCdpServer(): Promise<{
                       fieldName: "",
                       autocomplete: "",
                       href: "",
-                      secure: false,
                       actions: ["click", "type"],
                     },
                   ],

--- a/apps/zenx/test/user-browser-provider.test.ts
+++ b/apps/zenx/test/user-browser-provider.test.ts
@@ -615,6 +615,7 @@ test("caller abort after createTarget dispatch does not orphan an untracked targ
   await client.createSettled;
   await nextTurn();
 
+  assert.ok(client.observedSignals.includes(controller.signal));
   assert.equal(await backend.closeSession("work"), 2);
   assert.deepEqual(client.detachedTargets.sort(), ["target-1", "target-2"]);
   assert.deepEqual(client.closedTargets, []);
@@ -2520,6 +2521,7 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
   readonly closedTargets: string[] = [];
   readonly detachedTargets: string[] = [];
   readonly calls: string[] = [];
+  readonly observedSignals: AbortSignal[] = [];
   currentUrl = "https://example.test/account";
   primaryTargetPresent = true;
   documentToken = "document-a";
@@ -2650,7 +2652,8 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     this.#heldAction.reject(error);
   }
 
-  async listTargets() {
+  async listTargets(signal?: AbortSignal) {
+    if (signal !== undefined) this.observedSignals.push(signal);
     this.calls.push("Target.getTargets");
     if (this.listFailureOnce !== undefined) {
       const error = this.listFailureOnce;
@@ -2688,7 +2691,8 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     ];
   }
 
-  async createTarget(url: string) {
+  async createTarget(url: string, signal?: AbortSignal) {
+    if (signal !== undefined) this.observedSignals.push(signal);
     this.calls.push("Target.createTarget");
     this.createdUrl = url;
     const targetId = `target-${String(this.nextCreatedTarget++)}`;
@@ -2710,7 +2714,8 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
     return targetId;
   }
 
-  async findTargetsByUrl(url: string) {
+  async findTargetsByUrl(url: string, signal?: AbortSignal) {
+    if (signal !== undefined) this.observedSignals.push(signal);
     if (this.failCreateRecovery) return [];
     return [...this.createdTargets]
       .filter(([, targetUrl]) => targetUrl === url)
@@ -2743,9 +2748,10 @@ class FakeUserBrowserClient implements UserBrowserCdpClient {
       logicalSessionId: string;
       logicalSessionIncarnation: number;
     },
-    _signal?: AbortSignal,
+    signal?: AbortSignal,
     onDispatched?: () => void,
   ) {
+    if (signal !== undefined) this.observedSignals.push(signal);
     onDispatched?.();
     this.calls.push("Page.navigate");
     this.navigateCount += 1;

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -349,6 +349,24 @@ test("WinApp process runner enforces cancellation, timeout, and output bounds", 
   controller.abort(new DOMException("stopped", "AbortError"));
   await assert.rejects(cancelled, /stopped/u);
 
+  let bindings = 0;
+  let releases = 0;
+  await runBoundedProcess(
+    process.execPath,
+    ["-e", "process.stdout.write('ok')"],
+    {
+      timeoutMs: 1_000,
+      bindBeforeSpawn: async () => {
+        bindings += 1;
+        return async () => {
+          releases += 1;
+        };
+      },
+    },
+  );
+  assert.equal(bindings, 1);
+  assert.equal(releases, 1);
+
   await assert.rejects(
     runBoundedProcess(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
       timeoutMs: 25,

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -46,8 +46,7 @@ test("Windows provider maps WinApp JSON into opaque bounded UIA controls", async
   assert.equal(inspected.controls[0]?.title, "Save");
   assert.deepEqual(inspected.controls[0]?.actions, ["press"]);
   assert.deepEqual(inspected.controls[1]?.actions, ["set_value"]);
-  assert.equal(inspected.controls[2]?.secure, true);
-  assert.deepEqual(inspected.controls[2]?.actions, []);
+  assert.deepEqual(inspected.controls[2]?.actions, ["set_value"]);
   assert.doesNotMatch(JSON.stringify(inspected), /existing private value/u);
   assert.doesNotMatch(JSON.stringify(inspected), /provider-button-selector/u);
 
@@ -146,21 +145,18 @@ test("Windows provider confirms a screenshot through its real file identity", as
   }
 });
 
-test("Windows provider rejects ambiguous windows, stale selectors, and secure controls", async () => {
+test("Windows provider rejects ambiguous windows and stale selectors while dispatching ordinary values", async () => {
   const runner = new FixtureWinAppRunner();
   const backend = new WinAppCliComputerBackend({
     platform: "win32",
     runner,
   });
   const inspected = await backend.inspect(target);
-  const secure = inspected.controls.find((control) => control.secure)!;
-  await assert.rejects(
-    backend.setValue(target, secure.selector, "must-not-run"),
-    /rejects password or secure controls/u,
-  );
+  const secure = inspected.controls[2]!;
+  await backend.setValue(target, secure.selector, "must-run-normally");
   assert.equal(
-    runner.commands.some((args) => args.includes("must-not-run")),
-    false,
+    runner.commands.some((args) => args.includes("must-run-normally")),
+    true,
   );
 
   const first = inspected.controls[0]!.selector;
@@ -181,7 +177,7 @@ test("Windows provider revalidates secure state and semantic identity immediatel
   runner.secureField = true;
   await assert.rejects(
     backend.setValue(target, first.controls[1]!.selector, "must-not-run"),
-    /rejects password or secure controls/u,
+    /changed since the observation/u,
   );
   assert.equal(
     runner.commands.some(

--- a/apps/zenx/test/windows-computer-capability.test.ts
+++ b/apps/zenx/test/windows-computer-capability.test.ts
@@ -245,6 +245,17 @@ test("WinApp diagnostic is actionable without installing on non-Windows test hos
   assert.equal(ready.requiredVersion, "0.3.1");
   assert.equal(ready.schemaCompatible, true);
 
+  const pinnedMismatch = await new WinAppCliComputerBackend({
+    platform: "win32",
+    runner: new FixtureWinAppRunner(),
+    expectedVersion: "1.2.4",
+  }).diagnose();
+  assert.equal(pinnedMismatch.ready, false);
+  assert.match(
+    pinnedMismatch.message,
+    /does not match pinned version 1\.2\.4/u,
+  );
+
   const oldRunner = new FixtureWinAppRunner();
   oldRunner.versionOutput = "winapp 0.3.0\n";
   const old = await new WinAppCliComputerBackend({

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "ws": "^8.18.3"
       },
       "devDependencies": {
+        "@electron/packager": "^20.3.0",
         "@types/node": "^24.0.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
@@ -355,6 +356,23 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@electron/asar": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-4.2.1.tgz",
+      "integrity": "sha512-rGyEe7iy52zxiWuihV/h/AqQrFkx7YnUUJKW1bdufVDHCzIMP/XDrDI/NOzv/LLtzt3NduAzNa475WRmRnmswQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.2",
+        "minimatch": "^10.0.1"
+      },
+      "bin": {
+        "asar": "bin/asar.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/get": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.1.0.tgz",
@@ -387,6 +405,134 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-3.1.1.tgz",
+      "integrity": "sha512-uQQSlOiJnqRkTL1wlEBAxe90nVN/Fc/hEmk0bqpKk8nKjV1if/tXLHKUPePtv9Xsx90PtZU8aidx5lAiOpjkQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-2.6.0.tgz",
+      "integrity": "sha512-XiJHXekSfeQpk11d9uWZ9PtDm4ADIWvcrSTRJocaDgA46t1okxrQ1keL8rthURJX6AP3DDFnzrouiP6Q5qoHYA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "isbinaryfile": "^4.0.8",
+        "plist": "^3.0.5",
+        "semver": "^7.7.1"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.mjs",
+        "electron-osx-sign": "bin/electron-osx-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/packager": {
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/@electron/packager/-/packager-20.3.0.tgz",
+      "integrity": "sha512-3MvgJgy6YJ5ti0oGGBKrWKdYwpTaoRrhranMDgHSQ6i5t56yZV9IRDyoXTuqBp97LiKqnZeAMe2wTcF/9+fP5g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/asar": "^4.0.1",
+        "@electron/get": "^5.0.0",
+        "@electron/notarize": "^3.1.0",
+        "@electron/osx-sign": "^2.2.0",
+        "@electron/universal": "^3.0.1",
+        "@electron/windows-sign": "^2.0.2",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.4.1",
+        "filenamify": "^6.0.0",
+        "galactus": "^2.0.2",
+        "graceful-fs": "^4.2.11",
+        "junk": "^4.0.1",
+        "plist": "^3.1.0",
+        "resedit": "^2.0.3",
+        "semver": "^7.7.2",
+        "yargs-parser": "^22.0.0"
+      },
+      "bin": {
+        "electron-packager": "bin/electron-packager.mjs"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/electron/packager?sponsor=1"
+      }
+    },
+    "node_modules/@electron/packager/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-3.0.6.tgz",
+      "integrity": "sha512-MonS1kfkZdSEkLZI0pdR/TCx8ecxwRSFm7sORfwIkDI9UaIbHnk4Mgeqq+Ob9qDQRV8LZ9+hHCmimpA9BRcNxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^4.0.0",
+        "debug": "^4.3.1",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/windows-sign": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-2.0.6.tgz",
+      "integrity": "sha512-ESWgNkFsXFH06I5EB2uHv3hmZA3yF4j9GTB77W74x3b5KZNItxggNzuADw41HUy6mhnC2K+E2mT0Xgc4YKu3IQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "graceful-fs": "^4.2.11",
+        "postject": "^1.0.0-alpha.6"
+      },
+      "bin": {
+        "electron-windows-sign": "bin/electron-windows-sign.mjs"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -879,6 +1025,29 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
@@ -1410,9 +1579,50 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/@zen/zenx": {
       "resolved": "apps/zenx",
       "link": true
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.9",
@@ -1425,6 +1635,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1492,12 +1715,37 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -1593,6 +1841,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1663,6 +1918,48 @@
         }
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flora-colossus": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-3.0.2.tgz",
+      "integrity": "sha512-Jk78K/Tzt6saxQPGChlJw69xuFGpWyTSAS8EdU0h/FyXwD2K46yNOXmo6nRHcZ9ooekyBAzMkwmiGNt7wOC5zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1678,6 +1975,20 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/galactus": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/galactus/-/galactus-2.0.2.tgz",
+      "integrity": "sha512-HmKyTFGomdAchz4umx8MwBnrnfFmdpwiTyGA4ZOF7rya2Lmgbc9qate4yweInL+0gUBVImhaz12SBGpW3SY4Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "flora-colossus": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1688,10 +1999,48 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
@@ -1728,6 +2077,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/junk": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/junk/-/junk-4.0.1.tgz",
+      "integrity": "sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1746,6 +2108,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1784,6 +2172,58 @@
         "node": ">=18"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
+      "integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1802,6 +2242,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
       }
     },
     "node_modules/postcss": {
@@ -1833,6 +2288,22 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.9.6",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
@@ -1857,6 +2328,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react": {
@@ -1888,6 +2373,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.3.tgz",
+      "integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -1950,6 +2463,29 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -3115,6 +3651,22 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.21.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
@@ -3136,12 +3688,32 @@
         }
       }
     },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     }
   }
 }

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -165,8 +165,7 @@ async function assembleNpmProvider(id, platform, runtimePath) {
   const destination = path.join(providers, id);
   await cp(packageDir, destination, { recursive: true, force: true });
   if (id === "playwright-cli") {
-    await run(
-      "npm",
+    await runNpm(
       [
         "install",
         "--prefix",
@@ -282,6 +281,18 @@ async function fetchVerified(url, expected) {
 
 async function extract(archive, destination) {
   await run("tar", ["-xf", archive, "-C", destination]);
+}
+
+async function runNpm(args, options) {
+  const npmExecPath = process.env.npm_execpath;
+  if (npmExecPath !== undefined && npmExecPath.length > 0) {
+    return await run(process.execPath, [npmExecPath, ...args], options);
+  }
+  return await run(
+    process.platform === "win32" ? "npm.cmd" : "npm",
+    args,
+    options,
+  );
 }
 
 async function findFile(root, name) {

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -203,7 +203,10 @@ async function assembleNpmProvider(id, platform, runtimePath) {
       "node_modules",
       ".package-lock.json",
     );
-    const dependencyLock = await readFile(generatedLock);
+    const dependencyLock = Buffer.from(
+      (await readFile(generatedLock, "utf8")).replaceAll("\r\n", "\n"),
+      "utf8",
+    );
     const dependencyLockSha256 = sha256(dependencyLock);
     if (
       pin.dependencyLockSha256 !== undefined &&

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -335,36 +335,11 @@ function sha256(bytes) {
 
 function canonicalDependencyLock(source) {
   const parsed = JSON.parse(source);
-  const packages = {};
-  for (const [name, value] of Object.entries(parsed.packages ?? {}).sort()) {
-    if (name === "node_modules/fsevents") continue;
-    const stable = {};
-    for (const field of [
-      "version",
-      "resolved",
-      "integrity",
-      "license",
-      "dependencies",
-      "optionalDependencies",
-      "bin",
-      "engines",
-    ]) {
-      if (value[field] !== undefined) stable[field] = sortJson(value[field]);
-    }
-    packages[name] = stable;
-  }
-  return Buffer.from(
-    `${JSON.stringify({ lockfileVersion: 3, requires: true, packages }, null, 2)}\n`,
-    "utf8",
-  );
-}
-
-function sortJson(value) {
-  if (Array.isArray(value)) return value.map(sortJson);
-  if (typeof value !== "object" || value === null) return value;
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, child]) => [key, sortJson(child)]),
-  );
+  const packages = Object.entries(parsed.packages ?? {})
+    .filter(([name]) => !name.endsWith("/fsevents"))
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([name, value]) =>
+      [name, value.version, value.resolved, value.integrity].join("\u001f"),
+    );
+  return Buffer.from(`${packages.join("\n")}\n`, "utf8");
 }

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -1,0 +1,320 @@
+import { createHash } from "node:crypto";
+import { execFile } from "node:child_process";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+  cp,
+  readdir,
+  stat,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+
+const run = promisify(execFile);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const zenx = path.resolve(here, "..", "apps", "zenx");
+const lockPath = path.join(
+  zenx,
+  "resources",
+  "providers",
+  "provider-lock.json",
+);
+const lock = JSON.parse(await readFile(lockPath, "utf8"));
+const output = path.resolve(
+  process.argv[process.argv.indexOf("--output") + 1] ??
+    path.join(zenx, ".packaged", "resources"),
+);
+const providers = path.join(output, "providers");
+const work = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-assembly-"));
+const maxAssetBytes = 512 * 1024 * 1024;
+
+try {
+  await rm(providers, { recursive: true, force: true });
+  await mkdir(providers, { recursive: true, mode: 0o700 });
+  const platform = process.platform;
+  const arch = process.arch === "arm64" ? "arm64" : "x64";
+  const nodeKey = `${platform}-${arch}`;
+  const nodeArchive = lock.node.platformArchives[nodeKey];
+  if (nodeArchive === undefined)
+    throw new Error(`No pinned Node runtime for ${nodeKey}`);
+  const nodeBytes = await fetchVerified(
+    `${lock.node.releaseBase}${nodeArchive.file}`,
+    nodeArchive.sha256,
+  );
+  const nodeArchivePath = path.join(work, nodeArchive.file);
+  await writeFile(nodeArchivePath, nodeBytes);
+  const nodeExtract = path.join(work, "node");
+  await mkdir(nodeExtract);
+  await extract(nodeArchivePath, nodeExtract);
+  const nodeExecutable = await findFile(
+    nodeExtract,
+    platform === "win32" ? "node.exe" : "node",
+  );
+  const runtimePath = path.join(
+    providers,
+    "runtime",
+    path.basename(nodeExecutable),
+  );
+  await mkdir(path.dirname(runtimePath), { recursive: true, mode: 0o700 });
+  await cp(nodeExecutable, runtimePath);
+  const nodeLicense = await findFile(nodeExtract, "LICENSE");
+  await cp(nodeLicense, path.join(path.dirname(runtimePath), "LICENSE"));
+  await writeFile(
+    path.join(path.dirname(runtimePath), "THIRD_PARTY_NOTICES.txt"),
+    `Node.js ${lock.node.version} — bundled official runtime\n\n${await readFile(nodeLicense, "utf8")}`,
+    { mode: 0o600 },
+  );
+  const runtimeSha256 = sha256(await readFile(runtimePath));
+
+  const playwright = await assembleNpmProvider(
+    "playwright-cli",
+    platform,
+    runtimePath,
+  );
+  const winapp = await assembleNpmProvider(
+    "microsoft-winapp-cli",
+    platform,
+    runtimePath,
+  );
+  const browsersPath = path.join(providers, "playwright-browsers");
+  await mkdir(browsersPath, { recursive: true, mode: 0o700 });
+  await run(
+    runtimePath,
+    [
+      path.join(providers, "playwright-cli", "playwright-cli.js"),
+      "install-browser",
+    ],
+    {
+      cwd: path.join(providers, "playwright-cli"),
+      env: { ...process.env, PLAYWRIGHT_BROWSERS_PATH: browsersPath },
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
+  const manifest = {
+    schemaVersion: 1,
+    providers: {
+      "playwright-cli": {
+        executable: playwright.executable,
+        version: lock.providers["playwright-cli"].version,
+        sha256: playwright.sha256,
+        platforms: [platform],
+        runtime: {
+          path: path.relative(providers, runtimePath),
+          sha256: runtimeSha256,
+          version: lock.node.version,
+        },
+      },
+      "microsoft-winapp-cli": {
+        executable: winapp.executable,
+        version: lock.providers["microsoft-winapp-cli"].version,
+        sha256: winapp.sha256,
+        platforms: ["win32"],
+        runtime: {
+          path: path.relative(providers, runtimePath),
+          sha256: runtimeSha256,
+          version: lock.node.version,
+        },
+        assets: winapp.assets,
+      },
+    },
+  };
+  const manifestBytes = Buffer.from(
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+  await writeFile(path.join(providers, "manifest.json"), manifestBytes, {
+    mode: 0o600,
+  });
+  await writeFile(
+    path.join(providers, "THIRD_PARTY_NOTICES.txt"),
+    `ZenX bundled provider notices\n\n@playwright/cli ${lock.providers["playwright-cli"].version} — Apache-2.0\n@microsoft/winappcli ${lock.providers["microsoft-winapp-cli"].version} — MIT\nNode.js ${lock.node.version} — bundled official runtime; see nodejs.org/dist/${lock.node.version}/README.md\n\nArchive SHA-256:\n@playwright/cli ${lock.providers["playwright-cli"].sha256}\n@microsoft/winappcli ${lock.providers["microsoft-winapp-cli"].sha256}\nNode ${nodeArchive.sha256}\n\nThe complete upstream license texts are copied beside each assembled provider payload.\n`,
+    { mode: 0o600 },
+  );
+  const result = {
+    resourcesDirectory: output,
+    manifestSha256: sha256(manifestBytes),
+    platform,
+    arch,
+    runtimeVersion: lock.node.version,
+    releaseSizeBytes: await directorySize(output),
+  };
+  await writeFile(
+    path.join(output, "provider-assembly.json"),
+    `${JSON.stringify(result, null, 2)}\n`,
+    { mode: 0o600 },
+  );
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+} finally {
+  await rm(work, { recursive: true, force: true });
+}
+
+async function assembleNpmProvider(id, platform, runtimePath) {
+  const pin = lock.providers[id];
+  const archive = await fetchVerified(pin.tarball, pin.sha256);
+  const archivePath = path.join(work, `${id}.tgz`);
+  await writeFile(archivePath, archive);
+  const extracted = path.join(work, id);
+  await mkdir(extracted);
+  await extract(archivePath, extracted);
+  const packageDir = path.join(extracted, "package");
+  const destination = path.join(providers, id);
+  await cp(packageDir, destination, { recursive: true, force: true });
+  if (id === "playwright-cli") {
+    await run(
+      "npm",
+      [
+        "install",
+        "--prefix",
+        destination,
+        "--ignore-scripts",
+        "--no-save",
+        "--package-lock=true",
+        "--omit=dev",
+        "--omit=optional",
+      ],
+      { cwd: destination },
+    );
+  }
+  const executable =
+    id === "playwright-cli"
+      ? path.join(destination, "playwright-cli.js")
+      : path.join(destination, "dist", "cli.js");
+  const relative = path.relative(providers, executable);
+  const bytes = await readFile(executable);
+  if (bytes.byteLength > maxAssetBytes)
+    throw new Error(`${id} executable exceeds the release bound`);
+  await writeFile(
+    path.join(destination, "ARCHIVE-SHA256"),
+    `${pin.sha256}\n${pin.integrity}\n`,
+    { mode: 0o600 },
+  );
+  const license = path.join(destination, "LICENSE");
+  if (!(await exists(license)))
+    await writeFile(license, `${id} — ${pin.license}\n`, { mode: 0o600 });
+  await appendLicenseNotice(destination, id, pin.license);
+  const assets = [];
+  if (id === "playwright-cli") {
+    const generatedLock = path.join(
+      destination,
+      "node_modules",
+      ".package-lock.json",
+    );
+    const dependencyLock = await readFile(generatedLock);
+    const dependencyLockSha256 = sha256(dependencyLock);
+    if (
+      pin.dependencyLockSha256 !== undefined &&
+      dependencyLockSha256 !== pin.dependencyLockSha256
+    ) {
+      throw new Error(
+        `playwright-cli transitive dependency lock mismatch: expected ${pin.dependencyLockSha256}, got ${dependencyLockSha256}`,
+      );
+    }
+    const dependencyLockPath = path.join(destination, "DEPENDENCY-LOCK.json");
+    await writeFile(dependencyLockPath, dependencyLock, { mode: 0o600 });
+    assets.push({
+      path: path.relative(providers, dependencyLockPath),
+      sha256: dependencyLockSha256,
+    });
+  }
+  if (id === "microsoft-winapp-cli") {
+    const nativeRoot = path.join(
+      destination,
+      "bin",
+      platform === "win32" ? "win-x64" : "unsupported",
+    );
+    if (platform === "win32") {
+      const nativeExecutable = path.join(nativeRoot, "winapp.exe");
+      if (!(await exists(nativeExecutable)))
+        throw new Error(
+          "WinApp native companion is missing from the official archive",
+        );
+      const nativeBytes = await readFile(nativeExecutable);
+      assets.push({
+        path: path.relative(providers, nativeExecutable),
+        sha256: sha256(nativeBytes),
+      });
+    }
+  }
+  return { executable: relative, sha256: sha256(bytes), runtimePath, assets };
+}
+
+async function appendLicenseNotice(destination, id, license) {
+  const notices = [];
+  for (const file of await walkFiles(destination)) {
+    if (!/\/(?:LICENSE|NOTICE)(?:\.[^/]*)?$/iu.test(file.replaceAll("\\", "/")))
+      continue;
+    notices.push(
+      `\n--- ${path.relative(destination, file)} ---\n${await readFile(file, "utf8")}`,
+    );
+  }
+  await writeFile(
+    path.join(destination, "THIRD_PARTY_NOTICES.txt"),
+    `${id} declared license: ${license}\n${notices.join("\n")}`,
+    { mode: 0o600 },
+  );
+}
+
+async function walkFiles(rootDir) {
+  const files = [];
+  for (const entry of await readdir(rootDir, { withFileTypes: true })) {
+    const candidate = path.join(rootDir, entry.name);
+    if (entry.isFile()) files.push(candidate);
+    else if (entry.isDirectory()) files.push(...(await walkFiles(candidate)));
+  }
+  return files;
+}
+
+async function fetchVerified(url, expected) {
+  const response = await fetch(url, { redirect: "error" });
+  if (!response.ok)
+    throw new Error(`Provider archive fetch failed: ${response.status} ${url}`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  const actual = sha256(bytes);
+  if (actual !== expected)
+    throw new Error(`Provider archive integrity mismatch for ${url}`);
+  return bytes;
+}
+
+async function extract(archive, destination) {
+  await run("tar", ["-xf", archive, "-C", destination]);
+}
+
+async function findFile(root, name) {
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const candidate = path.join(root, entry.name);
+    if (entry.isFile() && entry.name === name) return candidate;
+    if (entry.isDirectory()) {
+      const found = await findFile(candidate, name);
+      if (found !== undefined) return found;
+    }
+  }
+  throw new Error(`Bundled runtime ${name} was not found`);
+}
+
+async function directorySize(root) {
+  let total = 0;
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const candidate = path.join(root, entry.name);
+    if (entry.isFile()) total += (await stat(candidate)).size;
+    else if (entry.isDirectory()) total += await directorySize(candidate);
+  }
+  return total;
+}
+
+async function exists(candidate) {
+  try {
+    await readFile(candidate);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -25,9 +25,11 @@ const lockPath = path.join(
   "provider-lock.json",
 );
 const lock = JSON.parse(await readFile(lockPath, "utf8"));
+const outputArgumentIndex = process.argv.indexOf("--output");
+const outputArgument =
+  outputArgumentIndex >= 0 ? process.argv[outputArgumentIndex + 1] : undefined;
 const output = path.resolve(
-  process.argv[process.argv.indexOf("--output") + 1] ??
-    path.join(zenx, ".packaged", "resources"),
+  outputArgument ?? path.join(zenx, ".packaged", "resources"),
 );
 const providers = path.join(output, "providers");
 const work = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-assembly-"));
@@ -203,9 +205,21 @@ async function assembleNpmProvider(id, platform, runtimePath) {
       "node_modules",
       ".package-lock.json",
     );
-    const dependencyLock = canonicalDependencyLock(
-      await readFile(generatedLock, "utf8"),
-    );
+    const generated = JSON.parse(await readFile(generatedLock, "utf8"));
+    for (const dependency of pin.transitive ?? []) {
+      const entry = generated.packages?.[`node_modules/${dependency.name}`];
+      if (
+        entry?.version !== dependency.version ||
+        entry.resolved !== dependency.tarball ||
+        entry.integrity !== dependency.integrity
+      ) {
+        throw new Error(
+          `playwright-cli transitive package mismatch for ${dependency.name}`,
+        );
+      }
+      await fetchVerified(dependency.tarball, dependency.sha256);
+    }
+    const dependencyLock = canonicalDependencyLock(pin.transitive ?? []);
     const dependencyLockSha256 = sha256(dependencyLock);
     if (
       pin.dependencyLockSha256 !== undefined &&
@@ -333,13 +347,18 @@ function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-function canonicalDependencyLock(source) {
-  const parsed = JSON.parse(source);
-  const packages = Object.entries(parsed.packages ?? {})
-    .filter(([name]) => !name.endsWith("/fsevents"))
-    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-    .map(([name, value]) =>
-      [name, value.version, value.resolved, value.integrity].join("\u001f"),
-    );
-  return Buffer.from(`${packages.join("\n")}\n`, "utf8");
+function canonicalDependencyLock(dependencies) {
+  const packages = [...dependencies]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map(({ name, version, tarball, integrity, sha256 }) => ({
+      name,
+      version,
+      tarball,
+      integrity,
+      sha256,
+    }));
+  return Buffer.from(
+    `${JSON.stringify({ schemaVersion: 1, packages }, null, 2)}\n`,
+    "utf8",
+  );
 }

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -203,9 +203,8 @@ async function assembleNpmProvider(id, platform, runtimePath) {
       "node_modules",
       ".package-lock.json",
     );
-    const dependencyLock = Buffer.from(
-      (await readFile(generatedLock, "utf8")).replaceAll("\r\n", "\n"),
-      "utf8",
+    const dependencyLock = canonicalDependencyLock(
+      await readFile(generatedLock, "utf8"),
     );
     const dependencyLockSha256 = sha256(dependencyLock);
     if (
@@ -287,15 +286,16 @@ async function extract(archive, destination) {
 }
 
 async function runNpm(args, options) {
-  const npmExecPath = process.env.npm_execpath;
-  if (npmExecPath !== undefined && npmExecPath.length > 0) {
-    return await run(process.execPath, [npmExecPath, ...args], options);
-  }
-  return await run(
-    process.platform === "win32" ? "npm.cmd" : "npm",
-    args,
-    options,
-  );
+  const npmExecPath =
+    process.env.npm_execpath ??
+    path.join(
+      path.dirname(process.execPath),
+      "node_modules",
+      "npm",
+      "bin",
+      "npm-cli.js",
+    );
+  return await run(process.execPath, [npmExecPath, ...args], options);
 }
 
 async function findFile(root, name) {
@@ -331,4 +331,40 @@ async function exists(candidate) {
 
 function sha256(bytes) {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function canonicalDependencyLock(source) {
+  const parsed = JSON.parse(source);
+  const packages = {};
+  for (const [name, value] of Object.entries(parsed.packages ?? {}).sort()) {
+    if (name === "node_modules/fsevents") continue;
+    const stable = {};
+    for (const field of [
+      "version",
+      "resolved",
+      "integrity",
+      "license",
+      "dependencies",
+      "optionalDependencies",
+      "bin",
+      "engines",
+    ]) {
+      if (value[field] !== undefined) stable[field] = sortJson(value[field]);
+    }
+    packages[name] = stable;
+  }
+  return Buffer.from(
+    `${JSON.stringify({ lockfileVersion: 3, requires: true, packages }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
+function sortJson(value) {
+  if (Array.isArray(value)) return value.map(sortJson);
+  if (typeof value !== "object" || value === null) return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => [key, sortJson(child)]),
+  );
 }


### PR DESCRIPTION
## Summary

- Complete the Browser Use provider path on the clean `origin/main@7f55bffe00596a2533508c4bf5f2e36d6a2deb31` base.
- Add bounded, observation-scoped PNG artifacts for Electron, Playwright, and attached user-browser inspections, with TTL and detach/session cleanup.
- Add a renderer-only live capability timeline/current screenshot projection; canonical tool calls/results remain the durable history.
- Dispatch Browser and supported Computer text through the ordinary path without field/value sensitivity classifiers or provider rejection.
- Add packaged-provider provisioning diagnostics requiring an offline pinned version and SHA-256 resource manifest, with no packaged PATH fallback.

Closes #51, closes #54, closes #55.

Historical PRs #57, #61, #67, and #72 are evidence-only and superseded by this current-main implementation; this PR does not revive or close them.

## Validation

- `npm --workspace apps/zenx exec -- tsx --test` on the 132 Browser/Computer/provider/provisioning focused tests: 132 passed.
- `npm --workspace apps/zenx run typecheck` and `npm --workspace apps/zenx run build`: passed.
- `npm run typecheck`, `npm run build`, and `npm run lint`: passed.
- `git diff --check` and Prettier on all changed files: passed.
- Full ZenX/root test runs were also recorded. Five ZenX failures and six root failures are Windows/POSIX baseline incompatibilities (`printf`, POSIX paths, and POSIX process execution) unrelated to this feature.
- Root `format:check` remains blocked by the repository's existing 127-file formatting baseline; changed files are formatted.
- Electron provider smoke reached Electron download and failed in this environment with `UnknownVizError`; no packaged Windows or real-browser host was available here.

## Safety and limits

- User-browser attachment preserves authenticated state in place, target/document identity fences, foreground/background behavior, cancellation/timeouts, and detach-only close semantics; it never exports cookies/storage/auth or sends target close commands.
- Screenshot bytes stay in provider-owned short-lived files, bounded to 4 MiB for Browser artifacts, with identity metadata and deterministic cleanup.
- Packaged external providers are selected only after manifest version/platform/path/hash validation; missing/offline/integrity failures are explicit diagnostics.
