### PR TITLE
Fix trigger process-tree termination races

### DIFF
--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -398,7 +398,6 @@ export interface WindowsProcessOperations {
     pid: number,
     tree: boolean,
   ): Promise<{ ok: boolean; error: string }>;
-  processIsAlive(pid: number): boolean;
 }
 
 type ProcessIdentity = WindowsProcessIdentity;
@@ -501,64 +500,74 @@ export async function verifyAndTerminateWindowsProcessTree(
   rootPid: number,
   tree: ProcessTreeSnapshot,
   operations: WindowsProcessOperations = realWindowsProcessOperations,
+  options: {
+    quiescenceTimeoutMs?: number;
+    quiescencePollMs?: number;
+  } = {},
 ): Promise<TerminationResult> {
-  const table = await operations.captureProcessTable();
   let tracked = [tree.root, ...tree.descendants];
-  const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
-  if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
-  tracked = addDescendants(tracked, table.entries);
-  const identityError = validateTrackedIdentities(tracked, table.entries);
-  if (identityError !== null) return { ok: false, error: identityError };
-  const live = tracked.filter((identity) =>
-    table.entries.some((candidate) => candidate.pid === identity.pid),
+  const timeoutMs = boundedDuration(
+    options.quiescenceTimeoutMs,
+    PROGRAM_QUIESCENCE_TIMEOUT_MS,
   );
-  const currentRoot = table.entries.find(
-    (candidate) => candidate.pid === tree.root.pid,
+  const pollMs = boundedDuration(
+    options.quiescencePollMs,
+    PROGRAM_QUIESCENCE_POLL_MS,
   );
-  if (currentRoot !== undefined) {
-    if (!identityMatches(tree.root, currentRoot))
-      return {
-        ok: false,
-        error: `PID ${String(tree.root.pid)} identity changed; containment was not proven`,
-      };
-    const rootResult = await operations.runTaskkill(rootPid, true);
-    if (!rootResult.ok && rootResult.error !== "process was not found")
-      return { ok: false, error: rootResult.error };
-  }
-  for (const identity of live) {
-    if (identity.pid === rootPid) continue;
-    const freshTable = await operations.captureProcessTable();
-    const current = freshTable.entries.find(
-      (candidate) => candidate.pid === identity.pid,
-    );
-    if (!identityMatches(identity, current)) continue;
-    const result = await operations.runTaskkill(identity.pid, true);
-    if (!result.ok && result.error !== "process was not found")
-      return {
-        ok: false,
-        error: `PID ${String(identity.pid)}: ${result.error}`,
-      };
-  }
-
   let stableAbsentPasses = 0;
-  const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const maybeAlive = tracked.filter((identity) =>
-      operations.processIsAlive(identity.pid),
+  const deadline = Date.now() + timeoutMs;
+  let firstPass = true;
+  while (firstPass || Date.now() < deadline) {
+    firstPass = false;
+    const table = await operations.captureProcessTable();
+    tracked = addWindowsDescendants(tracked, table.entries);
+    const unknownIdentity = tracked.find(
+      (identity) => identity.startTime === null,
     );
-    const originalStillAlive =
-      maybeAlive.length === 0
-        ? false
-        : await anyIdentityStillAlive(maybeAlive, operations);
-    if (!originalStillAlive) {
+    if (unknownIdentity !== undefined)
+      return {
+        ok: false,
+        error: `PID ${String(unknownIdentity.pid)} has unknown process identity; containment was not proven`,
+      };
+    const live = tracked.filter((identity) =>
+      identityMatches(
+        identity,
+        table.entries.find((candidate) => candidate.pid === identity.pid),
+      ),
+    );
+    if (live.length === 0) {
       stableAbsentPasses += 1;
       if (stableAbsentPasses >= PROGRAM_QUIESCENCE_PASSES)
         return { ok: true, error: "" };
     } else {
       stableAbsentPasses = 0;
+      for (const identity of live) {
+        if (Date.now() >= deadline) return quiescenceDeadlineFailure();
+        const freshTable = await operations.captureProcessTable();
+        const current = freshTable.entries.find(
+          (candidate) => candidate.pid === identity.pid,
+        );
+        if (!identityMatches(identity, current)) continue;
+        if (Date.now() >= deadline) return quiescenceDeadlineFailure();
+        const termination = await operations.runTaskkill(identity.pid, true);
+        if (!termination.ok && termination.error !== "process was not found")
+          return {
+            ok: false,
+            error:
+              identity.pid === rootPid
+                ? termination.error
+                : `PID ${String(identity.pid)}: ${termination.error}`,
+          };
+      }
     }
-    await delay(PROGRAM_QUIESCENCE_POLL_MS);
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return quiescenceDeadlineFailure();
+    await delay(Math.min(pollMs, remainingMs));
   }
+  return quiescenceDeadlineFailure();
+}
+
+function quiescenceDeadlineFailure(): TerminationResult {
   return {
     ok: false,
     error:
@@ -566,32 +575,14 @@ export async function verifyAndTerminateWindowsProcessTree(
   };
 }
 
-async function anyIdentityStillAlive(
-  identities: readonly ProcessIdentity[],
-  operations: WindowsProcessOperations,
-): Promise<boolean> {
-  const table = await operations.captureProcessTable();
-  return identities.some((identity) =>
-    identityMatches(
-      identity,
-      table.entries.find((candidate) => candidate.pid === identity.pid),
-    ),
-  );
-}
-
-function processIsAlive(pid: number): boolean {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ESRCH";
-  }
+function boundedDuration(value: number | undefined, maximum: number): number {
+  if (value === undefined || !Number.isFinite(value)) return maximum;
+  return Math.min(maximum, Math.max(0, Math.floor(value)));
 }
 
 const realWindowsProcessOperations: WindowsProcessOperations = {
   captureProcessTable,
   runTaskkill,
-  processIsAlive,
 };
 
 async function verifyAndTerminatePosix(
@@ -714,6 +705,52 @@ function addDescendants(
   return result;
 }
 
+function addWindowsDescendants(
+  tracked: readonly ProcessIdentity[],
+  entries: readonly ProcessIdentity[],
+): ProcessIdentity[] {
+  const result = [...tracked];
+  const known = new Set(result.map((identity) => identity.pid));
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const entry of entries) {
+      if (known.has(entry.pid)) continue;
+      const parent = result.find(
+        (identity) => identity.pid === entry.parentPid,
+      );
+      if (parent === undefined) continue;
+      const currentParent = entries.find(
+        (candidate) => candidate.pid === parent.pid,
+      );
+      if (
+        currentParent !== undefined &&
+        !identityMatches(parent, currentParent) &&
+        !windowsIdentityPredates(entry, currentParent)
+      )
+        continue;
+      result.push(entry);
+      known.add(entry.pid);
+      changed = true;
+    }
+  }
+  return result;
+}
+
+function windowsIdentityPredates(
+  identity: ProcessIdentity,
+  other: ProcessIdentity,
+): boolean {
+  if (
+    identity.startTime === null ||
+    other.startTime === null ||
+    !/^\d+$/u.test(identity.startTime) ||
+    !/^\d+$/u.test(other.startTime)
+  )
+    return false;
+  return BigInt(identity.startTime) < BigInt(other.startTime);
+}
+
 async function runTaskkill(
   pid: number,
   tree: boolean,
@@ -790,7 +827,10 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
             "}",
           ].join("; "),
         ]
-      : ["-eo", "pid=,ppid=,pgid=,sid=,lstart="];
+      : process.platform === "linux"
+        ? ["-eo", "pid=,ppid=,pgid=,sid=,lstart="]
+        : // Darwin ps has no sid= keyword; session identity is not used here.
+          ["-axo", "pid=,ppid=,pgid=,lstart="];
   const output = await new Promise<string>((resolve, reject) => {
     let text = "";
     let settled = false;
@@ -829,7 +869,7 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
   });
   return process.platform === "win32"
     ? parseWindowsProcessTable(output)
-    : parsePosixProcessTable(output);
+    : parsePosixProcessTable(output, process.platform === "linux");
 }
 
 function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
@@ -849,17 +889,22 @@ function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
   return { entries };
 }
 
-function parsePosixProcessTable(output: string): ProcessTableSnapshot {
+function parsePosixProcessTable(
+  output: string,
+  includesSessionId: boolean,
+): ProcessTableSnapshot {
   const entries: ProcessIdentity[] = [];
   for (const line of output.split(/\r?\n/u)) {
-    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u);
+    const match = includesSessionId
+      ? line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u)
+      : line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u);
     if (match === null) continue;
     entries.push({
       pid: Number(match[1]!),
       parentPid: Number(match[2]!),
       processGroupId: Number(match[3]!),
-      sessionId: Number(match[4]!),
-      startTime: match[5]!.trim() || null,
+      sessionId: includesSessionId ? Number(match[4]!) : null,
+      startTime: match[includesSessionId ? 5 : 4]!.trim() || null,
     });
   }
   return { entries };

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -55,15 +55,91 @@ test("Windows containment never reuses stale identity evidence for a second tree
         };
         return { ok: true, error: "" };
       },
-      processIsAlive: (pid) => table.entries.some((entry) => entry.pid === pid),
     },
+    { quiescencePollMs: 0 },
   );
 
   assert.deepEqual(result, { ok: true, error: "" });
   assert.deepEqual(taskkills, [[root.pid, true]]);
 });
 
-test("program runner passes bounded JSON input, cwd, and env", async () => {
+test("Windows containment discovers and kills a descendant born during termination", async () => {
+  const root: WindowsProcessIdentity = {
+    pid: 101,
+    parentPid: 1,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "root-original",
+  };
+  const lateDescendant: WindowsProcessIdentity = {
+    pid: 303,
+    parentPid: root.pid,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "late-descendant",
+  };
+  let table: WindowsProcessTableSnapshot = { entries: [root] };
+  const taskkills: Array<[number, boolean]> = [];
+
+  const result = await verifyAndTerminateWindowsProcessTree(
+    root.pid,
+    { root, descendants: [] },
+    {
+      captureProcessTable: async () => structuredClone(table),
+      runTaskkill: async (pid, tree) => {
+        taskkills.push([pid, tree]);
+        table =
+          pid === root.pid ? { entries: [lateDescendant] } : { entries: [] };
+        return { ok: true, error: "" };
+      },
+    },
+    { quiescencePollMs: 0 },
+  );
+
+  assert.deepEqual(result, { ok: true, error: "" });
+  assert.deepEqual(taskkills, [
+    [root.pid, true],
+    [lateDescendant.pid, true],
+  ]);
+});
+
+test("Windows containment fails when the deadline finds a non-empty tree", async () => {
+  const root: WindowsProcessIdentity = {
+    pid: 101,
+    parentPid: 1,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "root-original",
+  };
+  let captures = 0;
+  const taskkills: Array<[number, boolean]> = [];
+
+  const result = await verifyAndTerminateWindowsProcessTree(
+    root.pid,
+    { root, descendants: [] },
+    {
+      captureProcessTable: async () => {
+        captures += 1;
+        return { entries: [root] };
+      },
+      runTaskkill: async (pid, tree) => {
+        taskkills.push([pid, tree]);
+        return { ok: true, error: "" };
+      },
+    },
+    { quiescenceTimeoutMs: 0, quiescencePollMs: 0 },
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    error:
+      "process-tree quiescence could not be proven before the bounded deadline",
+  });
+  assert.equal(captures, 1);
+  assert.deepEqual(taskkills, []);
+});
+
+test("program runner preserves a normal exit with bounded JSON input, cwd, and env", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-"));
   const input: TriggerProgramRunInput = {
     invocationId: "invocation-stable",
@@ -107,7 +183,7 @@ test("predicate output distinguishes match and non-match", async () => {
   assert.equal((await make(false)).status, "non_match");
 });
 
-test("program runner records malformed, nonzero, oversized, timeout, and cancellation outcomes", async () => {
+test("program runner records malformed, nonzero, and oversized outcomes", async () => {
   const malformed = await runner.run(
     { command: process.execPath, args: ["-e", "console.log('nope')"] },
     { invocationId: "malformed", stage: "action", event: {} },
@@ -139,7 +215,9 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
     new AbortController().signal,
   );
   assert.equal(oversized.status, "oversized_output");
+});
 
+test("program runner preserves timeout and cancellation outcomes after containment", async () => {
   const timedOut = await runner.run(
     {
       command: process.execPath,
@@ -160,6 +238,62 @@ test("program runner records malformed, nonzero, oversized, timeout, and cancell
   controller.abort(new Error("fixture cancellation"));
   assert.equal((await cancelled).status, "cancelled");
 });
+
+test(
+  "program runner preserves cooperative termination",
+  { skip: process.platform === "win32" },
+  async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "zenx-program-cooperative-"),
+    );
+    const ready = path.join(directory, "ready");
+    const terminated = path.join(directory, "terminated");
+    const program = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));process.on('SIGTERM',()=>{fs.writeFileSync(${JSON.stringify(terminated)},'term');process.exit(0)});setInterval(()=>{},1000);`;
+    const controller = new AbortController();
+    try {
+      const running = runner.run(
+        { command: process.execPath, args: ["-e", program] },
+        { invocationId: "cooperative", stage: "action", event: {} },
+        controller.signal,
+      );
+      await waitForFile(ready);
+      controller.abort(new Error("cooperative fixture"));
+      assert.equal((await running).status, "cancelled");
+      assert.equal(await waitForFile(terminated), "term");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "program runner escalates from cooperative termination to a hard kill",
+  { skip: process.platform === "win32" },
+  async () => {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), "zenx-program-hard-kill-"),
+    );
+    const marker = path.join(directory, "late-marker");
+    const ready = path.join(directory, "ready");
+    const program = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));process.on('SIGTERM',()=>{});setTimeout(()=>fs.writeFileSync(${JSON.stringify(marker)},'late'),5000);`;
+    const controller = new AbortController();
+    try {
+      const running = runner.run(
+        { command: process.execPath, args: ["-e", program] },
+        { invocationId: "hard-kill", stage: "action", event: {} },
+        controller.signal,
+      );
+      const pid = Number(await waitForFile(ready));
+      controller.abort(new Error("hard-kill fixture"));
+      assert.equal((await running).status, "cancelled");
+      await waitForProcessExit(pid);
+      await assert.rejects(stat(marker), { code: "ENOENT" });
+    } finally {
+      await assert.rejects(stat(marker), { code: "ENOENT" });
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);
 
 test("program runner contains a descendant after cancellation", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-program-kill-"));


### PR DESCRIPTION
## Summary

- repeat Windows process discovery, identity validation, descendant expansion, and forced tree termination until the tree is stably empty or the bounded deadline expires
- use a Darwin-supported `ps` process-table probe while keeping Linux session discovery
- add public termination/runner regressions for termination-time descendants, normal and cooperative exits, hard kill escalation, stale PID identity, and non-empty deadline failure

Closes #98

## Validation

- `npm --workspace apps/zenx exec -- tsx --test test/trigger-program-runner.test.ts test/trigger-service.test.ts` (34 passed)
- `npm --workspace apps/zenx run typecheck`
- `npm --workspace apps/zenx run build`
- `npm run check` (format, lint, root typecheck, 96 Node tests, 38 IMZen tests)
- `git diff --check`

## Local aggregate note

The ZenX 374-test aggregate produced one clean run during implementation. Later exact-diff aggregate retries intermittently hit unrelated hosted timing flakes tracked by #96 in `user-browser-provider.test.ts` or `local-capability.test.ts`; each failing test passed when rerun in isolation. The focused Trigger suites and all checks above pass on the exact PR head.
