### PR TITLE
fix(zenx): serialize host state and guard active Threads

### DIFF
--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -1,4 +1,5 @@
-import { mkdir, open, rename, writeFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { mkdir, open, rename, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import type { ZenXHostConfig } from "./host-messages.js";
@@ -75,12 +76,18 @@ export class ZenXHostProfileStore {
     const validated = validateHostProfile(profile);
     const directory = path.dirname(this.#filePath);
     await mkdir(directory, { recursive: true, mode: 0o700 });
-    const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(validated, null, 2)}\n`, {
-      encoding: "utf8",
-      mode: 0o600,
-    });
-    await rename(temporary, this.#filePath);
+    const temporary = `${this.#filePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, `${JSON.stringify(validated, null, 2)}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      });
+      await rename(temporary, this.#filePath);
+    } finally {
+      await unlink(temporary).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      });
+    }
   }
 }
 

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -27,6 +27,7 @@ export class ZenXSettingsService {
     Partial<Pick<OpenAiSubscriptionAuthProfile, "acquireAccessLease">>;
   readonly #vault: ZenXCredentialVault;
   #profile: ZenXHostProfile | undefined;
+  #profileOperations: Promise<void> = Promise.resolve();
   #loginInProgress = false;
   #manualCode:
     | {
@@ -135,97 +136,109 @@ export class ZenXSettingsService {
 
   async save(profile: ZenXHostProfile, apiKey?: string): Promise<void> {
     const validated = validateHostProfile(profile);
-    if (apiKey !== undefined && apiKey.length > 0)
-      await this.#vault.writeApiKey(apiKey);
-    if (
-      validated.provider.type === "openai-compatible" &&
-      !(await this.#vault.hasApiKey())
-    ) {
-      throw new Error("Add an API key before activating this provider");
-    }
-    await this.#profileStore.write(validated);
-    this.#profile = validated;
+    await this.#queueProfileOperation(async () => {
+      if (apiKey !== undefined && apiKey.length > 0)
+        await this.#vault.writeApiKey(apiKey);
+      if (
+        validated.provider.type === "openai-compatible" &&
+        !(await this.#vault.hasApiKey())
+      ) {
+        throw new Error("Add an API key before activating this provider");
+      }
+      await this.#profileStore.write(validated);
+      this.#profile = validated;
+    });
   }
 
   async addWorkspace(workspace: string): Promise<boolean> {
-    const current = this.#requireProfile();
     const candidate = workspace.trim();
     if (candidate.length === 0) throw new Error("Workspace is required");
     const resolved = path.resolve(candidate);
-    if (
-      current.workspaces.some(
-        (entry) => workspaceKey(entry) === workspaceKey(resolved),
+    return await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      if (
+        current.workspaces.some(
+          (entry) => workspaceKey(entry) === workspaceKey(resolved),
+        )
       )
-    )
-      return false;
-    const isFirst = current.workspace === null;
-    const next = validateHostProfile({
-      ...current,
-      workspace: isFirst ? resolved : current.workspace,
-      workspaces: [...current.workspaces, resolved],
+        return false;
+      const isFirst = current.workspace === null;
+      const next = validateHostProfile({
+        ...current,
+        workspace: isFirst ? resolved : current.workspace,
+        workspaces: [...current.workspaces, resolved],
+      });
+      await this.#profileStore.write(next);
+      this.#profile = next;
+      return isFirst;
     });
-    await this.#profileStore.write(next);
-    this.#profile = next;
-    return isFirst;
   }
 
   async removeWorkspace(workspace: string): Promise<boolean> {
-    const current = this.#requireProfile();
     const key = workspaceKey(workspace);
-    const nextWorkspaces = current.workspaces.filter(
-      (entry) => workspaceKey(entry) !== key,
-    );
-    if (nextWorkspaces.length === current.workspaces.length) return false;
-    const defaultRemoved =
-      current.workspace !== null && workspaceKey(current.workspace) === key;
-    const next = validateHostProfile({
-      ...current,
-      workspace: defaultRemoved
-        ? (nextWorkspaces[0] ?? null)
-        : current.workspace,
-      workspaces: nextWorkspaces,
+    return await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      const nextWorkspaces = current.workspaces.filter(
+        (entry) => workspaceKey(entry) !== key,
+      );
+      if (nextWorkspaces.length === current.workspaces.length) return false;
+      const defaultRemoved =
+        current.workspace !== null && workspaceKey(current.workspace) === key;
+      const next = validateHostProfile({
+        ...current,
+        workspace: defaultRemoved
+          ? (nextWorkspaces[0] ?? null)
+          : current.workspace,
+        workspaces: nextWorkspaces,
+      });
+      await this.#profileStore.write(next);
+      this.#profile = next;
+      return defaultRemoved;
     });
-    await this.#profileStore.write(next);
-    this.#profile = next;
-    return defaultRemoved;
   }
 
   async setDefaultWorkspace(workspace: string): Promise<boolean> {
-    const current = this.#requireProfile();
     const key = workspaceKey(workspace);
-    const selected = current.workspaces.find(
-      (entry) => workspaceKey(entry) === key,
-    );
-    if (selected === undefined) throw new Error("Workspace is not configured");
-    if (
-      current.workspace !== null &&
-      workspaceKey(selected) === workspaceKey(current.workspace)
-    )
-      return false;
-    const next = validateHostProfile({ ...current, workspace: selected });
-    await this.#profileStore.write(next);
-    this.#profile = next;
-    return true;
+    return await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      const selected = current.workspaces.find(
+        (entry) => workspaceKey(entry) === key,
+      );
+      if (selected === undefined)
+        throw new Error("Workspace is not configured");
+      if (
+        current.workspace !== null &&
+        workspaceKey(selected) === workspaceKey(current.workspace)
+      )
+        return false;
+      const next = validateHostProfile({ ...current, workspace: selected });
+      await this.#profileStore.write(next);
+      this.#profile = next;
+      return true;
+    });
   }
 
   async markWorkspaceUsed(workspace: string): Promise<void> {
-    const current = this.#requireProfile();
     const key = workspaceKey(workspace);
-    const selected = current.workspaces.find(
-      (entry) => workspaceKey(entry) === key,
-    );
-    if (selected === undefined) throw new Error("Workspace is not configured");
-    if (
-      current.lastUsedWorkspace !== null &&
-      workspaceKey(current.lastUsedWorkspace) === key
-    )
-      return;
-    const next = validateHostProfile({
-      ...current,
-      lastUsedWorkspace: selected,
+    await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      const selected = current.workspaces.find(
+        (entry) => workspaceKey(entry) === key,
+      );
+      if (selected === undefined)
+        throw new Error("Workspace is not configured");
+      if (
+        current.lastUsedWorkspace !== null &&
+        workspaceKey(current.lastUsedWorkspace) === key
+      )
+        return;
+      const next = validateHostProfile({
+        ...current,
+        lastUsedWorkspace: selected,
+      });
+      await this.#profileStore.write(next);
+      this.#profile = next;
     });
-    await this.#profileStore.write(next);
-    this.#profile = next;
   }
 
   async login(
@@ -283,6 +296,15 @@ export class ZenXSettingsService {
     if (this.#profile === undefined)
       throw new Error("ZenX settings are not initialized");
     return this.#profile;
+  }
+
+  #queueProfileOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#profileOperations.then(operation);
+    this.#profileOperations = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 }
 

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -71,6 +71,7 @@ type ProductPage = "agent" | "settings" | "triggers" | "rooms";
 
 export function App() {
   const selectionEpoch = useRef(0);
+  const threadSummaryLoadEpoch = useRef(0);
   const projectLoadEpoch = useRef(0);
   const selectedThreadIdRef = useRef<string | null>(null);
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
@@ -149,11 +150,13 @@ export function App() {
   >({});
 
   const loadThreadSummaries = async (showLoading = false) => {
+    const epoch = ++threadSummaryLoadEpoch.current;
     if (showLoading) setThreadListLoaded({ active: false, archived: false });
     const [active, archived] = await Promise.allSettled([
       window.zenx.threads.list({ archived: false }),
       window.zenx.threads.list({ archived: true }),
     ]);
+    if (threadSummaryLoadEpoch.current !== epoch) return;
     if (active.status === "fulfilled") {
       setThreadSummaries(active.value);
       setThreadListErrors((current) => ({ ...current, active: null }));

--- a/apps/zenx/test/app-request-freshness.test.ts
+++ b/apps/zenx/test/app-request-freshness.test.ts
@@ -1,0 +1,158 @@
+/// <reference path="../src/renderer/src/env.d.ts" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { JSDOM } from "jsdom";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import type { AppServerHostStatus } from "../src/main/app-server-manager.js";
+import { App } from "../src/renderer/src/App.js";
+
+test("ignores an older Thread summary response after a newer refresh", async () => {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previousGlobals = {
+    document: globalThis.document,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    window: globalThis.window,
+  };
+  const requests: Array<ReturnType<typeof deferred<NativeThreadSummary[]>>> =
+    [];
+  let notifyStatus: ((status: AppServerHostStatus) => void) | undefined;
+  const never = new Promise<AppServerHostStatus>(() => undefined);
+  const zenx = {
+    platform: "darwin",
+    protocol: {
+      getStatus: async () => await never,
+      getPendingApprovals: async () => [],
+      request: async (method: string) => {
+        if (method === "model/list") return { data: [] };
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+      respondToApproval: async () => undefined,
+      onApprovalRequest: () => () => undefined,
+      onApprovalResolved: () => () => undefined,
+      onStatus: (listener: (status: AppServerHostStatus) => void) => {
+        notifyStatus = listener;
+        return () => undefined;
+      },
+      onNotification: () => () => undefined,
+    },
+    threads: {
+      list: () => {
+        const request = deferred<NativeThreadSummary[]>();
+        requests.push(request);
+        return request.promise;
+      },
+    },
+    projects: {
+      get: async () => ({
+        projects: [],
+        unavailableThreadIds: [],
+        lastUsedWorkspace: null,
+      }),
+    },
+    settings: {
+      get: async () => ({ profile: { onboardingComplete: true } }),
+    },
+    titles: {
+      get: async () => ({}),
+      onChange: () => () => undefined,
+    },
+    triggers: {
+      get: async () => ({ triggers: [], history: [], rooms: [] }),
+      onChange: () => () => undefined,
+    },
+    capabilities: {
+      get: async () => ({ capabilities: [], audit: [], providers: [] }),
+      onChange: () => () => undefined,
+    },
+    plugins: {
+      get: async () => ({ plugins: [], sidebar: [], pages: [] }),
+      onChange: () => () => undefined,
+    },
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  Object.defineProperty(dom.window, "zenx", { value: zenx });
+  dom.window.localStorage.setItem("zenx-sidebar-mode", "inbox");
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+
+  try {
+    await act(async () => root.render(createElement(App)));
+    assert.ok(notifyStatus);
+    await act(async () => {
+      notifyStatus?.({ type: "ready", reconnected: false });
+      await Promise.resolve();
+    });
+    await act(async () => {
+      notifyStatus?.({ type: "ready", reconnected: true });
+      await Promise.resolve();
+    });
+    assert.equal(requests.length, 4);
+
+    await act(async () => {
+      requests[2]?.resolve([summary("new-thread", "New summary")]);
+      requests[3]?.resolve([]);
+      await Promise.resolve();
+    });
+    assert.match(document.body.textContent ?? "", /New summary/u);
+
+    await act(async () => {
+      requests[0]?.resolve([summary("old-thread", "Old summary")]);
+      requests[1]?.resolve([]);
+      await Promise.resolve();
+    });
+    assert.match(document.body.textContent ?? "", /New summary/u);
+    assert.doesNotMatch(document.body.textContent ?? "", /Old summary/u);
+  } finally {
+    await act(async () => root.unmount());
+    Object.assign(globalThis, previousGlobals, {
+      IS_REACT_ACT_ENVIRONMENT: undefined,
+    });
+    dom.window.close();
+  }
+});
+
+function summary(threadId: string, name: string): NativeThreadSummary {
+  return {
+    threadId,
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: false,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    name,
+    preview: "",
+    status: "idle",
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
+}

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -94,6 +94,28 @@ test("reports a corrupt persisted host profile instead of silently replacing it"
     await writeFile(file, "{not-json", { mode: 0o600 });
     const store = new ZenXHostProfileStore(file);
     await assert.rejects(store.read(profile), /contains invalid JSON/u);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("concurrent profile stores use independent atomic staging files", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-profile-concurrent-"),
+  );
+  try {
+    const file = path.join(directory, "host-profile.json");
+    const first = new ZenXHostProfileStore(file);
+    const second = new ZenXHostProfileStore(file);
+
+    await Promise.all([
+      first.write({ ...profile, defaultModel: "qwen3" }),
+      second.write({ ...profile, defaultModel: "deepseek-r1" }),
+    ]);
+
+    const persisted = await first.read(profile);
+    assert.ok(["qwen3", "deepseek-r1"].includes(persisted.defaultModel));
+    assert.deepEqual(await readdir(directory), ["host-profile.json"]);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -134,6 +134,41 @@ test("starts with no implicit Project and activates the first added workspace", 
   }
 });
 
+test("serializes concurrent workspace mutations without losing either update", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-concurrent-workspaces-"),
+  );
+  const firstWorkspace = path.join(directory, "first");
+  const secondWorkspace = path.join(directory, "second");
+  try {
+    const service = settingsFor(directory, {
+      login: async () => undefined,
+      logout: async () => undefined,
+      status: async () => ({ authenticated: false, expired: false }),
+    });
+    await service.initialize({});
+
+    await Promise.all([
+      service.addWorkspace(firstWorkspace),
+      service.addWorkspace(secondWorkspace),
+    ]);
+
+    assert.deepEqual(
+      new Set((await service.publicSettings()).profile.workspaces),
+      new Set([path.resolve(firstWorkspace), path.resolve(secondWorkspace)]),
+    );
+    const persisted = JSON.parse(
+      await readFile(path.join(directory, "host-profile.json"), "utf8"),
+    ) as { workspaces: string[] };
+    assert.deepEqual(
+      new Set(persisted.workspaces),
+      new Set([path.resolve(firstWorkspace), path.resolve(secondWorkspace)]),
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("clears the OAuth concurrency guard after failure so login can retry", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-oauth-retry-"));
   let attempts = 0;

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -321,6 +321,17 @@ export class ZenAppServer {
           this.#activeTurns.get(threadId)?.turnId,
         );
       }
+      const active = this.#activeTurns.get(threadId);
+      if (
+        archived &&
+        ((active !== undefined && !this.#isTerminal(thread, active.turnId)) ||
+          this.#pendingReplacement(thread) !== undefined)
+      ) {
+        throw new AppServerError(
+          "thread_busy",
+          `Thread ${threadId} already has a running turn`,
+        );
+      }
       await this.#threadMetadata.setArchived(threadId, archived);
       await this.#refreshThreadSummary(thread);
       this.#emit({

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -187,6 +187,37 @@ test("allows active-turn model no-ops but rejects real changes", async () => {
   assert.equal((await server.readThread(thread.id)).model, "fake");
 });
 
+test("rejects archiving a Thread while its Turn is active", async () => {
+  let releaseModel: (() => void) | undefined;
+  const waiting = new Promise<void>((resolve) => {
+    releaseModel = resolve;
+  });
+  const slowModel: ModelAdapter = {
+    provider: "slow",
+    async *stream(): AsyncIterable<ModelEvent> {
+      await waiting;
+      yield { type: "text_delta", delta: "done" };
+    },
+  };
+  const server = createServer({ model: slowModel });
+  const thread = await server.startThread();
+  const active = await server.startTurn(thread.id, "wait");
+
+  await assert.rejects(
+    server.setThreadArchived(thread.id, true),
+    (error: unknown) =>
+      error instanceof Error && "code" in error && error.code === "thread_busy",
+  );
+  assert.equal((await server.readThread(thread.id)).archived, false);
+
+  releaseModel?.();
+  await active.done;
+  assert.equal(
+    (await server.setThreadArchived(thread.id, true)).archived,
+    true,
+  );
+});
+
 test("persists user-facing names outside the canonical ItemList", async () => {
   const temporaryDirectory = await mkdtemp(
     path.join(os.tmpdir(), "zen-thread-metadata-test-"),


### PR DESCRIPTION
## Outcome

Fixes three current correctness races without adding a coordinator or second state model:

- serializes host-profile mutations and uses unique atomic staging files
- makes ZAS reject archive while a Turn or replacement is active
- adds latest-wins freshness to renderer ThreadSummary loads

The archive rule now lives at the authoritative mutation boundary; renderer checks remain immediate UX feedback only.

## Verification

- focused tests: 52/52
- ZenX suite: 368 passed, 1 skipped; only 3 pre-existing macOS trigger process-tree baseline failures remain
- ZenX typecheck and production build
- root typecheck
- Prettier and `git diff --check`

Closes #100
Progresses #91