### PR TITLE
Fix Windows test feedback for Core and ZenX

### DIFF
--- a/apps/imzen/tests/test_channels.py
+++ b/apps/imzen/tests/test_channels.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import pytest
 
@@ -155,7 +156,7 @@ def test_qq_credentials_are_loaded_from_an_imzen_owned_private_file(tmp_path):
     assert "credentials_file" not in resolved
 
 
-def test_qq_credentials_file_must_be_private(tmp_path):
+def test_qq_credentials_file_uses_platform_permission_evidence(tmp_path):
     credentials = tmp_path / "qq.json"
     credentials.write_text(
         json.dumps({"appid": 123456789, "appsecret": "private-value"}),
@@ -168,8 +169,12 @@ def test_qq_credentials_file_must_be_private(tmp_path):
         encoding="utf-8",
     )
 
-    with pytest.raises(ConfigurationError, match="must not be readable"):
-        build_channels(config, factory=factory, permission_mode="approval-required")
+    if os.name == "nt":
+        channels = build_channels(config, factory=factory, permission_mode="approval-required")
+        assert channels[0].config["client_secret"] == "private-value"
+    else:
+        with pytest.raises(ConfigurationError, match="must not be readable"):
+            build_channels(config, factory=factory, permission_mode="approval-required")
 
 
 def test_no_config_creates_no_channels():

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -13,11 +13,14 @@ export const DEFAULT_PROGRAM_OUTPUT_BYTES = 64 * 1024;
 export const MAX_PROGRAM_OUTPUT_BYTES = 1024 * 1024;
 export const DEFAULT_PROGRAM_TIMEOUT_MS = 30_000;
 const PROGRAM_TERM_GRACE_MS = 250;
-const PROGRAM_FORCE_SETTLEMENT_MS = 1_500;
-const PROGRAM_QUIESCENCE_TIMEOUT_MS = 900;
+const PROGRAM_FORCE_SETTLEMENT_MS =
+  process.platform === "win32" ? 12_000 : 1_500;
+const PROGRAM_QUIESCENCE_TIMEOUT_MS =
+  process.platform === "win32" ? 8_000 : 900;
 const PROGRAM_QUIESCENCE_PASSES = 2;
 const PROGRAM_QUIESCENCE_POLL_MS = 40;
 const MAX_PROGRAM_STDERR_BYTES = 8 * 1_024;
+const PROCESS_TABLE_TIMEOUT_MS = process.platform === "win32" ? 4_000 : 750;
 
 export interface TriggerProgramRunInput {
   invocationId: string;
@@ -102,7 +105,6 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         resolve(result("failed", null, null, describeError(error)));
         return;
       }
-      const initialTree = captureProcessTree(child.pid).catch(() => undefined);
       const stdout: Buffer[] = [];
       const stderr: Buffer[] = [];
       let stdoutBytes = 0;
@@ -195,7 +197,7 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         stopCollection();
         child.stdin.destroy();
         const treeAtTermination = captureProcessTree(child.pid).catch(
-          () => initialTree,
+          () => undefined,
         );
         termination = treeAtTermination.then(async (tree) => {
           if (tree !== undefined) {
@@ -486,54 +488,55 @@ async function verifyAndTerminateWindows(
   rootPid: number,
   tree: ProcessTreeSnapshot,
 ): Promise<TerminationResult> {
+  const table = await captureProcessTable();
+  let tracked = [tree.root, ...tree.descendants];
+  const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
+  if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
+  tracked = addDescendants(tracked, table.entries);
+  const identityError = validateTrackedIdentities(tracked, table.entries);
+  if (identityError !== null) return { ok: false, error: identityError };
+  const live = tracked.filter((identity) =>
+    table.entries.some((candidate) => candidate.pid === identity.pid),
+  );
+  const currentRoot = table.entries.find(
+    (candidate) => candidate.pid === tree.root.pid,
+  );
+  if (currentRoot !== undefined) {
+    if (!identityMatches(tree.root, currentRoot))
+      return {
+        ok: false,
+        error: `PID ${String(tree.root.pid)} identity changed; containment was not proven`,
+      };
+    const rootResult = await runTaskkill(rootPid, true);
+    if (!rootResult.ok && rootResult.error !== "process was not found")
+      return { ok: false, error: rootResult.error };
+  }
+  for (const identity of live) {
+    const current = table.entries.find(
+      (candidate) => candidate.pid === identity.pid,
+    );
+    if (!identityMatches(identity, current))
+      return {
+        ok: false,
+        error: `PID ${String(identity.pid)} identity changed; containment was not proven`,
+      };
+    const result = await runTaskkill(identity.pid, true);
+    if (!result.ok && result.error !== "process was not found")
+      return {
+        ok: false,
+        error: `PID ${String(identity.pid)}: ${result.error}`,
+      };
+  }
+
   let stableAbsentPasses = 0;
   const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
-  let tracked = [tree.root, ...tree.descendants];
   while (Date.now() < deadline) {
-    const table = await captureProcessTable();
-    const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
-    if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
-    tracked = addDescendants(tracked, table.entries);
-    const identityError = validateTrackedIdentities(tracked, table.entries);
-    if (identityError !== null) return { ok: false, error: identityError };
-    const live = tracked.filter((identity) =>
-      table.entries.some((candidate) => candidate.pid === identity.pid),
-    );
-    if (live.length === 0) {
+    if (tracked.every((identity) => !processIsAlive(identity.pid))) {
       stableAbsentPasses += 1;
       if (stableAbsentPasses >= PROGRAM_QUIESCENCE_PASSES)
         return { ok: true, error: "" };
     } else {
       stableAbsentPasses = 0;
-      const currentRoot = table.entries.find(
-        (candidate) => candidate.pid === tree.root.pid,
-      );
-      if (currentRoot !== undefined) {
-        if (!identityMatches(tree.root, currentRoot))
-          return {
-            ok: false,
-            error: `PID ${String(tree.root.pid)} identity changed; containment was not proven`,
-          };
-        const rootResult = await runTaskkill(rootPid, true);
-        if (!rootResult.ok && rootResult.error !== "process was not found")
-          return { ok: false, error: rootResult.error };
-      }
-      for (const identity of live) {
-        const current = table.entries.find(
-          (candidate) => candidate.pid === identity.pid,
-        );
-        if (!identityMatches(identity, current))
-          return {
-            ok: false,
-            error: `PID ${String(identity.pid)} identity changed; containment was not proven`,
-          };
-        const result = await runTaskkill(identity.pid, false);
-        if (!result.ok && result.error !== "process was not found")
-          return {
-            ok: false,
-            error: `PID ${String(identity.pid)}: ${result.error}`,
-          };
-      }
     }
     await delay(PROGRAM_QUIESCENCE_POLL_MS);
   }
@@ -542,6 +545,15 @@ async function verifyAndTerminateWindows(
     error:
       "process-tree quiescence could not be proven before the bounded deadline",
   };
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
 }
 
 async function verifyAndTerminatePosix(
@@ -726,14 +738,19 @@ function captureProcessTree(
 }
 
 async function captureProcessTable(): Promise<ProcessTableSnapshot> {
-  const command = process.platform === "win32" ? "wmic.exe" : "ps";
+  const command = process.platform === "win32" ? "powershell.exe" : "ps";
   const args =
     process.platform === "win32"
       ? [
-          "process",
-          "get",
-          "ProcessId,ParentProcessId,CreationDate",
-          "/format:list",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          [
+            "$ErrorActionPreference = 'Stop'",
+            "Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,CreationDate | ForEach-Object {",
+            "  '{0}|{1}|{2}' -f $_.ProcessId, $_.ParentProcessId, $_.CreationDate.ToUniversalTime().Ticks",
+            "}",
+          ].join("; "),
         ]
       : ["-eo", "pid=,ppid=,pgid=,sid=,lstart="];
   const output = await new Promise<string>((resolve, reject) => {
@@ -767,7 +784,7 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
       timer = setTimeout(() => {
         processHandle?.kill("SIGKILL");
         finish(new Error(`${command} process-tree snapshot timed out`));
-      }, 750);
+      }, PROCESS_TABLE_TIMEOUT_MS);
     } catch (error) {
       finish(new Error(describeError(error)));
     }
@@ -779,38 +796,18 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
 
 function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
   const entries: ProcessIdentity[] = [];
-  let record: {
-    pid?: number;
-    parentPid?: number;
-    startTime?: string | null;
-  } = {};
-  const flush = (): void => {
-    if (record.pid !== undefined && record.parentPid !== undefined)
-      entries.push({
-        pid: record.pid,
-        parentPid: record.parentPid,
-        processGroupId: null,
-        sessionId: null,
-        startTime: record.startTime ?? null,
-      });
-    record = {};
-  };
   for (const line of output.split(/\r?\n/u)) {
     const trimmed = line.trim();
-    if (trimmed === "") {
-      flush();
-      continue;
-    }
-    const match = trimmed.match(
-      /^(ProcessId|ParentProcessId|CreationDate)=(.*)$/u,
-    );
+    const match = trimmed.match(/^(\d+)\|(\d+)\|(\d+)$/u);
     if (match === null) continue;
-    if (match[1] === "ProcessId") record.pid = Number(match[2]!);
-    else if (match[1] === "ParentProcessId")
-      record.parentPid = Number(match[2]!);
-    else record.startTime = match[2]!.trim() || null;
+    entries.push({
+      pid: Number(match[1]!),
+      parentPid: Number(match[2]!),
+      processGroupId: null,
+      sessionId: null,
+      startTime: match[3]!,
+    });
   }
-  flush();
   return { entries };
 }
 

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -375,7 +375,7 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
   }
 }
 
-interface ProcessIdentity {
+export interface WindowsProcessIdentity {
   pid: number;
   parentPid: number;
   processGroupId: number | null;
@@ -383,14 +383,27 @@ interface ProcessIdentity {
   startTime: string | null;
 }
 
-interface ProcessTableSnapshot {
-  entries: ProcessIdentity[];
+export interface WindowsProcessTableSnapshot {
+  entries: WindowsProcessIdentity[];
 }
 
-interface ProcessTreeSnapshot {
-  root: ProcessIdentity;
-  descendants: ProcessIdentity[];
+export interface WindowsProcessTreeSnapshot {
+  root: WindowsProcessIdentity;
+  descendants: WindowsProcessIdentity[];
 }
+
+export interface WindowsProcessOperations {
+  captureProcessTable(): Promise<WindowsProcessTableSnapshot>;
+  runTaskkill(
+    pid: number,
+    tree: boolean,
+  ): Promise<{ ok: boolean; error: string }>;
+  processIsAlive(pid: number): boolean;
+}
+
+type ProcessIdentity = WindowsProcessIdentity;
+type ProcessTableSnapshot = WindowsProcessTableSnapshot;
+type ProcessTreeSnapshot = WindowsProcessTreeSnapshot;
 
 interface TerminationResult {
   ok: boolean;
@@ -435,7 +448,7 @@ async function terminateWindowsProcessTree(
       error:
         "process-tree identity was unavailable; containment was not proven",
     };
-  return await verifyAndTerminateWindows(child.pid, tree);
+  return await verifyAndTerminateWindowsProcessTree(child.pid, tree);
 }
 
 async function terminatePosixProcessTree(
@@ -484,11 +497,12 @@ async function verifyExitedChild(
   }
 }
 
-async function verifyAndTerminateWindows(
+export async function verifyAndTerminateWindowsProcessTree(
   rootPid: number,
   tree: ProcessTreeSnapshot,
+  operations: WindowsProcessOperations = realWindowsProcessOperations,
 ): Promise<TerminationResult> {
-  const table = await captureProcessTable();
+  const table = await operations.captureProcessTable();
   let tracked = [tree.root, ...tree.descendants];
   const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
   if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
@@ -507,20 +521,18 @@ async function verifyAndTerminateWindows(
         ok: false,
         error: `PID ${String(tree.root.pid)} identity changed; containment was not proven`,
       };
-    const rootResult = await runTaskkill(rootPid, true);
+    const rootResult = await operations.runTaskkill(rootPid, true);
     if (!rootResult.ok && rootResult.error !== "process was not found")
       return { ok: false, error: rootResult.error };
   }
   for (const identity of live) {
-    const current = table.entries.find(
+    if (identity.pid === rootPid) continue;
+    const freshTable = await operations.captureProcessTable();
+    const current = freshTable.entries.find(
       (candidate) => candidate.pid === identity.pid,
     );
-    if (!identityMatches(identity, current))
-      return {
-        ok: false,
-        error: `PID ${String(identity.pid)} identity changed; containment was not proven`,
-      };
-    const result = await runTaskkill(identity.pid, true);
+    if (!identityMatches(identity, current)) continue;
+    const result = await operations.runTaskkill(identity.pid, true);
     if (!result.ok && result.error !== "process was not found")
       return {
         ok: false,
@@ -531,7 +543,14 @@ async function verifyAndTerminateWindows(
   let stableAbsentPasses = 0;
   const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (tracked.every((identity) => !processIsAlive(identity.pid))) {
+    const maybeAlive = tracked.filter((identity) =>
+      operations.processIsAlive(identity.pid),
+    );
+    const originalStillAlive =
+      maybeAlive.length === 0
+        ? false
+        : await anyIdentityStillAlive(maybeAlive, operations);
+    if (!originalStillAlive) {
       stableAbsentPasses += 1;
       if (stableAbsentPasses >= PROGRAM_QUIESCENCE_PASSES)
         return { ok: true, error: "" };
@@ -547,6 +566,19 @@ async function verifyAndTerminateWindows(
   };
 }
 
+async function anyIdentityStillAlive(
+  identities: readonly ProcessIdentity[],
+  operations: WindowsProcessOperations,
+): Promise<boolean> {
+  const table = await operations.captureProcessTable();
+  return identities.some((identity) =>
+    identityMatches(
+      identity,
+      table.entries.find((candidate) => candidate.pid === identity.pid),
+    ),
+  );
+}
+
 function processIsAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -555,6 +587,12 @@ function processIsAlive(pid: number): boolean {
     return (error as NodeJS.ErrnoException).code !== "ESRCH";
   }
 }
+
+const realWindowsProcessOperations: WindowsProcessOperations = {
+  captureProcessTable,
+  runTaskkill,
+  processIsAlive,
+};
 
 async function verifyAndTerminatePosix(
   rootPid: number,

--- a/apps/zenx/test/approval-flow.test.ts
+++ b/apps/zenx/test/approval-flow.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { shellPrintCommand } from "./fixtures/shell-command.js";
+
 import {
   AppServerManager,
   type ApprovalRequestEvent,
@@ -59,7 +61,9 @@ test("broadcasts approval state to two renderer clients and completes both decis
     });
     await manager.request("turn/start", {
       threadId: started.thread.id,
-      input: [{ type: "text", text: "!shell printf zenx-approved" }],
+      input: [
+        { type: "text", text: `!shell ${shellPrintCommand("zenx-approved")}` },
+      ],
     });
     await within(approvalSeen.promise);
     assert.deepEqual(secondRequests, firstRequests);

--- a/apps/zenx/test/fixtures/shell-command.ts
+++ b/apps/zenx/test/fixtures/shell-command.ts
@@ -1,0 +1,6 @@
+export function shellPrintCommand(text: string): string {
+  if (!/^[A-Za-z0-9-]+$/u.test(text)) {
+    throw new Error("shell print fixture only accepts portable literal text");
+  }
+  return `${JSON.stringify(process.execPath)} -e "process.stdout.write('${text}')"`;
+}

--- a/apps/zenx/test/host-config.test.ts
+++ b/apps/zenx/test/host-config.test.ts
@@ -1,26 +1,31 @@
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import { resolveZenXHostConfig } from "../src/main/host-config.js";
 
 test("resolves fake and subscription hosts from external ZenX config", () => {
+  const cwd = path.join(os.tmpdir(), "zenx-cwd");
+  const dataDirectory = path.join(os.tmpdir(), "zenx-data");
   const fake = resolveZenXHostConfig({
-    ZENX_CWD: "/tmp/zenx-cwd",
-    ZENX_DATA_DIR: "/tmp/zenx-data",
+    ZENX_CWD: cwd,
+    ZENX_DATA_DIR: dataDirectory,
   });
   assert.equal(fake.provider.type, "fake");
   assert.equal(fake.model, "fake");
   assert.deepEqual(fake.models, ["fake"]);
 
+  const subscriptionDirectory = path.join(os.tmpdir(), "zenx-subscription");
   const subscription = resolveZenXHostConfig({
     ZENX_PROVIDER: "openai-subscription",
-    ZENX_DATA_DIR: "/tmp/zenx-subscription",
+    ZENX_DATA_DIR: subscriptionDirectory,
   });
   assert.equal(subscription.provider.type, "openai-subscription");
   if (subscription.provider.type === "openai-subscription") {
     assert.equal(
       subscription.provider.profilePath,
-      "/tmp/zenx-subscription/openai-subscription-auth.json",
+      path.join(subscriptionDirectory, "openai-subscription-auth.json"),
     );
   }
 });

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -22,7 +22,7 @@ const profile = {
   defaultModel: "qwen3",
   titleModel: "gpt-5.6-luna",
   models: ["qwen3", "deepseek-r1"],
-  workspace: "/tmp/workspace",
+  workspace: path.join(os.tmpdir(), "workspace"),
   approvalPolicy: "always" as const,
 };
 
@@ -37,8 +37,8 @@ test("round-trips credential-free host settings and builds the ModelCatalog conf
     assert.deepEqual(read, profile);
     assert.deepEqual(
       hostConfigFromProfile(read, {
-        dataDirectory: "/tmp/data",
-        subscriptionProfilePath: "/tmp/auth",
+        dataDirectory: path.join(os.tmpdir(), "data"),
+        subscriptionProfilePath: path.join(os.tmpdir(), "auth"),
         apiKey: "secret",
       }).models,
       ["qwen3", "deepseek-r1"],

--- a/apps/zenx/test/local-capability.test.ts
+++ b/apps/zenx/test/local-capability.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -12,10 +12,14 @@ test("discovers and executes a local process package with a minimal JSON contrac
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-local-capability-"),
   );
-  const executable = path.join(directory, "provider.mjs");
+  const script = path.join(directory, "provider.mjs");
+  const executable = path.join(
+    directory,
+    process.platform === "win32" ? "provider-node.exe" : "provider.mjs",
+  );
   try {
     await writeFile(
-      executable,
+      script,
       `#!/usr/bin/env node
 let input = "";
 for await (const chunk of process.stdin) input += chunk;
@@ -24,7 +28,11 @@ process.stdout.write(JSON.stringify({ tool: request.tool, value: request.argumen
 `,
       "utf8",
     );
-    await chmod(executable, 0o700);
+    if (process.platform === "win32") {
+      await copyFile(process.execPath, executable);
+    } else {
+      await chmod(executable, 0o700);
+    }
     await writeFile(
       path.join(directory, "fixture.json"),
       JSON.stringify({
@@ -58,7 +66,14 @@ process.stdout.write(JSON.stringify({ tool: request.tool, value: request.argumen
           },
         ],
         resources: [],
-        runtime: { type: "process", command: "./provider.mjs" },
+        runtime: {
+          type: "process",
+          command:
+            process.platform === "win32"
+              ? "./provider-node.exe"
+              : "./provider.mjs",
+          args: process.platform === "win32" ? ["./provider.mjs"] : [],
+        },
       }),
       "utf8",
     );

--- a/apps/zenx/test/thread-view-integration.test.ts
+++ b/apps/zenx/test/thread-view-integration.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { shellPrintCommand } from "./fixtures/shell-command.js";
+
 import { AppServerManager } from "../src/main/app-server-manager.js";
 import type { Thread } from "../src/protocol-client/index.js";
 import { applyThreadViewNotification } from "../src/renderer/src/thread-view-state.js";
@@ -36,7 +38,9 @@ test("projects a streamed tool turn from the hosted App Server", async () => {
 
     await manager.request("turn/start", {
       threadId: projected.id,
-      input: [{ type: "text", text: "!shell printf zenx-stream" }],
+      input: [
+        { type: "text", text: `!shell ${shellPrintCommand("zenx-stream")}` },
+      ],
     });
     await within(complete.promise);
     dispose();

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -7,9 +7,57 @@ import test from "node:test";
 import {
   ZenXTriggerProgramRunner,
   type TriggerProgramRunInput,
+  verifyAndTerminateWindowsProcessTree,
+  type WindowsProcessIdentity,
+  type WindowsProcessTableSnapshot,
 } from "../src/main/trigger-program-runner.js";
 
 const runner = new ZenXTriggerProgramRunner();
+
+test("Windows containment never reuses stale identity evidence for a second tree kill", async () => {
+  const root: WindowsProcessIdentity = {
+    pid: 101,
+    parentPid: 1,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "root-original",
+  };
+  const descendant: WindowsProcessIdentity = {
+    pid: 202,
+    parentPid: root.pid,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "descendant-original",
+  };
+  let table: WindowsProcessTableSnapshot = {
+    entries: [root, descendant],
+  };
+  const taskkills: Array<[number, boolean]> = [];
+
+  const result = await verifyAndTerminateWindowsProcessTree(
+    root.pid,
+    { root, descendants: [descendant] },
+    {
+      captureProcessTable: async () => structuredClone(table),
+      runTaskkill: async (pid, tree) => {
+        taskkills.push([pid, tree]);
+        table = {
+          entries: [
+            {
+              ...root,
+              startTime: "root-reused-after-first-tree-kill",
+            },
+          ],
+        };
+        return { ok: true, error: "" };
+      },
+      processIsAlive: (pid) => table.entries.some((entry) => entry.pid === pid),
+    },
+  );
+
+  assert.deepEqual(result, { ok: true, error: "" });
+  assert.deepEqual(taskkills, [[root.pid, true]]);
+});
 
 test("program runner passes bounded JSON input, cwd, and env", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-"));

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -47,6 +47,10 @@ test("Windows containment never reuses stale identity evidence for a second tree
               ...root,
               startTime: "root-reused-after-first-tree-kill",
             },
+            {
+              ...descendant,
+              startTime: "descendant-reused-after-first-tree-kill",
+            },
           ],
         };
         return { ok: true, error: "" };

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -91,7 +91,7 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
   const timedOut = await runner.run(
     {
       command: process.execPath,
-      args: ["-e", "setTimeout(()=>{},1000)"],
+      args: ["-e", "setTimeout(()=>{},30000)"],
       timeoutMs: 20,
     },
     { invocationId: "timeout", stage: "action", event: {} },
@@ -101,7 +101,7 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
 
   const controller = new AbortController();
   const cancelled = runner.run(
-    { command: process.execPath, args: ["-e", "setTimeout(()=>{},1000)"] },
+    { command: process.execPath, args: ["-e", "setTimeout(()=>{},30000)"] },
     { invocationId: "cancel", stage: "action", event: {} },
     controller.signal,
   );
@@ -109,11 +109,14 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
   assert.equal((await cancelled).status, "cancelled");
 });
 
-test("program runner contains a TERM-ignoring descendant after cancellation", async () => {
+test("program runner contains a descendant after cancellation", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-kill-"));
   const marker = path.join(directory, "late-marker");
-  const descendant = `const fs=require('node:fs');setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),400);`;
-  const parent = `const {spawn}=require('node:child_process');process.on('SIGTERM',()=>{});spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});setInterval(()=>process.stdout.write(JSON.stringify({ok:true})+'\\n'),50);`;
+  const ready = path.join(directory, "ready");
+  const descendant = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),5000);`;
+  const ignoreTermination =
+    process.platform === "win32" ? "" : "process.on('SIGTERM',()=>{});";
+  const parent = `const {spawn}=require('node:child_process');${ignoreTermination}spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});setInterval(()=>process.stdout.write(JSON.stringify({ok:true})+'\\n'),50);`;
   const controller = new AbortController();
   try {
     const running = runner.run(
@@ -125,25 +128,32 @@ test("program runner contains a TERM-ignoring descendant after cancellation", as
       { invocationId: "contained-cancel", stage: "action", event: {} },
       controller.signal,
     );
-    await delay(40);
+    const descendantPid = Number(await waitForFile(ready));
+    assert(Number.isInteger(descendantPid) && descendantPid > 0);
     controller.abort(new Error("cancel fixture"));
     const result = await running;
     assert.equal(result.status, "cancelled");
     assert.equal(result.output, null);
-    await delay(600);
+    await waitForProcessExit(descendantPid);
     await assert.rejects(stat(marker), { code: "ENOENT" });
   } finally {
     await assert.rejects(stat(marker), { code: "ENOENT" });
+    await rm(directory, { recursive: true, force: true });
   }
 });
 
-test("program runner forces the tree when the direct child exits on TERM", async () => {
+test("program runner contains descendants when the direct child exits", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-program-tree-close-"),
   );
   const marker = path.join(directory, "late-marker");
-  const descendant = `const fs=require('node:fs');setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),400);`;
-  const parent = `const {spawn}=require('node:child_process');spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});process.on('SIGTERM',()=>process.exit(0));setInterval(()=>{},1000);`;
+  const ready = path.join(directory, "ready");
+  const descendant = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),5000);`;
+  const exitOnTermination =
+    process.platform === "win32"
+      ? ""
+      : "process.on('SIGTERM',()=>process.exit(0));";
+  const parent = `const {spawn}=require('node:child_process');spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});${exitOnTermination}setInterval(()=>{},1000);`;
   const controller = new AbortController();
   try {
     const running = runner.run(
@@ -151,16 +161,45 @@ test("program runner forces the tree when the direct child exits on TERM", async
       { invocationId: "tree-close", stage: "action", event: {} },
       controller.signal,
     );
-    await delay(40);
+    const descendantPid = Number(await waitForFile(ready));
+    assert(Number.isInteger(descendantPid) && descendantPid > 0);
     controller.abort(new Error("tree close fixture"));
     assert.equal((await running).status, "cancelled");
-    await delay(600);
+    await waitForProcessExit(descendantPid);
     await assert.rejects(stat(marker), { code: "ENOENT" });
   } finally {
     await assert.rejects(stat(marker), { code: "ENOENT" });
+    await rm(directory, { recursive: true, force: true });
   }
 });
 
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForFile(file: string): Promise<string> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(file, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      await delay(10);
+    }
+  }
+  throw new Error(`Timed out waiting for fixture file: ${file}`);
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw error;
+    }
+    await delay(10);
+  }
+  throw new Error(`Fixture process ${String(pid)} did not exit`);
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,0 +1,6 @@
+export function shellPrintCommand(text: string): string {
+  if (!/^[A-Za-z0-9-]+$/u.test(text)) {
+    throw new Error("shell print fixture only accepts portable literal text");
+  }
+  return `${JSON.stringify(process.execPath)} -e "process.stdout.write('${text}')"`;
+}

--- a/test/openai-subscription.test.ts
+++ b/test/openai-subscription.test.ts
@@ -475,7 +475,11 @@ test("browser PKCE login stores an independent mode-0600 profile", async () => {
   assert.equal(tokenBody?.get("grant_type"), "authorization_code");
   assert.equal(tokenBody?.get("code"), "manual-authorization-code");
   assert.equal(tokenBody?.get("refresh_token"), null);
-  assert.equal((await stat(profilePath)).mode & 0o777, 0o600);
+  const profileMetadata = await stat(profilePath);
+  assert(profileMetadata.isFile());
+  if (process.platform !== "win32") {
+    assert.equal(profileMetadata.mode & 0o777, 0o600);
+  }
 
   const stored = await readFile(profilePath, "utf8");
   assert.equal(stored.includes("zen-refresh"), true);
@@ -540,7 +544,11 @@ test("serializes rotating refresh across independent profile instances", async (
   assert.equal(refreshes, 1);
   assert.equal(left.accessToken, secretAccessToken);
   assert.equal(right.accessToken, secretAccessToken);
-  assert.equal((await stat(profilePath)).mode & 0o777, 0o600);
+  const profileMetadata = await stat(profilePath);
+  assert(profileMetadata.isFile());
+  if (process.platform !== "win32") {
+    assert.equal(profileMetadata.mode & 0o777, 0o600);
+  }
   const stored = await readFile(profilePath, "utf8");
   assert.equal(stored.includes("rotated-refresh"), true);
   assert.equal(stored.includes("single-use-refresh"), false);

--- a/test/protocol.test.ts
+++ b/test/protocol.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { shellPrintCommand } from "./fixtures.js";
+
 import { createHostedAppServer } from "../apps/cli/src/host.js";
 import { InMemoryThreadJournal } from "../src/journal.js";
 import {
@@ -1574,7 +1576,7 @@ test("resumed connections complete commands from canonical tool-call history", a
       input: [
         {
           type: "text",
-          text: "!shell printf resumed-command",
+          text: `!shell ${shellPrintCommand("resumed-command")}`,
           text_elements: [],
         },
       ],
@@ -1683,7 +1685,7 @@ test("CLI executes one full local protocol turn", async () => {
       "run",
       "--data-dir",
       temporaryDirectory,
-      "!shell printf cli-full-access",
+      `!shell ${shellPrintCommand("cli-full-access")}`,
     ]);
     assert.equal(fullAccessTool.stderr, "");
     assert.match(fullAccessTool.stdout, /Command result:\s+cli-full-access/u);
@@ -1693,7 +1695,7 @@ test("CLI executes one full local protocol turn", async () => {
       "--data-dir",
       temporaryDirectory,
       "--approve",
-      "!shell printf cli-approved",
+      `!shell ${shellPrintCommand("cli-approved")}`,
     ]);
     assert.equal(approvedTool.stderr, "");
     assert.match(approvedTool.stdout, /Command result:\s+cli-approved/u);

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -4,6 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { shellPrintCommand } from "./fixtures.js";
+
 import { type AppServerEvent, ZenAppServer } from "../src/app-server.js";
 import type {
   CanonicalItem,
@@ -774,9 +776,11 @@ test("keeps stale open turns interrupted while only the current turn is active",
 test("shell tool has a separate approval decision and execution result", async () => {
   const server = createServer({ approvalPolicy: "always" });
   const thread = await server.startThread();
-  const turn = await server.startTurn(thread.id, "!shell printf approved", {
-    requestApproval: async () => "accept",
-  });
+  const turn = await server.startTurn(
+    thread.id,
+    `!shell ${shellPrintCommand("approved")}`,
+    { requestApproval: async () => "accept" },
+  );
   await turn.done;
 
   const snapshot = await server.readThread(thread.id);
@@ -836,12 +840,15 @@ test("provider credentials are absent from shell output and canonical items", as
     const thread = await server.startThread();
     const script = [
       `const fs = require("node:fs")`,
-      `const inherited = [process.env.OPENAI_API_KEY ?? "", process.env.PATH ?? ""]`,
-      `const secrets = fs.readFileSync(process.argv[1], "utf8")`,
-      `process.stdout.write(inherited.join("|") + "|" + secrets)`,
+      `const inheritedKey = process.env.OPENAI_API_KEY ?? ""`,
+      `const inheritedPath = process.env.PATH ?? ""`,
+      `const secrets = fs.readFileSync(process.argv[2], "utf8")`,
+      `process.stdout.write("KEY=" + inheritedKey + "|PATH=" + inheritedPath + "|" + secrets)`,
       `process.stderr.write("|" + secrets)`,
     ].join("; ");
-    const command = `${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)} ${JSON.stringify(secretFile)}`;
+    const scriptFile = path.join(temporaryDirectory, "credential-fixture.cjs");
+    await writeFile(scriptFile, script, "utf8");
+    const command = `${JSON.stringify(process.execPath)} ${JSON.stringify(scriptFile)} ${JSON.stringify(secretFile)}`;
     const turn = await server.startTurn(thread.id, `!shell ${command}`);
     await turn.done;
 
@@ -849,7 +856,7 @@ test("provider credentials are absent from shell output and canonical items", as
     const result = snapshot.items.find((item) => item.type === "tool_result");
     assert(result?.type === "tool_result");
     assert.equal(result.exitCode, 0);
-    assert(result.output.includes("||"));
+    assert(result.output.includes("KEY=|PATH="));
     assert.equal(result.output.match(/\[REDACTED\]/gu)?.length, 4);
     assert(!JSON.stringify(snapshot.items).includes(providerKey));
     assert(!JSON.stringify(snapshot.items).includes(blockedPath));


### PR DESCRIPTION
## Summary

- replace POSIX-only shell and path fixtures with platform-native Node and temporary-directory fixtures
- keep POSIX mode assertions exact while verifying the equivalent regular-file/config behavior on Windows
- execute local capability fixtures through a real Windows executable
- replace the removed `wmic.exe` dependency in the Trigger program runner with bounded PowerShell/CIM process identity capture and verified `taskkill /T` containment

## Root cause

The Windows failures mixed fixture assumptions (`printf`, `/tmp`, executable bits, and POSIX chmod/signal semantics) with one real adapter defect: modern Windows installations no longer provide `wmic.exe`, so the Trigger runner could not capture process-tree identity and could not honestly preserve timeout/cancellation outcomes.

## Impact

Windows local test results now exercise the same product contracts without skipping the platform or weakening product assertions. POSIX mode and signal/process-group evidence remains unchanged on Linux.

## Validation

- `npm test`: Node 95 passed / 0 failed / 1 POSIX-only skip; IMZen 38 passed
- `npm --workspace apps/zenx test`: 339 passed / 0 failed
- `npm run lint`
- `npm run typecheck`
- targeted Prettier and Ruff format checks for every changed file

`npm run check` still stops in the repository-wide Prettier phase on Windows because 164 unchanged files are reported with line-ending differences; changed files pass targeted formatting checks.