### PR TITLE
fix(zenx): bound verified provider acquisition

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,8 @@
 - **ZenXPlaywrightSessionFence** — Playwright provider 在一个瞬时 CLI session 内串行执行操作，并用稳定 tab/document identity 与 lifecycle revision 围住选择、观察、截图、摘要和关闭；该 fence 不进入 Core 或 durable journal。
 - **ZenXProviderLaunchVerification** — 外部 provider 在实际 spawn 前再次验证绑定的 canonical executable、shim companion、manifest digest 与 pinned semantic version；失败只产生显式诊断，不自动改用未验证资产。
 - **ZenXPackagedProviderSmoke** — ZenX 构建验证用真实 resources/providers manifest、asset hash、version pin 与 bundled-only catalog path 检查离线 packaged provisioning；它是一次性测试流程，不是运行时 coordinator 或 durable state。
+- **VerifiedArtifactAcquisition** — ZenX release assembly 只以 artifact name、URL、SHA-256、deadline 与 cache location 取得 digest-addressed immutable file，并在内部收口 proxy-aware bounded transport、stream size、partial cleanup、cache revalidation 与 atomic publication；它不成为运行时下载器或第二条 packaging pipeline。
+- **ZenXPackagingRunStaging** — portable app 与 packaged smoke 继续复用同一 provider assembly、digest injection 与 Electron packager，但每次只在私有 run directory 内写 resources/app/artifact，以 target lock 拒绝同目标并发并在完整 staging 后发布稳定产物；它不复制 release pipeline。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，
   不持有第二套 Project、Thread、Turn、transcript 或调度状态。

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -54,6 +54,11 @@ a single-file executable. It is written below
 together and start `ZenX.exe` on Windows, `ZenX.app` on macOS, or `ZenX` on
 Linux.
 
+Each packaging command assembles resources and runs Electron packager in its
+own `.packaged/runs/` directory, reusing only SHA-256-addressed verified archive
+cache files. A completed directory replaces the stable artifact under a
+per-target lock; a concurrent command for the same target fails explicitly.
+
 The development package identity remains `@zen/zenx`, while the portable
 runtime identity is `zenx` and its packager product/display name is `ZenX`.
 Consequently, Electron keeps their default profiles separate: on Windows they

--- a/apps/zenx/resources/providers/README.md
+++ b/apps/zenx/resources/providers/README.md
@@ -12,6 +12,12 @@ digest. Missing network, archive, runtime, browser payload, or integrity
 verification is an explicit build failure; there is no PATH fallback in bundled
 mode.
 
+Pinned archives are acquired as bounded streams and atomically published into a
+SHA-256-addressed immutable cache after verification. Every cache hit is hashed
+again before use; partial, oversized, timed-out, or mismatched responses never
+become cache entries. Provider assembly writes only to the caller's private run
+staging directory.
+
 The Playwright provider also records every shipped transitive package in
 `provider-lock.json` with its exact tarball URL, npm SRI, and SHA-256. Assembly
 validates npm's resolved entries against those pins and writes the deterministic

--- a/apps/zenx/scripts/package-zenx-portable.mjs
+++ b/apps/zenx/scripts/package-zenx-portable.mjs
@@ -1,6 +1,15 @@
 import { execFile, spawn } from "node:child_process";
-import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import os from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
@@ -9,72 +18,146 @@ const run = promisify(execFile);
 const zenx = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
 const root = path.resolve(zenx, "..", "..");
 const out = path.join(zenx, "out");
-const resources = path.join(zenx, ".packaged", "resources");
+const packagedRoot = path.join(zenx, ".packaged");
+const runsRoot = path.join(packagedRoot, "runs");
+const artifactRoot = path.join(packagedRoot, "artifact");
+const artifactCache = path.join(packagedRoot, "cache", "artifacts");
 
 if (isDirectExecution()) await packageZenX(process.argv.slice(2));
 
 async function packageZenX(arguments_) {
   const target = arguments_.includes("--app") ? "app" : "smoke";
-  let staging;
-  try {
-    const assembly = JSON.parse(
-      (
-        await run(process.execPath, [
-          path.join(root, "scripts", "assemble-zenx-providers.mjs"),
-          "--output",
-          resources,
-        ])
-      ).stdout,
-    );
-    staging = await mkdtemp(path.join(os.tmpdir(), "zenx-package-"));
-    const appDir = path.join(staging, "app");
-    const zenxPackage = JSON.parse(
-      await readFile(path.join(zenx, "package.json"), "utf8"),
-    );
-    await stagePackage({
-      target,
-      outDirectory: out,
-      rootDirectory: root,
-      appDirectory: appDir,
-      manifestSha256: assembly.manifestSha256,
-    });
-    await writeFile(
-      path.join(appDir, "package.json"),
-      `${JSON.stringify(packageManifest(target, zenxPackage), null, 2)}\n`,
-    );
-    const { packager } = await import("@electron/packager");
-    const packaged = await packager({
-      dir: appDir,
-      out: path.join(zenx, ".packaged", "artifact"),
-      overwrite: true,
-      platform: process.platform,
-      arch: process.arch,
-      name: target === "app" ? "ZenX" : "ZenXProviderSmoke",
-      electronVersion: "43.2.0",
-      extraResource: [path.join(resources, "providers")],
-      asar: false,
-    });
-    const executable = executablePath(packaged[0], target);
-    console.log(
-      JSON.stringify(
-        {
-          packagedArtifact: packaged[0],
-          executable,
-          target,
-          version: zenxPackage.version,
-          manifestDigest: assembly.manifestSha256,
-          releaseSizeBytes: assembly.releaseSizeBytes,
-        },
-        null,
-        2,
-      ),
-    );
-    if (target === "smoke") await runExecutable(executable);
-  } finally {
-    if (staging !== undefined) {
+  const productName = target === "app" ? "ZenX" : "ZenXProviderSmoke";
+  const targetDirectory = `${productName}-${process.platform}-${process.arch}`;
+  await withPackagingTargetLock(packagedRoot, targetDirectory, async () => {
+    await mkdir(runsRoot, { recursive: true, mode: 0o700 });
+    const staging = await mkdtemp(path.join(runsRoot, "package-"));
+    try {
+      const resources = path.join(staging, "resources");
+      const appDir = path.join(staging, "app");
+      const stagedArtifacts = path.join(staging, "artifact");
+      const assembly = JSON.parse(
+        (
+          await run(process.execPath, [
+            path.join(root, "scripts", "assemble-zenx-providers.mjs"),
+            "--output",
+            resources,
+            "--cache",
+            artifactCache,
+          ])
+        ).stdout,
+      );
+      const zenxPackage = JSON.parse(
+        await readFile(path.join(zenx, "package.json"), "utf8"),
+      );
+      await stagePackage({
+        target,
+        outDirectory: out,
+        rootDirectory: root,
+        appDirectory: appDir,
+        manifestSha256: assembly.manifestSha256,
+      });
+      await writeFile(
+        path.join(appDir, "package.json"),
+        `${JSON.stringify(packageManifest(target, zenxPackage), null, 2)}\n`,
+      );
+      const { packager } = await import("@electron/packager");
+      const packaged = await packager({
+        dir: appDir,
+        out: stagedArtifacts,
+        overwrite: false,
+        platform: process.platform,
+        arch: process.arch,
+        name: productName,
+        electronVersion: "43.2.0",
+        extraResource: [path.join(resources, "providers")],
+        asar: false,
+      });
+      if (path.basename(packaged[0]) !== targetDirectory) {
+        throw new Error(
+          `Electron packager returned unexpected target ${path.basename(packaged[0])}`,
+        );
+      }
+      if (target === "smoke") {
+        await runExecutable(executablePath(packaged[0], target));
+      }
+      const publishedArtifact = await publishPackagedArtifact(
+        packaged[0],
+        path.join(artifactRoot, targetDirectory),
+      );
+      const executable = executablePath(publishedArtifact, target);
+      console.log(
+        JSON.stringify(
+          {
+            packagedArtifact: publishedArtifact,
+            executable,
+            target,
+            version: zenxPackage.version,
+            manifestDigest: assembly.manifestSha256,
+            releaseSizeBytes: assembly.releaseSizeBytes,
+          },
+          null,
+          2,
+        ),
+      );
+    } finally {
       await rm(staging, { recursive: true, force: true });
     }
+  });
+}
+
+export async function withPackagingTargetLock(
+  packageRoot,
+  targetDirectory,
+  action,
+) {
+  const locks = path.join(packageRoot, "locks");
+  await mkdir(locks, { recursive: true, mode: 0o700 });
+  const lockPath = path.join(locks, `${targetDirectory}.lock`);
+  let lock;
+  try {
+    lock = await open(lockPath, "wx", 0o600);
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      throw new Error(
+        `Packaging target ${targetDirectory} is already in progress; if no packaging process is active, remove the stale lock explicitly`,
+      );
+    }
+    throw error;
   }
+  try {
+    await lock.writeFile(`${String(process.pid)} ${randomUUID()}\n`);
+    await lock.sync();
+    return await action();
+  } finally {
+    await lock.close();
+    await rm(lockPath, { force: true });
+  }
+}
+
+export async function publishPackagedArtifact(stagedArtifact, finalArtifact) {
+  await mkdir(path.dirname(finalArtifact), { recursive: true, mode: 0o700 });
+  const retiredArtifact = path.join(
+    path.dirname(finalArtifact),
+    `.${path.basename(finalArtifact)}.${randomUUID()}.retired`,
+  );
+  let retired = false;
+  try {
+    await rename(finalArtifact, retiredArtifact);
+    retired = true;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  try {
+    await rename(stagedArtifact, finalArtifact);
+  } catch (error) {
+    if (retired) await rename(retiredArtifact, finalArtifact);
+    throw error;
+  }
+  if (retired) {
+    await rm(retiredArtifact, { recursive: true, force: true });
+  }
+  return finalArtifact;
 }
 
 export async function stagePackage(options) {

--- a/apps/zenx/test/package-zenx-portable.test.mjs
+++ b/apps/zenx/test/package-zenx-portable.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -13,7 +14,9 @@ import test from "node:test";
 
 import {
   packageManifest,
+  publishPackagedArtifact,
   stagePackage,
+  withPackagingTargetLock,
 } from "../scripts/package-zenx-portable.mjs";
 
 const placeholder = "__ZENX_PACKAGED_PROVIDER_MANIFEST_SHA256__";
@@ -93,6 +96,61 @@ test("stages only the provider smoke through the same digest path", async () => 
     );
   } finally {
     await rm(fixture.directory, { recursive: true, force: true });
+  }
+});
+
+test("publishes a complete run artifact without exposing its staging path", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-publish-test-"));
+  try {
+    const staged = path.join(directory, "run", "ZenX-fixture");
+    const published = path.join(directory, "artifact", "ZenX-fixture");
+    await mkdir(staged, { recursive: true });
+    await mkdir(published, { recursive: true });
+    await writeFile(path.join(staged, "version"), "new");
+    await writeFile(path.join(published, "version"), "old");
+
+    assert.equal(await publishPackagedArtifact(staged, published), published);
+    assert.equal(
+      await readFile(path.join(published, "version"), "utf8"),
+      "new",
+    );
+    await assert.rejects(access(staged), { code: "ENOENT" });
+    assert.deepEqual(await readdir(path.dirname(published)), ["ZenX-fixture"]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("fails concurrent packaging of the same target explicitly", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-lock-test-"));
+  let enter;
+  let release;
+  const entered = new Promise((resolve) => {
+    enter = resolve;
+  });
+  const held = new Promise((resolve) => {
+    release = resolve;
+  });
+  try {
+    const first = withPackagingTargetLock(
+      directory,
+      "ZenX-fixture",
+      async () => {
+        enter();
+        await held;
+      },
+    );
+    await entered;
+    await assert.rejects(
+      withPackagingTargetLock(directory, "ZenX-fixture", async () => {}),
+      /ZenX-fixture is already in progress/u,
+    );
+    release();
+    await first;
+    assert.deepEqual(await readdir(path.join(directory, "locks")), []);
+  } finally {
+    release?.();
+    await rm(directory, { recursive: true, force: true });
   }
 });
 

--- a/apps/zenx/test/verified-artifact-acquisition.test.mjs
+++ b/apps/zenx/test/verified-artifact-acquisition.test.mjs
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { createServer } from "node:http";
+import { connect } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { acquireVerifiedArtifact } from "../../../scripts/verified-artifact-acquisition.mjs";
+
+const run = promisify(execFile);
+const acquisitionModule = pathToFileURL(
+  fileURLToPath(
+    new URL(
+      "../../../scripts/verified-artifact-acquisition.mjs",
+      import.meta.url,
+    ),
+  ),
+).href;
+
+test("bounds a server that accepts a request but never responds", async () => {
+  const fixture = await createFixture((_request, _response) => {});
+  const started = Date.now();
+  try {
+    await assert.rejects(
+      acquireVerifiedArtifact({
+        artifactName: "hung provider fixture",
+        url: `${fixture.url}/hung?credential=hidden`,
+        digest: sha256("never returned"),
+        deadline: Date.now() + 500,
+        cacheLocation: fixture.cacheLocation,
+      }),
+      (error) => {
+        assert.match(error.message, /hung provider fixture/u);
+        assert.match(error.message, /overall deadline/u);
+        assert.doesNotMatch(error.message, /credential=hidden/u);
+        return true;
+      },
+    );
+    assert.ok(Date.now() - started < 3_000, "deadline must bound failure");
+    assert.deepEqual(await cacheFiles(fixture.cacheLocation), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("rejects a partial response and removes its partial cache file", async () => {
+  const fixture = await createFixture((_request, response) => {
+    response.writeHead(200, { "content-length": "12" });
+    response.write("partial");
+    response.destroy();
+  });
+  try {
+    await assert.rejects(
+      acquireVerifiedArtifact({
+        artifactName: "partial provider fixture",
+        url: `${fixture.url}/partial`,
+        digest: sha256("partial body"),
+        deadline: Date.now() + 2_000,
+        cacheLocation: fixture.cacheLocation,
+      }),
+      /partial provider fixture.*incomplete/iu,
+    );
+    assert.deepEqual(await cacheFiles(fixture.cacheLocation), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("rejects a digest mismatch without publishing a cache entry", async () => {
+  const fixture = await createFixture((_request, response) => {
+    response.end("wrong bytes");
+  });
+  try {
+    await assert.rejects(
+      acquireVerifiedArtifact({
+        artifactName: "mismatched provider fixture",
+        url: `${fixture.url}/mismatch`,
+        digest: sha256("expected bytes"),
+        deadline: Date.now() + 2_000,
+        cacheLocation: fixture.cacheLocation,
+      }),
+      /mismatched provider fixture.*digest mismatch/iu,
+    );
+    assert.deepEqual(await cacheFiles(fixture.cacheLocation), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("reuses a verified digest-keyed immutable cache entry offline", async () => {
+  const bytes = Buffer.from("verified provider bytes");
+  let requests = 0;
+  const fixture = await createFixture((_request, response) => {
+    requests += 1;
+    response.end(bytes);
+  });
+  try {
+    const options = {
+      artifactName: "cached provider fixture",
+      url: `${fixture.url}/cached`,
+      digest: sha256(bytes),
+      deadline: Date.now() + 2_000,
+      cacheLocation: fixture.cacheLocation,
+    };
+    const first = await acquireVerifiedArtifact(options);
+    await fixture.closeServer();
+    const second = await acquireVerifiedArtifact({
+      ...options,
+      url: "http://127.0.0.1:1/offline",
+      deadline: Date.now() + 2_000,
+    });
+
+    assert.equal(second, first);
+    assert.equal(path.basename(first), options.digest);
+    assert.deepEqual(await readFile(first), bytes);
+    if (process.platform !== "win32") {
+      assert.equal((await stat(first)).mode & 0o222, 0);
+    }
+    assert.equal(requests, 1);
+    assert.deepEqual(await cacheFiles(fixture.cacheLocation), [first]);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("re-verifies a cache hit before reuse", async () => {
+  const bytes = Buffer.from("authoritative bytes");
+  let requests = 0;
+  const fixture = await createFixture((_request, response) => {
+    requests += 1;
+    response.end(bytes);
+  });
+  try {
+    const options = {
+      artifactName: "reverified provider fixture",
+      url: `${fixture.url}/reverified`,
+      digest: sha256(bytes),
+      deadline: Date.now() + 2_000,
+      cacheLocation: fixture.cacheLocation,
+    };
+    const cached = await acquireVerifiedArtifact(options);
+    await chmod(cached, 0o600);
+    await writeFile(cached, "tampered");
+
+    assert.equal(await acquireVerifiedArtifact(options), cached);
+    assert.deepEqual(await readFile(cached), bytes);
+    assert.equal(requests, 2);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("rejects an oversized stream before accepting its body", async () => {
+  const fixture = await createFixture((_request, response) => {
+    response.writeHead(200, { "content-length": String(1024 ** 3) });
+    response.end();
+  });
+  try {
+    await assert.rejects(
+      acquireVerifiedArtifact({
+        artifactName: "oversized provider fixture",
+        url: `${fixture.url}/oversized`,
+        digest: sha256("unused"),
+        deadline: Date.now() + 2_000,
+        cacheLocation: fixture.cacheLocation,
+      }),
+      /oversized provider fixture.*size bound/iu,
+    );
+    assert.deepEqual(await cacheFiles(fixture.cacheLocation), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("honors isolated proxy and direct routing without changing global settings", async () => {
+  const bytes = Buffer.from("proxy routing fixture");
+  let requests = 0;
+  const fixture = await createFixture((_request, response) => {
+    requests += 1;
+    response.end(bytes);
+  });
+  const proxy = await createProxyFixture();
+  try {
+    const proxyResult = await acquireInChild(
+      {
+        artifactName: "proxied provider fixture",
+        url: `${fixture.url}/through-proxy`,
+        digest: sha256(bytes),
+        deadline: Date.now() + 5_000,
+        cacheLocation: path.join(fixture.cacheLocation, "proxied"),
+      },
+      {
+        HTTP_PROXY: proxy.url,
+        http_proxy: proxy.url,
+        HTTPS_PROXY: "",
+        https_proxy: "",
+        NO_PROXY: "",
+        no_proxy: "",
+      },
+    );
+    assert.deepEqual(await readFile(proxyResult), bytes);
+    assert.equal(proxy.connections(), 1);
+
+    const directResult = await acquireInChild(
+      {
+        artifactName: "direct provider fixture",
+        url: `${fixture.url}/direct`,
+        digest: sha256(bytes),
+        deadline: Date.now() + 5_000,
+        cacheLocation: path.join(fixture.cacheLocation, "direct"),
+      },
+      {
+        HTTP_PROXY: "http://127.0.0.1:1",
+        http_proxy: "http://127.0.0.1:1",
+        HTTPS_PROXY: "",
+        https_proxy: "",
+        NO_PROXY: "127.0.0.1",
+        no_proxy: "127.0.0.1",
+      },
+    );
+    assert.deepEqual(await readFile(directResult), bytes);
+    assert.equal(requests, 2);
+  } finally {
+    await proxy.close();
+    await fixture.close();
+  }
+});
+
+test("names the artifact and source without leaking URL credentials", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-redaction-test-"),
+  );
+  try {
+    await assert.rejects(
+      acquireVerifiedArtifact({
+        artifactName: "credentialed provider fixture",
+        url: "http://user:secret@127.0.0.1:1/archive?token=hidden",
+        digest: sha256("unavailable"),
+        deadline: Date.now() + 2_000,
+        cacheLocation: directory,
+      }),
+      (error) => {
+        assert.match(error.message, /credentialed provider fixture/u);
+        assert.match(error.message, /http:\/\/127\.0\.0\.1:1\/archive/u);
+        assert.doesNotMatch(error.message, /user|secret|token|hidden/u);
+        return true;
+      },
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function createFixture(listener) {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-artifact-test-"),
+  );
+  const cacheLocation = path.join(directory, "cache");
+  const server = createServer(listener);
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  assert.ok(address !== null && typeof address !== "string");
+  let closed = false;
+  const closeServer = async () => {
+    if (closed) return;
+    closed = true;
+    server.closeAllConnections();
+    await new Promise((resolve, reject) =>
+      server.close((error) =>
+        error === undefined ? resolve() : reject(error),
+      ),
+    );
+  };
+  return {
+    cacheLocation,
+    url: `http://127.0.0.1:${String(address.port)}`,
+    closeServer,
+    close: async () => {
+      await closeServer();
+      await rm(directory, { recursive: true, force: true });
+    },
+  };
+}
+
+async function createProxyFixture() {
+  let connections = 0;
+  const server = createServer();
+  server.on("connect", (request, client, head) => {
+    connections += 1;
+    const separator = request.url.lastIndexOf(":");
+    const host = request.url.slice(0, separator);
+    const port = Number(request.url.slice(separator + 1));
+    const upstream = connect({ host, port }, () => {
+      client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+      if (head.byteLength > 0) upstream.write(head);
+      client.pipe(upstream).pipe(client);
+    });
+    upstream.on("error", () => client.destroy());
+    client.on("error", () => upstream.destroy());
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  assert.ok(address !== null && typeof address !== "string");
+  return {
+    url: `http://127.0.0.1:${String(address.port)}`,
+    connections: () => connections,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise((resolve, reject) =>
+        server.close((error) =>
+          error === undefined ? resolve() : reject(error),
+        ),
+      );
+    },
+  };
+}
+
+async function acquireInChild(options, environment) {
+  const source = `
+    import { acquireVerifiedArtifact } from ${JSON.stringify(acquisitionModule)};
+    const result = await acquireVerifiedArtifact(JSON.parse(process.env.ZENX_ARTIFACT_OPTIONS));
+    process.stdout.write(result);
+  `;
+  const result = await run(
+    process.execPath,
+    ["--input-type=module", "--eval", source],
+    {
+      env: {
+        ...process.env,
+        ...environment,
+        ZENX_ARTIFACT_OPTIONS: JSON.stringify(options),
+      },
+    },
+  );
+  return result.stdout;
+}
+
+async function cacheFiles(root) {
+  const files = [];
+  const visit = async (directory) => {
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch (error) {
+      if (error?.code === "ENOENT") return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const candidate = path.join(directory, entry.name);
+      if (entry.isDirectory()) await visit(candidate);
+      else files.push(candidate);
+    }
+  };
+  await visit(root);
+  return files.sort();
+}
+
+function sha256(bytes) {
+  return createHash("sha256").update(bytes).digest("hex");
+}

--- a/scripts/assemble-zenx-providers.mjs
+++ b/scripts/assemble-zenx-providers.mjs
@@ -1,12 +1,13 @@
 import { createHash } from "node:crypto";
 import { execFile } from "node:child_process";
+import { createReadStream } from "node:fs";
 import {
+  cp,
   mkdir,
   mkdtemp,
   readFile,
   rm,
   writeFile,
-  cp,
   readdir,
   stat,
 } from "node:fs/promises";
@@ -14,6 +15,8 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { fileURLToPath } from "node:url";
+
+import { acquireVerifiedArtifact } from "./verified-artifact-acquisition.mjs";
 
 const run = promisify(execFile);
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -28,12 +31,26 @@ const lock = JSON.parse(await readFile(lockPath, "utf8"));
 const outputArgumentIndex = process.argv.indexOf("--output");
 const outputArgument =
   outputArgumentIndex >= 0 ? process.argv[outputArgumentIndex + 1] : undefined;
+const cacheArgumentIndex = process.argv.indexOf("--cache");
+const cacheArgument =
+  cacheArgumentIndex >= 0 ? process.argv[cacheArgumentIndex + 1] : undefined;
+const runs = path.join(zenx, ".packaged", "runs");
+await mkdir(runs, { recursive: true, mode: 0o700 });
+const defaultRun =
+  outputArgument === undefined
+    ? await mkdtemp(path.join(runs, "provider-assembly-"))
+    : undefined;
 const output = path.resolve(
-  outputArgument ?? path.join(zenx, ".packaged", "resources"),
+  outputArgument ?? path.join(defaultRun, "resources"),
+);
+const artifactCache = path.resolve(
+  cacheArgument ?? path.join(zenx, ".packaged", "cache", "artifacts"),
 );
 const providers = path.join(output, "providers");
 const work = await mkdtemp(path.join(os.tmpdir(), "zenx-provider-assembly-"));
 const maxAssetBytes = 512 * 1024 * 1024;
+const maxConnectMilliseconds = 10_000;
+const artifactDownloadMilliseconds = 2 * 60 * 1_000;
 
 try {
   await rm(providers, { recursive: true, force: true });
@@ -44,12 +61,11 @@ try {
   const nodeArchive = lock.node.platformArchives[nodeKey];
   if (nodeArchive === undefined)
     throw new Error(`No pinned Node runtime for ${nodeKey}`);
-  const nodeBytes = await fetchVerified(
+  const nodeArchivePath = await acquireArtifact(
+    `Node.js ${lock.node.version} ${nodeKey} runtime`,
     `${lock.node.releaseBase}${nodeArchive.file}`,
     nodeArchive.sha256,
   );
-  const nodeArchivePath = path.join(work, nodeArchive.file);
-  await writeFile(nodeArchivePath, nodeBytes);
   const nodeExtract = path.join(work, "node");
   await mkdir(nodeExtract);
   await extract(nodeArchivePath, nodeExtract);
@@ -85,18 +101,35 @@ try {
   );
   const browsersPath = path.join(providers, "playwright-browsers");
   await mkdir(browsersPath, { recursive: true, mode: 0o700 });
-  await run(
-    runtimePath,
-    [
-      path.join(providers, "playwright-cli", "playwright-cli.js"),
-      "install-browser",
-    ],
-    {
-      cwd: path.join(providers, "playwright-cli"),
-      env: { ...process.env, PLAYWRIGHT_BROWSERS_PATH: browsersPath },
-      maxBuffer: 8 * 1024 * 1024,
-    },
-  );
+  try {
+    await run(
+      runtimePath,
+      [
+        path.join(providers, "playwright-cli", "playwright-cli.js"),
+        "install-browser",
+      ],
+      {
+        cwd: path.join(providers, "playwright-cli"),
+        env: {
+          ...process.env,
+          PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+          PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: String(
+            maxConnectMilliseconds,
+          ),
+        },
+        timeout: artifactDownloadMilliseconds,
+        killSignal: "SIGTERM",
+        maxBuffer: 8 * 1024 * 1024,
+      },
+    );
+  } catch (error) {
+    if (error?.killed === true || error?.signal === "SIGTERM") {
+      throw new Error(
+        `Pinned Playwright browser payload installation exceeded ${String(artifactDownloadMilliseconds)}ms`,
+      );
+    }
+    throw new Error("Pinned Playwright browser payload installation failed");
+  }
   const manifest = {
     schemaVersion: 1,
     providers: {
@@ -157,9 +190,12 @@ try {
 
 async function assembleNpmProvider(id, platform, runtimePath) {
   const pin = lock.providers[id];
-  const archive = await fetchVerified(pin.tarball, pin.sha256);
-  const archivePath = path.join(work, `${id}.tgz`);
-  await writeFile(archivePath, archive);
+  const archivePath = await acquireArtifact(
+    `${id} ${pin.version}`,
+    pin.tarball,
+    pin.sha256,
+  );
+  await verifyNpmIntegrity(id, archivePath, pin.integrity);
   const extracted = path.join(work, id);
   await mkdir(extracted);
   await extract(archivePath, extracted);
@@ -167,19 +203,19 @@ async function assembleNpmProvider(id, platform, runtimePath) {
   const destination = path.join(providers, id);
   await cp(packageDir, destination, { recursive: true, force: true });
   if (id === "playwright-cli") {
-    await runNpm(
-      [
-        "install",
-        "--prefix",
-        destination,
-        "--ignore-scripts",
-        "--no-save",
-        "--package-lock=true",
-        "--omit=dev",
-        "--omit=optional",
-      ],
-      { cwd: destination },
-    );
+    for (const dependency of pin.transitive ?? []) {
+      const dependencyArchive = await acquireArtifact(
+        `${dependency.name} ${dependency.version}`,
+        dependency.tarball,
+        dependency.sha256,
+      );
+      await verifyNpmIntegrity(
+        dependency.name,
+        dependencyArchive,
+        dependency.integrity,
+      );
+      await installPinnedDependency(dependency, dependencyArchive, destination);
+    }
   }
   const executable =
     id === "playwright-cli"
@@ -200,25 +236,6 @@ async function assembleNpmProvider(id, platform, runtimePath) {
   await appendLicenseNotice(destination, id, pin.license);
   const assets = [];
   if (id === "playwright-cli") {
-    const generatedLock = path.join(
-      destination,
-      "node_modules",
-      ".package-lock.json",
-    );
-    const generated = JSON.parse(await readFile(generatedLock, "utf8"));
-    for (const dependency of pin.transitive ?? []) {
-      const entry = generated.packages?.[`node_modules/${dependency.name}`];
-      if (
-        entry?.version !== dependency.version ||
-        entry.resolved !== dependency.tarball ||
-        entry.integrity !== dependency.integrity
-      ) {
-        throw new Error(
-          `playwright-cli transitive package mismatch for ${dependency.name}`,
-        );
-      }
-      await fetchVerified(dependency.tarball, dependency.sha256);
-    }
     const dependencyLock = canonicalDependencyLock(pin.transitive ?? []);
     const dependencyLockSha256 = sha256(dependencyLock);
     if (
@@ -284,32 +301,67 @@ async function walkFiles(rootDir) {
   return files;
 }
 
-async function fetchVerified(url, expected) {
-  const response = await fetch(url, { redirect: "error" });
-  if (!response.ok)
-    throw new Error(`Provider archive fetch failed: ${response.status} ${url}`);
-  const bytes = Buffer.from(await response.arrayBuffer());
-  const actual = sha256(bytes);
-  if (actual !== expected)
-    throw new Error(`Provider archive integrity mismatch for ${url}`);
-  return bytes;
-}
-
 async function extract(archive, destination) {
   await run("tar", ["-xf", archive, "-C", destination]);
 }
 
-async function runNpm(args, options) {
-  const npmExecPath =
-    process.env.npm_execpath ??
-    path.join(
-      path.dirname(process.execPath),
-      "node_modules",
-      "npm",
-      "bin",
-      "npm-cli.js",
+async function acquireArtifact(artifactName, url, digest) {
+  return await acquireVerifiedArtifact({
+    artifactName,
+    url,
+    digest,
+    deadline: Date.now() + artifactDownloadMilliseconds,
+    cacheLocation: artifactCache,
+  });
+}
+
+async function verifyNpmIntegrity(id, archive, integrity) {
+  const separator = integrity.indexOf("-");
+  const algorithm = integrity.slice(0, separator);
+  const expected = integrity.slice(separator + 1);
+  if (algorithm !== "sha512" || expected.length === 0) {
+    throw new Error(`${id} has an unsupported npm integrity pin`);
+  }
+  const hash = createHash(algorithm);
+  const file = createReadStream(archive);
+  for await (const chunk of file) hash.update(chunk);
+  if (hash.digest("base64") !== expected) {
+    throw new Error(`${id} npm integrity mismatch`);
+  }
+}
+
+async function installPinnedDependency(dependency, archive, destination) {
+  const extracted = path.join(
+    work,
+    `dependency-${dependency.name.replaceAll("/", "-")}`,
+  );
+  await mkdir(extracted);
+  await extract(archive, extracted);
+  const packageDirectory = path.join(extracted, "package");
+  const metadata = JSON.parse(
+    await readFile(path.join(packageDirectory, "package.json"), "utf8"),
+  );
+  if (
+    metadata.name !== dependency.name ||
+    metadata.version !== dependency.version
+  ) {
+    throw new Error(
+      `playwright-cli transitive package mismatch for ${dependency.name}`,
     );
-  return await run(process.execPath, [npmExecPath, ...args], options);
+  }
+  const dependencyDirectory = path.join(
+    destination,
+    "node_modules",
+    ...dependency.name.split("/"),
+  );
+  await mkdir(path.dirname(dependencyDirectory), {
+    recursive: true,
+    mode: 0o700,
+  });
+  await cp(packageDirectory, dependencyDirectory, {
+    recursive: true,
+    force: true,
+  });
 }
 
 async function findFile(root, name) {

--- a/scripts/verified-artifact-acquisition.mjs
+++ b/scripts/verified-artifact-acquisition.mjs
@@ -1,0 +1,275 @@
+import { createHash, randomUUID } from "node:crypto";
+import { chmod, link, lstat, mkdir, open, rm, unlink } from "node:fs/promises";
+import path from "node:path";
+
+import { EnvHttpProxyAgent, fetch } from "undici";
+
+const digestPattern = /^[a-f0-9]{64}$/u;
+const maxArtifactBytes = 512 * 1024 * 1024;
+const maxConnectMilliseconds = 10_000;
+const readBufferBytes = 64 * 1024;
+
+/**
+ * Acquire one digest-addressed immutable file. Cache verification, proxy-aware
+ * transport, timeouts, streaming bounds, partial cleanup, and atomic cache
+ * publication stay behind this interface.
+ */
+export async function acquireVerifiedArtifact(options) {
+  const artifactName = requiredString(options?.artifactName, "artifactName");
+  const source = sourceDescription(options?.url);
+  const digest = requiredDigest(options?.digest);
+  const deadline = requiredDeadline(options?.deadline);
+  const cacheLocation = requiredString(options?.cacheLocation, "cacheLocation");
+  const cacheDirectory = path.resolve(cacheLocation, "sha256");
+  const cacheFile = path.join(cacheDirectory, digest);
+
+  try {
+    ensureBeforeDeadline(deadline);
+    await mkdir(cacheDirectory, { recursive: true, mode: 0o700 });
+    if (await isVerifiedFile(cacheFile, digest, deadline)) {
+      await makeImmutable(cacheFile);
+      return cacheFile;
+    }
+    await removeInvalidCacheEntry(cacheFile);
+    return await downloadAndPublish({
+      url: options.url,
+      digest,
+      deadline,
+      cacheDirectory,
+      cacheFile,
+    });
+  } catch (error) {
+    const reason = acquisitionReason(error);
+    throw new Error(
+      `Verified artifact acquisition failed for ${artifactName} from ${source}: ${reason}`,
+    );
+  }
+}
+
+async function downloadAndPublish(options) {
+  const partialFile = path.join(
+    options.cacheDirectory,
+    `.${options.digest}.${randomUUID()}.partial`,
+  );
+  const remaining = remainingMilliseconds(options.deadline);
+  const dispatcher = new EnvHttpProxyAgent({
+    connectTimeout: Math.min(maxConnectMilliseconds, remaining),
+    headersTimeout: remaining,
+    bodyTimeout: remaining,
+  });
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(new Error("artifact acquisition deadline")),
+    remaining,
+  );
+  timeout.unref();
+
+  try {
+    const response = await fetch(options.url, {
+      dispatcher,
+      redirect: "error",
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw acquisitionFailure(`source responded with HTTP ${response.status}`);
+    }
+    const contentLength = response.headers.get("content-length");
+    if (contentLength !== null) {
+      const advertisedBytes = Number(contentLength);
+      if (
+        !Number.isSafeInteger(advertisedBytes) ||
+        advertisedBytes < 0 ||
+        advertisedBytes > maxArtifactBytes
+      ) {
+        throw acquisitionFailure("response exceeds the stream size bound");
+      }
+    }
+
+    const file = await open(partialFile, "wx", 0o600);
+    let receivedBytes = 0;
+    const hash = createHash("sha256");
+    try {
+      if (response.body !== null) {
+        for await (const chunk of response.body) {
+          ensureBeforeDeadline(options.deadline);
+          receivedBytes += chunk.byteLength;
+          if (receivedBytes > maxArtifactBytes) {
+            throw acquisitionFailure("response exceeds the stream size bound");
+          }
+          hash.update(chunk);
+          await file.write(chunk);
+        }
+      }
+      if (contentLength !== null && receivedBytes !== Number(contentLength)) {
+        throw acquisitionFailure("response body was incomplete");
+      }
+      const actual = hash.digest("hex");
+      if (actual !== options.digest) {
+        throw acquisitionFailure("digest mismatch");
+      }
+      await file.sync();
+      await file.chmod(0o444);
+    } finally {
+      await file.close();
+    }
+
+    ensureBeforeDeadline(options.deadline);
+    try {
+      await link(partialFile, options.cacheFile);
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (
+        !(await isVerifiedFile(
+          options.cacheFile,
+          options.digest,
+          options.deadline,
+        ))
+      ) {
+        throw acquisitionFailure(
+          "atomic cache publication collided with an invalid entry",
+        );
+      }
+    }
+    await makeImmutable(options.cacheFile);
+    return options.cacheFile;
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw acquisitionFailure("overall deadline exceeded");
+    }
+    throw normalizeTransportFailure(error);
+  } finally {
+    clearTimeout(timeout);
+    await dispatcher.destroy().catch(() => {});
+    await rm(partialFile, { force: true });
+  }
+}
+
+async function isVerifiedFile(file, expectedDigest, deadline) {
+  let metadata;
+  try {
+    metadata = await lstat(file);
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+  if (!metadata.isFile() || metadata.size > maxArtifactBytes) return false;
+
+  const handle = await open(file, "r");
+  const hash = createHash("sha256");
+  const buffer = Buffer.allocUnsafe(readBufferBytes);
+  let position = 0;
+  try {
+    while (true) {
+      ensureBeforeDeadline(deadline);
+      const { bytesRead } = await handle.read(
+        buffer,
+        0,
+        buffer.byteLength,
+        position,
+      );
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+      position += bytesRead;
+      if (position > maxArtifactBytes) return false;
+    }
+  } finally {
+    await handle.close();
+  }
+  ensureBeforeDeadline(deadline);
+  return hash.digest("hex") === expectedDigest;
+}
+
+async function removeInvalidCacheEntry(file) {
+  try {
+    await chmod(file, 0o600);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  try {
+    await unlink(file);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+async function makeImmutable(file) {
+  await chmod(file, 0o444);
+}
+
+function normalizeTransportFailure(error) {
+  if (error?.name === "VerifiedArtifactAcquisitionFailure") return error;
+  const code = error?.cause?.code ?? error?.code;
+  if (code === "UND_ERR_CONNECT_TIMEOUT") {
+    return acquisitionFailure("connect timeout exceeded");
+  }
+  if (
+    code === "UND_ERR_SOCKET" ||
+    code === "UND_ERR_RES_CONTENT_LENGTH_MISMATCH" ||
+    code === "ECONNRESET"
+  ) {
+    return acquisitionFailure("response body was incomplete");
+  }
+  if (code === "UND_ERR_HEADERS_TIMEOUT" || code === "UND_ERR_BODY_TIMEOUT") {
+    return acquisitionFailure("overall deadline exceeded");
+  }
+  return acquisitionFailure("source request failed");
+}
+
+function acquisitionReason(error) {
+  return error?.name === "VerifiedArtifactAcquisitionFailure"
+    ? error.message
+    : "local cache operation failed";
+}
+
+function acquisitionFailure(message) {
+  const error = new Error(message);
+  error.name = "VerifiedArtifactAcquisitionFailure";
+  return error;
+}
+
+function ensureBeforeDeadline(deadline) {
+  if (Date.now() >= deadline) {
+    throw acquisitionFailure("overall deadline exceeded");
+  }
+}
+
+function remainingMilliseconds(deadline) {
+  ensureBeforeDeadline(deadline);
+  return Math.max(1, Math.min(2_147_483_647, deadline - Date.now()));
+}
+
+function requiredString(value, field) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError(`${field} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requiredDigest(value) {
+  if (typeof value !== "string" || !digestPattern.test(value.toLowerCase())) {
+    throw new TypeError("digest must be a SHA-256 hex digest");
+  }
+  return value.toLowerCase();
+}
+
+function requiredDeadline(value) {
+  if (!Number.isSafeInteger(value)) {
+    throw new TypeError(
+      "deadline must be a Unix epoch timestamp in milliseconds",
+    );
+  }
+  return value;
+}
+
+function sourceDescription(value) {
+  const parsed = new URL(requiredString(value, "url"));
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new TypeError("url must use HTTP or HTTPS");
+  }
+  parsed.username = "";
+  parsed.password = "";
+  parsed.search = "";
+  parsed.hash = "";
+  return parsed.toString();
+}


### PR DESCRIPTION

Closes #92. References the accepted packaging/staging boundary in #97.

## Summary

- add a `VerifiedArtifactAcquisition` deep module that returns a reverified SHA-256-addressed immutable file while hiding proxy-aware connect/overall deadlines, bounded streaming, partial cleanup, and atomic cache publication
- keep provider-lock authoritative, verify npm SRI as well as SHA-256, and install the already-pinned Playwright transitive archives without a second npm network path
- run provider assembly, app staging, and Electron packager only in a private per-run directory; serialize each final target and publish only a complete staged directory

## Verification

- Node 22 focused acquisition and packaging tests: 12 passed
- ZenX typecheck and build: passed
- format check and `git diff --check`: passed
- all five current-platform provider-lock artifacts were reverified from the digest cache with unreachable fixture URLs
- local real `package:portable` reached browser installation after build and offline artifact reuse, then failed explicitly at the new 120000ms bound because the Playwright browser CDN produced no payload; the run left no process, lock, run staging, or partial artifact
- exact-head CI: all 8 checks passed, including macOS packaged capability smoke and Windows bundled-provider smoke plus portable packaging

The first Linux ZenX test job hit an unrelated existing `self-control-capability` running-turn race; that file passed alone and the job passed on rerun. Local macOS full tests also retain three existing `trigger-program-runner` failures; focused tests and CI are green.
