### PR TITLE
fix(zenx): restore Vite development styles

### DIFF
--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -1,6 +1,23 @@
 import { defineConfig } from "electron-vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
+import type { Plugin } from "vite";
+
+const productionStylePolicy = "style-src 'self'";
+const developmentStylePolicy = "style-src 'self' 'unsafe-inline'";
+
+function allowViteDevelopmentStyles(html: string): string {
+  if (!html.includes(productionStylePolicy)) {
+    throw new Error("ZenX renderer CSP is missing its production style policy");
+  }
+  return html.replace(productionStylePolicy, developmentStylePolicy);
+}
+
+const viteDevelopmentCsp: Plugin = {
+  name: "zenx-vite-development-csp",
+  apply: "serve",
+  transformIndexHtml: allowViteDevelopmentStyles,
+};
 
 export default defineConfig({
   main: {
@@ -34,6 +51,6 @@ export default defineConfig({
     },
   },
   renderer: {
-    plugins: [react()],
+    plugins: [viteDevelopmentCsp, react()],
   },
 });

--- a/apps/zenx/test/renderer-csp.test.ts
+++ b/apps/zenx/test/renderer-csp.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { loadConfigFromFile } from "electron-vite";
+import type { Plugin } from "vite";
+
+const rendererIndexPath = new URL(
+  "../src/renderer/index.html",
+  import.meta.url,
+);
+const configPath = new URL("../electron.vite.config.ts", import.meta.url);
+
+test("keeps production styles strict while allowing Vite development injection", async () => {
+  const productionHtml = await readFile(rendererIndexPath, "utf8");
+
+  assert.match(productionHtml, /style-src 'self';/u);
+  assert.doesNotMatch(productionHtml, /style-src[^;]*'unsafe-inline'/u);
+  const loaded = await loadConfigFromFile(
+    { command: "serve", mode: "development" },
+    configPath.pathname,
+  );
+  const plugin = loaded.config.renderer?.plugins?.find(
+    (candidate) =>
+      candidate !== false &&
+      candidate !== null &&
+      candidate !== undefined &&
+      typeof candidate === "object" &&
+      "name" in candidate &&
+      candidate.name === "zenx-vite-development-csp",
+  ) as Plugin | undefined;
+  assert.ok(plugin && typeof plugin === "object");
+  assert.equal(plugin.apply, "serve");
+  const transformIndexHtml = plugin.transformIndexHtml;
+  assert.equal(typeof transformIndexHtml, "function");
+
+  const developmentHtml = await (
+    transformIndexHtml as (html: string) => string | Promise<string>
+  )(productionHtml);
+  assert.match(developmentHtml, /style-src 'self' 'unsafe-inline';/u);
+  assert.match(developmentHtml, /script-src 'self';/u);
+});


### PR DESCRIPTION
## Outcome

Restores the high-fidelity ZenX renderer in Electron development mode. Vite injects development CSS through inline `<style>` nodes, which the production `style-src 'self'` policy correctly blocks. The renderer config now applies a development-only CSP transform during `serve`; production HTML remains strict.

## Verification

- focused renderer CSP regression test
- ZenX typecheck
- ZenX production build
- Prettier
- `git diff --check`
- real Electron development launch: intended styles render and the console has no style CSP violation

Closes #99