### PR TITLE
feat(zenx): complete Thread management

### DIFF
--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -21,6 +21,9 @@ Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / 
 以及可显式授权的 bundled/local capability registry 已形成可运行 vertical slice。
 ZenX 的产品读取模型来自 ZAS 原生 `ThreadSummary` 查询，并经 Electron main/preload
 typed IPC 暴露；Codex Thread DTO 只属于兼容协议 adapter，不定义 ZenX 产品模型。
+高保真 renderer 提供 Active / Archived Thread 视图：活动 Thread 可重命名和归档，
+归档 Thread 可查看并取消归档；全部通过既有 App Server 操作，Archive 作为可逆的
+安全删除替代，不提供永久删除，也不在活动 Turn 期间暗改 Thread 设置。
 Capability package 同时是首期插件安装单元：main/preload 提供 typed plugin snapshot，Host 只从
 manifest 投影已启用 package 的受控 Sidebar/page contribution。Triggers 与 Rooms 已拆成两个
 独立 bundled plugins；任一关闭后，其 contribution 与 host tools 同时撤销，并通过既有 Capability

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -9,7 +9,14 @@ Thread list product data is defined by ZAS's native `ThreadSummary` /
 host-local process boundary and preload exposes a typed IPC method. Codex Thread
 DTOs remain compatibility-only protocol types; they do not define ZenX's product
 model.
-The current renderer is intentionally not migrated in this slice.
+
+The renderer offers explicit Active and Archived Thread views. Active Threads
+can be renamed or archived, and archived Threads can be opened and unarchived.
+These actions use `thread/name/set`, `thread/archive`, and `thread/unarchive`
+through the existing App Server client; the renderer never reads journals or
+keeps a second Thread model. Archive is the reversible alternative to deletion.
+The UI disables Archive while a Turn is active, reports query and mutation
+failures in place, and leaves the running Turn and its settings unchanged.
 
 ## Run
 

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -26,12 +26,14 @@
   },
   "devDependencies": {
     "@electron/packager": "^20.3.0",
+    "@types/jsdom": "^30.0.0",
     "@types/node": "^24.0.0",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
     "@vitejs/plugin-react": "^5.2.0",
     "electron": "^43.2.0",
     "electron-vite": "^5.0.0",
+    "jsdom": "^30.0.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.2",
     "vite": "^7.3.6"

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -52,6 +52,7 @@ import { Sidebar } from "./Sidebar.js";
 import {
   readSidebarMode,
   readThreadScope,
+  threadHasActiveTurn,
   threadTitle,
   writeSidebarMode,
   writeThreadScope,
@@ -520,26 +521,34 @@ export function App() {
       setSelectedRoomId(triggerSnapshot.rooms[0]?.id ?? null);
   };
 
-  const changeThreadLifecycle = async () => {
-    if (selectedSummary === null || selectedSummary.status === "systemError")
-      return;
-    if (!selectedSummary.archived && selectedSummary.status === "active") {
-      setThreadLifecycleError(
-        "Wait for the active Turn to finish before archiving.",
-      );
-      return;
+  const renameThread = async (threadId: string, title: string) => {
+    const projection = await window.zenx.titles.rename(threadId, title);
+    setTitleSnapshot((current) => ({
+      ...current,
+      [threadId]: projection,
+    }));
+  };
+
+  const performThreadLifecycle = async (summary: NativeThreadSummary) => {
+    if (!summary.archived && threadHasActiveTurn(summary, threadDetail)) {
+      throw new Error("Wait for the active Turn to finish before archiving.");
     }
+    await window.zenx.protocol.request(
+      summary.archived ? "thread/unarchive" : "thread/archive",
+      { threadId: summary.threadId },
+    );
+    await loadThreadSummaries();
+  };
+
+  const changeThreadLifecycle = async () => {
+    if (selectedSummary === null) return;
     const nextScope: ThreadScope = selectedSummary.archived
       ? "active"
       : "archived";
     setThreadLifecycleBusy(true);
     setThreadLifecycleError(null);
     try {
-      await window.zenx.protocol.request(
-        selectedSummary.archived ? "thread/unarchive" : "thread/archive",
-        { threadId: selectedSummary.threadId },
-      );
-      await loadThreadSummaries();
+      await performThreadLifecycle(selectedSummary);
       setThreadScope(nextScope);
       try {
         writeThreadScope(window.localStorage, nextScope);
@@ -556,9 +565,11 @@ export function App() {
   return (
     <div className="app-shell">
       <Sidebar
+        liveThread={threadDetail}
         mode={sidebarMode}
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
+        onChangeThreadLifecycle={performThreadLifecycle}
         onModeChange={(mode) => {
           setSidebarMode(mode);
           try {
@@ -571,6 +582,7 @@ export function App() {
         onOpenContribution={(target) => openPage(target)}
         onOpenSettings={() => openPage("settings")}
         onRetryThreads={() => void loadThreadSummaries(true)}
+        onRenameThread={renameThread}
         onSelectThread={(threadId) => void resumeThread(threadId)}
         onThreadScopeChange={(scope) => {
           setThreadScope(scope);
@@ -646,14 +658,7 @@ export function App() {
             onOpenWorkspace={() => setWorkspaceOpen(true)}
             onRename={async (title) => {
               if (selectedSummary === null) return;
-              const projection = await window.zenx.titles.rename(
-                selectedSummary.threadId,
-                title,
-              );
-              setTitleSnapshot((current) => ({
-                ...current,
-                [selectedSummary.threadId]: projection,
-              }));
+              await renameThread(selectedSummary.threadId, title);
             }}
             onRespondToApproval={respondToApproval}
             onRetryTitle={async () => {
@@ -767,33 +772,35 @@ function AgentSurface({
   return (
     <section className="agent-surface">
       <header className="workspace-header">
-        <button
-          className="icon-button mobile-menu"
-          type="button"
-          aria-label="Open sidebar"
-          onClick={onOpenSidebar}
-        >
-          <Icon name="tree" />
-        </button>
-        <div className="thread-heading">
-          {selectedSummary === null ? (
-            <strong>Start a conversation</strong>
-          ) : (
-            <ThreadTitleEditor
-              editable={!selectedSummary.archived}
-              onRename={onRename}
-              onRetry={onRetryTitle}
-              projection={titleProjection}
-              title={threadTitle(selectedSummary)}
-            />
-          )}
-          <span>
-            {selectedSummary === null
-              ? "Select a Thread or create a new one"
-              : selectedSummary.status === "systemError"
-                ? "Unavailable journal"
-                : selectedSummary.currentMetadata.cwd}
-          </span>
+        <div className="workspace-heading-row">
+          <button
+            className="icon-button mobile-menu"
+            type="button"
+            aria-label="Open sidebar"
+            onClick={onOpenSidebar}
+          >
+            <Icon name="tree" />
+          </button>
+          <div className="thread-heading">
+            {selectedSummary === null ? (
+              <strong>Start a conversation</strong>
+            ) : (
+              <ThreadTitleEditor
+                editable={!selectedSummary.archived}
+                onRename={onRename}
+                onRetry={onRetryTitle}
+                projection={titleProjection}
+                title={threadTitle(selectedSummary)}
+              />
+            )}
+            <span>
+              {selectedSummary === null
+                ? "Select a Thread or create a new one"
+                : selectedSummary.status === "systemError"
+                  ? "Unavailable journal"
+                  : selectedSummary.currentMetadata.cwd}
+            </span>
+          </div>
         </div>
         <div className="top-actions">
           {selectedSummary === null ||
@@ -802,7 +809,7 @@ function AgentSurface({
               archived={selectedSummary.archived}
               busy={threadLifecycleBusy}
               error={threadLifecycleError}
-              hasActiveTurn={selectedSummary.status === "active"}
+              hasActiveTurn={threadHasActiveTurn(selectedSummary, threadDetail)}
               onChange={onChangeThreadLifecycle}
             />
           )}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -51,11 +51,15 @@ import { SettingsView } from "./SettingsView.js";
 import { Sidebar } from "./Sidebar.js";
 import {
   readSidebarMode,
+  readThreadScope,
   threadTitle,
   writeSidebarMode,
+  writeThreadScope,
   type SidebarMode,
+  type ThreadScope,
 } from "./thread-list.js";
 import { applyThreadViewNotification } from "./thread-view-state.js";
+import { ThreadLifecycleAction } from "./ThreadLifecycleAction.js";
 import { ThreadView } from "./ThreadView.js";
 
 type ProductPage = "agent" | "settings" | "triggers" | "rooms";
@@ -84,6 +88,17 @@ export function App() {
   const [threadSummaries, setThreadSummaries] = useState<NativeThreadSummary[]>(
     [],
   );
+  const [archivedThreadSummaries, setArchivedThreadSummaries] = useState<
+    NativeThreadSummary[]
+  >([]);
+  const [threadListLoaded, setThreadListLoaded] = useState({
+    active: false,
+    archived: false,
+  });
+  const [threadListErrors, setThreadListErrors] = useState<{
+    active: string | null;
+    archived: string | null;
+  }>({ active: null, archived: null });
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
   const [threadLoading, setThreadLoading] = useState(false);
@@ -104,19 +119,47 @@ export function App() {
       return "projects";
     }
   });
+  const [threadScope, setThreadScope] = useState<ThreadScope>(() => {
+    try {
+      return readThreadScope(window.localStorage);
+    } catch {
+      return "active";
+    }
+  });
   const [requestError, setRequestError] = useState<string | null>(null);
+  const [threadLifecycleBusy, setThreadLifecycleBusy] = useState(false);
+  const [threadLifecycleError, setThreadLifecycleError] = useState<
+    string | null
+  >(null);
   const [composerStates, setComposerStates] = useState<
     Record<string, ComposerState>
   >({});
 
-  const loadThreadSummaries = async () => {
-    try {
-      const summaries = await window.zenx.threads.list();
-      setThreadSummaries(summaries);
-      setRequestError(null);
-    } catch (error) {
-      setRequestError(describeError(error));
+  const loadThreadSummaries = async (showLoading = false) => {
+    if (showLoading) setThreadListLoaded({ active: false, archived: false });
+    const [active, archived] = await Promise.allSettled([
+      window.zenx.threads.list({ archived: false }),
+      window.zenx.threads.list({ archived: true }),
+    ]);
+    if (active.status === "fulfilled") {
+      setThreadSummaries(active.value);
+      setThreadListErrors((current) => ({ ...current, active: null }));
+    } else {
+      setThreadListErrors((current) => ({
+        ...current,
+        active: describeError(active.reason),
+      }));
     }
+    if (archived.status === "fulfilled") {
+      setArchivedThreadSummaries(archived.value);
+      setThreadListErrors((current) => ({ ...current, archived: null }));
+    } else {
+      setThreadListErrors((current) => ({
+        ...current,
+        archived: describeError(archived.reason),
+      }));
+    }
+    setThreadListLoaded({ active: true, archived: true });
   };
 
   const resumeThread = async (threadId: string) => {
@@ -129,6 +172,7 @@ export function App() {
     setThreadDetail(null);
     setSelectedSettings(null);
     setModelUpdateError(null);
+    setThreadLifecycleError(null);
     setThreadLoading(true);
     setThreadError(null);
     try {
@@ -296,13 +340,22 @@ export function App() {
     return () => window.removeEventListener("keydown", close);
   }, [sidebarOpen, workspaceOpen]);
 
-  const summaries = threadSummaries.map((summary) =>
+  const activeSummaries = threadSummaries.map((summary) =>
     titleSnapshot[summary.threadId]?.title === undefined
       ? summary
       : { ...summary, name: titleSnapshot[summary.threadId]!.title },
   );
+  const archivedSummaries = archivedThreadSummaries.map((summary) =>
+    titleSnapshot[summary.threadId]?.title === undefined
+      ? summary
+      : { ...summary, name: titleSnapshot[summary.threadId]!.title },
+  );
+  const visibleSummaries =
+    threadScope === "active" ? activeSummaries : archivedSummaries;
   const selectedSummary =
-    summaries.find((summary) => summary.threadId === selectedThreadId) ?? null;
+    [...activeSummaries, ...archivedSummaries].find(
+      (summary) => summary.threadId === selectedThreadId,
+    ) ?? null;
   const pendingThreadIds = pendingApprovalThreadIds(approvals);
   const pluginContributions = loadedPluginContributions(pluginSnapshot);
 
@@ -315,6 +368,12 @@ export function App() {
       const result = await window.zenx.protocol.request("thread/start", {});
       if (selectionEpoch.current !== epoch) return;
       selectedThreadIdRef.current = result.thread.id;
+      setThreadScope("active");
+      try {
+        writeThreadScope(window.localStorage, "active");
+      } catch {
+        // The view remains active for this window.
+      }
       setPage("agent");
       setSidebarOpen(false);
       setSelectedThreadId(result.thread.id);
@@ -461,6 +520,39 @@ export function App() {
       setSelectedRoomId(triggerSnapshot.rooms[0]?.id ?? null);
   };
 
+  const changeThreadLifecycle = async () => {
+    if (selectedSummary === null || selectedSummary.status === "systemError")
+      return;
+    if (!selectedSummary.archived && selectedSummary.status === "active") {
+      setThreadLifecycleError(
+        "Wait for the active Turn to finish before archiving.",
+      );
+      return;
+    }
+    const nextScope: ThreadScope = selectedSummary.archived
+      ? "active"
+      : "archived";
+    setThreadLifecycleBusy(true);
+    setThreadLifecycleError(null);
+    try {
+      await window.zenx.protocol.request(
+        selectedSummary.archived ? "thread/unarchive" : "thread/archive",
+        { threadId: selectedSummary.threadId },
+      );
+      await loadThreadSummaries();
+      setThreadScope(nextScope);
+      try {
+        writeThreadScope(window.localStorage, nextScope);
+      } catch {
+        // The view remains valid for this window.
+      }
+    } catch (error) {
+      setThreadLifecycleError(describeError(error));
+    } finally {
+      setThreadLifecycleBusy(false);
+    }
+  };
+
   return (
     <div className="app-shell">
       <Sidebar
@@ -478,13 +570,25 @@ export function App() {
         onNewThread={() => void newThread()}
         onOpenContribution={(target) => openPage(target)}
         onOpenSettings={() => openPage("settings")}
+        onRetryThreads={() => void loadThreadSummaries(true)}
         onSelectThread={(threadId) => void resumeThread(threadId)}
+        onThreadScopeChange={(scope) => {
+          setThreadScope(scope);
+          try {
+            writeThreadScope(window.localStorage, scope);
+          } catch {
+            // The preference remains valid for this window.
+          }
+        }}
         pendingApprovalThreadIds={pendingThreadIds}
         pluginContributions={pluginContributions}
         selectedPage={page}
         selectedThreadId={selectedThreadId}
         serverReady={serverStatus.type === "ready"}
-        threads={summaries}
+        threadError={threadListErrors[threadScope]}
+        threadLoading={!threadListLoaded[threadScope]}
+        threadScope={threadScope}
+        threads={visibleSummaries}
         triggerSnapshot={triggerSnapshot}
       />
 
@@ -500,7 +604,7 @@ export function App() {
               (contribution) => contribution.page === "rooms",
             )}
             snapshot={triggerSnapshot}
-            threads={summaries}
+            threads={activeSummaries}
             onOpenThread={(id) => void resumeThread(id)}
             onOpenRoom={(id) => {
               setSelectedRoomId(id);
@@ -512,7 +616,7 @@ export function App() {
           <RoomView
             roomId={selectedRoomId}
             snapshot={triggerSnapshot}
-            threads={summaries}
+            threads={activeSummaries}
             onOpenThread={(id) => void resumeThread(id)}
             onOpenSidebar={() => setSidebarOpen(true)}
             onSelectRoom={setSelectedRoomId}
@@ -536,6 +640,7 @@ export function App() {
               });
             }}
             onModelChange={(model) => void changeModel(model)}
+            onChangeThreadLifecycle={changeThreadLifecycle}
             onNewThread={() => void newThread()}
             onOpenSidebar={() => setSidebarOpen(true)}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
@@ -567,6 +672,8 @@ export function App() {
             selectedSummary={selectedSummary}
             serverStatus={serverStatus}
             switchingModel={switchingModel}
+            threadLifecycleBusy={threadLifecycleBusy}
+            threadLifecycleError={threadLifecycleError}
             threadDetail={threadDetail}
             threadError={threadError}
             threadLoading={threadLoading}
@@ -598,6 +705,7 @@ function AgentSurface({
   models,
   modelCatalogError,
   modelUpdateError,
+  onChangeThreadLifecycle,
   onDraftChange,
   onInterrupt,
   onModelChange,
@@ -613,6 +721,8 @@ function AgentSurface({
   selectedSummary,
   serverStatus,
   switchingModel,
+  threadLifecycleBusy,
+  threadLifecycleError,
   threadDetail,
   threadError,
   threadLoading,
@@ -624,6 +734,7 @@ function AgentSurface({
   models: ModelSummary[];
   modelCatalogError: string | null;
   modelUpdateError: string | null;
+  onChangeThreadLifecycle(): Promise<void>;
   onDraftChange(threadId: string, draft: string): void;
   onInterrupt(turnId: string): Promise<void>;
   onModelChange(model: string): void;
@@ -645,6 +756,8 @@ function AgentSurface({
   selectedSummary: NativeThreadSummary | null;
   serverStatus: AppServerHostStatus;
   switchingModel: boolean;
+  threadLifecycleBusy: boolean;
+  threadLifecycleError: string | null;
   threadDetail: Thread | null;
   threadError: string | null;
   threadLoading: boolean;
@@ -667,6 +780,7 @@ function AgentSurface({
             <strong>Start a conversation</strong>
           ) : (
             <ThreadTitleEditor
+              editable={!selectedSummary.archived}
               onRename={onRename}
               onRetry={onRetryTitle}
               projection={titleProjection}
@@ -682,6 +796,16 @@ function AgentSurface({
           </span>
         </div>
         <div className="top-actions">
+          {selectedSummary === null ||
+          selectedSummary.status === "systemError" ? null : (
+            <ThreadLifecycleAction
+              archived={selectedSummary.archived}
+              busy={threadLifecycleBusy}
+              error={threadLifecycleError}
+              hasActiveTurn={selectedSummary.status === "active"}
+              onChange={onChangeThreadLifecycle}
+            />
+          )}
           <button
             className="icon-button search-thread"
             type="button"
@@ -959,11 +1083,13 @@ function EmptyState({
 }
 
 function ThreadTitleEditor({
+  editable,
   title,
   projection,
   onRename,
   onRetry,
 }: {
+  editable: boolean;
   title: string;
   projection: ThreadTitleProjection | undefined;
   onRename(title: string): Promise<void>;
@@ -1009,17 +1135,19 @@ function ThreadTitleEditor({
   return (
     <div className="thread-title-line">
       <strong>{title}</strong>
-      <button
-        type="button"
-        aria-label="Rename Thread"
-        onClick={() => setEditing(true)}
-      >
-        Rename
-      </button>
-      {projection?.status === "generating" ? (
+      {editable ? (
+        <button
+          type="button"
+          aria-label="Rename Thread"
+          onClick={() => setEditing(true)}
+        >
+          Rename
+        </button>
+      ) : null}
+      {editable && projection?.status === "generating" ? (
         <small>Generating title…</small>
       ) : null}
-      {projection?.status === "failed" ? (
+      {editable && projection?.status === "failed" ? (
         <button type="button" onClick={() => void onRetry()}>
           Retry title
         </button>

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   threadProject,
   threadTitle,
   type SidebarMode,
+  type ThreadScope,
 } from "./thread-list.js";
 
 interface SidebarProps {
@@ -21,12 +22,17 @@ interface SidebarProps {
   onNewThread(): void;
   onOpenContribution(page: "triggers" | "rooms"): void;
   onOpenSettings(): void;
+  onRetryThreads(): void;
   onSelectThread(threadId: string): void;
+  onThreadScopeChange(scope: ThreadScope): void;
   pendingApprovalThreadIds: ReadonlySet<string>;
   pluginContributions: readonly LoadedPluginContribution[];
   selectedPage: "agent" | "triggers" | "rooms" | "settings";
   selectedThreadId: string | null;
   serverReady: boolean;
+  threadError: string | null;
+  threadLoading: boolean;
+  threadScope: ThreadScope;
   threads: readonly NativeThreadSummary[];
   triggerSnapshot: TriggerSnapshot;
 }
@@ -39,12 +45,17 @@ export function Sidebar({
   onNewThread,
   onOpenContribution,
   onOpenSettings,
+  onRetryThreads,
   onSelectThread,
+  onThreadScopeChange,
   pendingApprovalThreadIds,
   pluginContributions,
   selectedPage,
   selectedThreadId,
   serverReady,
+  threadError,
+  threadLoading,
+  threadScope,
   threads,
   triggerSnapshot,
 }: SidebarProps) {
@@ -70,22 +81,24 @@ export function Sidebar({
               <span>ZENX</span>
             </div>
             <div className="brand-actions">
-              <button
-                className="icon-button inbox-button"
-                type="button"
-                aria-label={
-                  mode === "inbox" ? "Return to projects" : "Open inbox"
-                }
-                aria-pressed={mode === "inbox"}
-                onClick={() =>
-                  onModeChange(mode === "inbox" ? "projects" : "inbox")
-                }
-              >
-                <Icon name="inbox" />
-                {pendingApprovalThreadIds.size > 0 ? (
-                  <span className="inbox-dot" aria-hidden="true" />
-                ) : null}
-              </button>
+              {threadScope === "active" ? (
+                <button
+                  className="icon-button inbox-button"
+                  type="button"
+                  aria-label={
+                    mode === "inbox" ? "Return to projects" : "Open inbox"
+                  }
+                  aria-pressed={mode === "inbox"}
+                  onClick={() =>
+                    onModeChange(mode === "inbox" ? "projects" : "inbox")
+                  }
+                >
+                  <Icon name="inbox" />
+                  {pendingApprovalThreadIds.size > 0 ? (
+                    <span className="inbox-dot" aria-hidden="true" />
+                  ) : null}
+                </button>
+              ) : null}
               <button
                 className="icon-button"
                 type="button"
@@ -129,20 +142,65 @@ export function Sidebar({
             </section>
           )}
 
+          <div
+            className="thread-scope-tabs"
+            role="tablist"
+            aria-label="Thread views"
+          >
+            {(["active", "archived"] as const).map((scope) => (
+              <button
+                aria-controls="thread-scope-panel"
+                id={`thread-scope-${scope}`}
+                key={scope}
+                type="button"
+                role="tab"
+                aria-selected={threadScope === scope}
+                onClick={() => onThreadScopeChange(scope)}
+              >
+                {scope === "active" ? "Active" : "Archived"}
+              </button>
+            ))}
+          </div>
+
           <div className="sidebar-view-head">
-            <strong>{mode === "inbox" ? "Inbox" : "Projects"}</strong>
+            <strong>
+              {threadScope === "archived"
+                ? "Archived"
+                : mode === "inbox"
+                  ? "Inbox"
+                  : "Projects"}
+            </strong>
             <span>{threads.length}</span>
           </div>
         </header>
 
-        <div className="sidebar-scroll">
+        <div
+          className="sidebar-scroll"
+          id="thread-scope-panel"
+          role="tabpanel"
+          aria-labelledby={`thread-scope-${threadScope}`}
+        >
           {!serverReady ? (
             <p className="sidebar-empty">Waiting for the local App Server.</p>
+          ) : threadLoading ? (
+            <p className="sidebar-empty" role="status">
+              Loading {threadScope === "active" ? "active" : "archived"}{" "}
+              Threads…
+            </p>
+          ) : threadError !== null ? (
+            <div className="sidebar-empty sidebar-error" role="alert">
+              <p>{threadError}</p>
+              <button type="button" onClick={onRetryThreads}>
+                Try again
+              </button>
+            </div>
           ) : threads.length === 0 ? (
             <p className="sidebar-empty">
-              Your conversations will appear here.
+              {threadScope === "archived"
+                ? "No archived Threads yet. Archived conversations stay safe here until you restore them."
+                : "Your conversations will appear here."}
             </p>
-          ) : mode === "inbox" ? (
+          ) : threadScope === "active" && mode === "inbox" ? (
             <InboxView
               onSelectThread={onSelectThread}
               pendingApprovalThreadIds={pendingApprovalThreadIds}

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -1,13 +1,15 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { TriggerSnapshot } from "../../main/trigger-types.js";
+import type { Thread } from "../../protocol-client/index.js";
 import { Icon } from "./icons.js";
 import type { LoadedPluginContribution } from "./plugin-contributions.js";
 import {
   deriveInboxSections,
   deriveProjectGroups,
   threadModelIdentity,
+  threadHasActiveTurn,
   threadProject,
   threadTitle,
   type SidebarMode,
@@ -18,11 +20,13 @@ interface SidebarProps {
   mode: SidebarMode;
   open: boolean;
   onClose(): void;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
   onModeChange(mode: SidebarMode): void;
   onNewThread(): void;
   onOpenContribution(page: "triggers" | "rooms"): void;
   onOpenSettings(): void;
   onRetryThreads(): void;
+  onRenameThread(threadId: string, title: string): Promise<void>;
   onSelectThread(threadId: string): void;
   onThreadScopeChange(scope: ThreadScope): void;
   pendingApprovalThreadIds: ReadonlySet<string>;
@@ -30,6 +34,7 @@ interface SidebarProps {
   selectedPage: "agent" | "triggers" | "rooms" | "settings";
   selectedThreadId: string | null;
   serverReady: boolean;
+  liveThread: Thread | null;
   threadError: string | null;
   threadLoading: boolean;
   threadScope: ThreadScope;
@@ -41,11 +46,13 @@ export function Sidebar({
   mode,
   open,
   onClose,
+  onChangeThreadLifecycle,
   onModeChange,
   onNewThread,
   onOpenContribution,
   onOpenSettings,
   onRetryThreads,
+  onRenameThread,
   onSelectThread,
   onThreadScopeChange,
   pendingApprovalThreadIds,
@@ -53,6 +60,7 @@ export function Sidebar({
   selectedPage,
   selectedThreadId,
   serverReady,
+  liveThread,
   threadError,
   threadLoading,
   threadScope,
@@ -203,17 +211,23 @@ export function Sidebar({
           ) : threadScope === "active" && mode === "inbox" ? (
             <InboxView
               onSelectThread={onSelectThread}
+              onChangeThreadLifecycle={onChangeThreadLifecycle}
+              onRenameThread={onRenameThread}
               pendingApprovalThreadIds={pendingApprovalThreadIds}
               selectedThreadId={selectedThreadId}
               threads={threads}
+              liveThread={liveThread}
               watchingThreadIds={watchingThreadIds}
             />
           ) : (
             <ProjectsView
               onSelectThread={onSelectThread}
+              onChangeThreadLifecycle={onChangeThreadLifecycle}
+              onRenameThread={onRenameThread}
               pendingApprovalThreadIds={pendingApprovalThreadIds}
               selectedThreadId={selectedThreadId}
               threads={threads}
+              liveThread={liveThread}
               watchingThreadIds={watchingThreadIds}
             />
           )}
@@ -249,13 +263,19 @@ function InboxView({
   threads,
   selectedThreadId,
   onSelectThread,
+  onChangeThreadLifecycle,
+  onRenameThread,
   pendingApprovalThreadIds,
+  liveThread,
   watchingThreadIds,
 }: {
   threads: readonly NativeThreadSummary[];
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
+  liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
 }) {
   return deriveInboxSections(
@@ -270,6 +290,9 @@ function InboxView({
           <ThreadRow
             inbox
             key={thread.threadId}
+            hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
+            onChangeThreadLifecycle={onChangeThreadLifecycle}
+            onRenameThread={onRenameThread}
             onSelectThread={onSelectThread}
             pendingApproval={pendingApprovalThreadIds.has(thread.threadId)}
             selected={thread.threadId === selectedThreadId}
@@ -286,19 +309,28 @@ function ProjectsView({
   threads,
   selectedThreadId,
   onSelectThread,
+  onChangeThreadLifecycle,
+  onRenameThread,
   pendingApprovalThreadIds,
+  liveThread,
   watchingThreadIds,
 }: {
   threads: readonly NativeThreadSummary[];
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
+  liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
 }) {
   return deriveProjectGroups(threads).map((group) => (
     <ProjectRows
       group={group}
       key={group.key}
+      liveThread={liveThread}
+      onChangeThreadLifecycle={onChangeThreadLifecycle}
+      onRenameThread={onRenameThread}
       onSelectThread={onSelectThread}
       pendingApprovalThreadIds={pendingApprovalThreadIds}
       selectedThreadId={selectedThreadId}
@@ -311,13 +343,19 @@ function ProjectRows({
   group,
   selectedThreadId,
   onSelectThread,
+  onChangeThreadLifecycle,
+  onRenameThread,
   pendingApprovalThreadIds,
+  liveThread,
   watchingThreadIds,
 }: {
   group: ReturnType<typeof deriveProjectGroups>[number];
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
+  liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
 }) {
   const [open, setOpen] = useState(true);
@@ -342,7 +380,10 @@ function ProjectRows({
       {open
         ? group.threads.map((thread) => (
             <ThreadRow
+              hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
               key={thread.threadId}
+              onChangeThreadLifecycle={onChangeThreadLifecycle}
+              onRenameThread={onRenameThread}
               onSelectThread={onSelectThread}
               pendingApproval={pendingApprovalThreadIds.has(thread.threadId)}
               selected={thread.threadId === selectedThreadId}
@@ -358,6 +399,9 @@ function ProjectRows({
 function ThreadRow({
   thread,
   selected,
+  hasActiveTurn,
+  onChangeThreadLifecycle,
+  onRenameThread,
   onSelectThread,
   pendingApproval,
   watching,
@@ -365,11 +409,33 @@ function ThreadRow({
 }: {
   thread: NativeThreadSummary;
   selected: boolean;
+  hasActiveTurn: boolean;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onRenameThread(threadId: string, title: string): Promise<void>;
   onSelectThread(threadId: string): void;
   pendingApproval: boolean;
   watching: boolean;
   inbox?: boolean;
 }) {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [renaming, setRenaming] = useState(false);
+  const [renameDraft, setRenameDraft] = useState(threadTitle(thread));
+  const [busyAction, setBusyAction] = useState<
+    "rename" | "archive" | "unarchive" | null
+  >(null);
+  const [menuError, setMenuError] = useState<string | null>(null);
+  useEffect(() => {
+    if (!menuOpen) return;
+    const closeOutside = (event: PointerEvent) => {
+      if (!rowRef.current?.contains(event.target as Node)) {
+        setMenuOpen(false);
+        setRenaming(false);
+      }
+    };
+    document.addEventListener("pointerdown", closeOutside);
+    return () => document.removeEventListener("pointerdown", closeOutside);
+  }, [menuOpen]);
   const identity = threadModelIdentity(thread);
   const contents = (
     <>
@@ -396,22 +462,191 @@ function ThreadRow({
       )}
     </>
   );
-  if (thread.status === "systemError") {
-    return (
-      <div className={`thread-row system-error${inbox ? " inbox" : ""}`}>
-        {contents}
-      </div>
-    );
-  }
+  const runAction = async (
+    action: "rename" | "archive" | "unarchive",
+    operation: () => Promise<void>,
+  ) => {
+    setBusyAction(action);
+    setMenuError(null);
+    try {
+      await operation();
+      setMenuOpen(false);
+      setRenaming(false);
+    } catch (error) {
+      setMenuError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusyAction(null);
+    }
+  };
   return (
-    <button
-      className={`thread-row${selected ? " selected" : ""}${inbox ? " inbox" : ""}`}
-      type="button"
-      aria-current={selected ? "page" : undefined}
-      onClick={() => onSelectThread(thread.threadId)}
+    <div
+      ref={rowRef}
+      className="thread-row-shell"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          setMenuOpen(false);
+          setRenaming(false);
+        }
+      }}
     >
-      {contents}
-    </button>
+      {thread.status === "systemError" ? (
+        <div className={`thread-row system-error${inbox ? " inbox" : ""}`}>
+          {contents}
+        </div>
+      ) : (
+        <button
+          className={`thread-row${selected ? " selected" : ""}${inbox ? " inbox" : ""}`}
+          type="button"
+          aria-current={selected ? "page" : undefined}
+          onClick={() => onSelectThread(thread.threadId)}
+        >
+          {contents}
+        </button>
+      )}
+      <button
+        className="thread-menu-trigger"
+        type="button"
+        aria-label={`Manage ${threadTitle(thread)}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={() => {
+          setMenuError(null);
+          setRenaming(false);
+          setRenameDraft(threadTitle(thread));
+          setMenuOpen((value) => !value);
+        }}
+      >
+        <Icon name="more" />
+      </button>
+      <ThreadItemMenu
+        archived={thread.archived}
+        busyAction={busyAction}
+        error={menuError}
+        hasActiveTurn={hasActiveTurn}
+        open={menuOpen}
+        renaming={renaming}
+        renameDraft={renameDraft}
+        onArchive={() =>
+          void runAction("archive", () => onChangeThreadLifecycle(thread))
+        }
+        onBeginRename={() => setRenaming(true)}
+        onCancelRename={() => setRenaming(false)}
+        onDraftChange={setRenameDraft}
+        onRename={() =>
+          void runAction("rename", () =>
+            onRenameThread(thread.threadId, renameDraft),
+          )
+        }
+        onUnarchive={() =>
+          void runAction("unarchive", () => onChangeThreadLifecycle(thread))
+        }
+      />
+    </div>
+  );
+}
+
+export function ThreadItemMenu({
+  archived,
+  busyAction,
+  error,
+  hasActiveTurn,
+  open,
+  renaming,
+  renameDraft,
+  onArchive,
+  onBeginRename,
+  onCancelRename,
+  onDraftChange,
+  onRename,
+  onUnarchive,
+}: {
+  archived: boolean;
+  busyAction: "rename" | "archive" | "unarchive" | null;
+  error: string | null;
+  hasActiveTurn: boolean;
+  open: boolean;
+  renaming: boolean;
+  renameDraft: string;
+  onArchive(): void;
+  onBeginRename(): void;
+  onCancelRename(): void;
+  onDraftChange(value: string): void;
+  onRename(): void;
+  onUnarchive(): void;
+}) {
+  if (!open) return null;
+  const busy = busyAction !== null;
+  return (
+    <div className="thread-item-menu" role="menu">
+      {renaming ? (
+        <form
+          className="thread-menu-rename"
+          onSubmit={(event) => {
+            event.preventDefault();
+            onRename();
+          }}
+        >
+          <label>
+            <span>Thread name</span>
+            <input
+              autoFocus
+              value={renameDraft}
+              onChange={(event) => onDraftChange(event.target.value)}
+            />
+          </label>
+          <div>
+            <button type="submit" disabled={busy || !renameDraft.trim()}>
+              {busyAction === "rename" ? "Saving…" : "Save"}
+            </button>
+            <button type="button" disabled={busy} onClick={onCancelRename}>
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : archived ? (
+        <button
+          type="button"
+          role="menuitem"
+          disabled={busy}
+          onClick={onUnarchive}
+        >
+          <Icon name="restore" />
+          {busyAction === "unarchive" ? "Unarchiving…" : "Unarchive"}
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            role="menuitem"
+            disabled={busy}
+            onClick={onBeginRename}
+          >
+            <Icon name="compose" />
+            Rename
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            disabled={busy || hasActiveTurn}
+            title={
+              hasActiveTurn
+                ? "Wait for the active Turn to finish before archiving."
+                : undefined
+            }
+            onClick={onArchive}
+          >
+            <Icon name="archive" />
+            {busyAction === "archive" ? "Archiving…" : "Archive"}
+          </button>
+          {hasActiveTurn ? (
+            <p className="thread-menu-help">
+              Wait for the active Turn to finish before archiving.
+            </p>
+          ) : null}
+        </>
+      )}
+      {error === null ? null : <p role="alert">{error}</p>}
+    </div>
   );
 }
 

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { TriggerSnapshot } from "../../main/trigger-types.js";
@@ -418,6 +418,9 @@ function ThreadRow({
   inbox?: boolean;
 }) {
   const rowRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const initialMenuFocusRef = useRef<"first" | "last">("first");
   const [menuOpen, setMenuOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState(threadTitle(thread));
@@ -425,17 +428,36 @@ function ThreadRow({
     "rename" | "archive" | "unarchive" | null
   >(null);
   const [menuError, setMenuError] = useState<string | null>(null);
+  const restoreMenuTriggerFocus = () => {
+    queueMicrotask(() => menuTriggerRef.current?.focus());
+  };
+  const closeMenu = (restoreFocus = true) => {
+    setMenuOpen(false);
+    setRenaming(false);
+    if (restoreFocus) restoreMenuTriggerFocus();
+  };
+  const focusThreadScope = () => {
+    document
+      .getElementById(`thread-scope-${thread.archived ? "archived" : "active"}`)
+      ?.focus();
+  };
   useEffect(() => {
     if (!menuOpen) return;
     const closeOutside = (event: PointerEvent) => {
       if (!rowRef.current?.contains(event.target as Node)) {
-        setMenuOpen(false);
-        setRenaming(false);
+        closeMenu();
       }
     };
     document.addEventListener("pointerdown", closeOutside);
     return () => document.removeEventListener("pointerdown", closeOutside);
   }, [menuOpen]);
+  useEffect(() => {
+    if (!menuOpen || renaming) return;
+    const items = enabledMenuItems(menuRef.current);
+    const item =
+      initialMenuFocusRef.current === "last" ? items.at(-1) : items.at(0);
+    item?.focus();
+  }, [menuOpen, renaming]);
   const identity = threadModelIdentity(thread);
   const contents = (
     <>
@@ -469,11 +491,21 @@ function ThreadRow({
     setBusyAction(action);
     setMenuError(null);
     try {
+      if (action !== "rename") focusThreadScope();
       await operation();
-      setMenuOpen(false);
-      setRenaming(false);
+      if (action !== "rename") focusThreadScope();
+      closeMenu(action === "rename");
     } catch (error) {
       setMenuError(error instanceof Error ? error.message : String(error));
+      if (action !== "rename") {
+        queueMicrotask(() =>
+          menuRef.current
+            ?.querySelector<HTMLButtonElement>(
+              `[data-thread-action="${action}"]:not(:disabled)`,
+            )
+            ?.focus(),
+        );
+      }
     } finally {
       setBusyAction(null);
     }
@@ -484,8 +516,8 @@ function ThreadRow({
       className="thread-row-shell"
       onKeyDown={(event) => {
         if (event.key === "Escape") {
-          setMenuOpen(false);
-          setRenaming(false);
+          event.preventDefault();
+          closeMenu();
         }
       }}
     >
@@ -504,16 +536,34 @@ function ThreadRow({
         </button>
       )}
       <button
+        ref={menuTriggerRef}
         className="thread-menu-trigger"
         type="button"
+        id={`thread-menu-trigger-${thread.threadId}`}
         aria-label={`Manage ${threadTitle(thread)}`}
         aria-haspopup="menu"
         aria-expanded={menuOpen}
+        aria-controls={menuOpen ? `thread-menu-${thread.threadId}` : undefined}
         onClick={() => {
+          if (menuOpen) {
+            closeMenu();
+            return;
+          }
+          initialMenuFocusRef.current = "first";
           setMenuError(null);
           setRenaming(false);
           setRenameDraft(threadTitle(thread));
-          setMenuOpen((value) => !value);
+          setMenuOpen(true);
+        }}
+        onKeyDown={(event) => {
+          if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+          event.preventDefault();
+          initialMenuFocusRef.current =
+            event.key === "ArrowUp" ? "last" : "first";
+          setMenuError(null);
+          setRenaming(false);
+          setRenameDraft(threadTitle(thread));
+          setMenuOpen(true);
         }}
       >
         <Icon name="more" />
@@ -523,6 +573,9 @@ function ThreadRow({
         busyAction={busyAction}
         error={menuError}
         hasActiveTurn={hasActiveTurn}
+        labelledBy={`thread-menu-trigger-${thread.threadId}`}
+        menuId={`thread-menu-${thread.threadId}`}
+        menuRef={menuRef}
         open={menuOpen}
         renaming={renaming}
         renameDraft={renameDraft}
@@ -531,6 +584,7 @@ function ThreadRow({
         }
         onBeginRename={() => setRenaming(true)}
         onCancelRename={() => setRenaming(false)}
+        onRequestClose={() => closeMenu()}
         onDraftChange={setRenameDraft}
         onRename={() =>
           void runAction("rename", () =>
@@ -550,12 +604,16 @@ export function ThreadItemMenu({
   busyAction,
   error,
   hasActiveTurn,
+  labelledBy,
+  menuId,
+  menuRef,
   open,
   renaming,
   renameDraft,
   onArchive,
   onBeginRename,
   onCancelRename,
+  onRequestClose,
   onDraftChange,
   onRename,
   onUnarchive,
@@ -564,12 +622,16 @@ export function ThreadItemMenu({
   busyAction: "rename" | "archive" | "unarchive" | null;
   error: string | null;
   hasActiveTurn: boolean;
+  labelledBy?: string;
+  menuId?: string;
+  menuRef?: RefObject<HTMLDivElement | null>;
   open: boolean;
   renaming: boolean;
   renameDraft: string;
   onArchive(): void;
   onBeginRename(): void;
   onCancelRename(): void;
+  onRequestClose?(): void;
   onDraftChange(value: string): void;
   onRename(): void;
   onUnarchive(): void;
@@ -577,7 +639,43 @@ export function ThreadItemMenu({
   if (!open) return null;
   const busy = busyAction !== null;
   return (
-    <div className="thread-item-menu" role="menu">
+    <div
+      ref={menuRef}
+      className="thread-item-menu"
+      id={menuId}
+      role="menu"
+      aria-labelledby={labelledBy}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.preventDefault();
+          event.stopPropagation();
+          onRequestClose?.();
+          return;
+        }
+        if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key)) {
+          return;
+        }
+        const items = enabledMenuItems(event.currentTarget);
+        if (items.length === 0) return;
+        event.preventDefault();
+        const currentIndex = items.indexOf(
+          document.activeElement as HTMLButtonElement,
+        );
+        const nextIndex =
+          event.key === "Home"
+            ? 0
+            : event.key === "End"
+              ? items.length - 1
+              : currentIndex === -1
+                ? event.key === "ArrowUp"
+                  ? items.length - 1
+                  : 0
+                : event.key === "ArrowUp"
+                  ? (currentIndex - 1 + items.length) % items.length
+                  : (currentIndex + 1) % items.length;
+        items[nextIndex]?.focus();
+      }}
+    >
       {renaming ? (
         <form
           className="thread-menu-rename"
@@ -607,6 +705,8 @@ export function ThreadItemMenu({
         <button
           type="button"
           role="menuitem"
+          tabIndex={-1}
+          data-thread-action="unarchive"
           disabled={busy}
           onClick={onUnarchive}
         >
@@ -618,6 +718,8 @@ export function ThreadItemMenu({
           <button
             type="button"
             role="menuitem"
+            tabIndex={-1}
+            data-thread-action="rename"
             disabled={busy}
             onClick={onBeginRename}
           >
@@ -627,6 +729,8 @@ export function ThreadItemMenu({
           <button
             type="button"
             role="menuitem"
+            tabIndex={-1}
+            data-thread-action="archive"
             disabled={busy || hasActiveTurn}
             title={
               hasActiveTurn
@@ -647,6 +751,15 @@ export function ThreadItemMenu({
       )}
       {error === null ? null : <p role="alert">{error}</p>}
     </div>
+  );
+}
+
+function enabledMenuItems(container: HTMLElement | null): HTMLButtonElement[] {
+  if (container === null) return [];
+  return Array.from(
+    container.querySelectorAll<HTMLButtonElement>(
+      'button[role="menuitem"]:not(:disabled)',
+    ),
   );
 }
 

--- a/apps/zenx/src/renderer/src/ThreadLifecycleAction.tsx
+++ b/apps/zenx/src/renderer/src/ThreadLifecycleAction.tsx
@@ -1,0 +1,53 @@
+import { Icon } from "./icons.js";
+
+export function ThreadLifecycleAction({
+  archived,
+  busy,
+  error = null,
+  hasActiveTurn,
+  onChange,
+}: {
+  archived: boolean;
+  busy: boolean;
+  error?: string | null;
+  hasActiveTurn: boolean;
+  onChange(): Promise<void>;
+}) {
+  const blocked = !archived && hasActiveTurn;
+  const label = archived
+    ? busy
+      ? "Unarchiving…"
+      : "Unarchive"
+    : busy
+      ? "Archiving…"
+      : "Archive";
+  return (
+    <div className="thread-lifecycle-control">
+      <button
+        className="thread-lifecycle-action"
+        type="button"
+        aria-describedby={blocked ? "archive-active-turn-help" : undefined}
+        disabled={busy || blocked}
+        title={
+          blocked
+            ? "Wait for the active Turn to finish before archiving."
+            : undefined
+        }
+        onClick={() => void onChange()}
+      >
+        <Icon name={archived ? "restore" : "archive"} />
+        <span>{label}</span>
+      </button>
+      {blocked ? (
+        <span className="sr-only" id="archive-active-turn-help">
+          Wait for the active Turn to finish before archiving.
+        </span>
+      ) : null}
+      {error === null ? null : (
+        <span className="thread-action-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -13,6 +13,7 @@ type IconName =
   | "layers"
   | "lock"
   | "moon"
+  | "more"
   | "paperclip"
   | "panel-right"
   | "reasoning"
@@ -67,6 +68,7 @@ const paths: Record<IconName, ReactNode> = {
     </>
   ),
   moon: <path d="M13.4 9.4A5.8 5.8 0 0 1 6.6 2.6a5.8 5.8 0 1 0 6.8 6.8Z" />,
+  more: <path d="M3 8h.01M8 8h.01M13 8h.01" />,
   layers: (
     <>
       <path d="m8 2 6 3.2-6 3.2-6-3.2Z" />

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -2,6 +2,7 @@ import type { ReactNode, SVGProps } from "react";
 
 type IconName =
   | "arrow-down"
+  | "archive"
   | "check"
   | "chevron-down"
   | "chevron-right"
@@ -15,6 +16,7 @@ type IconName =
   | "paperclip"
   | "panel-right"
   | "reasoning"
+  | "restore"
   | "settings"
   | "search"
   | "thread"
@@ -34,6 +36,12 @@ type IconProps = SVGProps<SVGSVGElement> & {
 
 const paths: Record<IconName, ReactNode> = {
   "arrow-down": <path d="M8 2.2v11.2m-4-4 4 4 4-4" />,
+  archive: (
+    <>
+      <path d="M2.2 4.8h11.6v8.5H2.2zM1.6 2.3h12.8v2.5H1.6z" />
+      <path d="M6 8h4" />
+    </>
+  ),
   check: <path d="m2.4 8.4 3.4 3.4 7.8-7.8" />,
   "chevron-down": <path d="m3.6 6 4.4 4.4L12.4 6" />,
   "chevron-right": <path d="m6 3.6 4.4 4.4L6 12.4" />,
@@ -84,6 +92,12 @@ const paths: Record<IconName, ReactNode> = {
     <>
       <path d="M8 2.1a4.4 4.4 0 0 0-2.7 7.9c.5.4.8.9.8 1.5h3.8c0-.6.3-1.1.8-1.5A4.4 4.4 0 0 0 8 2.1Z" />
       <path d="M6.5 13.8h3M6.2 11.5h3.6" />
+    </>
+  ),
+  restore: (
+    <>
+      <path d="M3.1 5.6A5.4 5.4 0 1 1 2.8 10" />
+      <path d="M2.8 2.5v3.7h3.7" />
     </>
   ),
   settings: (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -370,12 +370,115 @@ a:focus-visible {
   display: grid;
   align-content: center;
   gap: 7px;
-  padding: 10px 10px 10px 12px;
+  padding: 10px 46px 10px 12px;
   border: 1px solid transparent;
   border-radius: 10px;
   background: transparent;
   text-align: left;
   transition: background 160ms ease;
+}
+.thread-row-shell {
+  position: relative;
+  min-width: 0;
+}
+.thread-menu-trigger {
+  position: absolute;
+  z-index: 2;
+  top: 12px;
+  right: 5px;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-3);
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+.thread-menu-trigger:hover,
+.thread-menu-trigger[aria-expanded="true"] {
+  color: var(--text);
+  background: var(--surface-3);
+}
+.thread-item-menu {
+  position: absolute;
+  z-index: 30;
+  top: 50px;
+  right: 5px;
+  width: min(210px, calc(100% - 10px));
+  display: grid;
+  gap: 3px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: #181a20;
+  box-shadow: 0 14px 36px rgb(0 0 0 / 45%);
+}
+.thread-item-menu > button {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-2);
+  font-size: 11px;
+  text-align: left;
+}
+.thread-item-menu > button:hover:not(:disabled) {
+  background: var(--surface-3);
+  color: var(--text);
+}
+.thread-item-menu > p,
+.thread-menu-help {
+  margin: 3px 6px;
+  color: var(--text-3);
+  font-size: 9px;
+  line-height: 1.45;
+}
+.thread-item-menu > p[role="alert"] {
+  color: var(--danger);
+}
+.thread-menu-rename {
+  display: grid;
+  gap: 7px;
+  padding: 3px;
+}
+.thread-menu-rename label {
+  display: grid;
+  gap: 5px;
+  color: var(--text-3);
+  font-size: 9px;
+}
+.thread-menu-rename input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #101116;
+  color: var(--text);
+}
+.thread-menu-rename > div {
+  display: flex;
+  justify-content: flex-end;
+  gap: 5px;
+}
+.thread-menu-rename button {
+  min-height: 30px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 6px;
+  background: var(--surface-3);
+  color: var(--text-2);
+  font-size: 10px;
 }
 .thread-row:hover {
   background: rgb(255 255 255 / 3.5%);
@@ -518,6 +621,16 @@ a:focus-visible {
   border-bottom: 1px solid var(--border-soft);
   background: rgb(13 14 17 / 92%);
 }
+.workspace-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+.workspace-heading-row {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
 .mobile-menu {
   display: none;
 }
@@ -590,6 +703,13 @@ a:focus-visible {
 .page-header-actions {
   flex: 0 0 auto;
   gap: 4px;
+}
+.top-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: nowrap;
+  margin-left: auto;
 }
 .thread-lifecycle-control {
   position: relative;
@@ -2175,6 +2295,11 @@ a:focus-visible {
   }
   .thread-scope-tabs button,
   .sidebar-error button {
+    min-height: 44px;
+  }
+  .thread-menu-trigger,
+  .thread-item-menu > button {
+    min-width: 44px;
     min-height: 44px;
   }
   .thread-lifecycle-action {

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -261,6 +261,32 @@ a:focus-visible {
 .sidebar-view-head span {
   font-size: 10px;
 }
+.thread-scope-tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3px;
+  margin-top: 8px;
+  padding: 3px;
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+  background: #0d0f13;
+}
+.thread-scope-tabs button {
+  min-height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 11px;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+.thread-scope-tabs button:hover,
+.thread-scope-tabs button[aria-selected="true"] {
+  color: var(--text);
+  background: var(--surface-2);
+}
 .sidebar-scroll {
   min-height: 0;
   flex: 1;
@@ -275,6 +301,19 @@ a:focus-visible {
   color: var(--text-3);
   font-size: 11px;
   line-height: 1.55;
+}
+.sidebar-error p {
+  margin: 0 0 10px;
+  color: var(--danger);
+}
+.sidebar-error button {
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface-2);
+  color: var(--text-2);
+  font-size: 11px;
 }
 .project-group + .project-group,
 .inbox-group + .inbox-group {
@@ -515,12 +554,13 @@ a:focus-visible {
   border: 0;
   border-radius: 5px;
   background: transparent;
-  color: transparent;
+  color: var(--text-3);
   font-size: 9px;
 }
-.thread-title-line:hover button,
+.thread-title-line button:hover,
 .thread-title-line button:focus-visible {
-  color: var(--text-3);
+  color: var(--text);
+  background: var(--surface-2);
 }
 .thread-title-line small {
   color: var(--text-3);
@@ -550,6 +590,47 @@ a:focus-visible {
 .page-header-actions {
   flex: 0 0 auto;
   gap: 4px;
+}
+.thread-lifecycle-control {
+  position: relative;
+}
+.thread-lifecycle-action {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 11px;
+  transition:
+    color 160ms ease,
+    border-color 160ms ease,
+    background 160ms ease;
+}
+.thread-lifecycle-action:hover:not(:disabled),
+.thread-lifecycle-action:focus-visible {
+  border-color: var(--border);
+  background: var(--surface-2);
+  color: var(--text);
+}
+.thread-action-error {
+  position: absolute;
+  top: calc(100% + 7px);
+  right: 0;
+  z-index: 10;
+  width: max-content;
+  max-width: min(320px, 70vw);
+  padding: 8px 10px;
+  border: 1px solid rgb(239 135 127 / 35%);
+  border-radius: 8px;
+  background: #211619;
+  box-shadow: 0 10px 28px rgb(0 0 0 / 35%);
+  color: var(--danger);
+  font-size: 10px;
+  line-height: 1.4;
 }
 
 .thread-view {
@@ -2091,6 +2172,23 @@ a:focus-visible {
   .icon-button {
     width: 44px;
     height: 44px;
+  }
+  .thread-scope-tabs button,
+  .sidebar-error button {
+    min-height: 44px;
+  }
+  .thread-lifecycle-action {
+    width: 44px;
+    height: 44px;
+    justify-content: center;
+    padding: 0;
+  }
+  .thread-lifecycle-action > span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
   }
   .search-thread {
     display: none;

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -1,4 +1,5 @@
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
+import type { Thread } from "../../protocol-client/index.js";
 
 export type SidebarMode = "inbox" | "projects";
 export type ThreadScope = "active" | "archived";
@@ -53,6 +54,18 @@ export function writeThreadScope(
   scope: ThreadScope,
 ): void {
   storage.setItem("zenx-thread-scope", scope);
+}
+
+export function threadHasActiveTurn(
+  thread: NativeThreadSummary,
+  liveThread: Thread | null,
+): boolean {
+  if (thread.status === "active") return true;
+  if (liveThread?.id !== thread.threadId) return false;
+  return (
+    liveThread.status.type === "active" ||
+    liveThread.turns.some((turn) => turn.status === "inProgress")
+  );
 }
 
 export function deriveInboxSections(

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -1,6 +1,7 @@
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 
 export type SidebarMode = "inbox" | "projects";
+export type ThreadScope = "active" | "archived";
 
 interface SidebarStorage {
   getItem(key: string): string | null;
@@ -37,6 +38,21 @@ export function writeSidebarMode(
   mode: SidebarMode,
 ): void {
   storage.setItem("zenx-sidebar-mode", mode);
+}
+
+export function readThreadScope(
+  storage: Pick<SidebarStorage, "getItem">,
+): ThreadScope {
+  return storage.getItem("zenx-thread-scope") === "archived"
+    ? "archived"
+    : "active";
+}
+
+export function writeThreadScope(
+  storage: Pick<SidebarStorage, "setItem">,
+  scope: ThreadScope,
+): void {
+  storage.setItem("zenx-thread-scope", scope);
 }
 
 export function deriveInboxSections(

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -71,10 +71,22 @@ test("hosts a real App Server and removes its private token on shutdown", async 
     });
     await manager.request("thread/archive", { threadId: started.thread.id });
     assert.deepEqual(await manager.listThreadSummaries(), []);
+    const archived = await manager.listThreadSummaries({ archived: true });
+    assert.equal(archived[0]?.threadId, started.thread.id);
+    await manager.request("thread/name/set", {
+      threadId: started.thread.id,
+      name: "Managed Thread",
+    });
     assert.equal(
-      (await manager.listThreadSummaries({ archived: true }))[0]?.threadId,
+      (await manager.listThreadSummaries({ archived: true }))[0]?.name,
+      "Managed Thread",
+    );
+    await manager.request("thread/unarchive", { threadId: started.thread.id });
+    assert.equal(
+      (await manager.listThreadSummaries())[0]?.threadId,
       started.thread.id,
     );
+    assert.deepEqual(await manager.listThreadSummaries({ archived: true }), []);
     if (process.platform !== "win32") {
       assert.equal((await stat(tokenFile)).mode & 0o777, 0o600);
     }

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -5,10 +5,12 @@ import type { NativeThreadSummary } from "../../../src/thread-summary.js";
 import {
   deriveInboxSections,
   deriveProjectGroups,
+  readThreadScope,
   readSidebarMode,
   threadModelIdentity,
   threadPreview,
   threadTitle,
+  writeThreadScope,
   writeSidebarMode,
 } from "../src/renderer/src/thread-list.js";
 
@@ -23,6 +25,19 @@ test("persists the selected sidebar mode and defaults invalid values to projects
   assert.equal(readSidebarMode(storage), "inbox");
   values.set("zenx-sidebar-mode", "unexpected");
   assert.equal(readSidebarMode(storage), "projects");
+});
+
+test("persists Active or Archived without accepting unknown Thread scopes", () => {
+  const values = new Map<string, string>();
+  const storage = {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+  };
+  assert.equal(readThreadScope(storage), "active");
+  writeThreadScope(storage, "archived");
+  assert.equal(readThreadScope(storage), "archived");
+  values.set("zenx-thread-scope", "deleted");
+  assert.equal(readThreadScope(storage), "active");
 });
 
 test("derives inbox groups from native summary status", () => {

--- a/apps/zenx/test/thread-management-component.test.ts
+++ b/apps/zenx/test/thread-management-component.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import test from "node:test";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import { ThreadLifecycleAction } from "../src/renderer/src/ThreadLifecycleAction.js";
+import { Sidebar } from "../src/renderer/src/Sidebar.js";
+
+const noop = () => undefined;
+
+test("sidebar exposes distinct Active and Archived Thread views", () => {
+  const active = renderSidebar("active", [summary(false)]);
+  assert.match(active, /role="tablist" aria-label="Thread views"/u);
+  assert.match(active, />Active</u);
+  assert.match(active, />Archived</u);
+  assert.match(active, /aria-selected="true"[^>]*>Active/u);
+
+  const archived = renderSidebar("archived", []);
+  assert.match(archived, /aria-selected="true"[^>]*>Archived/u);
+  assert.match(archived, /No archived Threads yet/u);
+});
+
+test("sidebar announces Thread query failures with a retry action", () => {
+  const html = renderSidebar("archived", [], {
+    error: "summary projection unavailable",
+  });
+  assert.match(html, /role="alert"/u);
+  assert.match(html, /summary projection unavailable/u);
+  assert.match(html, />Try again</u);
+});
+
+test("sidebar announces which Thread view is loading", () => {
+  const html = renderSidebar("archived", [], { loading: true });
+  assert.match(html, /role="status"/u);
+  assert.match(html, /Loading archived Threads…/u);
+});
+
+test("Thread lifecycle action is reversible and honest about active Turns", () => {
+  const idle = renderToStaticMarkup(
+    createElement(ThreadLifecycleAction, {
+      archived: false,
+      busy: false,
+      hasActiveTurn: false,
+      onChange: async () => undefined,
+    }),
+  );
+  assert.match(idle, />Archive</u);
+
+  const running = renderToStaticMarkup(
+    createElement(ThreadLifecycleAction, {
+      archived: false,
+      busy: false,
+      hasActiveTurn: true,
+      onChange: async () => undefined,
+    }),
+  );
+  assert.match(running, /disabled=""/u);
+  assert.match(running, /Wait for the active Turn to finish before archiving/u);
+
+  const archived = renderToStaticMarkup(
+    createElement(ThreadLifecycleAction, {
+      archived: true,
+      busy: true,
+      hasActiveTurn: false,
+      onChange: async () => undefined,
+    }),
+  );
+  assert.match(archived, />Unarchiving…</u);
+  assert.doesNotMatch(archived, />Delete</u);
+});
+
+function renderSidebar(
+  scope: "active" | "archived",
+  threads: NativeThreadSummary[],
+  state: { error?: string; loading?: boolean } = {},
+): string {
+  return renderToStaticMarkup(
+    createElement(Sidebar, {
+      mode: "projects",
+      open: true,
+      onClose: noop,
+      onModeChange: noop,
+      onNewThread: noop,
+      onOpenContribution: noop,
+      onOpenSettings: noop,
+      onRetryThreads: noop,
+      onSelectThread: noop,
+      onThreadScopeChange: noop,
+      pendingApprovalThreadIds: new Set<string>(),
+      pluginContributions: [],
+      selectedPage: "agent",
+      selectedThreadId: null,
+      serverReady: true,
+      threadError: state.error ?? null,
+      threadLoading: state.loading ?? false,
+      threadScope: scope,
+      threads,
+      triggerSnapshot: { triggers: [], history: [], rooms: [] },
+    }),
+  );
+}
+
+function summary(archived: boolean): NativeThreadSummary {
+  return {
+    threadId: archived ? "archived-thread" : "active-thread",
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    preview: "Thread preview",
+    status: "idle",
+  };
+}

--- a/apps/zenx/test/thread-management-component.test.ts
+++ b/apps/zenx/test/thread-management-component.test.ts
@@ -5,7 +5,7 @@ import test from "node:test";
 
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
 import { ThreadLifecycleAction } from "../src/renderer/src/ThreadLifecycleAction.js";
-import { Sidebar } from "../src/renderer/src/Sidebar.js";
+import { Sidebar, ThreadItemMenu } from "../src/renderer/src/Sidebar.js";
 
 const noop = () => undefined;
 
@@ -15,6 +15,7 @@ test("sidebar exposes distinct Active and Archived Thread views", () => {
   assert.match(active, />Active</u);
   assert.match(active, />Archived</u);
   assert.match(active, /aria-selected="true"[^>]*>Active/u);
+  assert.match(active, /aria-haspopup="menu"/u);
 
   const archived = renderSidebar("archived", []);
   assert.match(archived, /aria-selected="true"[^>]*>Archived/u);
@@ -70,6 +71,56 @@ test("Thread lifecycle action is reversible and honest about active Turns", () =
   assert.doesNotMatch(archived, />Delete</u);
 });
 
+test("active Thread menu offers Rename and a safely disabled Archive", () => {
+  const html = renderToStaticMarkup(
+    createElement(ThreadItemMenu, {
+      archived: false,
+      busyAction: null,
+      error: null,
+      hasActiveTurn: true,
+      open: true,
+      renaming: false,
+      renameDraft: "Active Thread",
+      onArchive: noop,
+      onBeginRename: noop,
+      onCancelRename: noop,
+      onDraftChange: noop,
+      onRename: noop,
+      onUnarchive: noop,
+    }),
+  );
+  assert.match(html, /role="menu"/u);
+  assert.match(html, />Rename</u);
+  assert.match(
+    html,
+    /role="menuitem" disabled=""[^>]*>[\s\S]*?Archive<\/button>/u,
+  );
+  assert.match(html, /Wait for the active Turn to finish before archiving/u);
+});
+
+test("archived Thread menu offers Unarchive without inventing Delete", () => {
+  const html = renderToStaticMarkup(
+    createElement(ThreadItemMenu, {
+      archived: true,
+      busyAction: "unarchive",
+      error: null,
+      hasActiveTurn: false,
+      open: true,
+      renaming: false,
+      renameDraft: "Archived Thread",
+      onArchive: noop,
+      onBeginRename: noop,
+      onCancelRename: noop,
+      onDraftChange: noop,
+      onRename: noop,
+      onUnarchive: noop,
+    }),
+  );
+  assert.match(html, />Unarchiving…</u);
+  assert.doesNotMatch(html, />Delete</u);
+  assert.doesNotMatch(html, />Rename</u);
+});
+
 function renderSidebar(
   scope: "active" | "archived",
   threads: NativeThreadSummary[],
@@ -78,12 +129,15 @@ function renderSidebar(
   return renderToStaticMarkup(
     createElement(Sidebar, {
       mode: "projects",
+      liveThread: null,
       open: true,
       onClose: noop,
       onModeChange: noop,
       onNewThread: noop,
       onOpenContribution: noop,
       onOpenSettings: noop,
+      onChangeThreadLifecycle: async () => undefined,
+      onRenameThread: async () => undefined,
       onRetryThreads: noop,
       onSelectThread: noop,
       onThreadScopeChange: noop,

--- a/apps/zenx/test/thread-management-component.test.ts
+++ b/apps/zenx/test/thread-management-component.test.ts
@@ -93,7 +93,7 @@ test("active Thread menu offers Rename and a safely disabled Archive", () => {
   assert.match(html, />Rename</u);
   assert.match(
     html,
-    /role="menuitem" disabled=""[^>]*>[\s\S]*?Archive<\/button>/u,
+    /role="menuitem"[^>]*disabled=""[^>]*>[\s\S]*?Archive<\/button>/u,
   );
   assert.match(html, /Wait for the active Turn to finish before archiving/u);
 });

--- a/apps/zenx/test/thread-menu-interaction.test.ts
+++ b/apps/zenx/test/thread-menu-interaction.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import { act, createElement, useState } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import { Sidebar } from "../src/renderer/src/Sidebar.js";
+
+const noop = () => undefined;
+
+test("Thread menu manages keyboard focus through close and row removal", async () => {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><main id=outside></main><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previousGlobals = {
+    document: globalThis.document,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    window: globalThis.window,
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+
+  try {
+    await act(async () => root.render(createElement(TestSidebar)));
+    const trigger = requiredElement<HTMLButtonElement>(".thread-menu-trigger");
+
+    await act(async () => trigger.click());
+    assert.equal(document.activeElement?.textContent?.trim(), "Rename");
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "ArrowDown",
+        }),
+      );
+    });
+    assert.equal(document.activeElement?.textContent?.trim(), "Archive");
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "Home",
+        }),
+      );
+    });
+    assert.equal(document.activeElement?.textContent?.trim(), "Rename");
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "End",
+        }),
+      );
+    });
+    assert.equal(document.activeElement?.textContent?.trim(), "Archive");
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "ArrowUp",
+        }),
+      );
+    });
+    assert.equal(document.activeElement?.textContent?.trim(), "Rename");
+
+    await act(async () => {
+      document.activeElement?.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "Escape",
+        }),
+      );
+      await Promise.resolve();
+    });
+    assert.equal(document.activeElement, trigger);
+    assert.equal(document.querySelector('[role="menu"]'), null);
+
+    await act(async () => trigger.click());
+    await act(async () => {
+      document
+        .getElementById("outside")
+        ?.dispatchEvent(new dom.window.Event("pointerdown", { bubbles: true }));
+      await Promise.resolve();
+    });
+    assert.equal(document.activeElement, trigger);
+    assert.equal(document.querySelector('[role="menu"]'), null);
+
+    await act(async () => trigger.click());
+    const archive = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+    ).find((item) => item.textContent?.includes("Archive"));
+    assert.ok(archive);
+    await act(async () => {
+      archive.click();
+      await Promise.resolve();
+    });
+    assert.equal(document.querySelector(".thread-row-shell"), null);
+    assert.equal(
+      document.activeElement,
+      document.getElementById("thread-scope-active"),
+    );
+  } finally {
+    await act(async () => root.unmount());
+    Object.assign(globalThis, previousGlobals, {
+      IS_REACT_ACT_ENVIRONMENT: undefined,
+    });
+    dom.window.close();
+  }
+});
+
+function TestSidebar() {
+  const [threads, setThreads] = useState<NativeThreadSummary[]>([
+    activeSummary(),
+  ]);
+  return createElement(Sidebar, {
+    mode: "projects",
+    liveThread: null,
+    open: true,
+    onClose: noop,
+    onModeChange: noop,
+    onNewThread: noop,
+    onOpenContribution: noop,
+    onOpenSettings: noop,
+    onChangeThreadLifecycle: async () => setThreads([]),
+    onRenameThread: async () => undefined,
+    onRetryThreads: noop,
+    onSelectThread: noop,
+    onThreadScopeChange: noop,
+    pendingApprovalThreadIds: new Set<string>(),
+    pluginContributions: [],
+    selectedPage: "agent",
+    selectedThreadId: null,
+    serverReady: true,
+    threadError: null,
+    threadLoading: false,
+    threadScope: "active",
+    threads,
+    triggerSnapshot: { triggers: [], history: [], rooms: [] },
+  });
+}
+
+function requiredElement<T extends Element>(selector: string): T {
+  const element = document.querySelector<T>(selector);
+  assert.ok(element, `Expected ${selector}`);
+  return element;
+}
+
+function activeSummary(): NativeThreadSummary {
+  return {
+    threadId: "active-thread",
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: false,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    preview: "Thread preview",
+    status: "idle",
+  };
+}

--- a/apps/zenx/test/thread-view-state.test.ts
+++ b/apps/zenx/test/thread-view-state.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { Thread, ThreadItem, Turn } from "../src/protocol-client/index.js";
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import { threadHasActiveTurn } from "../src/renderer/src/thread-list.js";
 import {
   activeTurn,
   applyThreadViewNotification,
@@ -113,6 +115,32 @@ test("projects hard steer as an interrupted turn followed by one successor", () 
     ],
   );
   assert.equal(activeTurn(current)?.id, "turn-new");
+});
+
+test("blocks Thread lifecycle changes from live turn state before summary refresh", () => {
+  const staleSummary: NativeThreadSummary = {
+    threadId: "thread-1",
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/workspace",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: false,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    preview: "",
+    status: "idle",
+  };
+  const live = applyThreadViewNotification(thread(), "turn/started", {
+    threadId: "thread-1",
+    turn: turn("turn-live", "inProgress"),
+  });
+
+  assert.equal(staleSummary.status, "idle");
+  assert.equal(threadHasActiveTurn(staleSummary, live), true);
+  assert.equal(threadHasActiveTurn(staleSummary, thread()), false);
 });
 
 function thread(turns: Turn[] = []): Thread {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,15 +37,70 @@
       },
       "devDependencies": {
         "@electron/packager": "^20.3.0",
+        "@types/jsdom": "^30.0.0",
         "@types/node": "^24.0.0",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
         "@vitejs/plugin-react": "^5.2.0",
         "electron": "^43.2.0",
         "electron-vite": "^5.0.0",
+        "jsdom": "^30.0.1",
         "tsx": "^4.20.6",
         "typescript": "^5.9.2",
         "vite": "^7.3.6"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -344,6 +399,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.0.tgz",
+      "integrity": "sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.8.tgz",
+      "integrity": "sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -977,6 +1185,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1518,6 +1744,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-30.0.0.tgz",
+      "integrity": "sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^8.0.0",
+        "undici-types": "^8.9.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.10.0.tgz",
+      "integrity": "sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
@@ -1547,6 +1793,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -1635,6 +1888,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1747,12 +2010,55 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1771,6 +2077,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron": {
       "version": "43.2.0",
@@ -1826,6 +2139,19 @@
         "@swc/core": {
           "optional": true
         }
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -2024,6 +2350,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -2050,6 +2396,67 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2109,6 +2516,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "10.2.6",
@@ -2170,6 +2584,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-key": {
@@ -2344,6 +2771,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
@@ -2369,6 +2806,16 @@
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
       "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2449,6 +2896,19 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2511,6 +2971,13 @@
         "node": ">= 8.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2526,6 +2993,52 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tsx": {
@@ -3651,6 +4164,54 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3688,6 +4249,16 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -3697,6 +4268,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",


### PR DESCRIPTION
## What changed

- added explicit Active and Archived Thread views to the high-fidelity ZenX Sidebar
- added visible Rename and reversible Archive/Unarchive controls with loading, empty, retry, error, and active-Turn states
- added a three-dot menu to every Sidebar Thread item: active items expose Rename/Archive and archived items expose Unarchive
- completed the menu keyboard contract with initial focus, Arrow/Home/End navigation, Escape/outside focus restoration, and stable focus when lifecycle operations remove a row
- merged native `ThreadSummary.status` with the selected Thread's live Turn projection so Archive is disabled before an asynchronous summary refresh completes
- kept the Thread title and right-aligned search/workspace/lifecycle controls in one responsive header row
- kept Thread reads on the native ZAS `ThreadSummary` query and lifecycle mutations on existing App Server methods
- documented the renderer behavior and the no-permanent-delete boundary
- added focused renderer/state coverage and extended the real hosted App Server integration through rename → archive → unarchive

## Why

ZenX exposed active Thread summaries and resume, but ordinary users had no complete UI path to inspect archived Threads or manage the Thread lifecycle. This closes that vertical slice without reading journals in the renderer or introducing another Thread state model.

R1 also found a real timing gap: `turn/started` updates the live selected Thread before the two summary queries finish. The lifecycle gate now treats either projection as active, so a stale idle summary cannot enable Archive.

## User impact

Users can switch between Active and Archived, rename active Threads, archive idle Threads, and unarchive archived Threads from either the header or each Thread's three-dot menu. Archive is disabled with a visible explanation while a Turn is active, so the operation does not hide or modify running work.

## Delete decision required

The pinned App Server subset has no canonical `thread/delete` or `thread/remove` API. This PR therefore does not show a fake Delete action and never removes journal files directly. Permanent deletion requires an explicit product and App Server API decision before it can be implemented safely. Pin/Unpin navigation semantics and permanent Delete remain follow-up product/API work tracked in #91.

## Validation

Passed on head `dd98ba6652ce3ace64c9656764f384f63859e29f`:

- focused renderer/state/host tests: 26/26
- `npm run typecheck --workspace @zen/zenx`
- `npm run build --workspace @zen/zenx`
- Prettier check and `git diff --check`

A real Electron visual launch was attempted for the screenshot-derived header acceptance, but this worktree's installed Electron package reports `Electron uninstall`; production build and responsive component/CSS checks remain green.

Known baseline/environment failure:

- `test/thread-view-integration.test.ts` streamed-shell case expects a completed `printf` command but receives `failed` on this Windows environment; it reproduces alone, and this PR does not modify that test or shell/runtime path. The steer/replace case in the same file passes.
