### PR TITLE
fix(zenx): update nanoid lockfile resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2144,9 +2144,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- refresh the transitive `nanoid` lockfile resolution from 3.3.16 to 3.3.18
- resolve GHSA-2v37-7h3g-55p8 without upgrading Vite or PostCSS
- avoid overrides because PostCSS's existing `^3.3.16` range already accepts the patched release

## Root cause and impact

`vite@7.3.6` resolves `postcss@8.5.25`, whose `nanoid@^3.3.16` dependency had been locked to vulnerable `3.3.16`. The lockfile now selects patched `3.3.18`. Application manifests and direct dependency ranges are unchanged, so there is no Vite/PostCSS compatibility impact.

## Validation

- `npm ci`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm ls vite postcss nanoid --all` — `vite@7.3.6 -> postcss@8.5.25 -> nanoid@3.3.18`
- `npm run typecheck --workspace=@zen/zenx`
- `npm run build --workspace=@zen/zenx`
- PR exact-head `ZenX typecheck, tests, and build` — passed on Ubuntu
- all ZenX capability/browser smoke jobs — passed across macOS and Windows
- `git diff --check`

## Known unrelated baseline failure

`Core, CLI, and IMZen` reaches a successful `npm ci` with 0 vulnerabilities, then fails `format:check` on two pre-existing, unchanged files under `apps/zenx/prototypes/high-fidelity/`. They are outside this one-file dependency remediation.