### PR TITLE
Fix ZenX prototype Prettier baseline

### DIFF
--- a/apps/zenx/prototypes/high-fidelity/zenx-high-fidelity-implementation-notes.md
+++ b/apps/zenx/prototypes/high-fidelity/zenx-high-fidelity-implementation-notes.md
@@ -35,12 +35,12 @@ Thread
 
 ## 3. Turn 状态投影
 
-| Turn 状态 | 默认展示 | Turn 级交互 | Agent Message |
-| --- | --- | --- | --- |
-| Running / incomplete | 完整展开历史 | 不允许整体收起 | 正常显示全部中间消息 |
-| Completed，默认 | 只显示 Final Message | 可主动展开 | 隐藏中间消息，只保留 Final |
-| Completed，用户已展开 | 历史 Items + Final Message | 可再次收起 | 中间消息恢复显示，Final 仍只出现一次 |
-| Interrupted / failed | 建议按完成态投影 | 可展开历史 | 保留明确的终止或错误结果 |
+| Turn 状态             | 默认展示                   | Turn 级交互    | Agent Message                        |
+| --------------------- | -------------------------- | -------------- | ------------------------------------ |
+| Running / incomplete  | 完整展开历史               | 不允许整体收起 | 正常显示全部中间消息                 |
+| Completed，默认       | 只显示 Final Message       | 可主动展开     | 隐藏中间消息，只保留 Final           |
+| Completed，用户已展开 | 历史 Items + Final Message | 可再次收起     | 中间消息恢复显示，Final 仍只出现一次 |
+| Interrupted / failed  | 建议按完成态投影           | 可展开历史     | 保留明确的终止或错误结果             |
 
 实现注意点：
 
@@ -63,13 +63,13 @@ Thread
 ```ts
 for (const item of turn.items) {
   if (item.kind === "thinking" || item.kind === "tool_call") {
-    appendToCurrentTraceGroup(item)
+    appendToCurrentTraceGroup(item);
   } else {
-    flushCurrentTraceGroup()
-    appendStandaloneItem(item)
+    flushCurrentTraceGroup();
+    appendStandaloneItem(item);
   }
 }
-flushCurrentTraceGroup()
+flushCurrentTraceGroup();
 ```
 
 Trace Group 摘要应由可读的行为概括和数量组成，例如“检查协议 Item 与投影约束 · 6 items”，而不是暴露内部事件名或原始 payload。
@@ -104,12 +104,12 @@ Trace Group 摘要应由可读的行为概括和数量组成，例如“检查�
 
 Composer 几何尺寸在运行和空闲状态之间保持稳定，只改变主要动作的语义。
 
-| Run 状态 | Draft | 主动作 |
-| --- | --- | --- |
-| Running | Empty | Stop |
-| Running | Non-empty | Interrupt & Send |
-| Idle | Non-empty | Send |
-| Idle | Empty | Send disabled |
+| Run 状态 | Draft     | 主动作           |
+| -------- | --------- | ---------------- |
+| Running  | Empty     | Stop             |
+| Running  | Non-empty | Interrupt & Send |
+| Idle     | Non-empty | Send             |
+| Idle     | Empty     | Send disabled    |
 
 实现注意点：
 
@@ -215,13 +215,13 @@ ThreadView
 
 当前产品原型包含以下一级或独立工作空间：
 
-| 产品面 | 现有应用依据 | 高保真原型中的投影 |
-| --- | --- | --- |
-| Agent / Thread | `ThreadView`、Composer、审批、模型切换 | 默认主页面，Projects/Inbox + Chat 两栏 |
-| Settings | `SettingsView` | Account、Models & Provider、Plugins、General 四个分区；插件统一在这里启停 |
-| Triggers plugin | `ScheduledView`、`TriggerRail` | 插件启用后贡献 Sidebar 入口；页面展示 Trigger、唤醒历史和开发信号模拟器 |
-| Rooms plugin | `RoomView` | 插件启用后贡献 Sidebar 入口；页面包含成员、消息、Source Thread 跳转和 Room Composer |
-| Plugin marketplace | Capability Registry、local package discovery | 代码保留但不进入当前评审主路径；当前只验证已安装插件的管理与贡献机制 |
+| 产品面             | 现有应用依据                                 | 高保真原型中的投影                                                                  |
+| ------------------ | -------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Agent / Thread     | `ThreadView`、Composer、审批、模型切换       | 默认主页面，Projects/Inbox + Chat 两栏                                              |
+| Settings           | `SettingsView`                               | Account、Models & Provider、Plugins、General 四个分区；插件统一在这里启停           |
+| Triggers plugin    | `ScheduledView`、`TriggerRail`               | 插件启用后贡献 Sidebar 入口；页面展示 Trigger、唤醒历史和开发信号模拟器             |
+| Rooms plugin       | `RoomView`                                   | 插件启用后贡献 Sidebar 入口；页面包含成员、消息、Source Thread 跳转和 Room Composer |
+| Plugin marketplace | Capability Registry、local package discovery | 代码保留但不进入当前评审主路径；当前只验证已安装插件的管理与贡献机制                |
 
 导航规则：
 
@@ -274,17 +274,17 @@ ThreadView
 
 ```ts
 type PluginManifest = {
-  id: string
+  id: string;
   contributions?: {
     sidebar?: Array<{
-      id: string
-      label: string
-      icon: string
-      route: string
-      order?: number
-    }>
-  }
-}
+      id: string;
+      label: string;
+      icon: string;
+      route: string;
+      order?: number;
+    }>;
+  };
+};
 ```
 
 ### Triggers plugin

--- a/apps/zenx/prototypes/high-fidelity/zenx-high-fidelity-prototype.html
+++ b/apps/zenx/prototypes/high-fidelity/zenx-high-fidelity-prototype.html
@@ -26,7 +26,13 @@
       height: min(900px, 100dvh);
       min-height: 620px;
       color: var(--zx-text);
-      font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-family:
+        Inter,
+        ui-sans-serif,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
       color-scheme: dark;
       box-sizing: border-box;
       background: transparent;
@@ -162,7 +168,7 @@
       border: 1px solid #3a3e49;
       border-radius: 9px;
       background: linear-gradient(145deg, #20232a, #121419);
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.05);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
     }
 
     #zenx-hifi-prototype .zx-brand-mark svg {
@@ -194,7 +200,10 @@
       border: 0;
       color: var(--zx-text-3);
       background: transparent;
-      transition: color 160ms ease, background 160ms ease, border-color 160ms ease;
+      transition:
+        color 160ms ease,
+        background 160ms ease,
+        border-color 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-icon-button {
@@ -275,7 +284,7 @@
 
     #zenx-hifi-prototype .zx-project-head:hover {
       color: var(--zx-text-2);
-      background: rgba(255,255,255,0.025);
+      background: rgba(255, 255, 255, 0.025);
     }
 
     #zenx-hifi-prototype .zx-project-label {
@@ -298,7 +307,9 @@
       transition: transform 180ms ease;
     }
 
-    #zenx-hifi-prototype .zx-project-head[aria-expanded="false"] .zx-project-chevron {
+    #zenx-hifi-prototype
+      .zx-project-head[aria-expanded="false"]
+      .zx-project-chevron {
       transform: rotate(-90deg);
     }
 
@@ -321,11 +332,13 @@
       border-radius: 10px;
       background: transparent;
       text-align: left;
-      transition: background 160ms ease, border-color 160ms ease;
+      transition:
+        background 160ms ease,
+        border-color 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-thread:hover {
-      background: rgba(255,255,255,0.035);
+      background: rgba(255, 255, 255, 0.035);
     }
 
     #zenx-hifi-prototype .zx-thread[aria-current="page"] {
@@ -370,10 +383,12 @@
       border-radius: 50%;
     }
 
-    #zenx-hifi-prototype .zx-needs-dot { background: var(--zx-warn); }
+    #zenx-hifi-prototype .zx-needs-dot {
+      background: var(--zx-warn);
+    }
     #zenx-hifi-prototype .zx-live-dot {
       background: var(--zx-good);
-      box-shadow: 0 0 0 4px rgba(115,210,173,0.10);
+      box-shadow: 0 0 0 4px rgba(115, 210, 173, 0.1);
     }
 
     #zenx-hifi-prototype .zx-model-line,
@@ -403,9 +418,18 @@
       height: 13px;
     }
 
-    #zenx-hifi-prototype .zx-logo-openai { background: #26342f; color: #d7e9e1; }
-    #zenx-hifi-prototype .zx-logo-qwen { background: #2f2948; color: #cbbcff; }
-    #zenx-hifi-prototype .zx-logo-deepseek { background: #272f47; color: #aabfff; }
+    #zenx-hifi-prototype .zx-logo-openai {
+      background: #26342f;
+      color: #d7e9e1;
+    }
+    #zenx-hifi-prototype .zx-logo-qwen {
+      background: #2f2948;
+      color: #cbbcff;
+    }
+    #zenx-hifi-prototype .zx-logo-deepseek {
+      background: #272f47;
+      color: #aabfff;
+    }
 
     #zenx-hifi-prototype .zx-inbox-group-title {
       display: flex;
@@ -464,7 +488,7 @@
       color: var(--zx-text-3);
       font-size: 9px;
       font-weight: 500;
-      letter-spacing: .12em;
+      letter-spacing: 0.12em;
       text-transform: uppercase;
     }
 
@@ -483,7 +507,9 @@
       color: var(--zx-text-3);
       font-size: 12px;
       text-align: left;
-      transition: color 160ms ease, background 160ms ease;
+      transition:
+        color 160ms ease,
+        background 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-global-link:hover,
@@ -546,7 +572,11 @@
       display: grid;
       grid-template-rows: 60px minmax(0, 1fr) auto;
       background:
-        radial-gradient(900px 420px at 66% -180px, rgba(142,169,255,0.08), transparent 60%),
+        radial-gradient(
+          900px 420px at 66% -180px,
+          rgba(142, 169, 255, 0.08),
+          transparent 60%
+        ),
         var(--zx-main);
     }
 
@@ -556,7 +586,7 @@
       gap: 16px;
       padding: 0 14px 0 22px;
       border-bottom: 1px solid var(--zx-border-soft);
-      background: rgba(13,14,17,0.92);
+      background: rgba(13, 14, 17, 0.92);
     }
 
     #zenx-hifi-prototype .zx-mobile-menu {
@@ -636,7 +666,7 @@
       color: #e6e7e9;
       font-size: 14px;
       line-height: 1.55;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.025);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.025);
     }
 
     #zenx-hifi-prototype .zx-turn {
@@ -713,12 +743,14 @@
       border-radius: 8px;
       background: transparent;
       text-align: left;
-      transition: color 160ms ease, background 160ms ease;
+      transition:
+        color 160ms ease,
+        background 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-turn-toggle:hover {
       color: var(--zx-text-2);
-      background: rgba(255,255,255,0.025);
+      background: rgba(255, 255, 255, 0.025);
     }
 
     #zenx-hifi-prototype .zx-turn-toggle .zx-chevron {
@@ -733,8 +765,12 @@
 
     #zenx-hifi-prototype .zx-turn[data-turn-state="running"] .zx-turn-toggle,
     #zenx-hifi-prototype .zx-turn[data-turn-state="running"] .zx-turn-final,
-    #zenx-hifi-prototype .zx-turn[data-turn-state="complete"] .zx-turn-running-label,
-    #zenx-hifi-prototype .zx-turn[data-turn-state="complete"][data-expanded="false"] .zx-turn-history {
+    #zenx-hifi-prototype
+      .zx-turn[data-turn-state="complete"]
+      .zx-turn-running-label,
+    #zenx-hifi-prototype
+      .zx-turn[data-turn-state="complete"][data-expanded="false"]
+      .zx-turn-history {
       display: none;
     }
 
@@ -767,12 +803,14 @@
       background: transparent;
       color: var(--zx-text-3);
       text-align: left;
-      transition: background 160ms ease, color 160ms ease;
+      transition:
+        background 160ms ease,
+        color 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-trace-group-toggle:hover,
     #zenx-hifi-prototype .zx-trace-group-toggle:focus-visible {
-      background: rgba(255,255,255,0.025);
+      background: rgba(255, 255, 255, 0.025);
       color: var(--zx-text-2);
     }
 
@@ -805,7 +843,9 @@
       transition: transform 180ms ease;
     }
 
-    #zenx-hifi-prototype .zx-trace-group-toggle[aria-expanded="true"] .zx-trace-group-chevron {
+    #zenx-hifi-prototype
+      .zx-trace-group-toggle[aria-expanded="true"]
+      .zx-trace-group-chevron {
       transform: rotate(180deg);
     }
 
@@ -835,7 +875,7 @@
 
     #zenx-hifi-prototype .zx-turn-step:hover,
     #zenx-hifi-prototype .zx-turn-step:focus-visible {
-      background: rgba(255,255,255,0.025);
+      background: rgba(255, 255, 255, 0.025);
     }
 
     #zenx-hifi-prototype .zx-turn-step-icon {
@@ -886,7 +926,9 @@
       transition: transform 180ms ease;
     }
 
-    #zenx-hifi-prototype .zx-turn-step[aria-expanded="true"] .zx-turn-step-chevron {
+    #zenx-hifi-prototype
+      .zx-turn-step[aria-expanded="true"]
+      .zx-turn-step-chevron {
       transform: rotate(180deg);
     }
 
@@ -894,7 +936,7 @@
       margin: 0 6px 3px 23px;
       padding: 6px 8px;
       border-radius: 6px;
-      background: rgba(255,255,255,0.018);
+      background: rgba(255, 255, 255, 0.018);
       color: var(--zx-text-3);
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 10px;
@@ -940,7 +982,11 @@
       animation: zx-spin 850ms linear infinite;
     }
 
-    @keyframes zx-spin { to { transform: rotate(360deg); } }
+    @keyframes zx-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
 
     #zenx-hifi-prototype .zx-back-live {
       position: absolute;
@@ -956,7 +1002,7 @@
       border-radius: 18px;
       background: #1a1c21;
       color: var(--zx-text-2);
-      box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
       font-size: 11px;
     }
 
@@ -1001,7 +1047,11 @@
       z-index: 4;
       min-width: 0;
       padding: 0 max(18px, calc((100% - 840px) / 2)) 18px;
-      background: linear-gradient(180deg, rgba(13,14,17,0), var(--zx-main) 18%);
+      background: linear-gradient(
+        180deg,
+        rgba(13, 14, 17, 0),
+        var(--zx-main) 18%
+      );
     }
 
     #zenx-hifi-prototype .zx-approval {
@@ -1015,10 +1065,10 @@
       gap: 10px;
       margin: 0 auto 8px;
       padding: 8px 10px;
-      border: 1px solid rgba(224,178,102,0.28);
+      border: 1px solid rgba(224, 178, 102, 0.28);
       border-radius: 12px;
       background: #1a1815;
-      box-shadow: 0 12px 36px rgba(0,0,0,0.18);
+      box-shadow: 0 12px 36px rgba(0, 0, 0, 0.18);
     }
 
     #zenx-hifi-prototype .zx-approval-icon {
@@ -1028,7 +1078,7 @@
       place-items: center;
       border-radius: 8px;
       color: var(--zx-warn);
-      background: rgba(224,178,102,0.10);
+      background: rgba(224, 178, 102, 0.1);
     }
 
     #zenx-hifi-prototype .zx-approval-copy {
@@ -1064,16 +1114,18 @@
       background: transparent;
       color: var(--zx-text-2);
       font-size: 10px;
-      transition: background 160ms ease, border-color 160ms ease;
+      transition:
+        background 160ms ease,
+        border-color 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-approval-button:hover {
-      background: rgba(255,255,255,0.04);
+      background: rgba(255, 255, 255, 0.04);
     }
 
     #zenx-hifi-prototype .zx-approval-button.zx-allow {
-      border-color: rgba(224,178,102,0.42);
-      background: rgba(224,178,102,0.12);
+      border-color: rgba(224, 178, 102, 0.42);
+      background: rgba(224, 178, 102, 0.12);
       color: #f0d6aa;
     }
 
@@ -1086,13 +1138,19 @@
       border: 1px solid #30333b;
       border-radius: 16px;
       background: #16181d;
-      box-shadow: 0 18px 52px rgba(0,0,0,0.24), inset 0 1px 0 rgba(255,255,255,0.025);
-      transition: border-color 160ms ease, box-shadow 160ms ease;
+      box-shadow:
+        0 18px 52px rgba(0, 0, 0, 0.24),
+        inset 0 1px 0 rgba(255, 255, 255, 0.025);
+      transition:
+        border-color 160ms ease,
+        box-shadow 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-composer:focus-within {
       border-color: #485264;
-      box-shadow: 0 18px 52px rgba(0,0,0,0.24), 0 0 0 3px rgba(142,169,255,0.08);
+      box-shadow:
+        0 18px 52px rgba(0, 0, 0, 0.24),
+        0 0 0 3px rgba(142, 169, 255, 0.08);
     }
 
     #zenx-hifi-prototype .zx-composer textarea {
@@ -1141,7 +1199,9 @@
       color: var(--zx-text-3);
       font-size: 10px;
       white-space: nowrap;
-      transition: color 160ms ease, background 160ms ease;
+      transition:
+        color 160ms ease,
+        background 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-control-button:hover {
@@ -1173,7 +1233,9 @@
       background: transparent;
       color: #10131b;
       box-shadow: none;
-      transition: color 160ms ease, opacity 160ms ease;
+      transition:
+        color 160ms ease,
+        opacity 160ms ease;
     }
 
     #zenx-hifi-prototype .zx-action-orb::before {
@@ -1183,8 +1245,11 @@
       border: 1px solid #9eaff1;
       border-radius: 50%;
       background: #91a8f8;
-      box-shadow: inset 0 1px 0 rgba(255,255,255,0.32);
-      transition: background 160ms ease, border-color 160ms ease, transform 100ms ease;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.32);
+      transition:
+        background 160ms ease,
+        border-color 160ms ease,
+        transform 100ms ease;
     }
 
     #zenx-hifi-prototype .zx-action-orb:hover:not(:disabled)::before {
@@ -1210,23 +1275,33 @@
       color: #f18a90;
     }
 
-    #zenx-hifi-prototype .zx-app[data-action-mode="stop"] .zx-action-orb::before {
+    #zenx-hifi-prototype
+      .zx-app[data-action-mode="stop"]
+      .zx-action-orb::before {
       border-color: #40383a;
       background: #241c1e;
       box-shadow: none;
     }
 
-    #zenx-hifi-prototype .zx-app[data-action-mode="stop"] .zx-action-orb:hover::before {
+    #zenx-hifi-prototype
+      .zx-app[data-action-mode="stop"]
+      .zx-action-orb:hover::before {
       border-color: #584143;
       background: #2d2022;
     }
 
     #zenx-hifi-prototype .zx-action-orb .zx-action-stop,
-    #zenx-hifi-prototype .zx-app[data-action-mode="stop"] .zx-action-orb .zx-action-send {
+    #zenx-hifi-prototype
+      .zx-app[data-action-mode="stop"]
+      .zx-action-orb
+      .zx-action-send {
       display: none;
     }
 
-    #zenx-hifi-prototype .zx-app[data-action-mode="stop"] .zx-action-orb .zx-action-stop {
+    #zenx-hifi-prototype
+      .zx-app[data-action-mode="stop"]
+      .zx-action-orb
+      .zx-action-stop {
       display: block;
     }
 
@@ -1243,13 +1318,21 @@
       grid-row: 1 / -1;
       display: grid;
       grid-template-rows: 60px minmax(0, 1fr);
-      background: radial-gradient(760px 300px at 75% -140px, rgba(142,169,255,0.07), transparent 64%), var(--zx-main);
+      background:
+        radial-gradient(
+          760px 300px at 75% -140px,
+          rgba(142, 169, 255, 0.07),
+          transparent 64%
+        ),
+        var(--zx-main);
     }
 
     #zenx-hifi-prototype .zx-app[data-page="agent"] .zx-product-page,
     #zenx-hifi-prototype .zx-app:not([data-page="agent"]) .zx-topbar,
     #zenx-hifi-prototype .zx-app:not([data-page="agent"]) .zx-transcript-shell,
-    #zenx-hifi-prototype .zx-app:not([data-page="agent"]) .zx-bottom-zone { display: none; }
+    #zenx-hifi-prototype .zx-app:not([data-page="agent"]) .zx-bottom-zone {
+      display: none;
+    }
 
     #zenx-hifi-prototype .zx-page-header {
       min-width: 0;
@@ -1259,13 +1342,39 @@
       gap: 18px;
       padding: 0 22px;
       border-bottom: 1px solid var(--zx-border-soft);
-      background: rgba(13,14,17,0.92);
+      background: rgba(13, 14, 17, 0.92);
     }
 
-    #zenx-hifi-prototype .zx-page-title { min-width: 0; display: flex; align-items: center; gap: 12px; }
-    #zenx-hifi-prototype .zx-page-title > div { min-width: 0; display: grid; gap: 2px; }
-    #zenx-hifi-prototype .zx-page-title h1 { margin: 0; overflow: hidden; color: var(--zx-text); font-size: 15px; font-weight: 550; line-height: 1.2; text-overflow: ellipsis; white-space: nowrap; }
-    #zenx-hifi-prototype .zx-page-title p { margin: 0; overflow: hidden; color: var(--zx-text-3); font-size: 10px; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
+    #zenx-hifi-prototype .zx-page-title {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    #zenx-hifi-prototype .zx-page-title > div {
+      min-width: 0;
+      display: grid;
+      gap: 2px;
+    }
+    #zenx-hifi-prototype .zx-page-title h1 {
+      margin: 0;
+      overflow: hidden;
+      color: var(--zx-text);
+      font-size: 15px;
+      font-weight: 550;
+      line-height: 1.2;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    #zenx-hifi-prototype .zx-page-title p {
+      margin: 0;
+      overflow: hidden;
+      color: var(--zx-text-3);
+      font-size: 10px;
+      line-height: 1.3;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
 
     #zenx-hifi-prototype .zx-page-scroll {
       min-width: 0;
@@ -1277,9 +1386,28 @@
       padding: 26px max(22px, calc((100% - 980px) / 2)) 48px;
     }
 
-    #zenx-hifi-prototype .zx-page-intro { display: flex; align-items: flex-end; justify-content: space-between; gap: 22px; margin-bottom: 22px; }
-    #zenx-hifi-prototype .zx-page-intro h2 { margin: 0 0 7px; color: var(--zx-text); font-size: clamp(20px, 2.4vw, 30px); font-weight: 560; letter-spacing: -.025em; line-height: 1.1; }
-    #zenx-hifi-prototype .zx-page-intro p { max-width: 660px; margin: 0; color: var(--zx-text-3); font-size: 12px; line-height: 1.6; }
+    #zenx-hifi-prototype .zx-page-intro {
+      display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: 22px;
+      margin-bottom: 22px;
+    }
+    #zenx-hifi-prototype .zx-page-intro h2 {
+      margin: 0 0 7px;
+      color: var(--zx-text);
+      font-size: clamp(20px, 2.4vw, 30px);
+      font-weight: 560;
+      letter-spacing: -0.025em;
+      line-height: 1.1;
+    }
+    #zenx-hifi-prototype .zx-page-intro p {
+      max-width: 660px;
+      margin: 0;
+      color: var(--zx-text-3);
+      font-size: 12px;
+      line-height: 1.6;
+    }
 
     #zenx-hifi-prototype .zx-primary-button,
     #zenx-hifi-prototype .zx-secondary-button,
@@ -1298,88 +1426,388 @@
       font-size: 11px;
       font-weight: 500;
       white-space: nowrap;
-      transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+      transition:
+        background 160ms ease,
+        color 160ms ease,
+        border-color 160ms ease;
     }
 
-    #zenx-hifi-prototype .zx-primary-button { border-color: #9db5ff; background: #91aaff; color: #111520; }
-    #zenx-hifi-prototype .zx-primary-button:hover { background: #a3b8ff; }
+    #zenx-hifi-prototype .zx-primary-button {
+      border-color: #9db5ff;
+      background: #91aaff;
+      color: #111520;
+    }
+    #zenx-hifi-prototype .zx-primary-button:hover {
+      background: #a3b8ff;
+    }
     #zenx-hifi-prototype .zx-secondary-button:hover,
-    #zenx-hifi-prototype .zx-quiet-button:hover { color: var(--zx-text); background: #22252c; }
-    #zenx-hifi-prototype .zx-danger-button { color: #f1a29c; border-color: #543532; background: #251b1c; }
-    #zenx-hifi-prototype .zx-quiet-button { border-color: transparent; background: transparent; }
+    #zenx-hifi-prototype .zx-quiet-button:hover {
+      color: var(--zx-text);
+      background: #22252c;
+    }
+    #zenx-hifi-prototype .zx-danger-button {
+      color: #f1a29c;
+      border-color: #543532;
+      background: #251b1c;
+    }
+    #zenx-hifi-prototype .zx-quiet-button {
+      border-color: transparent;
+      background: transparent;
+    }
 
-    #zenx-hifi-prototype .zx-page-tabs { display: flex; gap: 3px; margin: 0 0 18px; padding: 3px; width: fit-content; max-width: 100%; overflow-x: auto; border: 1px solid var(--zx-border-soft); border-radius: 10px; background: #111318; }
-    #zenx-hifi-prototype .zx-page-tabs button { min-height: 32px; padding: 0 11px; border: 0; border-radius: 7px; background: transparent; color: var(--zx-text-3); font-size: 10px; white-space: nowrap; }
-    #zenx-hifi-prototype .zx-page-tabs button:hover { color: var(--zx-text-2); }
-    #zenx-hifi-prototype .zx-page-tabs button[aria-selected="true"] { color: var(--zx-text); background: #22252b; }
+    #zenx-hifi-prototype .zx-page-tabs {
+      display: flex;
+      gap: 3px;
+      margin: 0 0 18px;
+      padding: 3px;
+      width: fit-content;
+      max-width: 100%;
+      overflow-x: auto;
+      border: 1px solid var(--zx-border-soft);
+      border-radius: 10px;
+      background: #111318;
+    }
+    #zenx-hifi-prototype .zx-page-tabs button {
+      min-height: 32px;
+      padding: 0 11px;
+      border: 0;
+      border-radius: 7px;
+      background: transparent;
+      color: var(--zx-text-3);
+      font-size: 10px;
+      white-space: nowrap;
+    }
+    #zenx-hifi-prototype .zx-page-tabs button:hover {
+      color: var(--zx-text-2);
+    }
+    #zenx-hifi-prototype .zx-page-tabs button[aria-selected="true"] {
+      color: var(--zx-text);
+      background: #22252b;
+    }
 
-    #zenx-hifi-prototype .zx-page-card { min-width: 0; border: 1px solid var(--zx-border-soft); border-radius: 13px; background: #121419; box-shadow: inset 0 1px 0 rgba(255,255,255,.018); }
+    #zenx-hifi-prototype .zx-page-card {
+      min-width: 0;
+      border: 1px solid var(--zx-border-soft);
+      border-radius: 13px;
+      background: #121419;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.018);
+    }
 
-    #zenx-hifi-prototype .zx-field { min-width: 0; display: grid; gap: 7px; color: var(--zx-text-3); font-size: 10px; }
-    #zenx-hifi-prototype .zx-field > span { display: flex; justify-content: space-between; gap: 8px; }
-    #zenx-hifi-prototype .zx-field small { color: #666a75; font-size: 9px; }
+    #zenx-hifi-prototype .zx-field {
+      min-width: 0;
+      display: grid;
+      gap: 7px;
+      color: var(--zx-text-3);
+      font-size: 10px;
+    }
+    #zenx-hifi-prototype .zx-field > span {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    #zenx-hifi-prototype .zx-field small {
+      color: #666a75;
+      font-size: 9px;
+    }
     #zenx-hifi-prototype .zx-field input,
     #zenx-hifi-prototype .zx-field select,
     #zenx-hifi-prototype .zx-field textarea,
     #zenx-hifi-prototype .zx-search-field,
-    #zenx-hifi-prototype .zx-room-composer textarea { width: 100%; border: 1px solid #30333c; border-radius: 9px; background: #0e1014; color: var(--zx-text); font-size: 11px; }
+    #zenx-hifi-prototype .zx-room-composer textarea {
+      width: 100%;
+      border: 1px solid #30333c;
+      border-radius: 9px;
+      background: #0e1014;
+      color: var(--zx-text);
+      font-size: 11px;
+    }
     #zenx-hifi-prototype .zx-field input,
     #zenx-hifi-prototype .zx-field select,
-    #zenx-hifi-prototype .zx-search-field { height: 38px; padding: 0 11px; }
-    #zenx-hifi-prototype .zx-field textarea { min-height: 86px; resize: vertical; padding: 10px 11px; line-height: 1.55; }
+    #zenx-hifi-prototype .zx-search-field {
+      height: 38px;
+      padding: 0 11px;
+    }
+    #zenx-hifi-prototype .zx-field textarea {
+      min-height: 86px;
+      resize: vertical;
+      padding: 10px 11px;
+      line-height: 1.55;
+    }
     #zenx-hifi-prototype .zx-field input::placeholder,
     #zenx-hifi-prototype .zx-search-field::placeholder,
-    #zenx-hifi-prototype .zx-room-composer textarea::placeholder { color: #5e626c; }
-    #zenx-hifi-prototype .zx-search-wrap { position: relative; width: min(330px, 100%); }
-    #zenx-hifi-prototype .zx-search-wrap .zx-icon { position: absolute; left: 11px; top: 50%; width: 15px; height: 15px; transform: translateY(-50%); color: var(--zx-text-3); pointer-events: none; }
-    #zenx-hifi-prototype .zx-search-field { padding-left: 34px; }
+    #zenx-hifi-prototype .zx-room-composer textarea::placeholder {
+      color: #5e626c;
+    }
+    #zenx-hifi-prototype .zx-search-wrap {
+      position: relative;
+      width: min(330px, 100%);
+    }
+    #zenx-hifi-prototype .zx-search-wrap .zx-icon {
+      position: absolute;
+      left: 11px;
+      top: 50%;
+      width: 15px;
+      height: 15px;
+      transform: translateY(-50%);
+      color: var(--zx-text-3);
+      pointer-events: none;
+    }
+    #zenx-hifi-prototype .zx-search-field {
+      padding-left: 34px;
+    }
 
-    #zenx-hifi-prototype .zx-plugin-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin-bottom: 14px; }
-    #zenx-hifi-prototype .zx-plugin-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-    #zenx-hifi-prototype .zx-plugin-card { min-width: 0; min-height: 186px; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; gap: 12px; padding: 16px; border: 1px solid var(--zx-border-soft); border-radius: 13px; background: #121419; transition: border-color 160ms ease, background 160ms ease, transform 160ms ease; }
-    #zenx-hifi-prototype .zx-plugin-card:hover { border-color: #353943; background: #15171c; transform: translateY(-1px); }
-    #zenx-hifi-prototype .zx-plugin-card-head { display: grid; grid-template-columns: 40px minmax(0, 1fr) auto; align-items: center; gap: 11px; }
-    #zenx-hifi-prototype .zx-plugin-icon { width: 40px; height: 40px; display: grid; place-items: center; border: 1px solid #323641; border-radius: 11px; background: linear-gradient(145deg, #232733, #16181d); color: #b9c7ff; }
-    #zenx-hifi-prototype .zx-plugin-card-head > div { min-width: 0; display: grid; gap: 3px; }
-    #zenx-hifi-prototype .zx-plugin-card h3 { margin: 0; font-size: 13px; font-weight: 540; }
-    #zenx-hifi-prototype .zx-plugin-card-head small { color: var(--zx-text-3); font-size: 9px; }
-    #zenx-hifi-prototype .zx-plugin-card > p { margin: 0; color: var(--zx-text-3); font-size: 11px; line-height: 1.55; }
-    #zenx-hifi-prototype .zx-plugin-badge { align-self: start; padding: 4px 7px; border-radius: 999px; background: rgba(115,210,173,.1); color: var(--zx-good); font-size: 8px; letter-spacing: .04em; text-transform: uppercase; }
-    #zenx-hifi-prototype .zx-plugin-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--zx-text-3); font-size: 9px; }
-    #zenx-hifi-prototype .zx-plugin-empty { grid-column: 1 / -1; padding: 38px; text-align: center; color: var(--zx-text-3); }
+    #zenx-hifi-prototype .zx-plugin-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 14px;
+      margin-bottom: 14px;
+    }
+    #zenx-hifi-prototype .zx-plugin-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+    }
+    #zenx-hifi-prototype .zx-plugin-card {
+      min-width: 0;
+      min-height: 186px;
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr) auto;
+      gap: 12px;
+      padding: 16px;
+      border: 1px solid var(--zx-border-soft);
+      border-radius: 13px;
+      background: #121419;
+      transition:
+        border-color 160ms ease,
+        background 160ms ease,
+        transform 160ms ease;
+    }
+    #zenx-hifi-prototype .zx-plugin-card:hover {
+      border-color: #353943;
+      background: #15171c;
+      transform: translateY(-1px);
+    }
+    #zenx-hifi-prototype .zx-plugin-card-head {
+      display: grid;
+      grid-template-columns: 40px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 11px;
+    }
+    #zenx-hifi-prototype .zx-plugin-icon {
+      width: 40px;
+      height: 40px;
+      display: grid;
+      place-items: center;
+      border: 1px solid #323641;
+      border-radius: 11px;
+      background: linear-gradient(145deg, #232733, #16181d);
+      color: #b9c7ff;
+    }
+    #zenx-hifi-prototype .zx-plugin-card-head > div {
+      min-width: 0;
+      display: grid;
+      gap: 3px;
+    }
+    #zenx-hifi-prototype .zx-plugin-card h3 {
+      margin: 0;
+      font-size: 13px;
+      font-weight: 540;
+    }
+    #zenx-hifi-prototype .zx-plugin-card-head small {
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
+    #zenx-hifi-prototype .zx-plugin-card > p {
+      margin: 0;
+      color: var(--zx-text-3);
+      font-size: 11px;
+      line-height: 1.55;
+    }
+    #zenx-hifi-prototype .zx-plugin-badge {
+      align-self: start;
+      padding: 4px 7px;
+      border-radius: 999px;
+      background: rgba(115, 210, 173, 0.1);
+      color: var(--zx-good);
+      font-size: 8px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    #zenx-hifi-prototype .zx-plugin-card-foot {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
+    #zenx-hifi-prototype .zx-plugin-empty {
+      grid-column: 1 / -1;
+      padding: 38px;
+      text-align: center;
+      color: var(--zx-text-3);
+    }
 
-    #zenx-hifi-prototype .zx-settings-layout { min-height: 520px; display: grid; grid-template-columns: 176px minmax(0, 1fr); gap: 24px; }
-    #zenx-hifi-prototype .zx-settings-nav { align-self: start; position: sticky; top: 0; display: grid; gap: 3px; }
-    #zenx-hifi-prototype .zx-settings-nav button { width: 100%; min-height: 38px; display: grid; grid-template-columns: 20px minmax(0,1fr); align-items: center; gap: 8px; padding: 0 10px; border: 0; border-radius: 8px; background: transparent; color: var(--zx-text-3); font-size: 11px; text-align: left; }
+    #zenx-hifi-prototype .zx-settings-layout {
+      min-height: 520px;
+      display: grid;
+      grid-template-columns: 176px minmax(0, 1fr);
+      gap: 24px;
+    }
+    #zenx-hifi-prototype .zx-settings-nav {
+      align-self: start;
+      position: sticky;
+      top: 0;
+      display: grid;
+      gap: 3px;
+    }
+    #zenx-hifi-prototype .zx-settings-nav button {
+      width: 100%;
+      min-height: 38px;
+      display: grid;
+      grid-template-columns: 20px minmax(0, 1fr);
+      align-items: center;
+      gap: 8px;
+      padding: 0 10px;
+      border: 0;
+      border-radius: 8px;
+      background: transparent;
+      color: var(--zx-text-3);
+      font-size: 11px;
+      text-align: left;
+    }
     #zenx-hifi-prototype .zx-settings-nav button:hover,
-    #zenx-hifi-prototype .zx-settings-nav button[aria-selected="true"] { color: var(--zx-text); background: #1c1f25; }
-    #zenx-hifi-prototype .zx-settings-panel { min-width: 0; display: grid; align-content: start; gap: 12px; }
-    #zenx-hifi-prototype .zx-settings-panel > header { margin-bottom: 4px; }
-    #zenx-hifi-prototype .zx-settings-panel h2 { margin: 0 0 5px; font-size: 17px; font-weight: 550; }
-    #zenx-hifi-prototype .zx-settings-panel > header p { margin: 0; color: var(--zx-text-3); font-size: 11px; line-height: 1.5; }
-    #zenx-hifi-prototype .zx-settings-card { padding: 17px; }
+    #zenx-hifi-prototype .zx-settings-nav button[aria-selected="true"] {
+      color: var(--zx-text);
+      background: #1c1f25;
+    }
+    #zenx-hifi-prototype .zx-settings-panel {
+      min-width: 0;
+      display: grid;
+      align-content: start;
+      gap: 12px;
+    }
+    #zenx-hifi-prototype .zx-settings-panel > header {
+      margin-bottom: 4px;
+    }
+    #zenx-hifi-prototype .zx-settings-panel h2 {
+      margin: 0 0 5px;
+      font-size: 17px;
+      font-weight: 550;
+    }
+    #zenx-hifi-prototype .zx-settings-panel > header p {
+      margin: 0;
+      color: var(--zx-text-3);
+      font-size: 11px;
+      line-height: 1.5;
+    }
+    #zenx-hifi-prototype .zx-settings-card {
+      padding: 17px;
+    }
     #zenx-hifi-prototype .zx-settings-card-head,
-    #zenx-hifi-prototype .zx-settings-row { display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-    #zenx-hifi-prototype .zx-settings-card-head { margin-bottom: 15px; }
+    #zenx-hifi-prototype .zx-settings-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    #zenx-hifi-prototype .zx-settings-card-head {
+      margin-bottom: 15px;
+    }
     #zenx-hifi-prototype .zx-settings-card-head div,
-    #zenx-hifi-prototype .zx-settings-row > div { min-width: 0; display: grid; gap: 4px; }
+    #zenx-hifi-prototype .zx-settings-row > div {
+      min-width: 0;
+      display: grid;
+      gap: 4px;
+    }
     #zenx-hifi-prototype .zx-settings-card-head h3,
-    #zenx-hifi-prototype .zx-settings-row strong { margin: 0; font-size: 12px; font-weight: 520; }
+    #zenx-hifi-prototype .zx-settings-row strong {
+      margin: 0;
+      font-size: 12px;
+      font-weight: 520;
+    }
     #zenx-hifi-prototype .zx-settings-card-head p,
-    #zenx-hifi-prototype .zx-settings-row span { margin: 0; color: var(--zx-text-3); font-size: 10px; line-height: 1.45; }
-    #zenx-hifi-prototype .zx-settings-row + .zx-settings-row { margin-top: 13px; padding-top: 13px; border-top: 1px solid var(--zx-border-soft); }
-    #zenx-hifi-prototype .zx-account-status { display: inline-flex; align-items: center; gap: 7px; color: var(--zx-good); font-size: 10px; }
-    #zenx-hifi-prototype .zx-settings-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 12px; }
-    #zenx-hifi-prototype .zx-field-wide { grid-column: 1 / -1; }
-    #zenx-hifi-prototype .zx-provider-tabs { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; margin-bottom: 15px; }
-    #zenx-hifi-prototype .zx-provider-tabs button { min-height: 38px; padding: 0 8px; border: 1px solid #2c3038; border-radius: 8px; background: #101217; color: var(--zx-text-3); font-size: 10px; }
-    #zenx-hifi-prototype .zx-provider-tabs button[aria-selected="true"] { border-color: #4d5d8d; color: var(--zx-text); background: var(--zx-accent-soft); }
-    #zenx-hifi-prototype .zx-capability-row { display: grid; grid-template-columns: 36px minmax(0,1fr) auto; align-items: center; gap: 11px; padding: 12px; border: 1px solid var(--zx-border-soft); border-radius: 10px; background: #101217; }
-    #zenx-hifi-prototype .zx-capability-row + .zx-capability-row { margin-top: 7px; }
-    #zenx-hifi-prototype .zx-capability-row .zx-plugin-icon { width: 36px; height: 36px; border-radius: 9px; }
-    #zenx-hifi-prototype .zx-capability-row > div { min-width: 0; display: grid; gap: 4px; }
-    #zenx-hifi-prototype .zx-capability-row strong { font-size: 11px; font-weight: 520; }
-    #zenx-hifi-prototype .zx-capability-row span { color: var(--zx-text-3); font-size: 9px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    #zenx-hifi-prototype .zx-settings-row span {
+      margin: 0;
+      color: var(--zx-text-3);
+      font-size: 10px;
+      line-height: 1.45;
+    }
+    #zenx-hifi-prototype .zx-settings-row + .zx-settings-row {
+      margin-top: 13px;
+      padding-top: 13px;
+      border-top: 1px solid var(--zx-border-soft);
+    }
+    #zenx-hifi-prototype .zx-account-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      color: var(--zx-good);
+      font-size: 10px;
+    }
+    #zenx-hifi-prototype .zx-settings-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+    #zenx-hifi-prototype .zx-field-wide {
+      grid-column: 1 / -1;
+    }
+    #zenx-hifi-prototype .zx-provider-tabs {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 5px;
+      margin-bottom: 15px;
+    }
+    #zenx-hifi-prototype .zx-provider-tabs button {
+      min-height: 38px;
+      padding: 0 8px;
+      border: 1px solid #2c3038;
+      border-radius: 8px;
+      background: #101217;
+      color: var(--zx-text-3);
+      font-size: 10px;
+    }
+    #zenx-hifi-prototype .zx-provider-tabs button[aria-selected="true"] {
+      border-color: #4d5d8d;
+      color: var(--zx-text);
+      background: var(--zx-accent-soft);
+    }
+    #zenx-hifi-prototype .zx-capability-row {
+      display: grid;
+      grid-template-columns: 36px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 11px;
+      padding: 12px;
+      border: 1px solid var(--zx-border-soft);
+      border-radius: 10px;
+      background: #101217;
+    }
+    #zenx-hifi-prototype .zx-capability-row + .zx-capability-row {
+      margin-top: 7px;
+    }
+    #zenx-hifi-prototype .zx-capability-row .zx-plugin-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 9px;
+    }
+    #zenx-hifi-prototype .zx-capability-row > div {
+      min-width: 0;
+      display: grid;
+      gap: 4px;
+    }
+    #zenx-hifi-prototype .zx-capability-row strong {
+      font-size: 11px;
+      font-weight: 520;
+    }
+    #zenx-hifi-prototype .zx-capability-row span {
+      color: var(--zx-text-3);
+      font-size: 9px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
     #zenx-hifi-prototype .zx-plugin-switch {
       position: relative;
       width: 52px;
@@ -1397,7 +1825,9 @@
       border: 1px solid #3c404a;
       border-radius: 999px;
       background: #23262d;
-      transition: border-color 160ms ease, background 160ms ease;
+      transition:
+        border-color 160ms ease,
+        background 160ms ease;
     }
     #zenx-hifi-prototype .zx-plugin-switch::after {
       content: "";
@@ -1408,62 +1838,270 @@
       height: 16px;
       border-radius: 50%;
       background: #858a95;
-      box-shadow: 0 1px 3px rgba(0,0,0,.35);
-      transition: transform 180ms ease, background 160ms ease;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+      transition:
+        transform 180ms ease,
+        background 160ms ease;
     }
-    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]::before { border-color: #7189d3; background: #6076bd; }
-    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]::after { transform: translateX(16px); background: #f4f6ff; }
-    #zenx-hifi-prototype .zx-plugin-switch:hover::before { border-color: #65708b; }
-    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]:hover::before { border-color: #91a9ef; background: #6b82cc; }
-    #zenx-hifi-prototype .zx-plugin-boundary { display: grid; grid-template-columns: 36px minmax(0,1fr) auto; align-items: center; gap: 12px; }
-    #zenx-hifi-prototype .zx-plugin-boundary .zx-plugin-icon { width: 36px; height: 36px; border-radius: 9px; }
-    #zenx-hifi-prototype .zx-plugin-boundary > div { min-width: 0; display: grid; gap: 4px; }
-    #zenx-hifi-prototype .zx-plugin-boundary strong { font-size: 12px; font-weight: 520; }
-    #zenx-hifi-prototype .zx-plugin-boundary span { color: var(--zx-text-3); font-size: 10px; line-height: 1.45; }
+    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]::before {
+      border-color: #7189d3;
+      background: #6076bd;
+    }
+    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]::after {
+      transform: translateX(16px);
+      background: #f4f6ff;
+    }
+    #zenx-hifi-prototype .zx-plugin-switch:hover::before {
+      border-color: #65708b;
+    }
+    #zenx-hifi-prototype .zx-plugin-switch[aria-checked="true"]:hover::before {
+      border-color: #91a9ef;
+      background: #6b82cc;
+    }
+    #zenx-hifi-prototype .zx-plugin-boundary {
+      display: grid;
+      grid-template-columns: 36px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 12px;
+    }
+    #zenx-hifi-prototype .zx-plugin-boundary .zx-plugin-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 9px;
+    }
+    #zenx-hifi-prototype .zx-plugin-boundary > div {
+      min-width: 0;
+      display: grid;
+      gap: 4px;
+    }
+    #zenx-hifi-prototype .zx-plugin-boundary strong {
+      font-size: 12px;
+      font-weight: 520;
+    }
+    #zenx-hifi-prototype .zx-plugin-boundary span {
+      color: var(--zx-text-3);
+      font-size: 10px;
+      line-height: 1.45;
+    }
 
-    #zenx-hifi-prototype .zx-metric-strip { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 8px; margin-bottom: 18px; }
-    #zenx-hifi-prototype .zx-metric { padding: 14px; }
-    #zenx-hifi-prototype .zx-metric strong { display: block; margin-bottom: 5px; font-size: 20px; font-weight: 560; }
-    #zenx-hifi-prototype .zx-metric span { color: var(--zx-text-3); font-size: 9px; letter-spacing: .05em; text-transform: uppercase; }
-    #zenx-hifi-prototype .zx-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin: 22px 0 9px; }
-    #zenx-hifi-prototype .zx-section-heading h2 { margin: 0; font-size: 12px; font-weight: 540; }
-    #zenx-hifi-prototype .zx-section-heading span { color: var(--zx-text-3); font-size: 9px; }
+    #zenx-hifi-prototype .zx-metric-strip {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 8px;
+      margin-bottom: 18px;
+    }
+    #zenx-hifi-prototype .zx-metric {
+      padding: 14px;
+    }
+    #zenx-hifi-prototype .zx-metric strong {
+      display: block;
+      margin-bottom: 5px;
+      font-size: 20px;
+      font-weight: 560;
+    }
+    #zenx-hifi-prototype .zx-metric span {
+      color: var(--zx-text-3);
+      font-size: 9px;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    #zenx-hifi-prototype .zx-section-heading {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin: 22px 0 9px;
+    }
+    #zenx-hifi-prototype .zx-section-heading h2 {
+      margin: 0;
+      font-size: 12px;
+      font-weight: 540;
+    }
+    #zenx-hifi-prototype .zx-section-heading span {
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
     #zenx-hifi-prototype .zx-schedule-row,
-    #zenx-hifi-prototype .zx-history-row { width: 100%; min-width: 0; display: grid; grid-template-columns: 78px minmax(0,1fr) auto; align-items: center; gap: 13px; padding: 12px 14px; border: 0; border-bottom: 1px solid var(--zx-border-soft); background: transparent; text-align: left; }
+    #zenx-hifi-prototype .zx-history-row {
+      width: 100%;
+      min-width: 0;
+      display: grid;
+      grid-template-columns: 78px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 13px;
+      padding: 12px 14px;
+      border: 0;
+      border-bottom: 1px solid var(--zx-border-soft);
+      background: transparent;
+      text-align: left;
+    }
     #zenx-hifi-prototype .zx-page-card > .zx-schedule-row:last-child,
-    #zenx-hifi-prototype .zx-page-card > .zx-history-row:last-child { border-bottom: 0; }
+    #zenx-hifi-prototype .zx-page-card > .zx-history-row:last-child {
+      border-bottom: 0;
+    }
     #zenx-hifi-prototype .zx-schedule-row:hover,
-    #zenx-hifi-prototype .zx-history-row:hover { background: rgba(255,255,255,.02); }
+    #zenx-hifi-prototype .zx-history-row:hover {
+      background: rgba(255, 255, 255, 0.02);
+    }
     #zenx-hifi-prototype .zx-schedule-row > div,
-    #zenx-hifi-prototype .zx-history-row > div { min-width: 0; display: grid; gap: 4px; }
+    #zenx-hifi-prototype .zx-history-row > div {
+      min-width: 0;
+      display: grid;
+      gap: 4px;
+    }
     #zenx-hifi-prototype .zx-schedule-row strong,
-    #zenx-hifi-prototype .zx-history-row strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; font-weight: 520; }
+    #zenx-hifi-prototype .zx-history-row strong {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 11px;
+      font-weight: 520;
+    }
     #zenx-hifi-prototype .zx-schedule-row small,
-    #zenx-hifi-prototype .zx-history-row small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--zx-text-3); font-size: 9px; }
+    #zenx-hifi-prototype .zx-history-row small {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
     #zenx-hifi-prototype .zx-schedule-row time,
-    #zenx-hifi-prototype .zx-history-row time { color: var(--zx-text-3); font-size: 9px; white-space: nowrap; }
-    #zenx-hifi-prototype .zx-kind-pill { width: fit-content; padding: 4px 7px; border-radius: 999px; background: var(--zx-accent-soft); color: #b7c6ff; font-size: 8px; text-transform: uppercase; }
-    #zenx-hifi-prototype .zx-kind-pill.zx-room-kind { color: #cbbcff; background: rgba(185,149,255,.12); }
-    #zenx-hifi-prototype .zx-kind-pill.zx-signal-kind { color: var(--zx-good); background: rgba(115,210,173,.1); }
-    #zenx-hifi-prototype .zx-inline-form { display: grid; grid-template-columns: 1fr 1fr auto; gap: 9px; padding: 14px; border-top: 1px solid var(--zx-border-soft); }
+    #zenx-hifi-prototype .zx-history-row time {
+      color: var(--zx-text-3);
+      font-size: 9px;
+      white-space: nowrap;
+    }
+    #zenx-hifi-prototype .zx-kind-pill {
+      width: fit-content;
+      padding: 4px 7px;
+      border-radius: 999px;
+      background: var(--zx-accent-soft);
+      color: #b7c6ff;
+      font-size: 8px;
+      text-transform: uppercase;
+    }
+    #zenx-hifi-prototype .zx-kind-pill.zx-room-kind {
+      color: #cbbcff;
+      background: rgba(185, 149, 255, 0.12);
+    }
+    #zenx-hifi-prototype .zx-kind-pill.zx-signal-kind {
+      color: var(--zx-good);
+      background: rgba(115, 210, 173, 0.1);
+    }
+    #zenx-hifi-prototype .zx-inline-form {
+      display: grid;
+      grid-template-columns: 1fr 1fr auto;
+      gap: 9px;
+      padding: 14px;
+      border-top: 1px solid var(--zx-border-soft);
+    }
 
-    #zenx-hifi-prototype .zx-room-page { grid-template-rows: 60px auto minmax(0,1fr) auto; }
-    #zenx-hifi-prototype .zx-room-members { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
-    #zenx-hifi-prototype .zx-member-pill { display: inline-flex; align-items: center; gap: 6px; height: 28px; padding: 0 9px; border: 1px solid #30333b; border-radius: 14px; background: #17191e; color: var(--zx-text-2); font-size: 9px; }
-    #zenx-hifi-prototype .zx-room-context { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 12px 22px; border-bottom: 1px solid var(--zx-border-soft); background: #101216; }
-    #zenx-hifi-prototype .zx-room-context p { margin: 0; color: var(--zx-text-3); font-size: 10px; }
-    #zenx-hifi-prototype .zx-room-feed { min-height: 0; overflow-y: auto; padding: 24px max(20px, calc((100% - 760px)/2)) 30px; }
-    #zenx-hifi-prototype .zx-room-note { margin-bottom: 20px; padding: 11px 13px; border: 1px solid #2d313a; border-radius: 10px; background: #12151a; color: var(--zx-text-3); font-size: 10px; line-height: 1.55; }
-    #zenx-hifi-prototype .zx-room-note strong { color: var(--zx-text-2); }
-    #zenx-hifi-prototype .zx-room-message { margin-bottom: 22px; }
-    #zenx-hifi-prototype .zx-room-message header { display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
-    #zenx-hifi-prototype .zx-room-message header strong { font-size: 11px; font-weight: 540; }
-    #zenx-hifi-prototype .zx-room-message header time { color: var(--zx-text-3); font-size: 9px; }
-    #zenx-hifi-prototype .zx-room-message p { margin: 0; color: #d6d8dd; font-size: 13px; line-height: 1.62; }
-    #zenx-hifi-prototype .zx-origin-card { margin-top: 9px; min-height: 38px; display: flex; align-items: center; gap: 8px; padding: 0 11px; border: 1px solid #2e323b; border-radius: 8px; background: #121419; color: var(--zx-text-3); font-size: 10px; }
-    #zenx-hifi-prototype .zx-origin-card:hover { color: var(--zx-text-2); background: #17191e; }
-    #zenx-hifi-prototype .zx-room-composer { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 8px; padding: 10px max(14px, calc((100% - 760px)/2)); border-top: 1px solid var(--zx-border-soft); background: #0f1013; }
-    #zenx-hifi-prototype .zx-room-composer textarea { height: 42px; resize: none; padding: 11px 12px; }
+    #zenx-hifi-prototype .zx-room-page {
+      grid-template-rows: 60px auto minmax(0, 1fr) auto;
+    }
+    #zenx-hifi-prototype .zx-room-members {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    #zenx-hifi-prototype .zx-member-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      height: 28px;
+      padding: 0 9px;
+      border: 1px solid #30333b;
+      border-radius: 14px;
+      background: #17191e;
+      color: var(--zx-text-2);
+      font-size: 9px;
+    }
+    #zenx-hifi-prototype .zx-room-context {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 12px 22px;
+      border-bottom: 1px solid var(--zx-border-soft);
+      background: #101216;
+    }
+    #zenx-hifi-prototype .zx-room-context p {
+      margin: 0;
+      color: var(--zx-text-3);
+      font-size: 10px;
+    }
+    #zenx-hifi-prototype .zx-room-feed {
+      min-height: 0;
+      overflow-y: auto;
+      padding: 24px max(20px, calc((100% - 760px) / 2)) 30px;
+    }
+    #zenx-hifi-prototype .zx-room-note {
+      margin-bottom: 20px;
+      padding: 11px 13px;
+      border: 1px solid #2d313a;
+      border-radius: 10px;
+      background: #12151a;
+      color: var(--zx-text-3);
+      font-size: 10px;
+      line-height: 1.55;
+    }
+    #zenx-hifi-prototype .zx-room-note strong {
+      color: var(--zx-text-2);
+    }
+    #zenx-hifi-prototype .zx-room-message {
+      margin-bottom: 22px;
+    }
+    #zenx-hifi-prototype .zx-room-message header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 7px;
+    }
+    #zenx-hifi-prototype .zx-room-message header strong {
+      font-size: 11px;
+      font-weight: 540;
+    }
+    #zenx-hifi-prototype .zx-room-message header time {
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
+    #zenx-hifi-prototype .zx-room-message p {
+      margin: 0;
+      color: #d6d8dd;
+      font-size: 13px;
+      line-height: 1.62;
+    }
+    #zenx-hifi-prototype .zx-origin-card {
+      margin-top: 9px;
+      min-height: 38px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 0 11px;
+      border: 1px solid #2e323b;
+      border-radius: 8px;
+      background: #121419;
+      color: var(--zx-text-3);
+      font-size: 10px;
+    }
+    #zenx-hifi-prototype .zx-origin-card:hover {
+      color: var(--zx-text-2);
+      background: #17191e;
+    }
+    #zenx-hifi-prototype .zx-room-composer {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 8px;
+      padding: 10px max(14px, calc((100% - 760px) / 2));
+      border-top: 1px solid var(--zx-border-soft);
+      background: #0f1013;
+    }
+    #zenx-hifi-prototype .zx-room-composer textarea {
+      height: 42px;
+      resize: none;
+      padding: 11px 12px;
+    }
 
     #zenx-hifi-prototype .zx-modal-layer {
       position: absolute;
@@ -1471,7 +2109,7 @@
       z-index: 60;
       display: flex;
       justify-content: flex-end;
-      background: rgba(0,0,0,0.48);
+      background: rgba(0, 0, 0, 0.48);
       backdrop-filter: blur(2px);
     }
 
@@ -1482,11 +2120,16 @@
       grid-template-rows: auto auto minmax(0, 1fr);
       border-left: 1px solid #343741;
       background: #15171b;
-      box-shadow: -20px 0 60px rgba(0,0,0,0.42);
-      animation: zx-sheet-in 220ms cubic-bezier(.2,.8,.2,1);
+      box-shadow: -20px 0 60px rgba(0, 0, 0, 0.42);
+      animation: zx-sheet-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
     }
 
-    @keyframes zx-sheet-in { from { transform: translateX(18px); opacity: 0; } }
+    @keyframes zx-sheet-in {
+      from {
+        transform: translateX(18px);
+        opacity: 0;
+      }
+    }
 
     #zenx-hifi-prototype .zx-sheet-head {
       min-height: 64px;
@@ -1531,7 +2174,7 @@
 
     #zenx-hifi-prototype .zx-sheet-tabs button:hover {
       color: var(--zx-text-2);
-      background: rgba(255,255,255,0.025);
+      background: rgba(255, 255, 255, 0.025);
     }
 
     #zenx-hifi-prototype .zx-sheet-tabs button[aria-selected="true"] {
@@ -1574,16 +2217,23 @@
       padding: 0 8px;
     }
 
-    #zenx-hifi-prototype .zx-file-row:hover { background: rgba(255,255,255,0.025); }
-    #zenx-hifi-prototype .zx-file-row[data-depth="1"] { padding-left: 28px; }
-    #zenx-hifi-prototype .zx-file-row small { color: var(--zx-text-3); font-size: 9px; }
+    #zenx-hifi-prototype .zx-file-row:hover {
+      background: rgba(255, 255, 255, 0.025);
+    }
+    #zenx-hifi-prototype .zx-file-row[data-depth="1"] {
+      padding-left: 28px;
+    }
+    #zenx-hifi-prototype .zx-file-row small {
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
 
     #zenx-hifi-prototype .zx-panel-row {
       grid-template-columns: 30px minmax(0, 1fr) auto;
       gap: 9px;
       padding: 8px;
       border: 1px solid var(--zx-border-soft);
-      background: rgba(255,255,255,0.018);
+      background: rgba(255, 255, 255, 0.018);
     }
 
     #zenx-hifi-prototype .zx-panel-row > div {
@@ -1592,8 +2242,14 @@
       gap: 3px;
     }
 
-    #zenx-hifi-prototype .zx-panel-row strong { font-size: 11px; font-weight: 500; }
-    #zenx-hifi-prototype .zx-panel-row span { color: var(--zx-text-3); font-size: 9px; }
+    #zenx-hifi-prototype .zx-panel-row strong {
+      font-size: 11px;
+      font-weight: 500;
+    }
+    #zenx-hifi-prototype .zx-panel-row span {
+      color: var(--zx-text-3);
+      font-size: 9px;
+    }
 
     #zenx-hifi-prototype .zx-toast {
       position: absolute;
@@ -1607,35 +2263,81 @@
       border-radius: 10px;
       background: #202228;
       color: var(--zx-text);
-      box-shadow: 0 16px 44px rgba(0,0,0,0.46);
+      box-shadow: 0 16px 44px rgba(0, 0, 0, 0.46);
       font-size: 11px;
       text-align: center;
       animation: zx-toast-in 180ms ease-out;
     }
 
-    @keyframes zx-toast-in { from { opacity: 0; transform: translate(-50%, 5px); } }
+    @keyframes zx-toast-in {
+      from {
+        opacity: 0;
+        transform: translate(-50%, 5px);
+      }
+    }
 
     #zenx-hifi-prototype .zx-mobile-scrim {
       display: none;
     }
 
     @media (max-width: 820px) {
-      #zenx-hifi-prototype .zx-app { grid-template-columns: 230px minmax(0, 1fr); }
-      #zenx-hifi-prototype .zx-sidebar-head { padding-inline: 9px; }
-      #zenx-hifi-prototype .zx-thread { padding-inline: 10px 8px; }
-      #zenx-hifi-prototype .zx-topbar { padding-left: 16px; }
-      #zenx-hifi-prototype .zx-transcript { padding-inline: 22px; }
-      #zenx-hifi-prototype .zx-bottom-zone { padding-inline: 16px; }
-      #zenx-hifi-prototype .zx-control-button[data-control="permission"] .zx-control-label-wide { display: none; }
-      #zenx-hifi-prototype .zx-user-row { padding-left: 10%; }
-      #zenx-hifi-prototype .zx-page-scroll { padding-inline: 18px; }
-      #zenx-hifi-prototype .zx-plugin-toolbar { align-items: stretch; flex-direction: column; }
-      #zenx-hifi-prototype .zx-search-wrap { width: 100%; }
-      #zenx-hifi-prototype .zx-plugin-grid { grid-template-columns: 1fr; }
-      #zenx-hifi-prototype .zx-plugin-card { min-height: 166px; }
-      #zenx-hifi-prototype .zx-settings-layout { display: block; min-height: 0; }
-      #zenx-hifi-prototype .zx-settings-nav { position: static; grid-auto-flow: column; grid-auto-columns: max-content; overflow-x: auto; margin: -2px 0 18px; padding-bottom: 4px; }
-      #zenx-hifi-prototype .zx-settings-nav button { padding-inline: 10px; }
+      #zenx-hifi-prototype .zx-app {
+        grid-template-columns: 230px minmax(0, 1fr);
+      }
+      #zenx-hifi-prototype .zx-sidebar-head {
+        padding-inline: 9px;
+      }
+      #zenx-hifi-prototype .zx-thread {
+        padding-inline: 10px 8px;
+      }
+      #zenx-hifi-prototype .zx-topbar {
+        padding-left: 16px;
+      }
+      #zenx-hifi-prototype .zx-transcript {
+        padding-inline: 22px;
+      }
+      #zenx-hifi-prototype .zx-bottom-zone {
+        padding-inline: 16px;
+      }
+      #zenx-hifi-prototype
+        .zx-control-button[data-control="permission"]
+        .zx-control-label-wide {
+        display: none;
+      }
+      #zenx-hifi-prototype .zx-user-row {
+        padding-left: 10%;
+      }
+      #zenx-hifi-prototype .zx-page-scroll {
+        padding-inline: 18px;
+      }
+      #zenx-hifi-prototype .zx-plugin-toolbar {
+        align-items: stretch;
+        flex-direction: column;
+      }
+      #zenx-hifi-prototype .zx-search-wrap {
+        width: 100%;
+      }
+      #zenx-hifi-prototype .zx-plugin-grid {
+        grid-template-columns: 1fr;
+      }
+      #zenx-hifi-prototype .zx-plugin-card {
+        min-height: 166px;
+      }
+      #zenx-hifi-prototype .zx-settings-layout {
+        display: block;
+        min-height: 0;
+      }
+      #zenx-hifi-prototype .zx-settings-nav {
+        position: static;
+        grid-auto-flow: column;
+        grid-auto-columns: max-content;
+        overflow-x: auto;
+        margin: -2px 0 18px;
+        padding-bottom: 4px;
+      }
+      #zenx-hifi-prototype .zx-settings-nav button {
+        padding-inline: 10px;
+      }
     }
 
     @media (max-width: 640px) {
@@ -1653,8 +2355,8 @@
         inset: 0 auto 0 0;
         width: min(286px, calc(100% - 44px));
         transform: translateX(-102%);
-        box-shadow: 18px 0 60px rgba(0,0,0,0.45);
-        transition: transform 220ms cubic-bezier(.2,.8,.2,1);
+        box-shadow: 18px 0 60px rgba(0, 0, 0, 0.45);
+        transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1);
       }
 
       #zenx-hifi-prototype .zx-app[data-sidebar-open="true"] .zx-sidebar {
@@ -1667,7 +2369,7 @@
         z-index: 15;
         display: block;
         border: 0;
-        background: rgba(0,0,0,0.5);
+        background: rgba(0, 0, 0, 0.5);
       }
 
       #zenx-hifi-prototype .zx-app[data-sidebar-open="false"] .zx-mobile-scrim {
@@ -1680,32 +2382,96 @@
         grid-template-rows: 56px minmax(0, 1fr) auto;
       }
 
-      #zenx-hifi-prototype .zx-product-page { height: 100%; grid-template-rows: 56px minmax(0,1fr); }
-      #zenx-hifi-prototype .zx-room-page { grid-template-rows: 56px auto minmax(0,1fr) auto; }
-      #zenx-hifi-prototype .zx-page-header { padding: 0 8px; gap: 8px; }
-      #zenx-hifi-prototype .zx-page-header .zx-mobile-menu { display: inline-grid; }
-      #zenx-hifi-prototype .zx-page-scroll { padding: 20px 14px 34px; }
-      #zenx-hifi-prototype .zx-page-intro { align-items: flex-start; flex-direction: column; gap: 14px; }
-      #zenx-hifi-prototype .zx-page-intro .zx-primary-button { width: 100%; }
-      #zenx-hifi-prototype .zx-plugin-toolbar { align-items: stretch; flex-direction: column; }
-      #zenx-hifi-prototype .zx-search-wrap { width: 100%; }
-      #zenx-hifi-prototype .zx-plugin-grid { grid-template-columns: 1fr; }
-      #zenx-hifi-prototype .zx-plugin-card { min-height: 178px; }
-      #zenx-hifi-prototype .zx-settings-layout { display: block; min-height: 0; }
-      #zenx-hifi-prototype .zx-settings-nav { position: static; grid-auto-flow: column; grid-auto-columns: max-content; overflow-x: auto; margin: -2px 0 18px; padding-bottom: 4px; }
-      #zenx-hifi-prototype .zx-settings-nav button { min-height: 44px; grid-template-columns: 18px auto; padding-inline: 10px; }
-      #zenx-hifi-prototype .zx-settings-grid { grid-template-columns: 1fr; }
-      #zenx-hifi-prototype .zx-field-wide { grid-column: auto; }
-      #zenx-hifi-prototype .zx-provider-tabs { grid-template-columns: 1fr; }
-      #zenx-hifi-prototype .zx-metric-strip { grid-template-columns: repeat(3,minmax(0,1fr)); }
+      #zenx-hifi-prototype .zx-product-page {
+        height: 100%;
+        grid-template-rows: 56px minmax(0, 1fr);
+      }
+      #zenx-hifi-prototype .zx-room-page {
+        grid-template-rows: 56px auto minmax(0, 1fr) auto;
+      }
+      #zenx-hifi-prototype .zx-page-header {
+        padding: 0 8px;
+        gap: 8px;
+      }
+      #zenx-hifi-prototype .zx-page-header .zx-mobile-menu {
+        display: inline-grid;
+      }
+      #zenx-hifi-prototype .zx-page-scroll {
+        padding: 20px 14px 34px;
+      }
+      #zenx-hifi-prototype .zx-page-intro {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 14px;
+      }
+      #zenx-hifi-prototype .zx-page-intro .zx-primary-button {
+        width: 100%;
+      }
+      #zenx-hifi-prototype .zx-plugin-toolbar {
+        align-items: stretch;
+        flex-direction: column;
+      }
+      #zenx-hifi-prototype .zx-search-wrap {
+        width: 100%;
+      }
+      #zenx-hifi-prototype .zx-plugin-grid {
+        grid-template-columns: 1fr;
+      }
+      #zenx-hifi-prototype .zx-plugin-card {
+        min-height: 178px;
+      }
+      #zenx-hifi-prototype .zx-settings-layout {
+        display: block;
+        min-height: 0;
+      }
+      #zenx-hifi-prototype .zx-settings-nav {
+        position: static;
+        grid-auto-flow: column;
+        grid-auto-columns: max-content;
+        overflow-x: auto;
+        margin: -2px 0 18px;
+        padding-bottom: 4px;
+      }
+      #zenx-hifi-prototype .zx-settings-nav button {
+        min-height: 44px;
+        grid-template-columns: 18px auto;
+        padding-inline: 10px;
+      }
+      #zenx-hifi-prototype .zx-settings-grid {
+        grid-template-columns: 1fr;
+      }
+      #zenx-hifi-prototype .zx-field-wide {
+        grid-column: auto;
+      }
+      #zenx-hifi-prototype .zx-provider-tabs {
+        grid-template-columns: 1fr;
+      }
+      #zenx-hifi-prototype .zx-metric-strip {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
       #zenx-hifi-prototype .zx-schedule-row,
-      #zenx-hifi-prototype .zx-history-row { min-height: 64px; grid-template-columns: 68px minmax(0,1fr); }
+      #zenx-hifi-prototype .zx-history-row {
+        min-height: 64px;
+        grid-template-columns: 68px minmax(0, 1fr);
+      }
       #zenx-hifi-prototype .zx-schedule-row time,
-      #zenx-hifi-prototype .zx-history-row time { grid-column: 2; }
-      #zenx-hifi-prototype .zx-inline-form { grid-template-columns: 1fr; }
-      #zenx-hifi-prototype .zx-room-context { align-items: flex-start; flex-direction: column; padding-inline: 14px; }
-      #zenx-hifi-prototype .zx-room-feed { padding: 20px 14px 26px; }
-      #zenx-hifi-prototype .zx-room-composer { padding-inline: 8px; }
+      #zenx-hifi-prototype .zx-history-row time {
+        grid-column: 2;
+      }
+      #zenx-hifi-prototype .zx-inline-form {
+        grid-template-columns: 1fr;
+      }
+      #zenx-hifi-prototype .zx-room-context {
+        align-items: flex-start;
+        flex-direction: column;
+        padding-inline: 14px;
+      }
+      #zenx-hifi-prototype .zx-room-feed {
+        padding: 20px 14px 26px;
+      }
+      #zenx-hifi-prototype .zx-room-composer {
+        padding-inline: 8px;
+      }
 
       #zenx-hifi-prototype .zx-topbar {
         gap: 8px;
@@ -1741,14 +2507,29 @@
         padding: 20px 14px 28px;
       }
 
-      #zenx-hifi-prototype .zx-conversation { gap: 19px; }
-      #zenx-hifi-prototype .zx-user-row { padding-left: 8%; }
+      #zenx-hifi-prototype .zx-conversation {
+        gap: 19px;
+      }
+      #zenx-hifi-prototype .zx-user-row {
+        padding-left: 8%;
+      }
       #zenx-hifi-prototype .zx-user-bubble,
-      #zenx-hifi-prototype .zx-agent-copy { font-size: 13px; }
-      #zenx-hifi-prototype .zx-turn-step { min-height: 44px; grid-template-columns: 16px minmax(0,1fr) 13px; }
-      #zenx-hifi-prototype .zx-trace-group-toggle { min-height: 44px; }
-      #zenx-hifi-prototype .zx-step-detail { margin-left: 23px; }
-      #zenx-hifi-prototype .zx-bottom-zone { padding: 0 8px 8px; }
+      #zenx-hifi-prototype .zx-agent-copy {
+        font-size: 13px;
+      }
+      #zenx-hifi-prototype .zx-turn-step {
+        min-height: 44px;
+        grid-template-columns: 16px minmax(0, 1fr) 13px;
+      }
+      #zenx-hifi-prototype .zx-trace-group-toggle {
+        min-height: 44px;
+      }
+      #zenx-hifi-prototype .zx-step-detail {
+        margin-left: 23px;
+      }
+      #zenx-hifi-prototype .zx-bottom-zone {
+        padding: 0 8px 8px;
+      }
       #zenx-hifi-prototype .zx-approval {
         grid-template-columns: 30px minmax(0, 1fr);
         gap: 8px;
@@ -1758,31 +2539,84 @@
         grid-column: 1 / -1;
         justify-content: flex-end;
       }
-      #zenx-hifi-prototype .zx-composer { border-radius: 14px; }
-      #zenx-hifi-prototype .zx-composer textarea { height: 60px; padding-inline: 13px; font-size: 16px; }
-      #zenx-hifi-prototype .zx-composer-rail { gap: 6px; padding-inline: 6px; }
-      #zenx-hifi-prototype .zx-composer-tools { gap: 1px; }
-      #zenx-hifi-prototype .zx-control-button { min-width: 44px; padding: 0 7px; }
+      #zenx-hifi-prototype .zx-composer {
+        border-radius: 14px;
+      }
+      #zenx-hifi-prototype .zx-composer textarea {
+        height: 60px;
+        padding-inline: 13px;
+        font-size: 16px;
+      }
+      #zenx-hifi-prototype .zx-composer-rail {
+        gap: 6px;
+        padding-inline: 6px;
+      }
+      #zenx-hifi-prototype .zx-composer-tools {
+        gap: 1px;
+      }
+      #zenx-hifi-prototype .zx-control-button {
+        min-width: 44px;
+        padding: 0 7px;
+      }
       #zenx-hifi-prototype .zx-control-button .zx-control-label-wide,
-      #zenx-hifi-prototype .zx-control-separator { display: none; }
-      #zenx-hifi-prototype .zx-action-orb { width: 44px; height: 44px; }
-      #zenx-hifi-prototype .zx-sheet { width: calc(100% - 10px); }
-      #zenx-hifi-prototype .zx-toast { bottom: 10px; }
+      #zenx-hifi-prototype .zx-control-separator {
+        display: none;
+      }
+      #zenx-hifi-prototype .zx-action-orb {
+        width: 44px;
+        height: 44px;
+      }
+      #zenx-hifi-prototype .zx-sheet {
+        width: calc(100% - 10px);
+      }
+      #zenx-hifi-prototype .zx-toast {
+        bottom: 10px;
+      }
     }
 
     @media (max-width: 380px) {
-      #zenx-hifi-prototype .zx-agent-meta time { display: none; }
-      #zenx-hifi-prototype .zx-approval-copy span { max-width: 190px; }
-      #zenx-hifi-prototype .zx-composer-tools .zx-control-button[data-control="permission"] { display: none; }
-      #zenx-hifi-prototype .zx-user-row { padding-left: 4%; }
-      #zenx-hifi-prototype .zx-plugin-card-head { grid-template-columns: 36px minmax(0,1fr); }
-      #zenx-hifi-prototype .zx-plugin-card-head .zx-plugin-badge { grid-column: 2; justify-self: start; }
-      #zenx-hifi-prototype .zx-capability-row { grid-template-columns: 34px minmax(0,1fr); }
-      #zenx-hifi-prototype .zx-capability-row > button:not(.zx-plugin-switch) { grid-column: 1 / -1; width: 100%; }
-      #zenx-hifi-prototype .zx-capability-row > .zx-plugin-switch { grid-column: 2; justify-self: end; }
-      #zenx-hifi-prototype .zx-plugin-boundary { grid-template-columns: 34px minmax(0,1fr); }
-      #zenx-hifi-prototype .zx-plugin-boundary > .zx-account-status { grid-column: 2; justify-self: start; }
-      #zenx-hifi-prototype .zx-metric strong { font-size: 17px; }
+      #zenx-hifi-prototype .zx-agent-meta time {
+        display: none;
+      }
+      #zenx-hifi-prototype .zx-approval-copy span {
+        max-width: 190px;
+      }
+      #zenx-hifi-prototype
+        .zx-composer-tools
+        .zx-control-button[data-control="permission"] {
+        display: none;
+      }
+      #zenx-hifi-prototype .zx-user-row {
+        padding-left: 4%;
+      }
+      #zenx-hifi-prototype .zx-plugin-card-head {
+        grid-template-columns: 36px minmax(0, 1fr);
+      }
+      #zenx-hifi-prototype .zx-plugin-card-head .zx-plugin-badge {
+        grid-column: 2;
+        justify-self: start;
+      }
+      #zenx-hifi-prototype .zx-capability-row {
+        grid-template-columns: 34px minmax(0, 1fr);
+      }
+      #zenx-hifi-prototype .zx-capability-row > button:not(.zx-plugin-switch) {
+        grid-column: 1 / -1;
+        width: 100%;
+      }
+      #zenx-hifi-prototype .zx-capability-row > .zx-plugin-switch {
+        grid-column: 2;
+        justify-self: end;
+      }
+      #zenx-hifi-prototype .zx-plugin-boundary {
+        grid-template-columns: 34px minmax(0, 1fr);
+      }
+      #zenx-hifi-prototype .zx-plugin-boundary > .zx-account-status {
+        grid-column: 2;
+        justify-self: start;
+      }
+      #zenx-hifi-prototype .zx-metric strong {
+        font-size: 17px;
+      }
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -1799,77 +2633,241 @@
 
   <svg class="zx-sr-only" aria-hidden="true">
     <defs>
-      <symbol id="zx-hifi-icon-inbox" viewBox="0 0 24 24"><path d="M4 4h16v13H4z"/><path d="M4 13h4l2 3h4l2-3h4"/></symbol>
-      <symbol id="zx-hifi-icon-compose" viewBox="0 0 24 24"><path d="M12 20h8"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z"/></symbol>
-      <symbol id="zx-hifi-icon-search" viewBox="0 0 24 24"><circle cx="11" cy="11" r="6.5"/><path d="m16 16 4 4"/></symbol>
-      <symbol id="zx-hifi-icon-folder" viewBox="0 0 24 24"><path d="M3 6.5h7l2 2h9v10H3z"/></symbol>
-      <symbol id="zx-hifi-icon-chevron-down" viewBox="0 0 24 24"><path d="m7 9.5 5 5 5-5"/></symbol>
-      <symbol id="zx-hifi-icon-chevron-right" viewBox="0 0 24 24"><path d="m9.5 7 5 5-5 5"/></symbol>
-      <symbol id="zx-hifi-icon-panel" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M15 4v16"/></symbol>
-      <symbol id="zx-hifi-icon-menu" viewBox="0 0 24 24"><path d="M4 7h16M4 12h16M4 17h16"/></symbol>
-      <symbol id="zx-hifi-icon-settings" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.4-2.4 1A8 8 0 0 0 15 6l-.3-2.6h-4L10.4 6A8 8 0 0 0 9 7.1l-2.5-1-2 3.4 2.1 1.5a7 7 0 0 0 0 2l-2 1.5 2 3.4 2.4-1A8 8 0 0 0 10.4 18l.3 2.6h4L15 18a8 8 0 0 0 1.5-1.1l2.4 1 2-3.4-2-1.5a7 7 0 0 0 .1-1Z"/></symbol>
-      <symbol id="zx-hifi-icon-brain" viewBox="0 0 24 24"><path d="M9.5 4.5A3.5 3.5 0 0 0 6 8v1a3 3 0 0 0-1 5.8A3.5 3.5 0 0 0 9.5 19H12V5.5a2.5 2.5 0 0 0-2.5-1Z"/><path d="M14.5 4.5A3.5 3.5 0 0 1 18 8v1a3 3 0 0 1 1 5.8 3.5 3.5 0 0 1-4.5 4.2H12V5.5a2.5 2.5 0 0 1 2.5-1Z"/><path d="M8 10h4m4 4h-4"/></symbol>
-      <symbol id="zx-hifi-icon-terminal" viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="3"/><path d="m7 9 3 3-3 3m6 0h4"/></symbol>
-      <symbol id="zx-hifi-icon-check" viewBox="0 0 24 24"><path d="m5 12 4 4L19 6"/></symbol>
-      <symbol id="zx-hifi-icon-code" viewBox="0 0 24 24"><path d="m8 9-3 3 3 3m8-6 3 3-3 3m-2.5-9-3 12"/></symbol>
-      <symbol id="zx-hifi-icon-arrow-down" viewBox="0 0 24 24"><path d="M12 4v15m-6-6 6 6 6-6"/></symbol>
-      <symbol id="zx-hifi-icon-shield" viewBox="0 0 24 24"><path d="M12 3 5 6v5c0 4.5 2.7 7.9 7 10 4.3-2.1 7-5.5 7-10V6Z"/><path d="m9 12 2 2 4-4"/></symbol>
-      <symbol id="zx-hifi-icon-plus" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></symbol>
-      <symbol id="zx-hifi-icon-paperclip" viewBox="0 0 24 24"><path d="m20 12.5-8.2 8.2a5 5 0 0 1-7-7L14.2 4.3a3.5 3.5 0 0 1 5 5L9.8 18.7a2 2 0 0 1-2.8-2.8l8.4-8.4"/></symbol>
-      <symbol id="zx-hifi-icon-lock" viewBox="0 0 24 24"><rect x="4" y="10" width="16" height="11" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></symbol>
-      <symbol id="zx-hifi-icon-stop" viewBox="0 0 24 24"><rect x="7" y="7" width="10" height="10" rx="1" fill="currentColor" stroke="none"/></symbol>
-      <symbol id="zx-hifi-icon-send" viewBox="0 0 24 24"><path d="m5 12 7-7 7 7m-7-7v14"/></symbol>
-      <symbol id="zx-hifi-icon-zap" viewBox="0 0 24 24"><path d="M13 2 5 14h7l-1 8 8-12h-7Z"/></symbol>
-      <symbol id="zx-hifi-icon-x" viewBox="0 0 24 24"><path d="m6 6 12 12M18 6 6 18"/></symbol>
-      <symbol id="zx-hifi-icon-file" viewBox="0 0 24 24"><path d="M6 3h8l4 4v14H6z"/><path d="M14 3v5h5"/></symbol>
-      <symbol id="zx-hifi-icon-layers" viewBox="0 0 24 24"><path d="m12 3 9 5-9 5-9-5Z"/><path d="m3 12 9 5 9-5m-18 4 9 5 9-5"/></symbol>
-      <symbol id="zx-hifi-icon-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></symbol>
-      <symbol id="zx-hifi-icon-plugin" viewBox="0 0 24 24"><path d="M9 3v4H5v4H3v4h2v4h4v2h4v-2h4v-4h4v-4h-4V7h-4V3Z"/><path d="M9 7h4v4h4v4h-4v4H9v-4H5v-4h4Z"/></symbol>
-      <symbol id="zx-hifi-icon-users" viewBox="0 0 24 24"><circle cx="9" cy="8" r="3"/><path d="M3.5 19c.5-3.5 2.3-5 5.5-5s5 1.5 5.5 5"/><circle cx="17" cy="9" r="2.2"/><path d="M15.5 14.7c2.9-.5 4.6.8 5 3.3"/></symbol>
-      <symbol id="zx-hifi-icon-account" viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M4.5 20c.7-4.3 3.2-6 7.5-6s6.8 1.7 7.5 6"/></symbol>
-      <symbol id="zx-hifi-icon-sliders" viewBox="0 0 24 24"><path d="M4 7h10m4 0h2M4 17h2m4 0h10M14 4v6M6 14v6"/></symbol>
-      <symbol id="zx-hifi-icon-globe" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3c3 3.2 3 14.8 0 18M12 3c-3 3.2-3 14.8 0 18"/></symbol>
+      <symbol id="zx-hifi-icon-inbox" viewBox="0 0 24 24">
+        <path d="M4 4h16v13H4z" />
+        <path d="M4 13h4l2 3h4l2-3h4" />
+      </symbol>
+      <symbol id="zx-hifi-icon-compose" viewBox="0 0 24 24">
+        <path d="M12 20h8" />
+        <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L8 18l-4 1 1-4Z" />
+      </symbol>
+      <symbol id="zx-hifi-icon-search" viewBox="0 0 24 24">
+        <circle cx="11" cy="11" r="6.5" />
+        <path d="m16 16 4 4" />
+      </symbol>
+      <symbol id="zx-hifi-icon-folder" viewBox="0 0 24 24">
+        <path d="M3 6.5h7l2 2h9v10H3z" />
+      </symbol>
+      <symbol id="zx-hifi-icon-chevron-down" viewBox="0 0 24 24">
+        <path d="m7 9.5 5 5 5-5" />
+      </symbol>
+      <symbol id="zx-hifi-icon-chevron-right" viewBox="0 0 24 24">
+        <path d="m9.5 7 5 5-5 5" />
+      </symbol>
+      <symbol id="zx-hifi-icon-panel" viewBox="0 0 24 24">
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M15 4v16" />
+      </symbol>
+      <symbol id="zx-hifi-icon-menu" viewBox="0 0 24 24">
+        <path d="M4 7h16M4 12h16M4 17h16" />
+      </symbol>
+      <symbol id="zx-hifi-icon-settings" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="3" />
+        <path
+          d="M19 12a7 7 0 0 0-.1-1l2-1.5-2-3.4-2.4 1A8 8 0 0 0 15 6l-.3-2.6h-4L10.4 6A8 8 0 0 0 9 7.1l-2.5-1-2 3.4 2.1 1.5a7 7 0 0 0 0 2l-2 1.5 2 3.4 2.4-1A8 8 0 0 0 10.4 18l.3 2.6h4L15 18a8 8 0 0 0 1.5-1.1l2.4 1 2-3.4-2-1.5a7 7 0 0 0 .1-1Z"
+        />
+      </symbol>
+      <symbol id="zx-hifi-icon-brain" viewBox="0 0 24 24">
+        <path
+          d="M9.5 4.5A3.5 3.5 0 0 0 6 8v1a3 3 0 0 0-1 5.8A3.5 3.5 0 0 0 9.5 19H12V5.5a2.5 2.5 0 0 0-2.5-1Z"
+        />
+        <path
+          d="M14.5 4.5A3.5 3.5 0 0 1 18 8v1a3 3 0 0 1 1 5.8 3.5 3.5 0 0 1-4.5 4.2H12V5.5a2.5 2.5 0 0 1 2.5-1Z"
+        />
+        <path d="M8 10h4m4 4h-4" />
+      </symbol>
+      <symbol id="zx-hifi-icon-terminal" viewBox="0 0 24 24">
+        <rect x="3" y="4" width="18" height="16" rx="3" />
+        <path d="m7 9 3 3-3 3m6 0h4" />
+      </symbol>
+      <symbol id="zx-hifi-icon-check" viewBox="0 0 24 24">
+        <path d="m5 12 4 4L19 6" />
+      </symbol>
+      <symbol id="zx-hifi-icon-code" viewBox="0 0 24 24">
+        <path d="m8 9-3 3 3 3m8-6 3 3-3 3m-2.5-9-3 12" />
+      </symbol>
+      <symbol id="zx-hifi-icon-arrow-down" viewBox="0 0 24 24">
+        <path d="M12 4v15m-6-6 6 6 6-6" />
+      </symbol>
+      <symbol id="zx-hifi-icon-shield" viewBox="0 0 24 24">
+        <path d="M12 3 5 6v5c0 4.5 2.7 7.9 7 10 4.3-2.1 7-5.5 7-10V6Z" />
+        <path d="m9 12 2 2 4-4" />
+      </symbol>
+      <symbol id="zx-hifi-icon-plus" viewBox="0 0 24 24">
+        <path d="M12 5v14M5 12h14" />
+      </symbol>
+      <symbol id="zx-hifi-icon-paperclip" viewBox="0 0 24 24">
+        <path
+          d="m20 12.5-8.2 8.2a5 5 0 0 1-7-7L14.2 4.3a3.5 3.5 0 0 1 5 5L9.8 18.7a2 2 0 0 1-2.8-2.8l8.4-8.4"
+        />
+      </symbol>
+      <symbol id="zx-hifi-icon-lock" viewBox="0 0 24 24">
+        <rect x="4" y="10" width="16" height="11" rx="2" />
+        <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+      </symbol>
+      <symbol id="zx-hifi-icon-stop" viewBox="0 0 24 24">
+        <rect
+          x="7"
+          y="7"
+          width="10"
+          height="10"
+          rx="1"
+          fill="currentColor"
+          stroke="none"
+        />
+      </symbol>
+      <symbol id="zx-hifi-icon-send" viewBox="0 0 24 24">
+        <path d="m5 12 7-7 7 7m-7-7v14" />
+      </symbol>
+      <symbol id="zx-hifi-icon-zap" viewBox="0 0 24 24">
+        <path d="M13 2 5 14h7l-1 8 8-12h-7Z" />
+      </symbol>
+      <symbol id="zx-hifi-icon-x" viewBox="0 0 24 24">
+        <path d="m6 6 12 12M18 6 6 18" />
+      </symbol>
+      <symbol id="zx-hifi-icon-file" viewBox="0 0 24 24">
+        <path d="M6 3h8l4 4v14H6z" />
+        <path d="M14 3v5h5" />
+      </symbol>
+      <symbol id="zx-hifi-icon-layers" viewBox="0 0 24 24">
+        <path d="m12 3 9 5-9 5-9-5Z" />
+        <path d="m3 12 9 5 9-5m-18 4 9 5 9-5" />
+      </symbol>
+      <symbol id="zx-hifi-icon-clock" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 7v5l3 2" />
+      </symbol>
+      <symbol id="zx-hifi-icon-plugin" viewBox="0 0 24 24">
+        <path d="M9 3v4H5v4H3v4h2v4h4v2h4v-2h4v-4h4v-4h-4V7h-4V3Z" />
+        <path d="M9 7h4v4h4v4h-4v4H9v-4H5v-4h4Z" />
+      </symbol>
+      <symbol id="zx-hifi-icon-users" viewBox="0 0 24 24">
+        <circle cx="9" cy="8" r="3" />
+        <path d="M3.5 19c.5-3.5 2.3-5 5.5-5s5 1.5 5.5 5" />
+        <circle cx="17" cy="9" r="2.2" />
+        <path d="M15.5 14.7c2.9-.5 4.6.8 5 3.3" />
+      </symbol>
+      <symbol id="zx-hifi-icon-account" viewBox="0 0 24 24">
+        <circle cx="12" cy="8" r="4" />
+        <path d="M4.5 20c.7-4.3 3.2-6 7.5-6s6.8 1.7 7.5 6" />
+      </symbol>
+      <symbol id="zx-hifi-icon-sliders" viewBox="0 0 24 24">
+        <path d="M4 7h10m4 0h2M4 17h2m4 0h10M14 4v6M6 14v6" />
+      </symbol>
+      <symbol id="zx-hifi-icon-globe" viewBox="0 0 24 24">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M3 12h18M12 3c3 3.2 3 14.8 0 18M12 3c-3 3.2-3 14.8 0 18" />
+      </symbol>
     </defs>
   </svg>
 
-  <section class="zx-app" data-page="agent" data-run-state="running" data-action-mode="stop" data-sidebar-open="false" aria-label="ZenX product workspace prototype">
-    <aside class="zx-sidebar" aria-label="Projects and threads" data-modal-background>
+  <section
+    class="zx-app"
+    data-page="agent"
+    data-run-state="running"
+    data-action-mode="stop"
+    data-sidebar-open="false"
+    aria-label="ZenX product workspace prototype"
+  >
+    <aside
+      class="zx-sidebar"
+      aria-label="Projects and threads"
+      data-modal-background
+    >
       <header class="zx-sidebar-head">
         <div class="zx-brand-row">
           <div class="zx-brand" aria-label="ZenX">
             <span class="zx-brand-mark" aria-hidden="true">
-              <svg viewBox="0 0 18 18"><defs><linearGradient id="zx-hifi-brand-gradient" x1="2" y1="15" x2="16" y2="3"><stop stop-color="#80b7ff"/><stop offset="1" stop-color="#c492ff"/></linearGradient></defs><path d="M3 13.5 7 5l4 8.5L15 5" fill="none" stroke="url(#zx-hifi-brand-gradient)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              <svg viewBox="0 0 18 18">
+                <defs>
+                  <linearGradient
+                    id="zx-hifi-brand-gradient"
+                    x1="2"
+                    y1="15"
+                    x2="16"
+                    y2="3"
+                  >
+                    <stop stop-color="#80b7ff" />
+                    <stop offset="1" stop-color="#c492ff" />
+                  </linearGradient>
+                </defs>
+                <path
+                  d="M3 13.5 7 5l4 8.5L15 5"
+                  fill="none"
+                  stroke="url(#zx-hifi-brand-gradient)"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
             </span>
             <span>ZENX</span>
           </div>
           <div class="zx-brand-actions">
-            <button type="button" class="zx-icon-button zx-inbox-button" aria-label="Open inbox" aria-pressed="false" data-sidebar-view-toggle>
-              <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-inbox"></use></svg>
+            <button
+              type="button"
+              class="zx-icon-button zx-inbox-button"
+              aria-label="Open inbox"
+              aria-pressed="false"
+              data-sidebar-view-toggle
+            >
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-inbox"></use>
+              </svg>
               <span class="zx-inbox-dot" aria-hidden="true"></span>
             </button>
-            <button type="button" class="zx-icon-button" aria-label="New thread" data-new-thread>
-              <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-compose"></use></svg>
+            <button
+              type="button"
+              class="zx-icon-button"
+              aria-label="New thread"
+              data-new-thread
+            >
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-compose"></use>
+              </svg>
             </button>
           </div>
         </div>
 
-        <section class="zx-plugin-contributions" aria-label="Enabled plugin spaces" data-plugin-contributions>
+        <section
+          class="zx-plugin-contributions"
+          aria-label="Enabled plugin spaces"
+          data-plugin-contributions
+        >
           <strong>Plugin spaces</strong>
-          <nav class="zx-global-nav" aria-label="Trigger plugin" data-plugin-contribution="triggers">
-            <button type="button" class="zx-global-link" data-open-page="scheduled">
-              <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-clock"></use></svg><span>Triggers</span><span class="zx-nav-count">3</span>
+          <nav
+            class="zx-global-nav"
+            aria-label="Trigger plugin"
+            data-plugin-contribution="triggers"
+          >
+            <button
+              type="button"
+              class="zx-global-link"
+              data-open-page="scheduled"
+            >
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-clock"></use></svg
+              ><span>Triggers</span><span class="zx-nav-count">3</span>
             </button>
           </nav>
           <div class="zx-room-shortcuts" data-plugin-contribution="rooms">
             <button type="button" class="zx-room-link" data-open-page="room">
-              <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-users"></use></svg><span>Rooms</span><small>3</small>
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-users"></use></svg
+              ><span>Rooms</span><small>3</small>
             </button>
           </div>
         </section>
         <div class="zx-side-view-head">
           <strong data-sidebar-view-title>Projects</strong>
-          <button type="button" class="zx-mini-button" aria-label="Search threads">
-            <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-search"></use></svg>
+          <button
+            type="button"
+            class="zx-mini-button"
+            aria-label="Search threads"
+          >
+            <svg class="zx-icon" aria-hidden="true">
+              <use href="#zx-hifi-icon-search"></use>
+            </svg>
           </button>
         </div>
       </header>
@@ -1877,35 +2875,158 @@
       <div class="zx-side-scroll">
         <div data-sidebar-view="projects">
           <section class="zx-project" aria-label="ZenX project">
-            <button type="button" class="zx-project-head" aria-expanded="true" data-project-toggle>
-              <span class="zx-project-label"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg><span>ZenX</span></span>
-              <svg class="zx-icon zx-project-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+            <button
+              type="button"
+              class="zx-project-head"
+              aria-expanded="true"
+              data-project-toggle
+            >
+              <span class="zx-project-label"
+                ><svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                ><span>ZenX</span></span
+              >
+              <svg class="zx-icon zx-project-chevron" aria-hidden="true">
+                <use href="#zx-hifi-icon-chevron-down"></use>
+              </svg>
             </button>
             <div class="zx-thread-list" data-project-list>
-              <button type="button" class="zx-thread" aria-current="page" data-thread="command-surface" data-title="Refine command surface" data-project="ZenX / apps / desktop" data-model="GPT-5.6 Sol">
-                <span class="zx-thread-title"><span>Refine command surface</span><span class="zx-needs-dot" aria-label="Needs you"></span></span>
-                <span class="zx-model-line"><span class="zx-provider-logo zx-logo-openai" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M9 2.7a3 3 0 0 1 2.8 1.8 3 3 0 0 1 3.2 4.8 3 3 0 0 1-2.7 4.8A3 3 0 0 1 7 15.3a3 3 0 0 1-3.2-4.8 3 3 0 0 1 2.7-4.8A3 3 0 0 1 9 2.7Z" fill="none" stroke="currentColor" stroke-width="1.2"/><path d="m6.4 5.8 5.2 3v5.3M11.6 12.2l-5.2-3V4.8m.1 6.1L9 9.5l2.5-1.4" fill="none" stroke="currentColor" stroke-width="1.15"/></svg></span><span>GPT-5.6 Sol</span></span>
+              <button
+                type="button"
+                class="zx-thread"
+                aria-current="page"
+                data-thread="command-surface"
+                data-title="Refine command surface"
+                data-project="ZenX / apps / desktop"
+                data-model="GPT-5.6 Sol"
+              >
+                <span class="zx-thread-title"
+                  ><span>Refine command surface</span
+                  ><span class="zx-needs-dot" aria-label="Needs you"></span
+                ></span>
+                <span class="zx-model-line"
+                  ><span
+                    class="zx-provider-logo zx-logo-openai"
+                    aria-hidden="true"
+                    ><svg viewBox="0 0 18 18">
+                      <path
+                        d="M9 2.7a3 3 0 0 1 2.8 1.8 3 3 0 0 1 3.2 4.8 3 3 0 0 1-2.7 4.8A3 3 0 0 1 7 15.3a3 3 0 0 1-3.2-4.8 3 3 0 0 1 2.7-4.8A3 3 0 0 1 9 2.7Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                      />
+                      <path
+                        d="m6.4 5.8 5.2 3v5.3M11.6 12.2l-5.2-3V4.8m.1 6.1L9 9.5l2.5-1.4"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.15"
+                      /></svg></span
+                  ><span>GPT-5.6 Sol</span></span
+                >
               </button>
-              <button type="button" class="zx-thread" data-thread="capability-lifecycle" data-title="Capability lifecycle" data-project="ZenX / packages / runtime" data-model="DeepSeek-V3.1">
-                <span class="zx-thread-title"><span>Capability lifecycle</span><span class="zx-live-dot" aria-label="Running"></span></span>
-                <span class="zx-model-line"><span class="zx-provider-logo zx-logo-deepseek" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M3 10.5c1.8 2.9 5.2 4.4 8.2 3.4 2.4-.8 3.6-2.7 3.8-5.2-1.8 1-3.9.8-5.5-.6C7.4 6.2 5.6 7 3 10.5Z" fill="currentColor"/><circle cx="11.8" cy="9.7" r=".8" fill="#272f47"/></svg></span><span>DeepSeek-V3.1</span></span>
+              <button
+                type="button"
+                class="zx-thread"
+                data-thread="capability-lifecycle"
+                data-title="Capability lifecycle"
+                data-project="ZenX / packages / runtime"
+                data-model="DeepSeek-V3.1"
+              >
+                <span class="zx-thread-title"
+                  ><span>Capability lifecycle</span
+                  ><span class="zx-live-dot" aria-label="Running"></span
+                ></span>
+                <span class="zx-model-line"
+                  ><span
+                    class="zx-provider-logo zx-logo-deepseek"
+                    aria-hidden="true"
+                    ><svg viewBox="0 0 18 18">
+                      <path
+                        d="M3 10.5c1.8 2.9 5.2 4.4 8.2 3.4 2.4-.8 3.6-2.7 3.8-5.2-1.8 1-3.9.8-5.5-.6C7.4 6.2 5.6 7 3 10.5Z"
+                        fill="currentColor"
+                      />
+                      <circle
+                        cx="11.8"
+                        cy="9.7"
+                        r=".8"
+                        fill="#272f47"
+                      /></svg></span
+                  ><span>DeepSeek-V3.1</span></span
+                >
               </button>
-              <button type="button" class="zx-thread" data-thread="protocol-notes" data-title="Protocol projection notes" data-project="ZenX / packages / protocol" data-model="Qwen3-Coder">
-                <span class="zx-thread-title"><span>Protocol projection notes</span></span>
-                <span class="zx-model-line"><span class="zx-provider-logo zx-logo-qwen" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M9 2.8a6.2 6.2 0 1 0 4.2 10.8l2 1.7v-4.6h-4.5l1.8 1.6A4.5 4.5 0 1 1 13.5 9h1.7A6.2 6.2 0 0 0 9 2.8Z" fill="currentColor"/><circle cx="9" cy="9" r="1.3" fill="#2f2948"/></svg></span><span>Qwen3-Coder</span></span>
+              <button
+                type="button"
+                class="zx-thread"
+                data-thread="protocol-notes"
+                data-title="Protocol projection notes"
+                data-project="ZenX / packages / protocol"
+                data-model="Qwen3-Coder"
+              >
+                <span class="zx-thread-title"
+                  ><span>Protocol projection notes</span></span
+                >
+                <span class="zx-model-line"
+                  ><span
+                    class="zx-provider-logo zx-logo-qwen"
+                    aria-hidden="true"
+                    ><svg viewBox="0 0 18 18">
+                      <path
+                        d="M9 2.8a6.2 6.2 0 1 0 4.2 10.8l2 1.7v-4.6h-4.5l1.8 1.6A4.5 4.5 0 1 1 13.5 9h1.7A6.2 6.2 0 0 0 9 2.8Z"
+                        fill="currentColor"
+                      />
+                      <circle
+                        cx="9"
+                        cy="9"
+                        r="1.3"
+                        fill="#2f2948"
+                      /></svg></span
+                  ><span>Qwen3-Coder</span></span
+                >
               </button>
             </div>
           </section>
 
           <section class="zx-project" aria-label="T3 reference project">
-            <button type="button" class="zx-project-head" aria-expanded="true" data-project-toggle>
-              <span class="zx-project-label"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg><span>T3 reference</span></span>
-              <svg class="zx-icon zx-project-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+            <button
+              type="button"
+              class="zx-project-head"
+              aria-expanded="true"
+              data-project-toggle
+            >
+              <span class="zx-project-label"
+                ><svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                ><span>T3 reference</span></span
+              >
+              <svg class="zx-icon zx-project-chevron" aria-hidden="true">
+                <use href="#zx-hifi-icon-chevron-down"></use>
+              </svg>
             </button>
             <div class="zx-thread-list" data-project-list>
-              <button type="button" class="zx-thread" data-thread="composer-study" data-title="Composer interaction study" data-project="References / t3code" data-model="GPT-5.2">
-                <span class="zx-thread-title"><span>Composer interaction study</span></span>
-                <span class="zx-model-line"><span class="zx-provider-logo zx-logo-openai" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M9 2.7a3 3 0 0 1 2.8 1.8 3 3 0 0 1 3.2 4.8 3 3 0 0 1-2.7 4.8A3 3 0 0 1 7 15.3a3 3 0 0 1-3.2-4.8 3 3 0 0 1 2.7-4.8A3 3 0 0 1 9 2.7Z" fill="none" stroke="currentColor" stroke-width="1.2"/></svg></span><span>GPT-5.2</span></span>
+              <button
+                type="button"
+                class="zx-thread"
+                data-thread="composer-study"
+                data-title="Composer interaction study"
+                data-project="References / t3code"
+                data-model="GPT-5.2"
+              >
+                <span class="zx-thread-title"
+                  ><span>Composer interaction study</span></span
+                >
+                <span class="zx-model-line"
+                  ><span
+                    class="zx-provider-logo zx-logo-openai"
+                    aria-hidden="true"
+                    ><svg viewBox="0 0 18 18">
+                      <path
+                        d="M9 2.7a3 3 0 0 1 2.8 1.8 3 3 0 0 1 3.2 4.8 3 3 0 0 1-2.7 4.8A3 3 0 0 1 7 15.3a3 3 0 0 1-3.2-4.8 3 3 0 0 1 2.7-4.8A3 3 0 0 1 9 2.7Z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="1.2"
+                      /></svg></span
+                  ><span>GPT-5.2</span></span
+                >
               </button>
             </div>
           </section>
@@ -1913,807 +3034,2440 @@
 
         <div data-sidebar-view="inbox" hidden>
           <section class="zx-inbox-group" aria-labelledby="zx-hifi-needs-title">
-            <div class="zx-inbox-group-title" id="zx-hifi-needs-title"><span class="zx-needs-dot" aria-hidden="true"></span>Needs you</div>
-            <button type="button" class="zx-thread zx-inbox-thread" data-thread="command-surface" data-title="Refine command surface" data-project="ZenX / apps / desktop" data-model="GPT-5.6 Sol">
-              <span class="zx-inbox-project"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg>ZenX · apps/desktop</span>
-              <span class="zx-thread-title"><span>Refine command surface</span><span class="zx-needs-dot" aria-label="Needs you"></span></span>
-              <span class="zx-model-line"><span class="zx-provider-logo zx-logo-openai" aria-hidden="true"><svg viewBox="0 0 18 18"><circle cx="9" cy="9" r="5" fill="none" stroke="currentColor"/></svg></span><span>GPT-5.6 Sol</span></span>
+            <div class="zx-inbox-group-title" id="zx-hifi-needs-title">
+              <span class="zx-needs-dot" aria-hidden="true"></span>Needs you
+            </div>
+            <button
+              type="button"
+              class="zx-thread zx-inbox-thread"
+              data-thread="command-surface"
+              data-title="Refine command surface"
+              data-project="ZenX / apps / desktop"
+              data-model="GPT-5.6 Sol"
+            >
+              <span class="zx-inbox-project"
+                ><svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                >ZenX · apps/desktop</span
+              >
+              <span class="zx-thread-title"
+                ><span>Refine command surface</span
+                ><span class="zx-needs-dot" aria-label="Needs you"></span
+              ></span>
+              <span class="zx-model-line"
+                ><span
+                  class="zx-provider-logo zx-logo-openai"
+                  aria-hidden="true"
+                  ><svg viewBox="0 0 18 18">
+                    <circle
+                      cx="9"
+                      cy="9"
+                      r="5"
+                      fill="none"
+                      stroke="currentColor"
+                    /></svg></span
+                ><span>GPT-5.6 Sol</span></span
+              >
             </button>
           </section>
-          <section class="zx-inbox-group" aria-labelledby="zx-hifi-active-title">
-            <div class="zx-inbox-group-title" id="zx-hifi-active-title"><span class="zx-live-dot" aria-hidden="true"></span>Active</div>
-            <button type="button" class="zx-thread zx-inbox-thread" data-thread="capability-lifecycle" data-title="Capability lifecycle" data-project="ZenX / packages / runtime" data-model="DeepSeek-V3.1">
-              <span class="zx-inbox-project"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg>ZenX · packages/runtime</span>
-              <span class="zx-thread-title"><span>Capability lifecycle</span><span class="zx-live-dot" aria-label="Running"></span></span>
-              <span class="zx-model-line"><span class="zx-provider-logo zx-logo-deepseek" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M3 10.5c1.8 2.9 5.2 4.4 8.2 3.4 2.4-.8 3.6-2.7 3.8-5.2-1.8 1-3.9.8-5.5-.6C7.4 6.2 5.6 7 3 10.5Z" fill="currentColor"/></svg></span><span>DeepSeek-V3.1</span></span>
+          <section
+            class="zx-inbox-group"
+            aria-labelledby="zx-hifi-active-title"
+          >
+            <div class="zx-inbox-group-title" id="zx-hifi-active-title">
+              <span class="zx-live-dot" aria-hidden="true"></span>Active
+            </div>
+            <button
+              type="button"
+              class="zx-thread zx-inbox-thread"
+              data-thread="capability-lifecycle"
+              data-title="Capability lifecycle"
+              data-project="ZenX / packages / runtime"
+              data-model="DeepSeek-V3.1"
+            >
+              <span class="zx-inbox-project"
+                ><svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                >ZenX · packages/runtime</span
+              >
+              <span class="zx-thread-title"
+                ><span>Capability lifecycle</span
+                ><span class="zx-live-dot" aria-label="Running"></span
+              ></span>
+              <span class="zx-model-line"
+                ><span
+                  class="zx-provider-logo zx-logo-deepseek"
+                  aria-hidden="true"
+                  ><svg viewBox="0 0 18 18">
+                    <path
+                      d="M3 10.5c1.8 2.9 5.2 4.4 8.2 3.4 2.4-.8 3.6-2.7 3.8-5.2-1.8 1-3.9.8-5.5-.6C7.4 6.2 5.6 7 3 10.5Z"
+                      fill="currentColor"
+                    /></svg></span
+                ><span>DeepSeek-V3.1</span></span
+              >
             </button>
           </section>
-          <section class="zx-inbox-group" aria-labelledby="zx-hifi-updated-title">
-            <div class="zx-inbox-group-title" id="zx-hifi-updated-title">Updated</div>
-            <button type="button" class="zx-thread zx-inbox-thread" data-thread="protocol-notes" data-title="Protocol projection notes" data-project="ZenX / packages / protocol" data-model="Qwen3-Coder">
-              <span class="zx-inbox-project"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg>ZenX · packages/protocol</span>
-              <span class="zx-thread-title"><span>Protocol projection notes</span></span>
-              <span class="zx-model-line"><span class="zx-provider-logo zx-logo-qwen" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M9 3a6 6 0 1 0 4 10.5l2 1.7v-4.5h-4.4l1.8 1.6A4.4 4.4 0 1 1 13.4 9H15A6 6 0 0 0 9 3Z" fill="currentColor"/></svg></span><span>Qwen3-Coder</span></span>
+          <section
+            class="zx-inbox-group"
+            aria-labelledby="zx-hifi-updated-title"
+          >
+            <div class="zx-inbox-group-title" id="zx-hifi-updated-title">
+              Updated
+            </div>
+            <button
+              type="button"
+              class="zx-thread zx-inbox-thread"
+              data-thread="protocol-notes"
+              data-title="Protocol projection notes"
+              data-project="ZenX / packages / protocol"
+              data-model="Qwen3-Coder"
+            >
+              <span class="zx-inbox-project"
+                ><svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                >ZenX · packages/protocol</span
+              >
+              <span class="zx-thread-title"
+                ><span>Protocol projection notes</span></span
+              >
+              <span class="zx-model-line"
+                ><span class="zx-provider-logo zx-logo-qwen" aria-hidden="true"
+                  ><svg viewBox="0 0 18 18">
+                    <path
+                      d="M9 3a6 6 0 1 0 4 10.5l2 1.7v-4.5h-4.4l1.8 1.6A4.4 4.4 0 1 1 13.4 9H15A6 6 0 0 0 9 3Z"
+                      fill="currentColor"
+                    /></svg></span
+                ><span>Qwen3-Coder</span></span
+              >
             </button>
           </section>
         </div>
       </div>
 
       <footer class="zx-sidebar-foot">
-        <div class="zx-service"><span class="zx-live-dot" aria-hidden="true"></span><span>Local service ready</span></div>
-        <button type="button" class="zx-icon-button" aria-label="Settings" data-open-page="settings"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-settings"></use></svg></button>
+        <div class="zx-service">
+          <span class="zx-live-dot" aria-hidden="true"></span
+          ><span>Local service ready</span>
+        </div>
+        <button
+          type="button"
+          class="zx-icon-button"
+          aria-label="Settings"
+          data-open-page="settings"
+        >
+          <svg class="zx-icon" aria-hidden="true">
+            <use href="#zx-hifi-icon-settings"></use>
+          </svg>
+        </button>
       </footer>
     </aside>
 
-    <button type="button" class="zx-mobile-scrim" aria-label="Close sidebar" data-close-sidebar></button>
+    <button
+      type="button"
+      class="zx-mobile-scrim"
+      aria-label="Close sidebar"
+      data-close-sidebar
+    ></button>
 
     <main class="zx-main" data-modal-background>
       <header class="zx-topbar">
-        <button type="button" class="zx-icon-button zx-mobile-menu" aria-label="Open sidebar" data-open-sidebar><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-menu"></use></svg></button>
+        <button
+          type="button"
+          class="zx-icon-button zx-mobile-menu"
+          aria-label="Open sidebar"
+          data-open-sidebar
+        >
+          <svg class="zx-icon" aria-hidden="true">
+            <use href="#zx-hifi-icon-menu"></use>
+          </svg>
+        </button>
         <div class="zx-thread-heading">
           <strong data-current-title>Refine command surface</strong>
-          <span class="zx-thread-context" data-current-project>ZenX / apps / desktop</span>
+          <span class="zx-thread-context" data-current-project
+            >ZenX / apps / desktop</span
+          >
         </div>
         <div class="zx-top-actions">
-          <button type="button" class="zx-icon-button" aria-label="Search in thread"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-search"></use></svg></button>
-          <button type="button" class="zx-icon-button" aria-label="Open workspace panel" aria-haspopup="dialog" data-open-workspace><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-panel"></use></svg></button>
+          <button
+            type="button"
+            class="zx-icon-button"
+            aria-label="Search in thread"
+          >
+            <svg class="zx-icon" aria-hidden="true">
+              <use href="#zx-hifi-icon-search"></use>
+            </svg>
+          </button>
+          <button
+            type="button"
+            class="zx-icon-button"
+            aria-label="Open workspace panel"
+            aria-haspopup="dialog"
+            data-open-workspace
+          >
+            <svg class="zx-icon" aria-hidden="true">
+              <use href="#zx-hifi-icon-panel"></use>
+            </svg>
+          </button>
         </div>
       </header>
 
       <div class="zx-transcript-shell">
-        <div class="zx-transcript" data-transcript aria-label="Refine command surface transcript">
+        <div
+          class="zx-transcript"
+          data-transcript
+          aria-label="Refine command surface transcript"
+        >
           <div class="zx-conversation" data-conversation>
             <article class="zx-user-row">
-              <div class="zx-user-bubble" data-thread-user>Rework this into a review-ready prototype. Keep the composer stable while the run is active, and make steering the obvious action.</div>
+              <div class="zx-user-bubble" data-thread-user>
+                Rework this into a review-ready prototype. Keep the composer
+                stable while the run is active, and make steering the obvious
+                action.
+              </div>
             </article>
 
-            <section class="zx-turn" data-turn data-turn-state="running" data-expanded="true">
+            <section
+              class="zx-turn"
+              data-turn
+              data-turn-state="running"
+              data-expanded="true"
+            >
               <div class="zx-agent-meta">
-                <span class="zx-agent-glyph" aria-hidden="true"><svg viewBox="0 0 18 18"><path d="M3 13.5 7 5l4 8.5L15 5" fill="none" stroke="url(#zx-hifi-brand-gradient)" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg></span>
+                <span class="zx-agent-glyph" aria-hidden="true"
+                  ><svg viewBox="0 0 18 18">
+                    <path
+                      d="M3 13.5 7 5l4 8.5L15 5"
+                      fill="none"
+                      stroke="url(#zx-hifi-brand-gradient)"
+                      stroke-width="1.7"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    /></svg
+                ></span>
                 <strong>ZenX</strong><time>10:42</time>
               </div>
-              <div class="zx-turn-running-label" data-turn-running-label><span class="zx-spinner" aria-hidden="true"></span><span>Working for <span data-turn-duration>24s</span></span></div>
-              <button type="button" class="zx-turn-toggle" aria-expanded="false" data-turn-toggle>
-                <span>Worked for <span data-turn-duration-complete>42s</span></span>
-                <svg class="zx-icon zx-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+              <div class="zx-turn-running-label" data-turn-running-label>
+                <span class="zx-spinner" aria-hidden="true"></span
+                ><span>Working for <span data-turn-duration>24s</span></span>
+              </div>
+              <button
+                type="button"
+                class="zx-turn-toggle"
+                aria-expanded="false"
+                data-turn-toggle
+              >
+                <span
+                  >Worked for <span data-turn-duration-complete>42s</span></span
+                >
+                <svg class="zx-icon zx-chevron" aria-hidden="true">
+                  <use href="#zx-hifi-icon-chevron-down"></use>
+                </svg>
               </button>
               <div class="zx-turn-history" data-turn-history>
-                <div class="zx-agent-copy" data-item-kind="agent-message"><p data-thread-assistant>I’m refining the turn projection now. The active surface stays focused on the Agent response while the execution trace remains available without competing for attention.</p></div>
+                <div class="zx-agent-copy" data-item-kind="agent-message">
+                  <p data-thread-assistant>
+                    I’m refining the turn projection now. The active surface
+                    stays focused on the Agent response while the execution
+                    trace remains available without competing for attention.
+                  </p>
+                </div>
 
                 <section class="zx-trace-group" data-item-kind="trace-group">
-                  <button type="button" class="zx-trace-group-toggle" aria-expanded="false" data-trace-group-toggle>
-                    <span class="zx-trace-group-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-layers"></use></svg></span>
-                    <span class="zx-trace-group-title" data-thread-trace-summary>Reasoned about the Item stream and inspected the current UI</span>
+                  <button
+                    type="button"
+                    class="zx-trace-group-toggle"
+                    aria-expanded="false"
+                    data-trace-group-toggle
+                  >
+                    <span class="zx-trace-group-icon"
+                      ><svg class="zx-icon" aria-hidden="true">
+                        <use href="#zx-hifi-icon-layers"></use></svg
+                    ></span>
+                    <span class="zx-trace-group-title" data-thread-trace-summary
+                      >Reasoned about the Item stream and inspected the current
+                      UI</span
+                    >
                     <span class="zx-trace-group-meta">2 items</span>
-                    <svg class="zx-icon zx-trace-group-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                    <svg
+                      class="zx-icon zx-trace-group-chevron"
+                      aria-hidden="true"
+                    >
+                      <use href="#zx-hifi-icon-chevron-down"></use>
+                    </svg>
                   </button>
-                  <div class="zx-trace-group-items" data-trace-group-items hidden>
-                    <button type="button" class="zx-turn-step" aria-expanded="false" data-step-toggle data-item-kind="thinking">
-                      <span class="zx-turn-step-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-brain"></use></svg></span>
-                      <span class="zx-turn-step-copy"><strong>Think</strong><span>Mapped the ZEM Turn and Item projection</span></span>
-                      <svg class="zx-icon zx-turn-step-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                  <div
+                    class="zx-trace-group-items"
+                    data-trace-group-items
+                    hidden
+                  >
+                    <button
+                      type="button"
+                      class="zx-turn-step"
+                      aria-expanded="false"
+                      data-step-toggle
+                      data-item-kind="thinking"
+                    >
+                      <span class="zx-turn-step-icon"
+                        ><svg class="zx-icon" aria-hidden="true">
+                          <use href="#zx-hifi-icon-brain"></use></svg
+                      ></span>
+                      <span class="zx-turn-step-copy"
+                        ><strong>Think</strong
+                        ><span
+                          >Mapped the ZEM Turn and Item projection</span
+                        ></span
+                      >
+                      <svg
+                        class="zx-icon zx-turn-step-chevron"
+                        aria-hidden="true"
+                      >
+                        <use href="#zx-hifi-icon-chevron-down"></use>
+                      </svg>
                     </button>
-                    <div class="zx-step-detail" data-step-detail hidden>Compared the live Item stream with the completed projection, then separated Turn-level completion from Item-level disclosure.</div>
-                    <button type="button" class="zx-turn-step" aria-expanded="false" data-step-toggle data-item-kind="tool-call">
-                      <span class="zx-turn-step-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-terminal"></use></svg></span>
-                      <span class="zx-turn-step-copy"><strong>Tool</strong><span data-thread-tool>Inspect current thread UI</span></span>
-                      <svg class="zx-icon zx-turn-step-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                    <div class="zx-step-detail" data-step-detail hidden>
+                      Compared the live Item stream with the completed
+                      projection, then separated Turn-level completion from
+                      Item-level disclosure.
+                    </div>
+                    <button
+                      type="button"
+                      class="zx-turn-step"
+                      aria-expanded="false"
+                      data-step-toggle
+                      data-item-kind="tool-call"
+                    >
+                      <span class="zx-turn-step-icon"
+                        ><svg class="zx-icon" aria-hidden="true">
+                          <use href="#zx-hifi-icon-terminal"></use></svg
+                      ></span>
+                      <span class="zx-turn-step-copy"
+                        ><strong>Tool</strong
+                        ><span data-thread-tool
+                          >Inspect current thread UI</span
+                        ></span
+                      >
+                      <svg
+                        class="zx-icon zx-turn-step-chevron"
+                        aria-hidden="true"
+                      >
+                        <use href="#zx-hifi-icon-chevron-down"></use>
+                      </svg>
                     </button>
-                    <div class="zx-step-detail" data-step-detail hidden><span data-thread-tool-summary>4 files · 186 matches · 312 ms</span><br>rg "turn|item|thinking|tool|final" apps/desktop/src</div>
+                    <div class="zx-step-detail" data-step-detail hidden>
+                      <span data-thread-tool-summary
+                        >4 files · 186 matches · 312 ms</span
+                      ><br />rg "turn|item|thinking|tool|final" apps/desktop/src
+                    </div>
                   </div>
                 </section>
 
-                <div class="zx-agent-copy zx-agent-progress" data-item-kind="agent-message">
-                  <p data-thread-progress>The active and completed projections now share one stream. Agent messages remain readable while internal steps stay compact.</p>
+                <div
+                  class="zx-agent-copy zx-agent-progress"
+                  data-item-kind="agent-message"
+                >
+                  <p data-thread-progress>
+                    The active and completed projections now share one stream.
+                    Agent messages remain readable while internal steps stay
+                    compact.
+                  </p>
                   <pre class="zx-code"><code>running + empty  →  Stop
 running + draft  →  Interrupt &amp; send
 idle + draft     →  Send</code></pre>
                 </div>
 
                 <section class="zx-trace-group" data-item-kind="trace-group">
-                  <button type="button" class="zx-trace-group-toggle" aria-expanded="false" data-trace-group-toggle>
-                    <span class="zx-trace-group-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-code"></use></svg></span>
-                    <span class="zx-trace-group-title">Applied the projection and verified responsive states</span>
+                  <button
+                    type="button"
+                    class="zx-trace-group-toggle"
+                    aria-expanded="false"
+                    data-trace-group-toggle
+                  >
+                    <span class="zx-trace-group-icon"
+                      ><svg class="zx-icon" aria-hidden="true">
+                        <use href="#zx-hifi-icon-code"></use></svg
+                    ></span>
+                    <span class="zx-trace-group-title"
+                      >Applied the projection and verified responsive
+                      states</span
+                    >
                     <span class="zx-trace-group-meta">2 items</span>
-                    <svg class="zx-icon zx-trace-group-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                    <svg
+                      class="zx-icon zx-trace-group-chevron"
+                      aria-hidden="true"
+                    >
+                      <use href="#zx-hifi-icon-chevron-down"></use>
+                    </svg>
                   </button>
-                  <div class="zx-trace-group-items" data-trace-group-items hidden>
-                    <button type="button" class="zx-turn-step" aria-expanded="false" data-step-toggle data-item-kind="thinking">
-                      <span class="zx-turn-step-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-brain"></use></svg></span>
-                      <span class="zx-turn-step-copy"><strong>Think</strong><span>Checked completion and disclosure invariants</span></span>
-                      <svg class="zx-icon zx-turn-step-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                  <div
+                    class="zx-trace-group-items"
+                    data-trace-group-items
+                    hidden
+                  >
+                    <button
+                      type="button"
+                      class="zx-turn-step"
+                      aria-expanded="false"
+                      data-step-toggle
+                      data-item-kind="thinking"
+                    >
+                      <span class="zx-turn-step-icon"
+                        ><svg class="zx-icon" aria-hidden="true">
+                          <use href="#zx-hifi-icon-brain"></use></svg
+                      ></span>
+                      <span class="zx-turn-step-copy"
+                        ><strong>Think</strong
+                        ><span
+                          >Checked completion and disclosure invariants</span
+                        ></span
+                      >
+                      <svg
+                        class="zx-icon zx-turn-step-chevron"
+                        aria-hidden="true"
+                      >
+                        <use href="#zx-hifi-icon-chevron-down"></use>
+                      </svg>
                     </button>
-                    <div class="zx-step-detail" data-step-detail hidden>Confirmed that an incomplete Turn always projects its Item stream and that a completed Turn can collapse to its final Agent Message.</div>
-                    <button type="button" class="zx-turn-step" aria-expanded="false" data-step-toggle data-item-kind="tool-call">
-                      <span class="zx-turn-step-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-code"></use></svg></span>
-                      <span class="zx-turn-step-copy"><strong>Tool</strong><span>Update prototype surface</span></span>
-                      <svg class="zx-icon zx-turn-step-chevron" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                    <div class="zx-step-detail" data-step-detail hidden>
+                      Confirmed that an incomplete Turn always projects its Item
+                      stream and that a completed Turn can collapse to its final
+                      Agent Message.
+                    </div>
+                    <button
+                      type="button"
+                      class="zx-turn-step"
+                      aria-expanded="false"
+                      data-step-toggle
+                      data-item-kind="tool-call"
+                    >
+                      <span class="zx-turn-step-icon"
+                        ><svg class="zx-icon" aria-hidden="true">
+                          <use href="#zx-hifi-icon-code"></use></svg
+                      ></span>
+                      <span class="zx-turn-step-copy"
+                        ><strong>Tool</strong
+                        ><span>Update prototype surface</span></span
+                      >
+                      <svg
+                        class="zx-icon zx-turn-step-chevron"
+                        aria-hidden="true"
+                      >
+                        <use href="#zx-hifi-icon-chevron-down"></use>
+                      </svg>
                     </button>
-                    <div class="zx-step-detail" data-step-detail hidden>Updated Turn, Trace Group, Thinking, Tool Call, and Agent Message projections; preserved keyboard and responsive behavior.</div>
+                    <div class="zx-step-detail" data-step-detail hidden>
+                      Updated Turn, Trace Group, Thinking, Tool Call, and Agent
+                      Message projections; preserved keyboard and responsive
+                      behavior.
+                    </div>
                   </div>
                 </section>
               </div>
-              <div class="zx-turn-final" data-turn-final data-item-kind="agent-message-final">
-                <div class="zx-agent-copy"><p data-thread-final>The conversation now shows only the final answer after completion, with the complete execution trace folded into one reviewable turn disclosure.</p></div>
+              <div
+                class="zx-turn-final"
+                data-turn-final
+                data-item-kind="agent-message-final"
+              >
+                <div class="zx-agent-copy">
+                  <p data-thread-final>
+                    The conversation now shows only the final answer after
+                    completion, with the complete execution trace folded into
+                    one reviewable turn disclosure.
+                  </p>
+                </div>
               </div>
             </section>
           </div>
         </div>
 
         <div class="zx-empty" data-empty-state hidden>
-          <div class="zx-empty-mark" aria-hidden="true"><svg class="zx-icon"><use href="#zx-hifi-icon-compose"></use></svg></div>
+          <div class="zx-empty-mark" aria-hidden="true">
+            <svg class="zx-icon"><use href="#zx-hifi-icon-compose"></use></svg>
+          </div>
           <h2>Start a new thread</h2>
-          <p>Describe the outcome you want. ZenX will use the selected model, workspace, and permission level below.</p>
+          <p>
+            Describe the outcome you want. ZenX will use the selected model,
+            workspace, and permission level below.
+          </p>
         </div>
 
-        <button type="button" class="zx-back-live" data-back-live hidden><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-arrow-down"></use></svg>Back to live</button>
+        <button type="button" class="zx-back-live" data-back-live hidden>
+          <svg class="zx-icon" aria-hidden="true">
+            <use href="#zx-hifi-icon-arrow-down"></use></svg
+          >Back to live
+        </button>
       </div>
 
       <section class="zx-bottom-zone" aria-label="Message composer">
         <div class="zx-approval" data-approval>
-          <span class="zx-approval-icon" aria-hidden="true"><svg class="zx-icon"><use href="#zx-hifi-icon-shield"></use></svg></span>
-          <div class="zx-approval-copy"><strong>Allow browser control for this step?</strong><span>127.0.0.1 · inspect and interact · this run only</span></div>
+          <span class="zx-approval-icon" aria-hidden="true"
+            ><svg class="zx-icon"><use href="#zx-hifi-icon-shield"></use></svg
+          ></span>
+          <div class="zx-approval-copy">
+            <strong>Allow browser control for this step?</strong
+            ><span>127.0.0.1 · inspect and interact · this run only</span>
+          </div>
           <div class="zx-approval-actions">
-            <button type="button" class="zx-approval-button" data-approval-action="deny">Deny</button>
-            <button type="button" class="zx-approval-button zx-allow" data-approval-action="allow">Allow once</button>
+            <button
+              type="button"
+              class="zx-approval-button"
+              data-approval-action="deny"
+            >
+              Deny
+            </button>
+            <button
+              type="button"
+              class="zx-approval-button zx-allow"
+              data-approval-action="allow"
+            >
+              Allow once
+            </button>
           </div>
         </div>
 
         <div class="zx-composer">
           <label class="zx-sr-only" for="zx-hifi-message">Message ZenX</label>
-          <textarea id="zx-hifi-message" placeholder="Steer the current run…" data-composer-input></textarea>
+          <textarea
+            id="zx-hifi-message"
+            placeholder="Steer the current run…"
+            data-composer-input
+          ></textarea>
           <div class="zx-composer-rail">
             <div class="zx-composer-tools">
-              <button type="button" class="zx-control-button" aria-label="Attach files" data-control="attach"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-paperclip"></use></svg></button>
-              <span class="zx-control-separator" aria-hidden="true"></span>
-              <button type="button" class="zx-control-button" data-control="model" aria-haspopup="listbox">
-                <span class="zx-provider-logo zx-logo-openai" aria-hidden="true"><svg viewBox="0 0 18 18"><circle cx="9" cy="9" r="5" fill="none" stroke="currentColor" stroke-width="1.2"/><path d="m6 7 6 4M12 7l-6 4" fill="none" stroke="currentColor" stroke-width="1.2"/></svg></span>
-                <span class="zx-control-label-wide">GPT-5.6 Sol</span>
-                <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+              <button
+                type="button"
+                class="zx-control-button"
+                aria-label="Attach files"
+                data-control="attach"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-paperclip"></use>
+                </svg>
               </button>
               <span class="zx-control-separator" aria-hidden="true"></span>
-              <button type="button" class="zx-control-button" data-control="permission" aria-haspopup="menu">
-                <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-lock"></use></svg>
+              <button
+                type="button"
+                class="zx-control-button"
+                data-control="model"
+                aria-haspopup="listbox"
+              >
+                <span class="zx-provider-logo zx-logo-openai" aria-hidden="true"
+                  ><svg viewBox="0 0 18 18">
+                    <circle
+                      cx="9"
+                      cy="9"
+                      r="5"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                    />
+                    <path
+                      d="m6 7 6 4M12 7l-6 4"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.2"
+                    /></svg
+                ></span>
+                <span class="zx-control-label-wide">GPT-5.6 Sol</span>
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-chevron-down"></use>
+                </svg>
+              </button>
+              <span class="zx-control-separator" aria-hidden="true"></span>
+              <button
+                type="button"
+                class="zx-control-button"
+                data-control="permission"
+                aria-haspopup="menu"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-lock"></use>
+                </svg>
                 <span class="zx-control-label-wide">Full access</span>
-                <svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-chevron-down"></use></svg>
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-chevron-down"></use>
+                </svg>
               </button>
             </div>
 
             <div class="zx-composer-submit">
-              <button type="button" class="zx-action-orb" aria-label="Stop run" data-composer-action>
-                <svg class="zx-icon zx-action-stop" aria-hidden="true"><use href="#zx-hifi-icon-stop"></use></svg>
-                <svg class="zx-icon zx-action-send" aria-hidden="true"><use href="#zx-hifi-icon-send"></use></svg>
+              <button
+                type="button"
+                class="zx-action-orb"
+                aria-label="Stop run"
+                data-composer-action
+              >
+                <svg class="zx-icon zx-action-stop" aria-hidden="true">
+                  <use href="#zx-hifi-icon-stop"></use>
+                </svg>
+                <svg class="zx-icon zx-action-send" aria-hidden="true">
+                  <use href="#zx-hifi-icon-send"></use>
+                </svg>
               </button>
             </div>
           </div>
         </div>
       </section>
 
-      <section class="zx-product-page" data-product-page="plugins" aria-label="Plugin marketplace" hidden>
+      <section
+        class="zx-product-page"
+        data-product-page="plugins"
+        aria-label="Plugin marketplace"
+        hidden
+      >
         <header class="zx-page-header">
           <div class="zx-page-title">
-            <button type="button" class="zx-icon-button zx-mobile-menu" aria-label="Open sidebar" data-open-sidebar><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-menu"></use></svg></button>
-            <div><h1>Plugin marketplace</h1><p>Capability packages available to ZenX Agents</p></div>
+            <button
+              type="button"
+              class="zx-icon-button zx-mobile-menu"
+              aria-label="Open sidebar"
+              data-open-sidebar
+            >
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-menu"></use>
+              </svg>
+            </button>
+            <div>
+              <h1>Plugin marketplace</h1>
+              <p>Capability packages available to ZenX Agents</p>
+            </div>
           </div>
-          <button type="button" class="zx-secondary-button" data-local-package><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-plus"></use></svg>Add local package</button>
+          <button type="button" class="zx-secondary-button" data-local-package>
+            <svg class="zx-icon" aria-hidden="true">
+              <use href="#zx-hifi-icon-plus"></use></svg
+            >Add local package
+          </button>
         </header>
         <div class="zx-page-scroll">
           <div class="zx-page-intro">
-            <div><h2>Extend what Agents can do.</h2><p>Plugins add structured tools and instruction resources. Installation, permission grants, and per-call approval remain separate decisions.</p></div>
+            <div>
+              <h2>Extend what Agents can do.</h2>
+              <p>
+                Plugins add structured tools and instruction resources.
+                Installation, permission grants, and per-call approval remain
+                separate decisions.
+              </p>
+            </div>
           </div>
           <div class="zx-plugin-toolbar">
             <div class="zx-page-tabs" role="tablist" aria-label="Plugin views">
-              <button type="button" role="tab" aria-selected="true" data-plugin-tab="discover">Discover</button>
-              <button type="button" role="tab" aria-selected="false" data-plugin-tab="installed">Installed <span>4</span></button>
-              <button type="button" role="tab" aria-selected="false" data-plugin-tab="updates">Updates</button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="true"
+                data-plugin-tab="discover"
+              >
+                Discover
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-plugin-tab="installed"
+              >
+                Installed <span>4</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-plugin-tab="updates"
+              >
+                Updates
+              </button>
             </div>
-            <label class="zx-search-wrap"><span class="zx-sr-only">Search plugins</span><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-search"></use></svg><input class="zx-search-field" type="search" placeholder="Search plugins" data-plugin-search></label>
+            <label class="zx-search-wrap"
+              ><span class="zx-sr-only">Search plugins</span
+              ><svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-search"></use></svg
+              ><input
+                class="zx-search-field"
+                type="search"
+                placeholder="Search plugins"
+                data-plugin-search
+            /></label>
           </div>
           <div class="zx-plugin-grid" data-plugin-grid>
-            <article class="zx-plugin-card" data-plugin-card data-plugin-status="installed" data-plugin-search-text="browser web research playwright electron cdp">
-              <div class="zx-plugin-card-head"><span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-globe"></use></svg></span><div><h3>Browser</h3><small>ZenX bundled · v1.0.0</small></div><span class="zx-plugin-badge">Installed</span></div>
-              <p>Bounded tabs, navigation, page inspection, and semantic interaction with isolated or user-session browser providers.</p>
-              <div class="zx-plugin-card-foot"><span>3 permissions · 8 tools</span><button type="button" class="zx-secondary-button" data-open-capability="browser">Manage</button></div>
+            <article
+              class="zx-plugin-card"
+              data-plugin-card
+              data-plugin-status="installed"
+              data-plugin-search-text="browser web research playwright electron cdp"
+            >
+              <div class="zx-plugin-card-head">
+                <span class="zx-plugin-icon"
+                  ><svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-globe"></use></svg
+                ></span>
+                <div>
+                  <h3>Browser</h3>
+                  <small>ZenX bundled · v1.0.0</small>
+                </div>
+                <span class="zx-plugin-badge">Installed</span>
+              </div>
+              <p>
+                Bounded tabs, navigation, page inspection, and semantic
+                interaction with isolated or user-session browser providers.
+              </p>
+              <div class="zx-plugin-card-foot">
+                <span>3 permissions · 8 tools</span
+                ><button
+                  type="button"
+                  class="zx-secondary-button"
+                  data-open-capability="browser"
+                >
+                  Manage
+                </button>
+              </div>
             </article>
-            <article class="zx-plugin-card" data-plugin-card data-plugin-status="installed" data-plugin-search-text="computer macos accessibility window capture input">
-              <div class="zx-plugin-card-head"><span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-panel"></use></svg></span><div><h3>Computer</h3><small>ZenX bundled · v1.0.0</small></div><span class="zx-plugin-badge">Installed</span></div>
-              <p>Background-safe window inspection and capture, with explicit foreground control when pointer or keyboard access is required.</p>
-              <div class="zx-plugin-card-foot"><span>4 permissions · 7 tools</span><button type="button" class="zx-secondary-button" data-open-capability="computer">Manage</button></div>
+            <article
+              class="zx-plugin-card"
+              data-plugin-card
+              data-plugin-status="installed"
+              data-plugin-search-text="computer macos accessibility window capture input"
+            >
+              <div class="zx-plugin-card-head">
+                <span class="zx-plugin-icon"
+                  ><svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-panel"></use></svg
+                ></span>
+                <div>
+                  <h3>Computer</h3>
+                  <small>ZenX bundled · v1.0.0</small>
+                </div>
+                <span class="zx-plugin-badge">Installed</span>
+              </div>
+              <p>
+                Background-safe window inspection and capture, with explicit
+                foreground control when pointer or keyboard access is required.
+              </p>
+              <div class="zx-plugin-card-foot">
+                <span>4 permissions · 7 tools</span
+                ><button
+                  type="button"
+                  class="zx-secondary-button"
+                  data-open-capability="computer"
+                >
+                  Manage
+                </button>
+              </div>
             </article>
-            <article class="zx-plugin-card" data-plugin-card data-plugin-status="installed" data-plugin-search-text="zenx self control thread project archive rename">
-              <div class="zx-plugin-card-head"><span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-zap"></use></svg></span><div><h3>ZenX self-control</h3><small>ZenX bundled · v1.0.0</small></div><span class="zx-plugin-badge">Installed</span></div>
-              <p>Lets an Agent create, inspect, rename, archive, and continue ZenX Threads through the App Server boundary.</p>
-              <div class="zx-plugin-card-foot"><span>2 permissions · 10 tools</span><button type="button" class="zx-secondary-button" data-open-capability="self">Manage</button></div>
+            <article
+              class="zx-plugin-card"
+              data-plugin-card
+              data-plugin-status="installed"
+              data-plugin-search-text="zenx self control thread project archive rename"
+            >
+              <div class="zx-plugin-card-head">
+                <span class="zx-plugin-icon"
+                  ><svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-zap"></use></svg
+                ></span>
+                <div>
+                  <h3>ZenX self-control</h3>
+                  <small>ZenX bundled · v1.0.0</small>
+                </div>
+                <span class="zx-plugin-badge">Installed</span>
+              </div>
+              <p>
+                Lets an Agent create, inspect, rename, archive, and continue
+                ZenX Threads through the App Server boundary.
+              </p>
+              <div class="zx-plugin-card-foot">
+                <span>2 permissions · 10 tools</span
+                ><button
+                  type="button"
+                  class="zx-secondary-button"
+                  data-open-capability="self"
+                >
+                  Manage
+                </button>
+              </div>
             </article>
-            <article class="zx-plugin-card" data-plugin-card data-plugin-status="installed" data-plugin-search-text="triggers rooms automation schedule wakeup signal">
-              <div class="zx-plugin-card-head"><span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-clock"></use></svg></span><div><h3>ZenX Triggers &amp; Rooms</h3><small>ZenX bundled · v1.0.0</small></div><span class="zx-plugin-badge">Installed</span></div>
-              <p>Creates timer, Thread, Room mention, and signal wakeups, then routes shared Room conclusions into ordinary Turns.</p>
-              <div class="zx-plugin-card-foot"><span>2 permissions · 12 tools</span><button type="button" class="zx-secondary-button" data-open-page="scheduled">Open</button></div>
+            <article
+              class="zx-plugin-card"
+              data-plugin-card
+              data-plugin-status="installed"
+              data-plugin-search-text="triggers rooms automation schedule wakeup signal"
+            >
+              <div class="zx-plugin-card-head">
+                <span class="zx-plugin-icon"
+                  ><svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-clock"></use></svg
+                ></span>
+                <div>
+                  <h3>ZenX Triggers &amp; Rooms</h3>
+                  <small>ZenX bundled · v1.0.0</small>
+                </div>
+                <span class="zx-plugin-badge">Installed</span>
+              </div>
+              <p>
+                Creates timer, Thread, Room mention, and signal wakeups, then
+                routes shared Room conclusions into ordinary Turns.
+              </p>
+              <div class="zx-plugin-card-foot">
+                <span>2 permissions · 12 tools</span
+                ><button
+                  type="button"
+                  class="zx-secondary-button"
+                  data-open-page="scheduled"
+                >
+                  Open
+                </button>
+              </div>
             </article>
-            <article class="zx-plugin-card" data-plugin-card data-plugin-status="available" data-plugin-search-text="local capability package manifest development">
-              <div class="zx-plugin-card-head"><span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-plugin"></use></svg></span><div><h3>Local capability package</h3><small>Development source</small></div><span class="zx-plugin-badge">Local</span></div>
-              <p>Load a signed or development manifest from this Mac. ZenX validates tools, permissions, resources, and provider availability before activation.</p>
-              <div class="zx-plugin-card-foot"><span>Manifest required</span><button type="button" class="zx-primary-button" data-local-package>Choose folder</button></div>
+            <article
+              class="zx-plugin-card"
+              data-plugin-card
+              data-plugin-status="available"
+              data-plugin-search-text="local capability package manifest development"
+            >
+              <div class="zx-plugin-card-head">
+                <span class="zx-plugin-icon"
+                  ><svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-plugin"></use></svg
+                ></span>
+                <div>
+                  <h3>Local capability package</h3>
+                  <small>Development source</small>
+                </div>
+                <span class="zx-plugin-badge">Local</span>
+              </div>
+              <p>
+                Load a signed or development manifest from this Mac. ZenX
+                validates tools, permissions, resources, and provider
+                availability before activation.
+              </p>
+              <div class="zx-plugin-card-foot">
+                <span>Manifest required</span
+                ><button
+                  type="button"
+                  class="zx-primary-button"
+                  data-local-package
+                >
+                  Choose folder
+                </button>
+              </div>
             </article>
-            <div class="zx-page-card zx-plugin-empty" data-plugin-empty hidden>No plugins match this view.</div>
+            <div class="zx-page-card zx-plugin-empty" data-plugin-empty hidden>
+              No plugins match this view.
+            </div>
           </div>
         </div>
       </section>
 
-      <section class="zx-product-page" data-product-page="settings" aria-label="ZenX settings" hidden>
+      <section
+        class="zx-product-page"
+        data-product-page="settings"
+        aria-label="ZenX settings"
+        hidden
+      >
         <header class="zx-page-header">
           <div class="zx-page-title">
-            <button type="button" class="zx-icon-button zx-mobile-menu" aria-label="Open sidebar" data-open-sidebar><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-menu"></use></svg></button>
-            <div><h1>Settings</h1><p>Account, models, plugins, and local host</p></div>
+            <button
+              type="button"
+              class="zx-icon-button zx-mobile-menu"
+              aria-label="Open sidebar"
+              data-open-sidebar
+            >
+              <svg class="zx-icon" aria-hidden="true">
+                <use href="#zx-hifi-icon-menu"></use>
+              </svg>
+            </button>
+            <div>
+              <h1>Settings</h1>
+              <p>Account, models, plugins, and local host</p>
+            </div>
           </div>
-          <button type="button" class="zx-primary-button" data-save-settings>Save and restart host</button>
+          <button type="button" class="zx-primary-button" data-save-settings>
+            Save and restart host
+          </button>
         </header>
         <div class="zx-page-scroll">
           <div class="zx-settings-layout">
-            <nav class="zx-settings-nav" role="tablist" aria-label="Settings sections">
-              <button type="button" role="tab" aria-selected="true" data-settings-tab="account"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-account"></use></svg><span>Account</span></button>
-              <button type="button" role="tab" aria-selected="false" data-settings-tab="models"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-layers"></use></svg><span>Models &amp; provider</span></button>
-              <button type="button" role="tab" aria-selected="false" data-settings-tab="plugins"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-plugin"></use></svg><span>Plugins</span></button>
-              <button type="button" role="tab" aria-selected="false" data-settings-tab="general"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-sliders"></use></svg><span>General</span></button>
+            <nav
+              class="zx-settings-nav"
+              role="tablist"
+              aria-label="Settings sections"
+            >
+              <button
+                type="button"
+                role="tab"
+                aria-selected="true"
+                data-settings-tab="account"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-account"></use></svg
+                ><span>Account</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-settings-tab="models"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-layers"></use></svg
+                ><span>Models &amp; provider</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-settings-tab="plugins"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-plugin"></use></svg
+                ><span>Plugins</span>
+              </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected="false"
+                data-settings-tab="general"
+              >
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-sliders"></use></svg
+                ><span>General</span>
+              </button>
             </nav>
 
             <section class="zx-settings-panel" data-settings-panel="account">
-              <header><h2>Account</h2><p>Credentials remain in the local ZenX vault and never enter the Thread Item stream.</p></header>
+              <header>
+                <h2>Account</h2>
+                <p>
+                  Credentials remain in the local ZenX vault and never enter the
+                  Thread Item stream.
+                </p>
+              </header>
               <div class="zx-page-card zx-settings-card">
-                <div class="zx-settings-card-head"><div><h3>OpenAI subscription</h3><p>Use an authenticated ChatGPT subscription for ZenX model access.</p></div><span class="zx-account-status"><span class="zx-live-dot" aria-hidden="true"></span>Signed in</span></div>
-                <div class="zx-settings-row"><div><strong>account@zenx.local</strong><span>Authentication refreshed today · stored in macOS Keychain</span></div><button type="button" class="zx-danger-button" data-subscription-action>Sign out</button></div>
+                <div class="zx-settings-card-head">
+                  <div>
+                    <h3>OpenAI subscription</h3>
+                    <p>
+                      Use an authenticated ChatGPT subscription for ZenX model
+                      access.
+                    </p>
+                  </div>
+                  <span class="zx-account-status"
+                    ><span class="zx-live-dot" aria-hidden="true"></span>Signed
+                    in</span
+                  >
+                </div>
+                <div class="zx-settings-row">
+                  <div>
+                    <strong>account@zenx.local</strong
+                    ><span
+                      >Authentication refreshed today · stored in macOS
+                      Keychain</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-danger-button"
+                    data-subscription-action
+                  >
+                    Sign out
+                  </button>
+                </div>
               </div>
               <div class="zx-page-card zx-settings-card">
-                <div class="zx-settings-row"><div><strong>Privacy boundary</strong><span>Thread history stores only the effective model. Subscription identity and provider secrets stay outside ZEM Items.</span></div><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-shield"></use></svg></div>
+                <div class="zx-settings-row">
+                  <div>
+                    <strong>Privacy boundary</strong
+                    ><span
+                      >Thread history stores only the effective model.
+                      Subscription identity and provider secrets stay outside
+                      ZEM Items.</span
+                    >
+                  </div>
+                  <svg class="zx-icon" aria-hidden="true">
+                    <use href="#zx-hifi-icon-shield"></use>
+                  </svg>
+                </div>
               </div>
             </section>
 
-            <section class="zx-settings-panel" data-settings-panel="models" hidden>
-              <header><h2>Models &amp; provider</h2><p>Choose the host adapter and models exposed to new Threads.</p></header>
+            <section
+              class="zx-settings-panel"
+              data-settings-panel="models"
+              hidden
+            >
+              <header>
+                <h2>Models &amp; provider</h2>
+                <p>
+                  Choose the host adapter and models exposed to new Threads.
+                </p>
+              </header>
               <div class="zx-page-card zx-settings-card">
-                <div class="zx-provider-tabs" role="tablist" aria-label="Provider type">
-                  <button type="button" role="tab" aria-selected="true" data-provider-tab="subscription">OpenAI subscription</button>
-                  <button type="button" role="tab" aria-selected="false" data-provider-tab="api">API provider</button>
-                  <button type="button" role="tab" aria-selected="false" data-provider-tab="local">Local demo</button>
+                <div
+                  class="zx-provider-tabs"
+                  role="tablist"
+                  aria-label="Provider type"
+                >
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected="true"
+                    data-provider-tab="subscription"
+                  >
+                    OpenAI subscription
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected="false"
+                    data-provider-tab="api"
+                  >
+                    API provider
+                  </button>
+                  <button
+                    type="button"
+                    role="tab"
+                    aria-selected="false"
+                    data-provider-tab="local"
+                  >
+                    Local demo
+                  </button>
                 </div>
-                <div class="zx-settings-grid" data-provider-panel="subscription">
-                  <label class="zx-field"><span>Default model</span><select><option>GPT-5.6 Terra</option><option>GPT-5.6 Sol</option><option>GPT-5.6 Luna</option></select></label>
-                  <label class="zx-field"><span>Title model</span><select><option>GPT-5.6 Luna</option><option>GPT-5.6 Terra</option></select></label>
-                  <label class="zx-field zx-field-wide"><span>Available models <small>one per line</small></span><textarea>gpt-5.6-terra&#10;gpt-5.6-sol&#10;gpt-5.6-luna</textarea></label>
+                <div
+                  class="zx-settings-grid"
+                  data-provider-panel="subscription"
+                >
+                  <label class="zx-field"
+                    ><span>Default model</span
+                    ><select>
+                      <option>GPT-5.6 Terra</option>
+                      <option>GPT-5.6 Sol</option>
+                      <option>GPT-5.6 Luna</option>
+                    </select></label
+                  >
+                  <label class="zx-field"
+                    ><span>Title model</span
+                    ><select>
+                      <option>GPT-5.6 Luna</option>
+                      <option>GPT-5.6 Terra</option>
+                    </select></label
+                  >
+                  <label class="zx-field zx-field-wide"
+                    ><span>Available models <small>one per line</small></span
+                    ><textarea>
+gpt-5.6-terra&#10;gpt-5.6-sol&#10;gpt-5.6-luna</textarea>
+                  </label>
                 </div>
                 <div class="zx-settings-grid" data-provider-panel="api" hidden>
-                  <label class="zx-field"><span>Display name</span><input value="OpenAI compatible"></label>
-                  <label class="zx-field"><span>Provider name</span><input value="openai"></label>
-                  <label class="zx-field zx-field-wide"><span>Base URL</span><input value="https://api.openai.com/v1"></label>
-                  <label class="zx-field zx-field-wide"><span>API key <small>saved securely</small></span><input type="password" placeholder="Leave blank to keep current key"></label>
+                  <label class="zx-field"
+                    ><span>Display name</span><input value="OpenAI compatible"
+                  /></label>
+                  <label class="zx-field"
+                    ><span>Provider name</span><input value="openai"
+                  /></label>
+                  <label class="zx-field zx-field-wide"
+                    ><span>Base URL</span
+                    ><input value="https://api.openai.com/v1"
+                  /></label>
+                  <label class="zx-field zx-field-wide"
+                    ><span>API key <small>saved securely</small></span
+                    ><input
+                      type="password"
+                      placeholder="Leave blank to keep current key"
+                  /></label>
                 </div>
-                <div class="zx-settings-grid" data-provider-panel="local" hidden>
-                  <div class="zx-settings-row zx-field-wide"><div><strong>Deterministic local provider</strong><span>Useful for offline UI testing. It is never shown as a model identity inside a Thread.</span></div><span class="zx-account-status">Ready</span></div>
+                <div
+                  class="zx-settings-grid"
+                  data-provider-panel="local"
+                  hidden
+                >
+                  <div class="zx-settings-row zx-field-wide">
+                    <div>
+                      <strong>Deterministic local provider</strong
+                      ><span
+                        >Useful for offline UI testing. It is never shown as a
+                        model identity inside a Thread.</span
+                      >
+                    </div>
+                    <span class="zx-account-status">Ready</span>
+                  </div>
                 </div>
               </div>
             </section>
 
-            <section class="zx-settings-panel" data-settings-panel="plugins" hidden>
-              <header><h2>Plugins</h2><p>Manage installed extensions here. Enabled plugins may contribute to declared ZenX slots without modifying the native Agent surface.</p></header>
+            <section
+              class="zx-settings-panel"
+              data-settings-panel="plugins"
+              hidden
+            >
+              <header>
+                <h2>Plugins</h2>
+                <p>
+                  Manage installed extensions here. Enabled plugins may
+                  contribute to declared ZenX slots without modifying the native
+                  Agent surface.
+                </p>
+              </header>
               <div class="zx-page-card zx-settings-card">
                 <div class="zx-plugin-boundary">
-                  <span class="zx-plugin-icon"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-layers"></use></svg></span>
-                  <div><strong>Extension boundary</strong><span>Projects, Inbox, Threads, and Settings remain native. Plugins can add one entry to the dedicated Sidebar space and open a page inside the shared shell.</span></div>
-                  <span class="zx-account-status" data-plugin-active-count>2 Sidebar contributions active</span>
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon" aria-hidden="true">
+                      <use href="#zx-hifi-icon-layers"></use></svg
+                  ></span>
+                  <div>
+                    <strong>Extension boundary</strong
+                    ><span
+                      >Projects, Inbox, Threads, and Settings remain native.
+                      Plugins can add one entry to the dedicated Sidebar space
+                      and open a page inside the shared shell.</span
+                    >
+                  </div>
+                  <span class="zx-account-status" data-plugin-active-count
+                    >2 Sidebar contributions active</span
+                  >
                 </div>
               </div>
               <div class="zx-page-card zx-settings-card">
-                <div class="zx-settings-card-head"><div><h3>Installed plugins</h3><p>Enablement, tool grants, per-call approval, and runtime sandboxing remain independent states.</p></div><span class="zx-account-status">5 installed locally</span></div>
-                <div class="zx-capability-row" data-plugin-row="browser"><span class="zx-plugin-icon"><svg class="zx-icon"><use href="#zx-hifi-icon-globe"></use></svg></span><div><strong>Browser</strong><span>Enabled · 3 permissions granted · 8 tools · no Sidebar contribution</span></div><button type="button" class="zx-plugin-switch" role="switch" aria-checked="true" aria-label="Disable Browser plugin" data-plugin-toggle="browser"></button></div>
-                <div class="zx-capability-row" data-plugin-row="computer"><span class="zx-plugin-icon"><svg class="zx-icon"><use href="#zx-hifi-icon-panel"></use></svg></span><div><strong>Computer</strong><span>Enabled · 2 of 4 permissions granted · foreground control blocked</span></div><button type="button" class="zx-plugin-switch" role="switch" aria-checked="true" aria-label="Disable Computer plugin" data-plugin-toggle="computer"></button></div>
-                <div class="zx-capability-row" data-plugin-row="self"><span class="zx-plugin-icon"><svg class="zx-icon"><use href="#zx-hifi-icon-zap"></use></svg></span><div><strong>ZenX self-control</strong><span>Enabled · workspace read granted · local device write blocked</span></div><button type="button" class="zx-plugin-switch" role="switch" aria-checked="true" aria-label="Disable ZenX self-control plugin" data-plugin-toggle="self"></button></div>
-                <div class="zx-capability-row" data-plugin-row="triggers"><span class="zx-plugin-icon"><svg class="zx-icon"><use href="#zx-hifi-icon-clock"></use></svg></span><div><strong>Triggers</strong><span>Enabled · contributes “Triggers” to Plugin spaces · 7 tools</span></div><button type="button" class="zx-plugin-switch" role="switch" aria-checked="true" aria-label="Disable Triggers plugin" data-plugin-toggle="triggers"></button></div>
-                <div class="zx-capability-row" data-plugin-row="rooms"><span class="zx-plugin-icon"><svg class="zx-icon"><use href="#zx-hifi-icon-users"></use></svg></span><div><strong>Rooms</strong><span>Enabled · contributes “Rooms” to Plugin spaces · 5 tools</span></div><button type="button" class="zx-plugin-switch" role="switch" aria-checked="true" aria-label="Disable Rooms plugin" data-plugin-toggle="rooms"></button></div>
+                <div class="zx-settings-card-head">
+                  <div>
+                    <h3>Installed plugins</h3>
+                    <p>
+                      Enablement, tool grants, per-call approval, and runtime
+                      sandboxing remain independent states.
+                    </p>
+                  </div>
+                  <span class="zx-account-status">5 installed locally</span>
+                </div>
+                <div class="zx-capability-row" data-plugin-row="browser">
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon">
+                      <use href="#zx-hifi-icon-globe"></use></svg
+                  ></span>
+                  <div>
+                    <strong>Browser</strong
+                    ><span
+                      >Enabled · 3 permissions granted · 8 tools · no Sidebar
+                      contribution</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-plugin-switch"
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Disable Browser plugin"
+                    data-plugin-toggle="browser"
+                  ></button>
+                </div>
+                <div class="zx-capability-row" data-plugin-row="computer">
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon">
+                      <use href="#zx-hifi-icon-panel"></use></svg
+                  ></span>
+                  <div>
+                    <strong>Computer</strong
+                    ><span
+                      >Enabled · 2 of 4 permissions granted · foreground control
+                      blocked</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-plugin-switch"
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Disable Computer plugin"
+                    data-plugin-toggle="computer"
+                  ></button>
+                </div>
+                <div class="zx-capability-row" data-plugin-row="self">
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon">
+                      <use href="#zx-hifi-icon-zap"></use></svg
+                  ></span>
+                  <div>
+                    <strong>ZenX self-control</strong
+                    ><span
+                      >Enabled · workspace read granted · local device write
+                      blocked</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-plugin-switch"
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Disable ZenX self-control plugin"
+                    data-plugin-toggle="self"
+                  ></button>
+                </div>
+                <div class="zx-capability-row" data-plugin-row="triggers">
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon">
+                      <use href="#zx-hifi-icon-clock"></use></svg
+                  ></span>
+                  <div>
+                    <strong>Triggers</strong
+                    ><span
+                      >Enabled · contributes “Triggers” to Plugin spaces · 7
+                      tools</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-plugin-switch"
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Disable Triggers plugin"
+                    data-plugin-toggle="triggers"
+                  ></button>
+                </div>
+                <div class="zx-capability-row" data-plugin-row="rooms">
+                  <span class="zx-plugin-icon"
+                    ><svg class="zx-icon">
+                      <use href="#zx-hifi-icon-users"></use></svg
+                  ></span>
+                  <div>
+                    <strong>Rooms</strong
+                    ><span
+                      >Enabled · contributes “Rooms” to Plugin spaces · 5
+                      tools</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-plugin-switch"
+                    role="switch"
+                    aria-checked="true"
+                    aria-label="Disable Rooms plugin"
+                    data-plugin-toggle="rooms"
+                  ></button>
+                </div>
               </div>
-              <div class="zx-page-card zx-settings-card"><div class="zx-settings-row"><div><strong>Execution providers</strong><span>playwright-cli selected · isolated session · integrity verified</span></div><span class="zx-account-status">Healthy</span></div><div class="zx-settings-row"><div><strong>Recent capability use</strong><span>browser.inspect · completed · 10:42:18</span></div><button type="button" class="zx-quiet-button">View log</button></div></div>
+              <div class="zx-page-card zx-settings-card">
+                <div class="zx-settings-row">
+                  <div>
+                    <strong>Execution providers</strong
+                    ><span
+                      >playwright-cli selected · isolated session · integrity
+                      verified</span
+                    >
+                  </div>
+                  <span class="zx-account-status">Healthy</span>
+                </div>
+                <div class="zx-settings-row">
+                  <div>
+                    <strong>Recent capability use</strong
+                    ><span>browser.inspect · completed · 10:42:18</span>
+                  </div>
+                  <button type="button" class="zx-quiet-button">
+                    View log
+                  </button>
+                </div>
+              </div>
             </section>
 
-            <section class="zx-settings-panel" data-settings-panel="general" hidden>
-              <header><h2>General</h2><p>Local workspace defaults and Zen App Server lifecycle.</p></header>
+            <section
+              class="zx-settings-panel"
+              data-settings-panel="general"
+              hidden
+            >
+              <header>
+                <h2>General</h2>
+                <p>Local workspace defaults and Zen App Server lifecycle.</p>
+              </header>
               <div class="zx-page-card zx-settings-card">
-                <div class="zx-settings-grid"><label class="zx-field zx-field-wide"><span>Default workspace</span><input value="/path/to/zen"></label></div>
-                <div class="zx-settings-row" style="margin-top:15px"><div><strong>Zen App Server</strong><span>Loopback transport · ready · local data in ~/.zen</span></div><button type="button" class="zx-secondary-button" data-restart-host>Restart</button></div>
-                <div class="zx-settings-row"><div><strong>On launch</strong><span>Restore the most recent Thread and reconnect to the local App Server.</span></div><select aria-label="On launch behavior" style="height:36px;border:1px solid #30333c;border-radius:8px;background:#0e1014;color:var(--zx-text);padding:0 9px;font-size:10px"><option>Restore last Thread</option><option>Open new Thread</option></select></div>
+                <div class="zx-settings-grid">
+                  <label class="zx-field zx-field-wide"
+                    ><span>Default workspace</span><input value="/path/to/zen"
+                  /></label>
+                </div>
+                <div class="zx-settings-row" style="margin-top: 15px">
+                  <div>
+                    <strong>Zen App Server</strong
+                    ><span
+                      >Loopback transport · ready · local data in ~/.zen</span
+                    >
+                  </div>
+                  <button
+                    type="button"
+                    class="zx-secondary-button"
+                    data-restart-host
+                  >
+                    Restart
+                  </button>
+                </div>
+                <div class="zx-settings-row">
+                  <div>
+                    <strong>On launch</strong
+                    ><span
+                      >Restore the most recent Thread and reconnect to the local
+                      App Server.</span
+                    >
+                  </div>
+                  <select
+                    aria-label="On launch behavior"
+                    style="
+                      height: 36px;
+                      border: 1px solid #30333c;
+                      border-radius: 8px;
+                      background: #0e1014;
+                      color: var(--zx-text);
+                      padding: 0 9px;
+                      font-size: 10px;
+                    "
+                  >
+                    <option>Restore last Thread</option>
+                    <option>Open new Thread</option>
+                  </select>
+                </div>
               </div>
             </section>
           </div>
         </div>
       </section>
 
-      <section class="zx-product-page" data-product-page="scheduled" aria-label="Trigger plugin" hidden>
+      <section
+        class="zx-product-page"
+        data-product-page="scheduled"
+        aria-label="Trigger plugin"
+        hidden
+      >
         <header class="zx-page-header">
-          <div class="zx-page-title"><button type="button" class="zx-icon-button zx-mobile-menu" aria-label="Open sidebar" data-open-sidebar><svg class="zx-icon"><use href="#zx-hifi-icon-menu"></use></svg></button><div><h1>Triggers</h1><p>Schedules, external signals, and recent runs</p></div></div>
-          <button type="button" class="zx-primary-button" data-toggle-trigger-form><svg class="zx-icon"><use href="#zx-hifi-icon-plus"></use></svg>New trigger</button>
+          <div class="zx-page-title">
+            <button
+              type="button"
+              class="zx-icon-button zx-mobile-menu"
+              aria-label="Open sidebar"
+              data-open-sidebar
+            >
+              <svg class="zx-icon"><use href="#zx-hifi-icon-menu"></use></svg>
+            </button>
+            <div>
+              <h1>Triggers</h1>
+              <p>Schedules, external signals, and recent runs</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            class="zx-primary-button"
+            data-toggle-trigger-form
+          >
+            <svg class="zx-icon"><use href="#zx-hifi-icon-plus"></use></svg>New
+            trigger
+          </button>
         </header>
         <div class="zx-page-scroll">
-          <div class="zx-page-intro"><div><h2>Agents sleep until something matters.</h2><p>Every trigger starts an ordinary Turn through the App Server. Scheduling state stays in the ZenX outer layer.</p></div></div>
-          <div class="zx-metric-strip"><div class="zx-page-card zx-metric"><strong>3</strong><span>Active triggers</span></div><div class="zx-page-card zx-metric"><strong>2</strong><span>Watched Threads</span></div><div class="zx-page-card zx-metric"><strong>1</strong><span>External signal</span></div></div>
-          <div class="zx-section-heading"><h2>Active triggers</h2><span>Next wakeup in 12 min</span></div>
-          <div class="zx-page-card">
-            <button type="button" class="zx-schedule-row" data-thread-jump="capability-lifecycle"><span class="zx-kind-pill">Timer</span><div><strong>Review capability health</strong><small>Inspect lifecycle and report only if a provider is unavailable.</small></div><time>10:54</time></button>
-            <button type="button" class="zx-schedule-row" data-thread-jump="command-surface"><span class="zx-kind-pill">Thread</span><div><strong>Review command surface completion</strong><small>When “Capability lifecycle” completes, inspect the final Turn.</small></div><time>Event driven</time></button>
-            <button type="button" class="zx-schedule-row" data-open-page="room" data-plugin-dependent="rooms"><span class="zx-kind-pill zx-room-kind">Mention</span><div><strong>#release-review · @Zen</strong><small>Wake this Thread with a bounded window of recent Room messages.</small></div><time>Event driven</time></button>
-            <form class="zx-inline-form" data-trigger-form hidden><label class="zx-field"><span>Type</span><select><option>Timer</option><option>Thread completed</option><option data-room-trigger-option>Room mention</option><option>External signal</option></select></label><label class="zx-field"><span>Label</span><input placeholder="Wake up"></label><button type="submit" class="zx-primary-button" data-create-trigger>Create</button></form>
+          <div class="zx-page-intro">
+            <div>
+              <h2>Agents sleep until something matters.</h2>
+              <p>
+                Every trigger starts an ordinary Turn through the App Server.
+                Scheduling state stays in the ZenX outer layer.
+              </p>
+            </div>
           </div>
-          <div class="zx-section-heading" data-plugin-dependent="rooms"><h2>Rooms</h2><span>Provided by the Rooms plugin</span></div>
-          <div class="zx-page-card" data-plugin-dependent="rooms"><button type="button" class="zx-schedule-row" data-open-page="room"><span class="zx-kind-pill zx-room-kind">Room</span><div><strong># release-review</strong><small>@You · @Builder · @Monitor</small></div><time>3 messages</time></button></div>
-          <div class="zx-section-heading"><h2>Recent wakeups</h2><span>Last 30 retained locally</span></div>
-          <div class="zx-page-card"><button type="button" class="zx-history-row" data-thread-jump="protocol-notes"><time>10:36</time><div><strong>Timer · protocol projection review</strong><small>Completed normally · 18 seconds</small></div><span class="zx-kind-pill zx-signal-kind">Completed</span></button><button type="button" class="zx-history-row" data-thread-jump="capability-lifecycle"><time>10:18</time><div><strong>Thread completion relay</strong><small>Source Turn 81af3b2c · review started</small></div><span class="zx-kind-pill zx-signal-kind">Completed</span></button></div>
-          <div class="zx-section-heading"><h2>Developer tools</h2><span>Local testing only</span></div>
-          <div class="zx-page-card zx-settings-card"><div class="zx-settings-card-head"><div><h3>Signal simulator</h3><p>Test a registered external-signal trigger through the local renderer bridge.</p></div></div><form class="zx-inline-form" data-signal-form style="padding:0;border:0"><label class="zx-field"><span>Signal</span><input value="deploy.completed"></label><label class="zx-field"><span>Detail</span><input value="release-review passed"></label><button type="submit" class="zx-secondary-button" data-send-signal>Simulate</button></form></div>
+          <div class="zx-metric-strip">
+            <div class="zx-page-card zx-metric">
+              <strong>3</strong><span>Active triggers</span>
+            </div>
+            <div class="zx-page-card zx-metric">
+              <strong>2</strong><span>Watched Threads</span>
+            </div>
+            <div class="zx-page-card zx-metric">
+              <strong>1</strong><span>External signal</span>
+            </div>
+          </div>
+          <div class="zx-section-heading">
+            <h2>Active triggers</h2>
+            <span>Next wakeup in 12 min</span>
+          </div>
+          <div class="zx-page-card">
+            <button
+              type="button"
+              class="zx-schedule-row"
+              data-thread-jump="capability-lifecycle"
+            >
+              <span class="zx-kind-pill">Timer</span>
+              <div>
+                <strong>Review capability health</strong
+                ><small
+                  >Inspect lifecycle and report only if a provider is
+                  unavailable.</small
+                >
+              </div>
+              <time>10:54</time>
+            </button>
+            <button
+              type="button"
+              class="zx-schedule-row"
+              data-thread-jump="command-surface"
+            >
+              <span class="zx-kind-pill">Thread</span>
+              <div>
+                <strong>Review command surface completion</strong
+                ><small
+                  >When “Capability lifecycle” completes, inspect the final
+                  Turn.</small
+                >
+              </div>
+              <time>Event driven</time>
+            </button>
+            <button
+              type="button"
+              class="zx-schedule-row"
+              data-open-page="room"
+              data-plugin-dependent="rooms"
+            >
+              <span class="zx-kind-pill zx-room-kind">Mention</span>
+              <div>
+                <strong>#release-review · @Zen</strong
+                ><small
+                  >Wake this Thread with a bounded window of recent Room
+                  messages.</small
+                >
+              </div>
+              <time>Event driven</time>
+            </button>
+            <form class="zx-inline-form" data-trigger-form hidden>
+              <label class="zx-field"
+                ><span>Type</span
+                ><select>
+                  <option>Timer</option>
+                  <option>Thread completed</option>
+                  <option data-room-trigger-option>Room mention</option>
+                  <option>External signal</option>
+                </select></label
+              ><label class="zx-field"
+                ><span>Label</span><input placeholder="Wake up" /></label
+              ><button
+                type="submit"
+                class="zx-primary-button"
+                data-create-trigger
+              >
+                Create
+              </button>
+            </form>
+          </div>
+          <div class="zx-section-heading" data-plugin-dependent="rooms">
+            <h2>Rooms</h2>
+            <span>Provided by the Rooms plugin</span>
+          </div>
+          <div class="zx-page-card" data-plugin-dependent="rooms">
+            <button type="button" class="zx-schedule-row" data-open-page="room">
+              <span class="zx-kind-pill zx-room-kind">Room</span>
+              <div>
+                <strong># release-review</strong
+                ><small>@You · @Builder · @Monitor</small>
+              </div>
+              <time>3 messages</time>
+            </button>
+          </div>
+          <div class="zx-section-heading">
+            <h2>Recent wakeups</h2>
+            <span>Last 30 retained locally</span>
+          </div>
+          <div class="zx-page-card">
+            <button
+              type="button"
+              class="zx-history-row"
+              data-thread-jump="protocol-notes"
+            >
+              <time>10:36</time>
+              <div>
+                <strong>Timer · protocol projection review</strong
+                ><small>Completed normally · 18 seconds</small>
+              </div>
+              <span class="zx-kind-pill zx-signal-kind">Completed</span></button
+            ><button
+              type="button"
+              class="zx-history-row"
+              data-thread-jump="capability-lifecycle"
+            >
+              <time>10:18</time>
+              <div>
+                <strong>Thread completion relay</strong
+                ><small>Source Turn 81af3b2c · review started</small>
+              </div>
+              <span class="zx-kind-pill zx-signal-kind">Completed</span>
+            </button>
+          </div>
+          <div class="zx-section-heading">
+            <h2>Developer tools</h2>
+            <span>Local testing only</span>
+          </div>
+          <div class="zx-page-card zx-settings-card">
+            <div class="zx-settings-card-head">
+              <div>
+                <h3>Signal simulator</h3>
+                <p>
+                  Test a registered external-signal trigger through the local
+                  renderer bridge.
+                </p>
+              </div>
+            </div>
+            <form
+              class="zx-inline-form"
+              data-signal-form
+              style="padding: 0; border: 0"
+            >
+              <label class="zx-field"
+                ><span>Signal</span><input value="deploy.completed" /></label
+              ><label class="zx-field"
+                ><span>Detail</span
+                ><input value="release-review passed" /></label
+              ><button
+                type="submit"
+                class="zx-secondary-button"
+                data-send-signal
+              >
+                Simulate
+              </button>
+            </form>
+          </div>
         </div>
       </section>
 
-      <section class="zx-product-page zx-room-page" data-product-page="room" aria-label="Release review Room" hidden>
+      <section
+        class="zx-product-page zx-room-page"
+        data-product-page="room"
+        aria-label="Release review Room"
+        hidden
+      >
         <header class="zx-page-header">
-          <div class="zx-page-title"><button type="button" class="zx-icon-button zx-mobile-menu" aria-label="Open sidebar" data-open-sidebar><svg class="zx-icon"><use href="#zx-hifi-icon-menu"></use></svg></button><div><h1># release-review</h1><p>Shared conclusions and bounded routing</p></div></div>
-          <button type="button" class="zx-secondary-button" data-add-member><svg class="zx-icon"><use href="#zx-hifi-icon-plus"></use></svg>Add member</button>
+          <div class="zx-page-title">
+            <button
+              type="button"
+              class="zx-icon-button zx-mobile-menu"
+              aria-label="Open sidebar"
+              data-open-sidebar
+            >
+              <svg class="zx-icon"><use href="#zx-hifi-icon-menu"></use></svg>
+            </button>
+            <div>
+              <h1># release-review</h1>
+              <p>Shared conclusions and bounded routing</p>
+            </div>
+          </div>
+          <button type="button" class="zx-secondary-button" data-add-member>
+            <svg class="zx-icon"><use href="#zx-hifi-icon-plus"></use></svg>Add
+            member
+          </button>
         </header>
-        <div class="zx-room-context"><p>Reasoning stays in each member Thread. @mentions create a normal new Turn for that member.</p><div class="zx-room-members" aria-label="Room members"><span class="zx-member-pill">@You</span><span class="zx-member-pill">@Builder</span><span class="zx-member-pill">@Monitor</span></div></div>
-        <div class="zx-room-feed" data-room-feed>
-          <div class="zx-room-note"><strong>Room ≠ Thread.</strong> This surface carries concise conclusions and routing context. Tool calls and private reasoning remain in each source Thread.</div>
-          <article class="zx-room-message"><header><strong>You</strong><time>10:14</time></header><p>Use this Room to coordinate the ZenX surface review. Builder owns the product-page prototype; Monitor checks model identity and permission boundaries.</p></article>
-          <article class="zx-room-message"><header><strong>Builder</strong><time>10:31</time></header><p>The native Agent surface stays unchanged. Triggers and Rooms appear in the dedicated Plugin spaces area only while their plugins are enabled.</p><button type="button" class="zx-origin-card" data-thread-jump="command-surface"><svg class="zx-icon"><use href="#zx-hifi-icon-file"></use></svg>Source Thread · Refine command surface <span>Open →</span></button></article>
-          <article class="zx-room-message"><header><strong>Monitor</strong><time>10:39</time></header><p>Checked the privacy boundary: subscription identity and provider credentials stay in Settings; Threads display only the model logo and model name.</p><button type="button" class="zx-origin-card" data-thread-jump="protocol-notes"><svg class="zx-icon"><use href="#zx-hifi-icon-file"></use></svg>Source Thread · Protocol projection notes <span>Open →</span></button></article>
+        <div class="zx-room-context">
+          <p>
+            Reasoning stays in each member Thread. @mentions create a normal new
+            Turn for that member.
+          </p>
+          <div class="zx-room-members" aria-label="Room members">
+            <span class="zx-member-pill">@You</span
+            ><span class="zx-member-pill">@Builder</span
+            ><span class="zx-member-pill">@Monitor</span>
+          </div>
         </div>
-        <form class="zx-room-composer" data-room-form><label class="zx-sr-only" for="zx-hifi-room-message">Message the Room</label><textarea id="zx-hifi-room-message" placeholder="Message the Room… use @name to wake a member" data-room-input></textarea><button type="submit" class="zx-primary-button" disabled data-room-send>Send</button></form>
+        <div class="zx-room-feed" data-room-feed>
+          <div class="zx-room-note">
+            <strong>Room ≠ Thread.</strong> This surface carries concise
+            conclusions and routing context. Tool calls and private reasoning
+            remain in each source Thread.
+          </div>
+          <article class="zx-room-message">
+            <header><strong>You</strong><time>10:14</time></header>
+            <p>
+              Use this Room to coordinate the ZenX surface review. Builder owns
+              the product-page prototype; Monitor checks model identity and
+              permission boundaries.
+            </p>
+          </article>
+          <article class="zx-room-message">
+            <header><strong>Builder</strong><time>10:31</time></header>
+            <p>
+              The native Agent surface stays unchanged. Triggers and Rooms
+              appear in the dedicated Plugin spaces area only while their
+              plugins are enabled.
+            </p>
+            <button
+              type="button"
+              class="zx-origin-card"
+              data-thread-jump="command-surface"
+            >
+              <svg class="zx-icon"><use href="#zx-hifi-icon-file"></use></svg
+              >Source Thread · Refine command surface <span>Open →</span>
+            </button>
+          </article>
+          <article class="zx-room-message">
+            <header><strong>Monitor</strong><time>10:39</time></header>
+            <p>
+              Checked the privacy boundary: subscription identity and provider
+              credentials stay in Settings; Threads display only the model logo
+              and model name.
+            </p>
+            <button
+              type="button"
+              class="zx-origin-card"
+              data-thread-jump="protocol-notes"
+            >
+              <svg class="zx-icon"><use href="#zx-hifi-icon-file"></use></svg
+              >Source Thread · Protocol projection notes <span>Open →</span>
+            </button>
+          </article>
+        </div>
+        <form class="zx-room-composer" data-room-form>
+          <label class="zx-sr-only" for="zx-hifi-room-message"
+            >Message the Room</label
+          ><textarea
+            id="zx-hifi-room-message"
+            placeholder="Message the Room… use @name to wake a member"
+            data-room-input
+          ></textarea
+          ><button
+            type="submit"
+            class="zx-primary-button"
+            disabled
+            data-room-send
+          >
+            Send
+          </button>
+        </form>
       </section>
     </main>
 
     <div class="zx-modal-layer" data-workspace-layer hidden>
-      <aside class="zx-sheet" role="dialog" aria-modal="true" aria-labelledby="zx-hifi-workspace-title">
+      <aside
+        class="zx-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="zx-hifi-workspace-title"
+      >
         <header class="zx-sheet-head">
-          <div class="zx-sheet-title"><strong id="zx-hifi-workspace-title">Workspace</strong><span>Linked context for this thread</span></div>
-          <button type="button" class="zx-icon-button" aria-label="Close workspace" data-close-workspace><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-x"></use></svg></button>
+          <div class="zx-sheet-title">
+            <strong id="zx-hifi-workspace-title">Workspace</strong
+            ><span>Linked context for this thread</span>
+          </div>
+          <button
+            type="button"
+            class="zx-icon-button"
+            aria-label="Close workspace"
+            data-close-workspace
+          >
+            <svg class="zx-icon" aria-hidden="true">
+              <use href="#zx-hifi-icon-x"></use>
+            </svg>
+          </button>
         </header>
         <div class="zx-sheet-tabs" role="tablist" aria-label="Workspace views">
-          <button type="button" role="tab" aria-selected="true" aria-controls="zx-hifi-files-panel" data-panel-tab="files">Files</button>
-          <button type="button" role="tab" aria-selected="false" aria-controls="zx-hifi-artifacts-panel" data-panel-tab="artifacts">Artifacts</button>
-          <button type="button" role="tab" aria-selected="false" aria-controls="zx-hifi-context-panel" data-panel-tab="context">Context</button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected="true"
+            aria-controls="zx-hifi-files-panel"
+            data-panel-tab="files"
+          >
+            Files
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="zx-hifi-artifacts-panel"
+            data-panel-tab="artifacts"
+          >
+            Artifacts
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected="false"
+            aria-controls="zx-hifi-context-panel"
+            data-panel-tab="context"
+          >
+            Context
+          </button>
         </div>
         <div class="zx-sheet-content">
           <section id="zx-hifi-files-panel" role="tabpanel" data-panel="files">
-            <p class="zx-sheet-note">Files referenced or changed in this thread.</p>
+            <p class="zx-sheet-note">
+              Files referenced or changed in this thread.
+            </p>
             <div class="zx-file-tree">
-              <div class="zx-file-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg><span>apps/desktop</span><small>4 files</small></div>
-              <div class="zx-file-row" data-depth="1"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-file"></use></svg><span>Composer.tsx</span><small>M</small></div>
-              <div class="zx-file-row" data-depth="1"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-file"></use></svg><span>ThreadView.tsx</span><small>M</small></div>
-              <div class="zx-file-row" data-depth="1"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-file"></use></svg><span>Sidebar.tsx</span><small>M</small></div>
-              <div class="zx-file-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg><span>packages/protocol</span><small>read</small></div>
+              <div class="zx-file-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                ><span>apps/desktop</span><small>4 files</small>
+              </div>
+              <div class="zx-file-row" data-depth="1">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-file"></use></svg
+                ><span>Composer.tsx</span><small>M</small>
+              </div>
+              <div class="zx-file-row" data-depth="1">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-file"></use></svg
+                ><span>ThreadView.tsx</span><small>M</small>
+              </div>
+              <div class="zx-file-row" data-depth="1">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-file"></use></svg
+                ><span>Sidebar.tsx</span><small>M</small>
+              </div>
+              <div class="zx-file-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use></svg
+                ><span>packages/protocol</span><small>read</small>
+              </div>
             </div>
           </section>
-          <section id="zx-hifi-artifacts-panel" role="tabpanel" data-panel="artifacts" hidden>
-            <p class="zx-sheet-note">Reviewable outputs created during this run.</p>
+          <section
+            id="zx-hifi-artifacts-panel"
+            role="tabpanel"
+            data-panel="artifacts"
+            hidden
+          >
+            <p class="zx-sheet-note">
+              Reviewable outputs created during this run.
+            </p>
             <div class="zx-panel-list">
-              <div class="zx-panel-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-layers"></use></svg><div><strong>Responsive UI prototype</strong><span>HTML · updated just now</span></div><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-chevron-right"></use></svg></div>
-              <div class="zx-panel-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-file"></use></svg><div><strong>Interaction notes</strong><span>Markdown · 3 decisions</span></div><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-chevron-right"></use></svg></div>
+              <div class="zx-panel-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-layers"></use>
+                </svg>
+                <div>
+                  <strong>Responsive UI prototype</strong
+                  ><span>HTML · updated just now</span>
+                </div>
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-chevron-right"></use>
+                </svg>
+              </div>
+              <div class="zx-panel-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-file"></use>
+                </svg>
+                <div>
+                  <strong>Interaction notes</strong
+                  ><span>Markdown · 3 decisions</span>
+                </div>
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-chevron-right"></use>
+                </svg>
+              </div>
             </div>
           </section>
-          <section id="zx-hifi-context-panel" role="tabpanel" data-panel="context" hidden>
-            <p class="zx-sheet-note">Runtime and workspace context available to this thread.</p>
+          <section
+            id="zx-hifi-context-panel"
+            role="tabpanel"
+            data-panel="context"
+            hidden
+          >
+            <p class="zx-sheet-note">
+              Runtime and workspace context available to this thread.
+            </p>
             <div class="zx-panel-list">
-              <div class="zx-panel-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-folder"></use></svg><div><strong>ZenX desktop</strong><span>Local checkout · main</span></div><span>Ready</span></div>
-              <div class="zx-panel-row"><svg class="zx-icon" aria-hidden="true"><use href="#zx-hifi-icon-clock"></use></svg><div><strong>Active run</strong><span>24 seconds · browser approval pending</span></div><span>Live</span></div>
+              <div class="zx-panel-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-folder"></use>
+                </svg>
+                <div>
+                  <strong>ZenX desktop</strong
+                  ><span>Local checkout · main</span>
+                </div>
+                <span>Ready</span>
+              </div>
+              <div class="zx-panel-row">
+                <svg class="zx-icon" aria-hidden="true">
+                  <use href="#zx-hifi-icon-clock"></use>
+                </svg>
+                <div>
+                  <strong>Active run</strong
+                  ><span>24 seconds · browser approval pending</span>
+                </div>
+                <span>Live</span>
+              </div>
             </div>
           </section>
         </div>
       </aside>
     </div>
 
-    <div class="zx-toast" role="status" aria-live="polite" data-toast hidden></div>
+    <div
+      class="zx-toast"
+      role="status"
+      aria-live="polite"
+      data-toast
+      hidden
+    ></div>
   </section>
 
   <script>
     (() => {
-      const root = document.getElementById('zenx-hifi-prototype');
-      if (!root || root.dataset.ready === 'true') return;
-      root.dataset.ready = 'true';
+      const root = document.getElementById("zenx-hifi-prototype");
+      if (!root || root.dataset.ready === "true") return;
+      root.dataset.ready = "true";
 
-      const app = root.querySelector('.zx-app');
-      const transcript = root.querySelector('[data-transcript]');
-      const conversation = root.querySelector('[data-conversation]');
-      const emptyState = root.querySelector('[data-empty-state]');
-      const input = root.querySelector('[data-composer-input]');
-      const composerAction = root.querySelector('[data-composer-action]');
-      const toast = root.querySelector('[data-toast]');
-      const workspaceLayer = root.querySelector('[data-workspace-layer]');
-      const workspaceSheet = root.querySelector('.zx-sheet');
-      const modalBackgrounds = Array.from(root.querySelectorAll('[data-modal-background]'));
-      const backLive = root.querySelector('[data-back-live]');
-      const turn = root.querySelector('[data-turn]');
-      const turnToggle = root.querySelector('[data-turn-toggle]');
-      const turnHistory = root.querySelector('[data-turn-history]');
-      const productPages = Array.from(root.querySelectorAll('[data-product-page]'));
+      const app = root.querySelector(".zx-app");
+      const transcript = root.querySelector("[data-transcript]");
+      const conversation = root.querySelector("[data-conversation]");
+      const emptyState = root.querySelector("[data-empty-state]");
+      const input = root.querySelector("[data-composer-input]");
+      const composerAction = root.querySelector("[data-composer-action]");
+      const toast = root.querySelector("[data-toast]");
+      const workspaceLayer = root.querySelector("[data-workspace-layer]");
+      const workspaceSheet = root.querySelector(".zx-sheet");
+      const modalBackgrounds = Array.from(
+        root.querySelectorAll("[data-modal-background]"),
+      );
+      const backLive = root.querySelector("[data-back-live]");
+      const turn = root.querySelector("[data-turn]");
+      const turnToggle = root.querySelector("[data-turn-toggle]");
+      const turnHistory = root.querySelector("[data-turn-history]");
+      const productPages = Array.from(
+        root.querySelectorAll("[data-product-page]"),
+      );
       let toastTimer;
       let workspaceReturnFocus = null;
       let newThreadMode = false;
-      const pluginState = { browser: true, computer: true, self: true, triggers: true, rooms: true };
+      const pluginState = {
+        browser: true,
+        computer: true,
+        self: true,
+        triggers: true,
+        rooms: true,
+      };
 
-      Array.from(conversation.children).forEach((item) => { item.dataset.baseItem = 'true'; });
+      Array.from(conversation.children).forEach((item) => {
+        item.dataset.baseItem = "true";
+      });
 
       const threadContent = {
-        'command-surface': {
-          user: 'Rework this into a review-ready prototype. Keep the composer stable while the run is active, and make steering the obvious action.',
-          assistant: 'I’m refining the turn projection now. The active surface stays focused on the Agent response while the execution trace remains available without competing for attention.',
-          progress: 'The active and completed projections now share one stream. Agent messages remain readable while internal steps stay compact.',
-          trace: 'Reasoned about the Item stream and inspected the current UI',
-          tool: 'Inspect current thread UI',
-          summary: '4 files · 186 matches · 312 ms',
-          final: 'The projection now follows the ZEM hierarchy: a Turn contains sequential Agent Message and Trace Group Items, while completion collapses the history to this Final Message.',
-          duration: '24s', state: 'running', approval: true
+        "command-surface": {
+          user: "Rework this into a review-ready prototype. Keep the composer stable while the run is active, and make steering the obvious action.",
+          assistant:
+            "I’m refining the turn projection now. The active surface stays focused on the Agent response while the execution trace remains available without competing for attention.",
+          progress:
+            "The active and completed projections now share one stream. Agent messages remain readable while internal steps stay compact.",
+          trace: "Reasoned about the Item stream and inspected the current UI",
+          tool: "Inspect current thread UI",
+          summary: "4 files · 186 matches · 312 ms",
+          final:
+            "The projection now follows the ZEM hierarchy: a Turn contains sequential Agent Message and Trace Group Items, while completion collapses the history to this Final Message.",
+          duration: "24s",
+          state: "running",
+          approval: true,
         },
-        'capability-lifecycle': {
-          user: 'Trace the browser capability lifecycle and confirm active invocations settle before the local service restarts.',
-          assistant: 'I’m tracing request, approval, invocation, disposal, and remount while keeping the live surface focused on the Agent response.',
-          progress: 'The active invocation has settled. I’m checking disposal and remount next, while each runtime step stays available as a compact disclosure.',
-          trace: 'Traced capability transitions and inspected active invocations',
-          tool: 'Trace capability lifecycle',
-          summary: '5 states · 2 adapters · 241 ms',
-          final: 'The capability lifecycle now settles active invocations before restart, and interruption never strands the composer.',
-          duration: '18s', state: 'running', approval: false
+        "capability-lifecycle": {
+          user: "Trace the browser capability lifecycle and confirm active invocations settle before the local service restarts.",
+          assistant:
+            "I’m tracing request, approval, invocation, disposal, and remount while keeping the live surface focused on the Agent response.",
+          progress:
+            "The active invocation has settled. I’m checking disposal and remount next, while each runtime step stays available as a compact disclosure.",
+          trace:
+            "Traced capability transitions and inspected active invocations",
+          tool: "Trace capability lifecycle",
+          summary: "5 states · 2 adapters · 241 ms",
+          final:
+            "The capability lifecycle now settles active invocations before restart, and interruption never strands the composer.",
+          duration: "18s",
+          state: "running",
+          approval: false,
         },
-        'protocol-notes': {
-          user: 'Summarize the protocol constraints the new thread UI must preserve without exposing internal provider fields.',
-          assistant: 'I’m checking the append-only item stream against the new turn projection and separating visible model identity from internal provider metadata.',
-          progress: 'The visual projection remains append-only, so the interface can collapse a completed Turn without discarding any intermediate message or tool result.',
-          trace: 'Read protocol Items and checked projection constraints',
-          tool: 'Read protocol item surface',
-          summary: '6 item kinds · 12 events · 96 ms',
-          final: 'The thread UI can change its projection without changing the append-only item stream. Internal provider configuration remains outside the conversation surface.',
-          duration: '42s', state: 'idle', approval: false
+        "protocol-notes": {
+          user: "Summarize the protocol constraints the new thread UI must preserve without exposing internal provider fields.",
+          assistant:
+            "I’m checking the append-only item stream against the new turn projection and separating visible model identity from internal provider metadata.",
+          progress:
+            "The visual projection remains append-only, so the interface can collapse a completed Turn without discarding any intermediate message or tool result.",
+          trace: "Read protocol Items and checked projection constraints",
+          tool: "Read protocol item surface",
+          summary: "6 item kinds · 12 events · 96 ms",
+          final:
+            "The thread UI can change its projection without changing the append-only item stream. Internal provider configuration remains outside the conversation surface.",
+          duration: "42s",
+          state: "idle",
+          approval: false,
         },
-        'composer-study': {
-          user: 'Compare the running composer with T3 and DeepSeek Harness, but keep the interaction model specific to ZenX.',
-          assistant: 'I’m comparing stable input geometry and interruption semantics, then removing controls that do not help the current ZenX task.',
-          progress: 'The composer keeps one action affordance and derives its meaning from the run state and whether a draft exists.',
-          trace: 'Compared composer states and interruption semantics',
-          tool: 'Compare composer patterns',
-          summary: '3 products · 8 interactions · 428 ms',
-          final: 'The composer now uses one circular action: stop when empty during a run, interrupt-and-send when a draft exists, and send when idle.',
-          duration: '31s', state: 'idle', approval: false
-        }
+        "composer-study": {
+          user: "Compare the running composer with T3 and DeepSeek Harness, but keep the interaction model specific to ZenX.",
+          assistant:
+            "I’m comparing stable input geometry and interruption semantics, then removing controls that do not help the current ZenX task.",
+          progress:
+            "The composer keeps one action affordance and derives its meaning from the run state and whether a draft exists.",
+          trace: "Compared composer states and interruption semantics",
+          tool: "Compare composer patterns",
+          summary: "3 products · 8 interactions · 428 ms",
+          final:
+            "The composer now uses one circular action: stop when empty during a run, interrupt-and-send when a draft exists, and send when idle.",
+          duration: "31s",
+          state: "idle",
+          approval: false,
+        },
       };
 
       const showToast = (message) => {
         window.clearTimeout(toastTimer);
         toast.textContent = message;
         toast.hidden = false;
-        toastTimer = window.setTimeout(() => { toast.hidden = true; }, 2600);
+        toastTimer = window.setTimeout(() => {
+          toast.hidden = true;
+        }, 2600);
       };
 
       const showPage = (page) => {
-        if (page === 'scheduled' && !pluginState.triggers) { showToast('Enable Triggers in Settings → Plugins first'); return; }
-        if (page === 'room' && !pluginState.rooms) { showToast('Enable Rooms in Settings → Plugins first'); return; }
+        if (page === "scheduled" && !pluginState.triggers) {
+          showToast("Enable Triggers in Settings → Plugins first");
+          return;
+        }
+        if (page === "room" && !pluginState.rooms) {
+          showToast("Enable Rooms in Settings → Plugins first");
+          return;
+        }
         app.dataset.page = page;
-        productPages.forEach((panel) => { panel.hidden = panel.dataset.productPage !== page; });
-        root.querySelectorAll('[data-open-page]').forEach((button) => {
-          if (button.dataset.openPage === page) button.setAttribute('aria-current', 'page');
-          else button.removeAttribute('aria-current');
+        productPages.forEach((panel) => {
+          panel.hidden = panel.dataset.productPage !== page;
         });
-        if (page !== 'agent') root.querySelectorAll('[data-thread]').forEach((item) => item.removeAttribute('aria-current'));
-        app.dataset.sidebarOpen = 'false';
-        const pageScroll = root.querySelector(`[data-product-page="${page}"] .zx-page-scroll`);
+        root.querySelectorAll("[data-open-page]").forEach((button) => {
+          if (button.dataset.openPage === page)
+            button.setAttribute("aria-current", "page");
+          else button.removeAttribute("aria-current");
+        });
+        if (page !== "agent")
+          root
+            .querySelectorAll("[data-thread]")
+            .forEach((item) => item.removeAttribute("aria-current"));
+        app.dataset.sidebarOpen = "false";
+        const pageScroll = root.querySelector(
+          `[data-product-page="${page}"] .zx-page-scroll`,
+        );
         if (pageScroll) pageScroll.scrollTop = 0;
       };
 
-      root.querySelectorAll('[data-open-page]').forEach((button) => {
-        button.addEventListener('click', () => showPage(button.dataset.openPage));
+      root.querySelectorAll("[data-open-page]").forEach((button) => {
+        button.addEventListener("click", () =>
+          showPage(button.dataset.openPage),
+        );
       });
 
       const updateComposerAction = () => {
         const hasDraft = input.value.trim().length > 0;
-        const running = app.dataset.runState === 'running';
-        const mode = running ? (hasDraft ? 'interrupt' : 'stop') : 'send';
+        const running = app.dataset.runState === "running";
+        const mode = running ? (hasDraft ? "interrupt" : "stop") : "send";
         app.dataset.actionMode = mode;
-        composerAction.disabled = mode === 'send' && !hasDraft;
-        composerAction.setAttribute('aria-label', mode === 'stop' ? 'Stop run' : mode === 'interrupt' ? 'Interrupt and send' : 'Send message');
-        composerAction.title = mode === 'stop' ? 'Stop' : mode === 'interrupt' ? 'Interrupt & send' : 'Send';
+        composerAction.disabled = mode === "send" && !hasDraft;
+        composerAction.setAttribute(
+          "aria-label",
+          mode === "stop"
+            ? "Stop run"
+            : mode === "interrupt"
+              ? "Interrupt and send"
+              : "Send message",
+        );
+        composerAction.title =
+          mode === "stop"
+            ? "Stop"
+            : mode === "interrupt"
+              ? "Interrupt & send"
+              : "Send";
       };
 
       const setRunState = (state) => {
         app.dataset.runState = state;
-        input.placeholder = state === 'running' ? 'Type to interrupt and send…' : 'Ask ZenX anything…';
+        input.placeholder =
+          state === "running"
+            ? "Type to interrupt and send…"
+            : "Ask ZenX anything…";
         updateComposerAction();
       };
 
       const setTurnState = (state, duration) => {
-        const turnState = state === 'running' ? 'running' : 'complete';
-        const expanded = turnState === 'running';
+        const turnState = state === "running" ? "running" : "complete";
+        const expanded = turnState === "running";
         turn.dataset.turnState = turnState;
         turn.dataset.expanded = String(expanded);
-        turnToggle.setAttribute('aria-expanded', 'false');
+        turnToggle.setAttribute("aria-expanded", "false");
         turnHistory.hidden = !expanded;
-        root.querySelectorAll('[data-trace-group-toggle]').forEach((button) => { button.setAttribute('aria-expanded', 'false'); });
-        root.querySelectorAll('[data-trace-group-items]').forEach((group) => { group.hidden = true; });
-        root.querySelectorAll('[data-step-toggle]').forEach((button) => { button.setAttribute('aria-expanded', 'false'); });
-        root.querySelectorAll('[data-step-detail]').forEach((detail) => { detail.hidden = true; });
-        root.querySelectorAll('[data-turn-duration], [data-turn-duration-complete]').forEach((node) => {
-          node.textContent = duration || '24s';
+        root.querySelectorAll("[data-trace-group-toggle]").forEach((button) => {
+          button.setAttribute("aria-expanded", "false");
         });
+        root.querySelectorAll("[data-trace-group-items]").forEach((group) => {
+          group.hidden = true;
+        });
+        root.querySelectorAll("[data-step-toggle]").forEach((button) => {
+          button.setAttribute("aria-expanded", "false");
+        });
+        root.querySelectorAll("[data-step-detail]").forEach((detail) => {
+          detail.hidden = true;
+        });
+        root
+          .querySelectorAll(
+            "[data-turn-duration], [data-turn-duration-complete]",
+          )
+          .forEach((node) => {
+            node.textContent = duration || "24s";
+          });
       };
 
       const updateBackToLive = () => {
-        const distance = transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight;
+        const distance =
+          transcript.scrollHeight -
+          transcript.scrollTop -
+          transcript.clientHeight;
         backLive.hidden = distance < 80 || emptyState.hidden === false;
       };
 
       const scrollToLive = () => {
-        transcript.scrollTo({ top: transcript.scrollHeight, behavior: 'smooth' });
+        transcript.scrollTo({
+          top: transcript.scrollHeight,
+          behavior: "smooth",
+        });
         backLive.hidden = true;
       };
 
       const setSidebarView = (view) => {
-        root.querySelectorAll('[data-sidebar-view]').forEach((panel) => { panel.hidden = panel.dataset.sidebarView !== view; });
-        const inbox = view === 'inbox';
-        const toggle = root.querySelector('[data-sidebar-view-toggle]');
-        toggle.setAttribute('aria-pressed', String(inbox));
-        toggle.setAttribute('aria-label', inbox ? 'Return to projects' : 'Open inbox');
-        root.querySelector('[data-sidebar-view-title]').textContent = inbox ? 'Inbox' : 'Projects';
+        root.querySelectorAll("[data-sidebar-view]").forEach((panel) => {
+          panel.hidden = panel.dataset.sidebarView !== view;
+        });
+        const inbox = view === "inbox";
+        const toggle = root.querySelector("[data-sidebar-view-toggle]");
+        toggle.setAttribute("aria-pressed", String(inbox));
+        toggle.setAttribute(
+          "aria-label",
+          inbox ? "Return to projects" : "Open inbox",
+        );
+        root.querySelector("[data-sidebar-view-title]").textContent = inbox
+          ? "Inbox"
+          : "Projects";
       };
 
-      root.querySelector('[data-sidebar-view-toggle]').addEventListener('click', (event) => {
-        const inbox = event.currentTarget.getAttribute('aria-pressed') !== 'true';
-        setSidebarView(inbox ? 'inbox' : 'projects');
-      });
+      root
+        .querySelector("[data-sidebar-view-toggle]")
+        .addEventListener("click", (event) => {
+          const inbox =
+            event.currentTarget.getAttribute("aria-pressed") !== "true";
+          setSidebarView(inbox ? "inbox" : "projects");
+        });
 
-      root.querySelectorAll('[data-project-toggle]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const expanded = button.getAttribute('aria-expanded') === 'true';
-          button.setAttribute('aria-expanded', String(!expanded));
-          button.parentElement.querySelector('[data-project-list]').hidden = expanded;
+      root.querySelectorAll("[data-project-toggle]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const expanded = button.getAttribute("aria-expanded") === "true";
+          button.setAttribute("aria-expanded", String(!expanded));
+          button.parentElement.querySelector("[data-project-list]").hidden =
+            expanded;
         });
       });
 
       const selectThread = (button) => {
-        const data = threadContent[button.dataset.thread] || threadContent['command-surface'];
-        showPage('agent');
+        const data =
+          threadContent[button.dataset.thread] ||
+          threadContent["command-surface"];
+        showPage("agent");
         newThreadMode = false;
-        root.querySelectorAll('[data-new-thread-item], [data-thread-item]').forEach((item) => item.remove());
-        Array.from(conversation.children).forEach((item) => { item.hidden = false; });
-        root.querySelectorAll('[data-thread]').forEach((item) => {
-          if (item.dataset.thread === button.dataset.thread) item.setAttribute('aria-current', 'page');
-          else item.removeAttribute('aria-current');
+        root
+          .querySelectorAll("[data-new-thread-item], [data-thread-item]")
+          .forEach((item) => item.remove());
+        Array.from(conversation.children).forEach((item) => {
+          item.hidden = false;
         });
-        root.querySelector('[data-current-title]').textContent = button.dataset.title;
-        root.querySelector('[data-current-project]').textContent = button.dataset.project;
-        root.querySelector('[data-thread-user]').textContent = data.user;
-        root.querySelector('[data-thread-assistant]').textContent = data.assistant;
-        root.querySelector('[data-thread-progress]').textContent = data.progress;
-        root.querySelector('[data-thread-trace-summary]').textContent = data.trace;
-        root.querySelector('[data-thread-tool]').textContent = data.tool;
-        root.querySelector('[data-thread-tool-summary]').textContent = data.summary;
-        root.querySelector('[data-thread-final]').textContent = data.final;
-        root.querySelector('[data-approval]').hidden = !data.approval;
+        root.querySelectorAll("[data-thread]").forEach((item) => {
+          if (item.dataset.thread === button.dataset.thread)
+            item.setAttribute("aria-current", "page");
+          else item.removeAttribute("aria-current");
+        });
+        root.querySelector("[data-current-title]").textContent =
+          button.dataset.title;
+        root.querySelector("[data-current-project]").textContent =
+          button.dataset.project;
+        root.querySelector("[data-thread-user]").textContent = data.user;
+        root.querySelector("[data-thread-assistant]").textContent =
+          data.assistant;
+        root.querySelector("[data-thread-progress]").textContent =
+          data.progress;
+        root.querySelector("[data-thread-trace-summary]").textContent =
+          data.trace;
+        root.querySelector("[data-thread-tool]").textContent = data.tool;
+        root.querySelector("[data-thread-tool-summary]").textContent =
+          data.summary;
+        root.querySelector("[data-thread-final]").textContent = data.final;
+        root.querySelector("[data-approval]").hidden = !data.approval;
         transcript.hidden = false;
         emptyState.hidden = true;
         setTurnState(data.state, data.duration);
         setRunState(data.state);
-        app.dataset.sidebarOpen = 'false';
-        window.setTimeout(() => { transcript.scrollTop = 0; updateBackToLive(); }, 0);
+        app.dataset.sidebarOpen = "false";
+        window.setTimeout(() => {
+          transcript.scrollTop = 0;
+          updateBackToLive();
+        }, 0);
       };
 
-      root.querySelectorAll('[data-thread]').forEach((button) => button.addEventListener('click', () => selectThread(button)));
+      root
+        .querySelectorAll("[data-thread]")
+        .forEach((button) =>
+          button.addEventListener("click", () => selectThread(button)),
+        );
 
-      root.querySelectorAll('[data-thread-jump]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const target = root.querySelector(`[data-thread="${button.dataset.threadJump}"]`);
+      root.querySelectorAll("[data-thread-jump]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const target = root.querySelector(
+            `[data-thread="${button.dataset.threadJump}"]`,
+          );
           if (target) selectThread(target);
         });
       });
 
-      root.querySelector('[data-new-thread]').addEventListener('click', () => {
-        showPage('agent');
+      root.querySelector("[data-new-thread]").addEventListener("click", () => {
+        showPage("agent");
         newThreadMode = true;
-        root.querySelectorAll('[data-thread]').forEach((item) => item.removeAttribute('aria-current'));
-        root.querySelector('[data-current-title]').textContent = 'New thread';
-        root.querySelector('[data-current-project]').textContent = 'ZenX / local workspace';
-        root.querySelector('[data-approval]').hidden = true;
+        root
+          .querySelectorAll("[data-thread]")
+          .forEach((item) => item.removeAttribute("aria-current"));
+        root.querySelector("[data-current-title]").textContent = "New thread";
+        root.querySelector("[data-current-project]").textContent =
+          "ZenX / local workspace";
+        root.querySelector("[data-approval]").hidden = true;
         transcript.hidden = true;
         emptyState.hidden = false;
-        setRunState('idle');
-        app.dataset.sidebarOpen = 'false';
+        setRunState("idle");
+        app.dataset.sidebarOpen = "false";
         input.focus();
       });
 
       const selectSettingsTab = (name) => {
-        root.querySelectorAll('[data-settings-tab]').forEach((button) => button.setAttribute('aria-selected', String(button.dataset.settingsTab === name)));
-        root.querySelectorAll('[data-settings-panel]').forEach((panel) => { panel.hidden = panel.dataset.settingsPanel !== name; });
+        root
+          .querySelectorAll("[data-settings-tab]")
+          .forEach((button) =>
+            button.setAttribute(
+              "aria-selected",
+              String(button.dataset.settingsTab === name),
+            ),
+          );
+        root.querySelectorAll("[data-settings-panel]").forEach((panel) => {
+          panel.hidden = panel.dataset.settingsPanel !== name;
+        });
       };
 
-      root.querySelectorAll('[data-settings-tab]').forEach((button) => {
-        button.addEventListener('click', () => selectSettingsTab(button.dataset.settingsTab));
+      root.querySelectorAll("[data-settings-tab]").forEach((button) => {
+        button.addEventListener("click", () =>
+          selectSettingsTab(button.dataset.settingsTab),
+        );
       });
 
-      const settingsTabs = Array.from(root.querySelectorAll('[data-settings-tab]'));
-      root.querySelector('.zx-settings-nav').addEventListener('keydown', (event) => {
-        const current = settingsTabs.indexOf(document.activeElement);
-        if (current < 0 || !['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
-        event.preventDefault();
-        let next = current;
-        if (event.key === 'ArrowDown' || event.key === 'ArrowRight') next = (current + 1) % settingsTabs.length;
-        if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') next = (current - 1 + settingsTabs.length) % settingsTabs.length;
-        if (event.key === 'Home') next = 0;
-        if (event.key === 'End') next = settingsTabs.length - 1;
-        settingsTabs[next].focus();
-        selectSettingsTab(settingsTabs[next].dataset.settingsTab);
-      });
+      const settingsTabs = Array.from(
+        root.querySelectorAll("[data-settings-tab]"),
+      );
+      root
+        .querySelector(".zx-settings-nav")
+        .addEventListener("keydown", (event) => {
+          const current = settingsTabs.indexOf(document.activeElement);
+          if (
+            current < 0 ||
+            ![
+              "ArrowUp",
+              "ArrowDown",
+              "ArrowLeft",
+              "ArrowRight",
+              "Home",
+              "End",
+            ].includes(event.key)
+          )
+            return;
+          event.preventDefault();
+          let next = current;
+          if (event.key === "ArrowDown" || event.key === "ArrowRight")
+            next = (current + 1) % settingsTabs.length;
+          if (event.key === "ArrowUp" || event.key === "ArrowLeft")
+            next = (current - 1 + settingsTabs.length) % settingsTabs.length;
+          if (event.key === "Home") next = 0;
+          if (event.key === "End") next = settingsTabs.length - 1;
+          settingsTabs[next].focus();
+          selectSettingsTab(settingsTabs[next].dataset.settingsTab);
+        });
 
       const selectProvider = (name) => {
-        root.querySelectorAll('[data-provider-tab]').forEach((button) => button.setAttribute('aria-selected', String(button.dataset.providerTab === name)));
-        root.querySelectorAll('[data-provider-panel]').forEach((panel) => { panel.hidden = panel.dataset.providerPanel !== name; });
+        root
+          .querySelectorAll("[data-provider-tab]")
+          .forEach((button) =>
+            button.setAttribute(
+              "aria-selected",
+              String(button.dataset.providerTab === name),
+            ),
+          );
+        root.querySelectorAll("[data-provider-panel]").forEach((panel) => {
+          panel.hidden = panel.dataset.providerPanel !== name;
+        });
       };
 
-      root.querySelectorAll('[data-provider-tab]').forEach((button) => button.addEventListener('click', () => selectProvider(button.dataset.providerTab)));
+      root
+        .querySelectorAll("[data-provider-tab]")
+        .forEach((button) =>
+          button.addEventListener("click", () =>
+            selectProvider(button.dataset.providerTab),
+          ),
+        );
 
-      const subscriptionButton = root.querySelector('[data-subscription-action]');
-      subscriptionButton.addEventListener('click', () => {
-        const signedIn = subscriptionButton.textContent.trim() === 'Sign out';
-        const status = root.querySelector('.zx-account-status');
-        subscriptionButton.textContent = signedIn ? 'Sign in with OpenAI' : 'Sign out';
-        subscriptionButton.className = signedIn ? 'zx-primary-button' : 'zx-danger-button';
-        status.lastChild.textContent = signedIn ? 'Not signed in' : 'Signed in';
-        showToast(signedIn ? 'Signed out locally' : 'Subscription connected');
+      const subscriptionButton = root.querySelector(
+        "[data-subscription-action]",
+      );
+      subscriptionButton.addEventListener("click", () => {
+        const signedIn = subscriptionButton.textContent.trim() === "Sign out";
+        const status = root.querySelector(".zx-account-status");
+        subscriptionButton.textContent = signedIn
+          ? "Sign in with OpenAI"
+          : "Sign out";
+        subscriptionButton.className = signedIn
+          ? "zx-primary-button"
+          : "zx-danger-button";
+        status.lastChild.textContent = signedIn ? "Not signed in" : "Signed in";
+        showToast(signedIn ? "Signed out locally" : "Subscription connected");
       });
 
-      root.querySelectorAll('[data-capability-toggle]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const granted = button.dataset.granted === 'true';
+      root.querySelectorAll("[data-capability-toggle]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const granted = button.dataset.granted === "true";
           button.dataset.granted = String(!granted);
-          button.textContent = granted ? 'Grant all' : 'Revoke';
-          button.className = granted ? 'zx-secondary-button' : 'zx-danger-button';
-          showToast(granted ? 'Capability revoked · host restart required' : 'Capability permissions granted');
+          button.textContent = granted ? "Grant all" : "Revoke";
+          button.className = granted
+            ? "zx-secondary-button"
+            : "zx-danger-button";
+          showToast(
+            granted
+              ? "Capability revoked · host restart required"
+              : "Capability permissions granted",
+          );
         });
       });
 
       const syncPluginState = () => {
-        root.querySelectorAll('[data-plugin-toggle]').forEach((button) => {
+        root.querySelectorAll("[data-plugin-toggle]").forEach((button) => {
           const id = button.dataset.pluginToggle;
           const enabled = pluginState[id];
-          button.setAttribute('aria-checked', String(enabled));
-          const name = root.querySelector(`[data-plugin-row="${id}"] strong`).textContent.trim();
-          button.setAttribute('aria-label', `${enabled ? 'Disable' : 'Enable'} ${name} plugin`);
-          const detail = root.querySelector(`[data-plugin-row="${id}"] > div > span`);
-          detail.textContent = detail.textContent.replace(/^(Enabled|Disabled)/, enabled ? 'Enabled' : 'Disabled');
+          button.setAttribute("aria-checked", String(enabled));
+          const name = root
+            .querySelector(`[data-plugin-row="${id}"] strong`)
+            .textContent.trim();
+          button.setAttribute(
+            "aria-label",
+            `${enabled ? "Disable" : "Enable"} ${name} plugin`,
+          );
+          const detail = root.querySelector(
+            `[data-plugin-row="${id}"] > div > span`,
+          );
+          detail.textContent = detail.textContent.replace(
+            /^(Enabled|Disabled)/,
+            enabled ? "Enabled" : "Disabled",
+          );
         });
-        ['triggers', 'rooms'].forEach((id) => {
-          root.querySelectorAll(`[data-plugin-contribution="${id}"]`).forEach((node) => { node.hidden = !pluginState[id]; });
+        ["triggers", "rooms"].forEach((id) => {
+          root
+            .querySelectorAll(`[data-plugin-contribution="${id}"]`)
+            .forEach((node) => {
+              node.hidden = !pluginState[id];
+            });
         });
-        root.querySelectorAll('[data-plugin-dependent="rooms"]').forEach((node) => { node.hidden = !pluginState.rooms; });
-        root.querySelector('[data-room-trigger-option]').disabled = !pluginState.rooms;
-        const activeContributions = Number(pluginState.triggers) + Number(pluginState.rooms);
-        root.querySelector('[data-plugin-contributions]').hidden = activeContributions === 0;
-        root.querySelector('[data-plugin-active-count]').textContent = `${activeContributions} Sidebar contribution${activeContributions === 1 ? '' : 's'} active`;
+        root
+          .querySelectorAll('[data-plugin-dependent="rooms"]')
+          .forEach((node) => {
+            node.hidden = !pluginState.rooms;
+          });
+        root.querySelector("[data-room-trigger-option]").disabled =
+          !pluginState.rooms;
+        const activeContributions =
+          Number(pluginState.triggers) + Number(pluginState.rooms);
+        root.querySelector("[data-plugin-contributions]").hidden =
+          activeContributions === 0;
+        root.querySelector("[data-plugin-active-count]").textContent =
+          `${activeContributions} Sidebar contribution${activeContributions === 1 ? "" : "s"} active`;
       };
 
-      root.querySelectorAll('[data-plugin-toggle]').forEach((button) => {
-        button.addEventListener('click', () => {
+      root.querySelectorAll("[data-plugin-toggle]").forEach((button) => {
+        button.addEventListener("click", () => {
           const id = button.dataset.pluginToggle;
           pluginState[id] = !pluginState[id];
           syncPluginState();
-          showToast(`${root.querySelector(`[data-plugin-row="${id}"] strong`).textContent.trim()} ${pluginState[id] ? 'enabled' : 'disabled'}`);
+          showToast(
+            `${root.querySelector(`[data-plugin-row="${id}"] strong`).textContent.trim()} ${pluginState[id] ? "enabled" : "disabled"}`,
+          );
         });
       });
 
-      root.querySelectorAll('[data-open-capability]').forEach((button) => {
-        button.addEventListener('click', () => { showPage('settings'); selectSettingsTab('plugins'); });
+      root.querySelectorAll("[data-open-capability]").forEach((button) => {
+        button.addEventListener("click", () => {
+          showPage("settings");
+          selectSettingsTab("plugins");
+        });
       });
 
-      root.querySelectorAll('[data-save-settings]').forEach((button) => button.addEventListener('click', () => {
-        button.textContent = 'Restarting host…';
-        button.disabled = true;
-        window.setTimeout(() => { button.textContent = 'Save and restart host'; button.disabled = false; showToast('Settings saved · local host ready'); }, 850);
-      }));
+      root.querySelectorAll("[data-save-settings]").forEach((button) =>
+        button.addEventListener("click", () => {
+          button.textContent = "Restarting host…";
+          button.disabled = true;
+          window.setTimeout(() => {
+            button.textContent = "Save and restart host";
+            button.disabled = false;
+            showToast("Settings saved · local host ready");
+          }, 850);
+        }),
+      );
 
-      root.querySelectorAll('[data-restart-host]').forEach((button) => button.addEventListener('click', () => {
-        button.textContent = 'Restarting…';
-        button.disabled = true;
-        window.setTimeout(() => { button.textContent = 'Restart'; button.disabled = false; showToast('Zen App Server restarted'); }, 700);
-      }));
+      root.querySelectorAll("[data-restart-host]").forEach((button) =>
+        button.addEventListener("click", () => {
+          button.textContent = "Restarting…";
+          button.disabled = true;
+          window.setTimeout(() => {
+            button.textContent = "Restart";
+            button.disabled = false;
+            showToast("Zen App Server restarted");
+          }, 700);
+        }),
+      );
 
       const filterPlugins = () => {
-        const selected = root.querySelector('[data-plugin-tab][aria-selected="true"]').dataset.pluginTab;
-        const query = root.querySelector('[data-plugin-search]').value.trim().toLowerCase();
+        const selected = root.querySelector(
+          '[data-plugin-tab][aria-selected="true"]',
+        ).dataset.pluginTab;
+        const query = root
+          .querySelector("[data-plugin-search]")
+          .value.trim()
+          .toLowerCase();
         let visible = 0;
-        root.querySelectorAll('[data-plugin-card]').forEach((card) => {
-          const matchesTab = selected === 'discover' || (selected === 'installed' && card.dataset.pluginStatus === 'installed') || selected === 'updates' && card.dataset.pluginStatus === 'update';
-          const matchesQuery = !query || card.dataset.pluginSearchText.includes(query);
+        root.querySelectorAll("[data-plugin-card]").forEach((card) => {
+          const matchesTab =
+            selected === "discover" ||
+            (selected === "installed" &&
+              card.dataset.pluginStatus === "installed") ||
+            (selected === "updates" && card.dataset.pluginStatus === "update");
+          const matchesQuery =
+            !query || card.dataset.pluginSearchText.includes(query);
           card.hidden = !(matchesTab && matchesQuery);
           if (!card.hidden) visible += 1;
         });
-        root.querySelector('[data-plugin-empty]').hidden = visible > 0;
+        root.querySelector("[data-plugin-empty]").hidden = visible > 0;
       };
 
-      root.querySelectorAll('[data-plugin-tab]').forEach((button) => {
-        button.addEventListener('click', () => {
-          root.querySelectorAll('[data-plugin-tab]').forEach((item) => item.setAttribute('aria-selected', String(item === button)));
+      root.querySelectorAll("[data-plugin-tab]").forEach((button) => {
+        button.addEventListener("click", () => {
+          root
+            .querySelectorAll("[data-plugin-tab]")
+            .forEach((item) =>
+              item.setAttribute("aria-selected", String(item === button)),
+            );
           filterPlugins();
         });
       });
-      root.querySelector('[data-plugin-search]').addEventListener('input', filterPlugins);
-      root.querySelectorAll('[data-local-package]').forEach((button) => button.addEventListener('click', () => showToast('Local package folder picker opened')));
+      root
+        .querySelector("[data-plugin-search]")
+        .addEventListener("input", filterPlugins);
+      root
+        .querySelectorAll("[data-local-package]")
+        .forEach((button) =>
+          button.addEventListener("click", () =>
+            showToast("Local package folder picker opened"),
+          ),
+        );
 
-      const triggerForm = root.querySelector('[data-trigger-form]');
-      root.querySelector('[data-toggle-trigger-form]').addEventListener('click', () => {
-        triggerForm.hidden = !triggerForm.hidden;
-        if (!triggerForm.hidden) triggerForm.querySelector('input').focus();
+      const triggerForm = root.querySelector("[data-trigger-form]");
+      root
+        .querySelector("[data-toggle-trigger-form]")
+        .addEventListener("click", () => {
+          triggerForm.hidden = !triggerForm.hidden;
+          if (!triggerForm.hidden) triggerForm.querySelector("input").focus();
+        });
+      const createTrigger = (event) => {
+        event.preventDefault();
+        triggerForm.hidden = true;
+        showToast("Trigger created");
+      };
+      triggerForm.addEventListener("submit", createTrigger);
+      root
+        .querySelector("[data-create-trigger]")
+        .addEventListener("click", createTrigger);
+      const sendSignal = (event) => {
+        event.preventDefault();
+        showToast("Signal simulated · matching Threads will wake");
+      };
+      root
+        .querySelector("[data-signal-form]")
+        .addEventListener("submit", sendSignal);
+      root
+        .querySelector("[data-send-signal]")
+        .addEventListener("click", sendSignal);
+
+      root
+        .querySelector("[data-add-member]")
+        .addEventListener("click", () => showToast("Member picker opened"));
+      const roomInput = root.querySelector("[data-room-input]");
+      const roomSend = root.querySelector("[data-room-send]");
+      roomInput.addEventListener("input", () => {
+        roomSend.disabled = roomInput.value.trim().length === 0;
       });
-      const createTrigger = (event) => { event.preventDefault(); triggerForm.hidden = true; showToast('Trigger created'); };
-      triggerForm.addEventListener('submit', createTrigger);
-      root.querySelector('[data-create-trigger]').addEventListener('click', createTrigger);
-      const sendSignal = (event) => { event.preventDefault(); showToast('Signal simulated · matching Threads will wake'); };
-      root.querySelector('[data-signal-form]').addEventListener('submit', sendSignal);
-      root.querySelector('[data-send-signal]').addEventListener('click', sendSignal);
-
-      root.querySelector('[data-add-member]').addEventListener('click', () => showToast('Member picker opened'));
-      const roomInput = root.querySelector('[data-room-input]');
-      const roomSend = root.querySelector('[data-room-send]');
-      roomInput.addEventListener('input', () => { roomSend.disabled = roomInput.value.trim().length === 0; });
       const sendRoomMessage = (event) => {
         event.preventDefault();
         const message = roomInput.value.trim();
         if (!message) return;
-        const article = document.createElement('article');
-        article.className = 'zx-room-message';
-        const header = document.createElement('header');
-        const author = document.createElement('strong');
-        author.textContent = 'You';
-        const time = document.createElement('time');
-        time.textContent = 'now';
+        const article = document.createElement("article");
+        article.className = "zx-room-message";
+        const header = document.createElement("header");
+        const author = document.createElement("strong");
+        author.textContent = "You";
+        const time = document.createElement("time");
+        time.textContent = "now";
         header.append(author, time);
-        const copy = document.createElement('p');
+        const copy = document.createElement("p");
         copy.textContent = message;
         article.append(header, copy);
-        root.querySelector('[data-room-feed]').appendChild(article);
-        roomInput.value = '';
+        root.querySelector("[data-room-feed]").appendChild(article);
+        roomInput.value = "";
         roomSend.disabled = true;
-        article.scrollIntoView({ behavior: 'smooth', block: 'end' });
-        showToast('Room message sent');
+        article.scrollIntoView({ behavior: "smooth", block: "end" });
+        showToast("Room message sent");
       };
-      root.querySelector('[data-room-form]').addEventListener('submit', sendRoomMessage);
-      roomSend.addEventListener('click', sendRoomMessage);
+      root
+        .querySelector("[data-room-form]")
+        .addEventListener("submit", sendRoomMessage);
+      roomSend.addEventListener("click", sendRoomMessage);
 
-      turnToggle.addEventListener('click', () => {
-        if (turn.dataset.turnState !== 'complete') return;
-        const expanded = turnToggle.getAttribute('aria-expanded') === 'true';
-        turnToggle.setAttribute('aria-expanded', String(!expanded));
+      turnToggle.addEventListener("click", () => {
+        if (turn.dataset.turnState !== "complete") return;
+        const expanded = turnToggle.getAttribute("aria-expanded") === "true";
+        turnToggle.setAttribute("aria-expanded", String(!expanded));
         turn.dataset.expanded = String(!expanded);
         turnHistory.hidden = expanded;
         window.setTimeout(updateBackToLive, 200);
       });
 
-      root.querySelectorAll('[data-trace-group-toggle]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const expanded = button.getAttribute('aria-expanded') === 'true';
-          const items = button.parentElement.querySelector('[data-trace-group-items]');
-          button.setAttribute('aria-expanded', String(!expanded));
+      root.querySelectorAll("[data-trace-group-toggle]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const expanded = button.getAttribute("aria-expanded") === "true";
+          const items = button.parentElement.querySelector(
+            "[data-trace-group-items]",
+          );
+          button.setAttribute("aria-expanded", String(!expanded));
           if (items) items.hidden = expanded;
           if (expanded && items) {
-            items.querySelectorAll('[data-step-toggle]').forEach((step) => { step.setAttribute('aria-expanded', 'false'); });
-            items.querySelectorAll('[data-step-detail]').forEach((detail) => { detail.hidden = true; });
+            items.querySelectorAll("[data-step-toggle]").forEach((step) => {
+              step.setAttribute("aria-expanded", "false");
+            });
+            items.querySelectorAll("[data-step-detail]").forEach((detail) => {
+              detail.hidden = true;
+            });
           }
           window.setTimeout(updateBackToLive, 160);
         });
       });
 
-      root.querySelectorAll('[data-step-toggle]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const expanded = button.getAttribute('aria-expanded') === 'true';
+      root.querySelectorAll("[data-step-toggle]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const expanded = button.getAttribute("aria-expanded") === "true";
           const detail = button.nextElementSibling;
-          button.setAttribute('aria-expanded', String(!expanded));
-          if (detail && detail.matches('[data-step-detail]')) detail.hidden = expanded;
+          button.setAttribute("aria-expanded", String(!expanded));
+          if (detail && detail.matches("[data-step-detail]"))
+            detail.hidden = expanded;
           window.setTimeout(updateBackToLive, 160);
         });
       });
 
-      root.querySelectorAll('[data-approval-action]').forEach((button) => {
-        button.addEventListener('click', () => {
-          root.querySelector('[data-approval]').hidden = true;
-          showToast(button.dataset.approvalAction === 'allow' ? 'Browser control allowed once' : 'Browser control denied');
+      root.querySelectorAll("[data-approval-action]").forEach((button) => {
+        button.addEventListener("click", () => {
+          root.querySelector("[data-approval]").hidden = true;
+          showToast(
+            button.dataset.approvalAction === "allow"
+              ? "Browser control allowed once"
+              : "Browser control denied",
+          );
         });
       });
 
@@ -2721,45 +5475,52 @@ idle + draft     →  Send</code></pre>
         if (emptyState.hidden === false) {
           transcript.hidden = false;
           emptyState.hidden = true;
-          root.querySelector('[data-current-title]').textContent = message.length > 42 ? `${message.slice(0, 42)}…` : message;
-          root.querySelector('[data-current-project]').textContent = 'ZenX / local workspace';
-          Array.from(conversation.children).forEach((item) => { item.hidden = true; });
-          if (!root.querySelector('[data-new-thread-turn]')) {
-            const newTurn = document.createElement('section');
-            newTurn.className = 'zx-turn-new';
-            newTurn.setAttribute('data-new-thread-turn', '');
-            newTurn.setAttribute('data-new-thread-item', '');
-            const meta = document.createElement('div');
-            meta.className = 'zx-agent-meta';
-            const brand = document.createElement('strong');
-            brand.textContent = 'ZenX';
-            const working = document.createElement('span');
-            working.className = 'zx-turn-status';
-            const spinner = document.createElement('span');
-            spinner.className = 'zx-spinner';
-            spinner.setAttribute('aria-hidden', 'true');
-            const status = document.createElement('span');
-            status.textContent = 'Working';
+          root.querySelector("[data-current-title]").textContent =
+            message.length > 42 ? `${message.slice(0, 42)}…` : message;
+          root.querySelector("[data-current-project]").textContent =
+            "ZenX / local workspace";
+          Array.from(conversation.children).forEach((item) => {
+            item.hidden = true;
+          });
+          if (!root.querySelector("[data-new-thread-turn]")) {
+            const newTurn = document.createElement("section");
+            newTurn.className = "zx-turn-new";
+            newTurn.setAttribute("data-new-thread-turn", "");
+            newTurn.setAttribute("data-new-thread-item", "");
+            const meta = document.createElement("div");
+            meta.className = "zx-agent-meta";
+            const brand = document.createElement("strong");
+            brand.textContent = "ZenX";
+            const working = document.createElement("span");
+            working.className = "zx-turn-status";
+            const spinner = document.createElement("span");
+            spinner.className = "zx-spinner";
+            spinner.setAttribute("aria-hidden", "true");
+            const status = document.createElement("span");
+            status.textContent = "Working";
             working.append(spinner, status);
             meta.append(brand, working);
-            const copy = document.createElement('div');
-            copy.className = 'zx-agent-copy';
-            copy.textContent = 'I’m starting a new run and gathering the context needed for this request.';
+            const copy = document.createElement("div");
+            copy.className = "zx-agent-copy";
+            copy.textContent =
+              "I’m starting a new run and gathering the context needed for this request.";
             newTurn.append(meta, copy);
             conversation.appendChild(newTurn);
           }
         }
-        const article = document.createElement('article');
-        article.className = 'zx-user-row';
-        if (newThreadMode) article.setAttribute('data-new-thread-item', '');
-        else article.setAttribute('data-thread-item', '');
-        const bubble = document.createElement('div');
-        bubble.className = 'zx-user-bubble';
+        const article = document.createElement("article");
+        article.className = "zx-user-row";
+        if (newThreadMode) article.setAttribute("data-new-thread-item", "");
+        else article.setAttribute("data-thread-item", "");
+        const bubble = document.createElement("div");
+        bubble.className = "zx-user-bubble";
         bubble.textContent = message;
         article.appendChild(bubble);
-        const activeTurn = newThreadMode ? root.querySelector('[data-new-thread-turn]') : turn;
+        const activeTurn = newThreadMode
+          ? root.querySelector("[data-new-thread-turn]")
+          : turn;
         conversation.insertBefore(article, activeTurn || null);
-        input.value = '';
+        input.value = "";
         updateComposerAction();
         window.setTimeout(scrollToLive, 0);
       };
@@ -2767,109 +5528,175 @@ idle + draft     →  Send</code></pre>
       const performComposerAction = () => {
         const mode = app.dataset.actionMode;
         const message = input.value.trim();
-        if (mode === 'stop') {
-          setRunState('idle');
+        if (mode === "stop") {
+          setRunState("idle");
           if (!newThreadMode) {
-            root.querySelector('[data-thread-final]').textContent = 'Run stopped. The latest Agent response is preserved, and the partial execution trace remains available from the turn disclosure.';
-            setTurnState('idle', '24s');
+            root.querySelector("[data-thread-final]").textContent =
+              "Run stopped. The latest Agent response is preserved, and the partial execution trace remains available from the turn disclosure.";
+            setTurnState("idle", "24s");
           }
-          showToast('Run stopped');
+          showToast("Run stopped");
           return;
         }
         if (!message) {
           input.focus();
-          showToast('Type a message first');
+          showToast("Type a message first");
           return;
         }
         appendMessage(message);
         if (!newThreadMode) {
-          root.querySelector('[data-thread-assistant]').textContent = mode === 'interrupt' ? 'I’ve interrupted the previous path and I’m working from your latest direction now.' : 'I’m working through your follow-up now and checking the affected states.';
-          setTurnState('running', '0s');
+          root.querySelector("[data-thread-assistant]").textContent =
+            mode === "interrupt"
+              ? "I’ve interrupted the previous path and I’m working from your latest direction now."
+              : "I’m working through your follow-up now and checking the affected states.";
+          setTurnState("running", "0s");
         }
-        setRunState('running');
-        showToast(mode === 'interrupt' ? 'Run interrupted · message sent' : 'Message sent');
+        setRunState("running");
+        showToast(
+          mode === "interrupt"
+            ? "Run interrupted · message sent"
+            : "Message sent",
+        );
       };
 
-      composerAction.addEventListener('click', performComposerAction);
-      input.addEventListener('input', updateComposerAction);
+      composerAction.addEventListener("click", performComposerAction);
+      input.addEventListener("input", updateComposerAction);
 
-      input.addEventListener('keydown', (event) => {
-        if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+      input.addEventListener("keydown", (event) => {
+        if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
           event.preventDefault();
           performComposerAction();
         }
       });
 
-      root.querySelectorAll('[data-control]').forEach((button) => {
-        button.addEventListener('click', () => {
-          const messages = { attach: 'Attachment picker opened', model: 'Model picker opened', permission: 'Permission menu opened' };
+      root.querySelectorAll("[data-control]").forEach((button) => {
+        button.addEventListener("click", () => {
+          const messages = {
+            attach: "Attachment picker opened",
+            model: "Model picker opened",
+            permission: "Permission menu opened",
+          };
           showToast(messages[button.dataset.control]);
         });
       });
 
       const openWorkspace = () => {
         workspaceReturnFocus = document.activeElement;
-        modalBackgrounds.forEach((element) => { element.inert = true; });
+        modalBackgrounds.forEach((element) => {
+          element.inert = true;
+        });
         workspaceLayer.hidden = false;
-        root.querySelector('[data-close-workspace]').focus();
+        root.querySelector("[data-close-workspace]").focus();
       };
 
       const closeWorkspace = () => {
         workspaceLayer.hidden = true;
-        modalBackgrounds.forEach((element) => { element.inert = false; });
-        if (workspaceReturnFocus && typeof workspaceReturnFocus.focus === 'function') workspaceReturnFocus.focus();
+        modalBackgrounds.forEach((element) => {
+          element.inert = false;
+        });
+        if (
+          workspaceReturnFocus &&
+          typeof workspaceReturnFocus.focus === "function"
+        )
+          workspaceReturnFocus.focus();
       };
 
-      root.querySelector('[data-open-workspace]').addEventListener('click', openWorkspace);
-      root.querySelector('[data-close-workspace]').addEventListener('click', closeWorkspace);
-      workspaceLayer.addEventListener('pointerdown', (event) => { if (event.target === workspaceLayer) closeWorkspace(); });
-
-      const tabs = Array.from(root.querySelectorAll('[data-panel-tab]'));
-      const selectPanelTab = (tab) => {
-        tabs.forEach((item) => item.setAttribute('aria-selected', String(item === tab)));
-        root.querySelectorAll('[data-panel]').forEach((panel) => { panel.hidden = panel.dataset.panel !== tab.dataset.panelTab; });
-      };
-      tabs.forEach((tab) => tab.addEventListener('click', () => selectPanelTab(tab)));
-      root.querySelector('.zx-sheet-tabs').addEventListener('keydown', (event) => {
-        const current = tabs.indexOf(document.activeElement);
-        if (current < 0 || !['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
-        event.preventDefault();
-        let next = current;
-        if (event.key === 'ArrowRight') next = (current + 1) % tabs.length;
-        if (event.key === 'ArrowLeft') next = (current - 1 + tabs.length) % tabs.length;
-        if (event.key === 'Home') next = 0;
-        if (event.key === 'End') next = tabs.length - 1;
-        tabs[next].focus();
-        selectPanelTab(tabs[next]);
+      root
+        .querySelector("[data-open-workspace]")
+        .addEventListener("click", openWorkspace);
+      root
+        .querySelector("[data-close-workspace]")
+        .addEventListener("click", closeWorkspace);
+      workspaceLayer.addEventListener("pointerdown", (event) => {
+        if (event.target === workspaceLayer) closeWorkspace();
       });
 
-      workspaceSheet.addEventListener('keydown', (event) => {
-        if (event.key !== 'Tab') return;
-        const focusable = Array.from(workspaceSheet.querySelectorAll('button:not([disabled]):not([hidden])')).filter((element) => !element.closest('[hidden]'));
+      const tabs = Array.from(root.querySelectorAll("[data-panel-tab]"));
+      const selectPanelTab = (tab) => {
+        tabs.forEach((item) =>
+          item.setAttribute("aria-selected", String(item === tab)),
+        );
+        root.querySelectorAll("[data-panel]").forEach((panel) => {
+          panel.hidden = panel.dataset.panel !== tab.dataset.panelTab;
+        });
+      };
+      tabs.forEach((tab) =>
+        tab.addEventListener("click", () => selectPanelTab(tab)),
+      );
+      root
+        .querySelector(".zx-sheet-tabs")
+        .addEventListener("keydown", (event) => {
+          const current = tabs.indexOf(document.activeElement);
+          if (
+            current < 0 ||
+            !["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)
+          )
+            return;
+          event.preventDefault();
+          let next = current;
+          if (event.key === "ArrowRight") next = (current + 1) % tabs.length;
+          if (event.key === "ArrowLeft")
+            next = (current - 1 + tabs.length) % tabs.length;
+          if (event.key === "Home") next = 0;
+          if (event.key === "End") next = tabs.length - 1;
+          tabs[next].focus();
+          selectPanelTab(tabs[next]);
+        });
+
+      workspaceSheet.addEventListener("keydown", (event) => {
+        if (event.key !== "Tab") return;
+        const focusable = Array.from(
+          workspaceSheet.querySelectorAll(
+            "button:not([disabled]):not([hidden])",
+          ),
+        ).filter((element) => !element.closest("[hidden]"));
         if (!focusable.length) return;
         const first = focusable[0];
         const last = focusable[focusable.length - 1];
-        if (event.shiftKey && document.activeElement === first) { event.preventDefault(); last.focus(); }
-        else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus(); }
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
       });
 
-      root.querySelectorAll('[data-open-sidebar]').forEach((button) => button.addEventListener('click', () => { app.dataset.sidebarOpen = 'true'; }));
-      root.querySelector('[data-close-sidebar]').addEventListener('click', () => { app.dataset.sidebarOpen = 'false'; });
+      root.querySelectorAll("[data-open-sidebar]").forEach((button) =>
+        button.addEventListener("click", () => {
+          app.dataset.sidebarOpen = "true";
+        }),
+      );
+      root
+        .querySelector("[data-close-sidebar]")
+        .addEventListener("click", () => {
+          app.dataset.sidebarOpen = "false";
+        });
 
-      transcript.addEventListener('scroll', updateBackToLive, { passive: true });
-      backLive.addEventListener('click', scrollToLive);
+      transcript.addEventListener("scroll", updateBackToLive, {
+        passive: true,
+      });
+      backLive.addEventListener("click", scrollToLive);
 
-      app.addEventListener('keydown', (event) => {
-        if (event.key !== 'Escape') return;
-        if (!workspaceLayer.hidden) { event.preventDefault(); closeWorkspace(); }
-        else if (app.dataset.sidebarOpen === 'true') { event.preventDefault(); app.dataset.sidebarOpen = 'false'; }
+      app.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape") return;
+        if (!workspaceLayer.hidden) {
+          event.preventDefault();
+          closeWorkspace();
+        } else if (app.dataset.sidebarOpen === "true") {
+          event.preventDefault();
+          app.dataset.sidebarOpen = "false";
+        }
       });
 
-      setTurnState('running', '24s');
-      setRunState('running');
+      setTurnState("running", "24s");
+      setRunState("running");
       syncPluginState();
-      showPage('agent');
-      window.setTimeout(() => { transcript.scrollTop = 0; updateBackToLive(); }, 0);
+      showPage("agent");
+      window.setTimeout(() => {
+        transcript.scrollTop = 0;
+        updateBackToLive();
+      }, 0);
     })();
   </script>
 </div>


### PR DESCRIPTION
## What changed

- Ran the repository Prettier formatter on the two ZenX high-fidelity prototype files reported by CI.
- Made no semantic or out-of-scope changes.

## Why

The current `origin/main` baseline failed Prettier checks for these two files.

## Impact

Formatting-only change; runtime and prototype behavior are unchanged.

## Validation

- Targeted `prettier --check` passes for both files.
- `git diff --check` passes.
- `npm run format:check` reaches Prettier, but the Windows checkout reports 172 unrelated CRLF-format mismatches; the two target files are not among them.