### PR TITLE
fix(zenx): stabilize hosted lifecycle waits

### DIFF
--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "test": "tsx --test test/**/*.test.ts test/**/*.test.mjs",
     "test:project-identity": "tsx --test test/project-projection.test.ts test/settings-service.test.ts test/self-control-capability.test.ts",
+    "stress:hosted-flakes": "node ./scripts/stress-hosted-flakes.mjs",
     "smoke:capabilities": "npm run smoke:packaged",
     "smoke:unit-capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "assemble:providers": "node ../../scripts/assemble-zenx-providers.mjs",

--- a/apps/zenx/scripts/stress-hosted-flakes.mjs
+++ b/apps/zenx/scripts/stress-hosted-flakes.mjs
@@ -1,0 +1,104 @@
+import { spawn } from "node:child_process";
+import { availableParallelism } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const zenx = fileURLToPath(new URL("..", import.meta.url));
+const tsx = fileURLToPath(import.meta.resolve("tsx/cli"));
+const iterations = positiveInteger(
+  process.env.ZENX_HOSTED_FLAKE_ITERATIONS,
+  20,
+  "ZENX_HOSTED_FLAKE_ITERATIONS",
+);
+const workers = Math.min(
+  iterations,
+  positiveInteger(
+    process.env.ZENX_HOSTED_FLAKE_WORKERS,
+    Math.min(2, availableParallelism()),
+    "ZENX_HOSTED_FLAKE_WORKERS",
+  ),
+);
+const testNamePattern = [
+  "real ZenX host control tools make active semantics explicit",
+  "stages the first meaningful input immediately, bounds it, then generates",
+  "failure preserves the provisional title and explicit retry can generate",
+  "an externally-originated completed userMessage starts staged naming once",
+].join("|");
+const testFiles = [
+  "test/self-control-capability.test.ts",
+  "test/thread-title-coordinator.test.ts",
+  "test/thread-title-notification.test.ts",
+].map((file) => path.join(zenx, file));
+
+let nextIteration = 1;
+let failure;
+
+await Promise.all(
+  Array.from({ length: workers }, (_, index) => runWorker(index + 1)),
+);
+
+if (failure === undefined) {
+  console.log(
+    `hosted-flake stress passed: ${String(iterations)} iterations across ${String(
+      workers,
+    )} workers`,
+  );
+} else {
+  console.error(
+    `hosted-flake stress failed: iteration ${String(
+      failure.iteration,
+    )} on worker ${String(failure.worker)} exited ${String(failure.exitCode)}`,
+  );
+  process.exitCode = 1;
+}
+
+async function runWorker(worker) {
+  while (failure === undefined) {
+    const iteration = nextIteration;
+    nextIteration += 1;
+    if (iteration > iterations) return;
+    console.log(
+      `hosted-flake stress iteration ${String(iteration)}/${String(
+        iterations,
+      )} (worker ${String(worker)})`,
+    );
+    const exitCode = await runFocusedTests();
+    if (exitCode !== 0 && failure === undefined) {
+      failure = { iteration, worker, exitCode };
+    }
+  }
+}
+
+async function runFocusedTests() {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      [
+        tsx,
+        "--test",
+        "--test-concurrency=1",
+        "--test-name-pattern",
+        testNamePattern,
+        ...testFiles,
+      ],
+      { cwd: zenx, stdio: "inherit" },
+    );
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (signal !== null) {
+        reject(new Error(`focused hosted-flake tests exited via ${signal}`));
+        return;
+      }
+      resolve(code ?? 1);
+    });
+  });
+}
+
+function positiveInteger(raw, fallback, name) {
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -336,8 +336,18 @@ export class AppServerManager {
     const child = this.#child;
     if (child !== undefined && child.exitCode === null) {
       child.send({ type: "shutdown" } satisfies HostCommand);
-      await waitForExit(child, 3_000);
-      if (child.exitCode === null) child.kill("SIGTERM");
+      const exitedGracefully = await waitForExit(child, 3_000);
+      if (!exitedGracefully) {
+        child.kill("SIGTERM");
+        const terminated = await waitForExit(child, 3_000);
+        if (!terminated) {
+          throw new Error(
+            `Timed out after 3000ms waiting for Zen App Server child ${String(
+              child.pid ?? "unknown",
+            )} to settle after SIGTERM`,
+          );
+        }
+      }
     }
     this.#child = undefined;
     await this.#recoveryPromise;
@@ -701,18 +711,25 @@ async function waitForReady(
 async function waitForExit(
   child: ChildProcess,
   timeoutMs: number,
-): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return;
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(() => {
-      child.off("exit", exited);
-      resolve();
-    }, timeoutMs);
-    const exited = (): void => {
-      clearTimeout(timer);
-      resolve();
+): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const finish = (exited: boolean): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      child.off("exit", didExit);
+      resolve(exited);
     };
-    child.once("exit", exited);
+    const didExit = (): void => finish(true);
+    child.once("exit", didExit);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      finish(true);
+      return;
+    }
+    timer = setTimeout(() => finish(false), timeoutMs);
   });
 }
 

--- a/apps/zenx/src/main/owned-child-process.ts
+++ b/apps/zenx/src/main/owned-child-process.ts
@@ -1,0 +1,65 @@
+import type { ChildProcess } from "node:child_process";
+
+export type OwnedChildTerminalOutcome =
+  | {
+      readonly type: "close";
+      readonly code: number | null;
+      readonly signal: NodeJS.Signals | null;
+    }
+  | {
+      readonly type: "spawn_error";
+      readonly code: null;
+      readonly signal: null;
+      readonly error: Error;
+    };
+
+export interface OwnedChildObservation {
+  readonly terminal: Promise<OwnedChildTerminalOutcome>;
+  outcome(): OwnedChildTerminalOutcome | undefined;
+  lastError(): Error | undefined;
+}
+
+/**
+ * Observe the terminal state of one exact owned child process.
+ *
+ * ChildProcess `error` is not generally terminal: Node also emits it when a
+ * signal cannot be delivered to a process that was successfully spawned. The
+ * only error that proves there is no process to settle is a spawn failure with
+ * no PID. Every other spawned-child error remains diagnostic until `close`.
+ */
+export function observeOwnedChild(child: ChildProcess): OwnedChildObservation {
+  let spawned = child.pid !== undefined;
+  let outcome: OwnedChildTerminalOutcome | undefined;
+  let lastError: Error | undefined;
+  let resolveTerminal!: (value: OwnedChildTerminalOutcome) => void;
+  const terminal = new Promise<OwnedChildTerminalOutcome>((resolve) => {
+    resolveTerminal = resolve;
+  });
+  const finish = (value: OwnedChildTerminalOutcome): void => {
+    if (outcome !== undefined) return;
+    outcome = value;
+    resolveTerminal(value);
+  };
+  child.once("spawn", () => {
+    spawned = true;
+  });
+  child.on("error", (error) => {
+    lastError = error;
+    if (!spawned && child.pid === undefined) {
+      finish({
+        type: "spawn_error",
+        code: null,
+        signal: null,
+        error,
+      });
+    }
+  });
+  child.once("close", (code, signal) => {
+    finish({ type: "close", code, signal });
+  });
+  return {
+    terminal,
+    outcome: () => outcome,
+    lastError: () => lastError,
+  };
+}

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -1,10 +1,18 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
 
 import type {
   TriggerProgramSpec,
   TriggerProgramStage,
 } from "./trigger-types.js";
 import { MAX_PROGRAM_TIMEOUT_MS } from "./trigger-limits.js";
+import {
+  observeOwnedChild,
+  type OwnedChildObservation,
+} from "./owned-child-process.js";
 
 export { MAX_PROGRAM_TIMEOUT_MS } from "./trigger-limits.js";
 
@@ -846,6 +854,67 @@ if (!$matched) { exit 3 }
     let lastStage = "spawn";
     let identityHookStarted = false;
     let forcedFailure: string | undefined;
+    let killerObservation: OwnedChildObservation | undefined;
+    let escalationStarted = false;
+    const appendFailure = (detail: string): void => {
+      forcedFailure =
+        forcedFailure === undefined ? detail : `${forcedFailure}; ${detail}`;
+    };
+    const escalateOwnedHelper = async (): Promise<void> => {
+      if (
+        escalationStarted ||
+        killer === undefined ||
+        killer.pid === undefined ||
+        killerObservation?.outcome() !== undefined
+      )
+        return;
+      escalationStarted = true;
+      const pid = killer.pid;
+      const cleanup = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      let cleanupStdout = "";
+      let cleanupStderr = "";
+      cleanup.stdout?.setEncoding("utf8");
+      cleanup.stdout?.on("data", (chunk: string) => {
+        if (cleanupStdout.length < MAX_PROGRAM_STDERR_BYTES)
+          cleanupStdout += chunk;
+      });
+      cleanup.stderr?.setEncoding("utf8");
+      cleanup.stderr?.on("data", (chunk: string) => {
+        if (cleanupStderr.length < MAX_PROGRAM_STDERR_BYTES)
+          cleanupStderr += chunk;
+      });
+      const cleanupObservation = observeOwnedChild(cleanup);
+      const cleanupResult = await cleanupObservation.terminal;
+      if (cleanupResult.type === "spawn_error" || cleanupResult.code !== 0) {
+        appendFailure(
+          `exact helper PID ${String(pid)} taskkill escalation failed: outcome=${JSON.stringify(
+            cleanupResult.type === "spawn_error"
+              ? { type: cleanupResult.type, error: cleanupResult.error.message }
+              : cleanupResult,
+          )}; stdout=${JSON.stringify(boundedError(cleanupStdout) ?? "")}; stderr=${JSON.stringify(boundedError(cleanupStderr) ?? "")}`,
+        );
+        try {
+          killer.kill("SIGKILL");
+        } catch (error) {
+          appendFailure(
+            `final exact helper kill failed: ${describeError(error)}`,
+          );
+        }
+      }
+    };
+    const requestOwnedHelperTermination = (): void => {
+      if (killer === undefined || killerObservation?.outcome() !== undefined)
+        return;
+      try {
+        if (!killer.kill("SIGKILL")) void escalateOwnedHelper();
+      } catch (error) {
+        appendFailure(`exact helper kill failed: ${describeError(error)}`);
+        void escalateOwnedHelper();
+      }
+    };
     const finish = (value: TerminationResult): void => {
       if (settled) return;
       settled = true;
@@ -864,6 +933,7 @@ if (!$matched) { exit 3 }
               : ["pipe", "pipe", "pipe"],
         },
       );
+      killerObservation = observeOwnedChild(killer as ChildProcess);
       killer.stderr?.setEncoding("utf8");
       killer.stderr?.on("data", (chunk: string) => {
         if (stderr.length < MAX_PROGRAM_STDERR_BYTES) stderr += chunk;
@@ -885,7 +955,7 @@ if (!$matched) { exit 3 }
               },
               (error: unknown) => {
                 forcedFailure = `identity-match fixture failed: ${describeError(error)}`;
-                killer?.kill("SIGKILL");
+                requestOwnedHelperTermination();
               },
             );
         }
@@ -898,27 +968,33 @@ if (!$matched) { exit 3 }
       forcedFailure = `PID ${String(expected.pid)} identity-aware termination timed out during ${lastStage}; stdout=${JSON.stringify(
         boundedError(stdout) ?? "",
       )}; stderr=${JSON.stringify(boundedError(stderr) ?? "")}`;
-      killer?.kill("SIGKILL");
+      requestOwnedHelperTermination();
     }, WINDOWS_IDENTITY_TERMINATION_TIMEOUT_MS);
-    killer.once("error", (error: unknown) =>
-      finish({ ok: false, error: describeError(error) }),
-    );
-    killer.once("close", (code: number | null, signal: NodeJS.Signals | null) =>
+    killer.on("error", (error: unknown) => {
+      if (killerObservation?.outcome()?.type === "spawn_error") return;
+      appendFailure(
+        `identity-aware termination helper error: ${describeError(error)}`,
+      );
+      void escalateOwnedHelper();
+    });
+    void killerObservation.terminal.then((outcome) =>
       finish(
-        forcedFailure !== undefined
-          ? { ok: false, error: forcedFailure }
-          : code === 0
-            ? { ok: true, error: "" }
-            : code === 3
-              ? { ok: false, error: "process was not found" }
-              : {
-                  ok: false,
-                  error:
-                    boundedError(stderr) ??
-                    `identity-aware termination exited with code ${String(code)} and signal ${String(signal)} during ${lastStage}; stdout=${JSON.stringify(
-                      boundedError(stdout) ?? "",
-                    )}`,
-                },
+        outcome.type === "spawn_error"
+          ? { ok: false, error: describeError(outcome.error) }
+          : forcedFailure !== undefined
+            ? { ok: false, error: forcedFailure }
+            : outcome.code === 0
+              ? { ok: true, error: "" }
+              : outcome.code === 3
+                ? { ok: false, error: "process was not found" }
+                : {
+                    ok: false,
+                    error:
+                      boundedError(stderr) ??
+                      `identity-aware termination exited with code ${String(outcome.code)} and signal ${String(outcome.signal)} during ${lastStage}; stdout=${JSON.stringify(
+                        boundedError(stdout) ?? "",
+                      )}`,
+                  },
       ),
     );
   });

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -786,67 +786,29 @@ export async function terminateWindowsProcessIdentity(
     };
   const script = `
 $ErrorActionPreference = 'Stop'
-Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-
-public static class ZenXExpectedProcessTermination
-{
-    [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern IntPtr OpenProcess(uint access, bool inheritHandle, uint processId);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool GetProcessTimes(IntPtr process, out long creation, out long exit, out long kernel, out long user);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool TerminateProcess(IntPtr process, uint exitCode);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    public static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
-
-    [DllImport("kernel32.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static extern bool CloseHandle(IntPtr handle);
-}
-'@
-
-function Test-ProcessExited([IntPtr]$process, [string]$context) {
-  $wait = [ZenXExpectedProcessTermination]::WaitForSingleObject($process, 0)
-  if ($wait -eq 0) { return $true }
-  if ($wait -eq 258) { return $false }
-  if ($wait -eq [UInt32]::MaxValue) {
-    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    throw "WaitForSingleObject ($context) failed with Win32 error $code"
-  }
-  throw "WaitForSingleObject ($context) returned unexpected status $wait"
-}
-
-# PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE
-$handle = [ZenXExpectedProcessTermination]::OpenProcess(0x101001, $false, ${String(expected.pid)})
-if ($handle -eq [IntPtr]::Zero) {
-  $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-  if ($code -eq 87 -or $code -eq 1168) { exit 3 }
-  throw "OpenProcess failed with Win32 error $code"
-}
-
+$process = $null
 $matched = $false
 try {
-  $expectedStartTime = [Int64]::Parse('${expected.startTime}')
-  $creation = 0L
-  $exit = 0L
-  $kernel = 0L
-  $user = 0L
-  if (![ZenXExpectedProcessTermination]::GetProcessTimes($handle, [ref]$creation, [ref]$exit, [ref]$kernel, [ref]$user)) {
-    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-    throw "GetProcessTimes failed with Win32 error $code"
+  [Console]::Out.WriteLine('ZENX_STAGE:started')
+  [Console]::Out.Flush()
+  try {
+    $process = [System.Diagnostics.Process]::GetProcessById(${String(expected.pid)})
+    # Force one exact OS handle to be acquired before checking identity. Later
+    # StartTime, HasExited, Kill, and WaitForExit calls stay bound to it.
+    $null = $process.Handle
+  } catch [System.ArgumentException] {
+    exit 3
   }
-  $actualStartTime = ([DateTime]::FromFileTimeUtc($creation)).Ticks
+  [Console]::Out.WriteLine('ZENX_STAGE:handle-opened')
+  [Console]::Out.Flush()
+  $expectedStartTime = [Int64]::Parse('${expected.startTime}')
+  $actualStartTime = $process.StartTime.ToUniversalTime().Ticks
   # CIM datetime exposes microseconds while FILETIME exposes 100-nanosecond ticks.
   $actualStartTime -= $actualStartTime % 10
   if ($actualStartTime -eq $expectedStartTime) {
     $matched = $true
+    [Console]::Out.WriteLine('ZENX_STAGE:identity-matched')
+    [Console]::Out.Flush()
 ${
   identityMatchedFixture === undefined
     ? ""
@@ -856,17 +818,21 @@ ${
       throw "identity-match fixture did not continue"
     }
 `
-}    if (!(Test-ProcessExited $handle 'before termination')) {
-      if (![ZenXExpectedProcessTermination]::TerminateProcess($handle, 1)) {
-        $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        if (!(Test-ProcessExited $handle 'after TerminateProcess failure')) {
-          throw "TerminateProcess failed with Win32 error $code"
-        }
+}    if (!$process.HasExited) {
+      try {
+        $process.Kill()
+        [Console]::Out.WriteLine('ZENX_STAGE:kill-dispatched')
+        [Console]::Out.Flush()
+      } catch {
+        if (!$process.HasExited) { throw }
       }
+      if (!$process.HasExited) { $process.WaitForExit() }
     }
+    [Console]::Out.WriteLine('ZENX_STAGE:target-exited')
+    [Console]::Out.Flush()
   }
 } finally {
-  [void][ZenXExpectedProcessTermination]::CloseHandle($handle)
+  if ($null -ne $process) { $process.Dispose() }
 }
 if (!$matched) { exit 3 }
 `;
@@ -877,7 +843,9 @@ if (!$matched) { exit 3 }
     let killer: ReturnType<typeof spawn> | undefined;
     let stderr = "";
     let stdout = "";
+    let lastStage = "spawn";
     let identityHookStarted = false;
+    let forcedFailure: string | undefined;
     const finish = (value: TerminationResult): void => {
       if (settled) return;
       settled = true;
@@ -892,7 +860,7 @@ if (!$matched) { exit 3 }
           windowsHide: true,
           stdio:
             identityMatchedFixture === undefined
-              ? ["ignore", "ignore", "pipe"]
+              ? ["ignore", "pipe", "pipe"]
               : ["pipe", "pipe", "pipe"],
         },
       );
@@ -900,11 +868,13 @@ if (!$matched) { exit 3 }
       killer.stderr?.on("data", (chunk: string) => {
         if (stderr.length < MAX_PROGRAM_STDERR_BYTES) stderr += chunk;
       });
-      if (identityMatchedFixture !== undefined) {
-        killer.stdout?.setEncoding("utf8");
-        killer.stdout?.on("data", (chunk: string) => {
-          if (identityHookStarted) return;
-          stdout += chunk;
+      killer.stdout?.setEncoding("utf8");
+      killer.stdout?.on("data", (chunk: string) => {
+        if (stdout.length < MAX_PROGRAM_STDERR_BYTES) stdout += chunk;
+        for (const match of chunk.matchAll(/ZENX_STAGE:([^\r\n]+)/gu)) {
+          lastStage = match[1] ?? lastStage;
+        }
+        if (identityMatchedFixture !== undefined && !identityHookStarted) {
           if (!stdout.includes("ZENX_IDENTITY_MATCHED")) return;
           identityHookStarted = true;
           void Promise.resolve()
@@ -914,41 +884,41 @@ if (!$matched) { exit 3 }
                 if (!settled) killer?.stdin?.end("continue\n");
               },
               (error: unknown) => {
+                forcedFailure = `identity-match fixture failed: ${describeError(error)}`;
                 killer?.kill("SIGKILL");
-                finish({
-                  ok: false,
-                  error: `identity-match fixture failed: ${describeError(error)}`,
-                });
               },
             );
-        });
-      }
+        }
+      });
     } catch (error) {
       finish({ ok: false, error: describeError(error) });
       return;
     }
     timer = setTimeout(() => {
+      forcedFailure = `PID ${String(expected.pid)} identity-aware termination timed out during ${lastStage}; stdout=${JSON.stringify(
+        boundedError(stdout) ?? "",
+      )}; stderr=${JSON.stringify(boundedError(stderr) ?? "")}`;
       killer?.kill("SIGKILL");
-      finish({
-        ok: false,
-        error: `PID ${String(expected.pid)} identity-aware termination timed out`,
-      });
     }, WINDOWS_IDENTITY_TERMINATION_TIMEOUT_MS);
     killer.once("error", (error: unknown) =>
       finish({ ok: false, error: describeError(error) }),
     );
-    killer.once("close", (code: number | null) =>
+    killer.once("close", (code: number | null, signal: NodeJS.Signals | null) =>
       finish(
-        code === 0
-          ? { ok: true, error: "" }
-          : code === 3
-            ? { ok: false, error: "process was not found" }
-            : {
-                ok: false,
-                error:
-                  boundedError(stderr) ??
-                  `identity-aware termination exited with code ${String(code)}`,
-              },
+        forcedFailure !== undefined
+          ? { ok: false, error: forcedFailure }
+          : code === 0
+            ? { ok: true, error: "" }
+            : code === 3
+              ? { ok: false, error: "process was not found" }
+              : {
+                  ok: false,
+                  error:
+                    boundedError(stderr) ??
+                    `identity-aware termination exited with code ${String(code)} and signal ${String(signal)} during ${lastStage}; stdout=${JSON.stringify(
+                      boundedError(stdout) ?? "",
+                    )}`,
+                },
       ),
     );
   });

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -13,6 +13,11 @@ import {
   UserBrowserCdpOutcomeUnknownError,
   windowsBrowserExecutableCandidates,
 } from "./capabilities/user-browser-provider.js";
+import {
+  observeOwnedChild,
+  type OwnedChildObservation,
+  type OwnedChildTerminalOutcome,
+} from "./owned-child-process.js";
 
 if (process.platform !== "win32") {
   throw new Error("The real user-browser CDP smoke is Windows-only");
@@ -597,23 +602,16 @@ async function findBrowserExecutable(): Promise<string> {
   );
 }
 
-interface SmokeChildOutcome {
-  readonly type: "close" | "error";
-  readonly code: number | null;
-  readonly signal: NodeJS.Signals | null;
-  readonly error?: Error;
-}
-
 interface SmokeChildObservation {
-  readonly ended: Promise<SmokeChildOutcome>;
-  outcome(): SmokeChildOutcome | undefined;
+  readonly terminal: Promise<OwnedChildTerminalOutcome>;
+  outcome(): OwnedChildTerminalOutcome | undefined;
   diagnostics(stage: string, detail?: string): string;
 }
 
 function observeSmokeChild(child: ChildProcess): SmokeChildObservation {
   let stdout = "";
   let stderr = "";
-  let outcome: SmokeChildOutcome | undefined;
+  const owned = observeOwnedChild(child);
   const append = (current: string, chunk: string): string =>
     current.length >= 8_192 ? current : `${current}${chunk}`.slice(0, 8_192);
   child.stdout?.setEncoding("utf8");
@@ -624,27 +622,11 @@ function observeSmokeChild(child: ChildProcess): SmokeChildObservation {
   child.stderr?.on("data", (chunk: string) => {
     stderr = append(stderr, chunk);
   });
-  const ended = new Promise<SmokeChildOutcome>((resolve) => {
-    child.once("error", (error) => {
-      outcome = {
-        type: "error",
-        code: child.exitCode,
-        signal: child.signalCode,
-        error,
-      };
-      resolve(outcome);
-    });
-    child.once("close", (code, signal) => {
-      if (outcome?.type === "error") return;
-      outcome = { type: "close", code, signal };
-      resolve(outcome);
-    });
-  });
   return {
-    ended,
-    outcome: () => outcome,
+    terminal: owned.terminal,
+    outcome: owned.outcome,
     diagnostics: (stage, detail) =>
-      `real user browser fixture ${stage}; pid=${String(child.pid ?? "unavailable")}; exitCode=${String(child.exitCode)}; signal=${String(child.signalCode)}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}${detail === undefined ? "" : `; ${detail}`}`,
+      `real user browser fixture ${stage}; pid=${String(child.pid ?? "unavailable")}; exitCode=${String(child.exitCode)}; signal=${String(child.signalCode)}; childError=${JSON.stringify(owned.lastError()?.message ?? "")}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}${detail === undefined ? "" : `; ${detail}`}`,
   };
 }
 
@@ -693,23 +675,28 @@ async function readDevToolsPort(
         ),
       );
     }, 15_000);
-    void observation.ended.then((outcome) => {
+    void observation.terminal.then((outcome) => {
       finish(
         new Error(
           observation.diagnostics(
-            "exited before publishing DevToolsActivePort",
+            outcome.type === "spawn_error"
+              ? "failed to create a process before publishing DevToolsActivePort"
+              : "exited before publishing DevToolsActivePort",
             `outcome=${JSON.stringify({
               type: outcome.type,
               code: outcome.code,
               signal: outcome.signal,
-              error: outcome.error?.message,
+              error:
+                outcome.type === "spawn_error"
+                  ? outcome.error.message
+                  : undefined,
             })}; path=${activePort}; lastRead=${lastRead}`,
           ),
         ),
       );
     });
     if (child.exitCode !== null || child.signalCode !== null) {
-      void observation.ended;
+      void observation.terminal;
     }
   });
   return await readiness;
@@ -778,19 +765,30 @@ async function stopProcessTree(
       },
     );
     const cleanupObservation = observeSmokeChild(cleanup);
-    const cleanupResult = await cleanupObservation.ended;
-    if (cleanupResult.type === "error" || cleanupResult.code !== 0) {
-      const killed = child.kill("SIGKILL");
-      if (!killed && observation.outcome() === undefined) {
-        throw new Error(
+    const cleanupResult = await cleanupObservation.terminal;
+    if (cleanupResult.type === "spawn_error" || cleanupResult.code !== 0) {
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        console.error(
           cleanupObservation.diagnostics(
-            "taskkill failed and direct child termination was unavailable",
+            "taskkill failed and the final exact child kill threw",
+            `error=${error instanceof Error ? error.message : String(error)}`,
           ),
         );
       }
     } else if (observation.outcome() === undefined) {
-      child.kill("SIGKILL");
+      try {
+        child.kill("SIGKILL");
+      } catch (error) {
+        console.error(
+          observation.diagnostics(
+            "taskkill completed but the final exact child kill threw",
+            `error=${error instanceof Error ? error.message : String(error)}`,
+          ),
+        );
+      }
     }
   }
-  await observation.ended;
+  await observation.terminal;
 }

--- a/apps/zenx/src/main/user-browser-smoke.ts
+++ b/apps/zenx/src/main/user-browser-smoke.ts
@@ -42,6 +42,7 @@ const server = createServer((request, response) => {
 });
 
 let browser: ChildProcess | undefined;
+let browserObservation: SmokeChildObservation | undefined;
 let directory: string | undefined;
 
 try {
@@ -57,9 +58,14 @@ try {
       "--no-default-browser-check",
       `http://127.0.0.1:${String(port)}/seed`,
     ],
-    { stdio: "ignore", windowsHide: true },
+    { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
   );
-  const debuggingPort = await readDevToolsPort(directory);
+  browserObservation = observeSmokeChild(browser);
+  const debuggingPort = await readDevToolsPort(
+    directory,
+    browser,
+    browserObservation,
+  );
   const endpoint = `http://127.0.0.1:${debuggingPort}`;
   const selection = await selectBrowserProvider({
     userDataDirectory: directory,
@@ -238,10 +244,10 @@ try {
     }),
   );
 } finally {
-  await closeServer();
-  if (browser?.pid !== undefined) {
-    await stopProcessTree(browser.pid);
+  if (browser !== undefined && browserObservation !== undefined) {
+    await stopProcessTree(browser, browserObservation);
   }
+  await closeServer();
   if (directory !== undefined) {
     await rm(directory, {
       recursive: true,
@@ -591,20 +597,122 @@ async function findBrowserExecutable(): Promise<string> {
   );
 }
 
-async function readDevToolsPort(userDataDirectory: string): Promise<string> {
-  return await retry(async () => {
-    try {
-      const [port] = (
-        await readFile(
-          path.join(userDataDirectory, "DevToolsActivePort"),
-          "utf8",
-        )
-      ).split(/\r?\n/u);
-      return /^\d+$/u.test(port ?? "") ? port : undefined;
-    } catch {
-      return undefined;
+interface SmokeChildOutcome {
+  readonly type: "close" | "error";
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly error?: Error;
+}
+
+interface SmokeChildObservation {
+  readonly ended: Promise<SmokeChildOutcome>;
+  outcome(): SmokeChildOutcome | undefined;
+  diagnostics(stage: string, detail?: string): string;
+}
+
+function observeSmokeChild(child: ChildProcess): SmokeChildObservation {
+  let stdout = "";
+  let stderr = "";
+  let outcome: SmokeChildOutcome | undefined;
+  const append = (current: string, chunk: string): string =>
+    current.length >= 8_192 ? current : `${current}${chunk}`.slice(0, 8_192);
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (chunk: string) => {
+    stdout = append(stdout, chunk);
+  });
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", (chunk: string) => {
+    stderr = append(stderr, chunk);
+  });
+  const ended = new Promise<SmokeChildOutcome>((resolve) => {
+    child.once("error", (error) => {
+      outcome = {
+        type: "error",
+        code: child.exitCode,
+        signal: child.signalCode,
+        error,
+      };
+      resolve(outcome);
+    });
+    child.once("close", (code, signal) => {
+      if (outcome?.type === "error") return;
+      outcome = { type: "close", code, signal };
+      resolve(outcome);
+    });
+  });
+  return {
+    ended,
+    outcome: () => outcome,
+    diagnostics: (stage, detail) =>
+      `real user browser fixture ${stage}; pid=${String(child.pid ?? "unavailable")}; exitCode=${String(child.exitCode)}; signal=${String(child.signalCode)}; stdout=${JSON.stringify(stdout.trim())}; stderr=${JSON.stringify(stderr.trim())}${detail === undefined ? "" : `; ${detail}`}`,
+  };
+}
+
+async function readDevToolsPort(
+  userDataDirectory: string,
+  child: ChildProcess,
+  observation: SmokeChildObservation,
+): Promise<string> {
+  const activePort = path.join(userDataDirectory, "DevToolsActivePort");
+  let lastRead = "not attempted";
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pollTimer: ReturnType<typeof setTimeout> | undefined;
+  const readiness = new Promise<string>((resolve, reject) => {
+    let settled = false;
+    const finish = (value: string | Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      if (pollTimer !== undefined) clearTimeout(pollTimer);
+      if (value instanceof Error) reject(value);
+      else resolve(value);
+    };
+    const poll = async (): Promise<void> => {
+      if (settled) return;
+      try {
+        const [port] = (await readFile(activePort, "utf8")).split(/\r?\n/u);
+        if (/^\d+$/u.test(port ?? "")) {
+          finish(port!);
+          return;
+        }
+        lastRead = `invalid contents ${JSON.stringify(port ?? "")}`;
+      } catch (error) {
+        const failure = error as NodeJS.ErrnoException;
+        lastRead = `${failure.code ?? "read error"}: ${failure.message}`;
+      }
+      pollTimer = setTimeout(() => void poll(), 100);
+    };
+    void poll();
+    timer = setTimeout(() => {
+      finish(
+        new Error(
+          observation.diagnostics(
+            "did not publish DevToolsActivePort before the readiness deadline",
+            `path=${activePort}; lastRead=${lastRead}`,
+          ),
+        ),
+      );
+    }, 15_000);
+    void observation.ended.then((outcome) => {
+      finish(
+        new Error(
+          observation.diagnostics(
+            "exited before publishing DevToolsActivePort",
+            `outcome=${JSON.stringify({
+              type: outcome.type,
+              code: outcome.code,
+              signal: outcome.signal,
+              error: outcome.error?.message,
+            })}; path=${activePort}; lastRead=${lastRead}`,
+          ),
+        ),
+      );
+    });
+    if (child.exitCode !== null || child.signalCode !== null) {
+      void observation.ended;
     }
   });
+  return await readiness;
 }
 
 async function retry<T>(operation: () => Promise<T | undefined>): Promise<T> {
@@ -649,18 +757,40 @@ async function listen(): Promise<number> {
 
 async function closeServer(): Promise<void> {
   if (!server.listening) return;
-  await new Promise<void>((resolve, reject) =>
+  const closed = new Promise<void>((resolve, reject) =>
     server.close((error) => (error === undefined ? resolve() : reject(error))),
   );
+  server.closeAllConnections();
+  await closed;
 }
 
-async function stopProcessTree(pid: number): Promise<void> {
-  await new Promise<void>((resolve) => {
-    const cleanup = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    cleanup.once("exit", () => resolve());
-    cleanup.once("error", () => resolve());
-  });
+async function stopProcessTree(
+  child: ChildProcess,
+  observation: SmokeChildObservation,
+): Promise<void> {
+  if (observation.outcome() === undefined && child.pid !== undefined) {
+    const cleanup = spawn(
+      "taskkill.exe",
+      ["/PID", String(child.pid), "/T", "/F"],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+      },
+    );
+    const cleanupObservation = observeSmokeChild(cleanup);
+    const cleanupResult = await cleanupObservation.ended;
+    if (cleanupResult.type === "error" || cleanupResult.code !== 0) {
+      const killed = child.kill("SIGKILL");
+      if (!killed && observation.outcome() === undefined) {
+        throw new Error(
+          cleanupObservation.diagnostics(
+            "taskkill failed and direct child termination was unavailable",
+          ),
+        );
+      }
+    } else if (observation.outcome() === undefined) {
+      child.kill("SIGKILL");
+    }
+  }
+  await observation.ended;
 }

--- a/apps/zenx/test/fixtures/thread-title-state.ts
+++ b/apps/zenx/test/fixtures/thread-title-state.ts
@@ -1,0 +1,88 @@
+import type { ZenXThreadTitleCoordinator } from "../../src/main/thread-title-coordinator.js";
+import type {
+  ThreadTitleProjection,
+  ThreadTitleSnapshot,
+} from "../../src/main/thread-title-types.js";
+
+const TITLE_STAGE_TIMEOUT_MS = 5_000;
+
+export async function waitForTitleStatus(
+  titles: ZenXThreadTitleCoordinator,
+  threadId: string,
+  status: ThreadTitleProjection["status"],
+  stage: string,
+): Promise<void> {
+  let latest: ThreadTitleProjection | undefined;
+  let dispose = (): void => undefined;
+  let timer: NodeJS.Timeout | undefined;
+  let settled = false;
+
+  await new Promise<void>((resolve, reject) => {
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      dispose();
+      if (error === undefined) resolve();
+      else reject(error);
+    };
+    const inspect = (snapshot: ThreadTitleSnapshot): void => {
+      latest = snapshot[threadId];
+      if (latest?.status === status) finish();
+    };
+
+    dispose = titles.onChange(inspect);
+    try {
+      inspect(titles.snapshot());
+    } catch (error) {
+      finish(
+        new Error(
+          `Title state observation failed during ${stage}: ${describeError(error)}`,
+        ),
+      );
+      return;
+    }
+    if (settled) return;
+    timer = setTimeout(() => {
+      finish(
+        new Error(
+          `Timed out after ${String(
+            TITLE_STAGE_TIMEOUT_MS,
+          )}ms during ${stage}: waiting for title status ${status} on ${threadId}; last projection=${JSON.stringify(
+            latest ?? null,
+          )}`,
+        ),
+      );
+    }, TITLE_STAGE_TIMEOUT_MS);
+  });
+}
+
+export async function waitForTitleStage<T>(
+  work: Promise<T>,
+  stage: string,
+  diagnostics: () => string,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Timed out after ${String(
+                TITLE_STAGE_TIMEOUT_MS,
+              )}ms during ${stage}: ${diagnostics()}`,
+            ),
+          );
+        }, TITLE_STAGE_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/zenx/test/owned-child-process.test.ts
+++ b/apps/zenx/test/owned-child-process.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type { ChildProcess } from "node:child_process";
+
+import { observeOwnedChild } from "../src/main/owned-child-process.js";
+
+function childWithPid(pid: number | undefined): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  Object.defineProperty(child, "pid", { configurable: true, value: pid });
+  return child;
+}
+
+test("post-spawn errors remain diagnostic until the exact child closes", async () => {
+  const child = childWithPid(1234);
+  const observation = observeOwnedChild(child);
+  const failure = new Error("signal delivery failed");
+  let settled = false;
+  void observation.terminal.then(() => {
+    settled = true;
+  });
+
+  child.emit("error", failure);
+  await Promise.resolve();
+
+  assert.equal(settled, false);
+  assert.equal(observation.outcome(), undefined);
+  assert.equal(observation.lastError(), failure);
+
+  child.emit("close", 7, null);
+  assert.deepEqual(await observation.terminal, {
+    type: "close",
+    code: 7,
+    signal: null,
+  });
+  assert.equal(observation.lastError(), failure);
+});
+
+test("a spawn error with no PID proves no child process was created", async () => {
+  const child = childWithPid(undefined);
+  const observation = observeOwnedChild(child);
+  const failure = new Error("spawn ENOENT");
+
+  child.emit("error", failure);
+
+  assert.deepEqual(await observation.terminal, {
+    type: "spawn_error",
+    code: null,
+    signal: null,
+    error: failure,
+  });
+});
+
+test("owned cleanup cannot advance before a post-error close", async () => {
+  const child = childWithPid(5678);
+  const observation = observeOwnedChild(child);
+  const cleanupOrder: string[] = [];
+  const cleanup = observation.terminal.then(() => {
+    cleanupOrder.push("remove-owned-resource");
+  });
+
+  child.emit("error", new Error("kill EPERM"));
+  await Promise.resolve();
+  assert.deepEqual(cleanupOrder, []);
+
+  child.emit("close", null, "SIGKILL");
+  await cleanup;
+  assert.deepEqual(cleanupOrder, ["remove-owned-resource"]);
+});

--- a/apps/zenx/test/self-control-capability.test.ts
+++ b/apps/zenx/test/self-control-capability.test.ts
@@ -72,7 +72,11 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     });
     const threadId = stringField(created, "threadId");
 
-    const firstCommand = waitForCommand(manager, threadId);
+    const firstCommand = waitForCommand(
+      manager,
+      threadId,
+      "initial self-control command start",
+    );
     const first = await invoke(tools, "zenx_threads_send", {
       threadId,
       mode: "start",
@@ -85,6 +89,12 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     assert.equal(active.status, "active");
     assert.equal(active.activeTurnId, firstTurnId);
 
+    const firstCompleted = waitForManagerTurnCompleted(
+      manager,
+      threadId,
+      "steered initial Turn completion",
+      (turnId) => turnId === firstTurnId,
+    );
     const steered = await invoke(tools, "zenx_threads_send", {
       threadId,
       mode: "steer",
@@ -94,9 +104,13 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     });
     assert.equal(steered.mode, "steer");
     assert.equal(steered.expectedTurnId, firstTurnId);
-    await waitUntilIdle(tools, threadId);
+    await firstCompleted;
 
-    const secondCommand = waitForCommand(manager, threadId);
+    const secondCommand = waitForCommand(
+      manager,
+      threadId,
+      "replace target command start",
+    );
     const second = await invoke(tools, "zenx_threads_send", {
       threadId,
       mode: "start",
@@ -105,6 +119,12 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     });
     const secondTurnId = stringField(second, "turnId");
     await secondCommand;
+    const successorCompleted = waitForManagerTurnCompleted(
+      manager,
+      threadId,
+      "replacement successor completion",
+      (turnId) => turnId !== secondTurnId,
+    );
     const replaced = await invoke(tools, "zenx_threads_send", {
       threadId,
       mode: "replace",
@@ -114,15 +134,22 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     });
     assert.equal(replaced.interruptedTurnId, secondTurnId);
     assert.notEqual(replaced.turnId, secondTurnId);
-    await waitUntilIdle(tools, threadId);
+    await successorCompleted;
 
+    const followUpCompleted = waitForManagerTurnCompleted(
+      manager,
+      threadId,
+      "follow-up Turn completion",
+      (turnId) =>
+        turnId !== secondTurnId && turnId !== stringField(replaced, "turnId"),
+    );
     await invoke(tools, "zenx_threads_send", {
       threadId,
       mode: "start",
       text: "Follow-up prompt.",
       clientUserMessageId: "host-follow-up",
     });
-    await waitUntilIdle(tools, threadId);
+    await followUpCompleted;
 
     const recent = await invoke(tools, "zenx_threads_read", {
       threadId,
@@ -200,6 +227,7 @@ test("real ZenX host control tools make active semantics explicit", async () => 
     const bridgeCompleted = waitForManagerTurnCompleted(
       manager,
       bridgeThread.thread.id,
+      "host capability bridge Turn completion",
     );
     await manager.request("turn/start", {
       threadId: bridgeThread.thread.id,
@@ -847,11 +875,16 @@ async function invoke(
 function waitForCommand(
   manager: AppServerManager,
   threadId: string,
+  stage: string,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       dispose();
-      reject(new Error("Timed out waiting for command execution"));
+      reject(
+        new Error(
+          `Timed out after 10000ms during ${stage}: waiting for command item/started on Thread ${threadId}`,
+        ),
+      );
     }, 10_000);
     const dispose = manager.onNotification((method, params) => {
       if (method === "item/started") {
@@ -868,19 +901,6 @@ function waitForCommand(
       }
     });
   });
-}
-
-async function waitUntilIdle(
-  tools: ToolExecutor,
-  threadId: string,
-): Promise<void> {
-  const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
-    const status = await invoke(tools, "zenx_threads_status", { threadId });
-    if (status.status === "idle") return;
-    await new Promise((resolve) => setTimeout(resolve, 20));
-  }
-  throw new Error("Timed out waiting for Thread to become idle");
 }
 
 function waitForTurnCompleted(
@@ -905,16 +925,27 @@ function waitForTurnCompleted(
 function waitForManagerTurnCompleted(
   manager: AppServerManager,
   threadId: string,
+  stage: string,
+  matchesTurn: (turnId: string) => boolean = () => true,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    const observedTurnIds: string[] = [];
     const timer = setTimeout(() => {
       dispose();
-      reject(new Error("Timed out waiting for hosted turn/completed"));
+      reject(
+        new Error(
+          `Timed out after 10000ms during ${stage}: waiting for hosted turn/completed on Thread ${threadId}; observed Turn IDs=${JSON.stringify(
+            observedTurnIds,
+          )}`,
+        ),
+      );
     }, 10_000);
     const dispose = manager.onNotification((method, params) => {
       if (method !== "turn/completed") return;
       const completed = params as ServerNotificationParams["turn/completed"];
       if (completed.threadId !== threadId) return;
+      observedTurnIds.push(completed.turn.id);
+      if (!matchesTurn(completed.turn.id)) return;
       clearTimeout(timer);
       dispose();
       resolve();

--- a/apps/zenx/test/thread-title-coordinator.test.ts
+++ b/apps/zenx/test/thread-title-coordinator.test.ts
@@ -13,6 +13,7 @@ import type {
   ThreadTitleInference,
   ThreadTitleSnapshot,
 } from "../src/main/thread-title-types.js";
+import { waitForTitleStatus } from "./fixtures/thread-title-state.js";
 
 test("stages the first meaningful input immediately, bounds it, then generates", async () => {
   await withCoordinator(async ({ coordinator, inference, events, names }) => {
@@ -22,11 +23,17 @@ test("stages the first meaningful input immediately, bounds it, then generates",
     assert.equal(observed?.status, "generating");
     assert.ok(Array.from(observed?.title ?? "").length <= 64);
     inference.resolve("Semantic release planning");
-    await waitFor(events, "thread-a", "generated");
+    await waitForTitleStatus(
+      coordinator,
+      "thread-a",
+      "generated",
+      "initial title generation",
+    );
     assert.equal(
       coordinator.snapshot()["thread-a"]?.title,
       "Semantic release planning",
     );
+    await coordinator.stop();
     assert.deepEqual(names.slice(-1), ["Semantic release planning"]);
   });
 });
@@ -38,12 +45,22 @@ test("failure preserves the provisional title and explicit retry can generate", 
       "Investigate flaky CI",
     );
     inference.reject(new Error("title model unavailable"));
-    await waitFor(events, "thread-a", "failed");
+    await waitForTitleStatus(
+      coordinator,
+      "thread-a",
+      "failed",
+      "failed title generation",
+    );
     assert.equal(coordinator.snapshot()["thread-a"]?.title, observed?.title);
     const retry = await coordinator.retry("thread-a");
     assert.equal(retry.status, "generating");
     inference.resolve("Flaky CI investigation");
-    await waitFor(events, "thread-a", "generated");
+    await waitForTitleStatus(
+      coordinator,
+      "thread-a",
+      "generated",
+      "explicit title retry",
+    );
   });
 });
 
@@ -55,7 +72,7 @@ test("manual rename before a late completion is authoritative", async () => {
       "My authoritative title",
     );
     inference.resolve("Late generated title");
-    await tick();
+    await coordinator.stop();
     assert.equal(manual.status, "manual");
     assert.equal(
       coordinator.snapshot()["thread-a"]?.title,
@@ -69,7 +86,12 @@ test("manual rename after generation remains authoritative", async () => {
   await withCoordinator(async ({ coordinator, inference, events }) => {
     await coordinator.observe("thread-a", "Original request");
     inference.resolve("Generated title");
-    await waitFor(events, "thread-a", "generated");
+    await waitForTitleStatus(
+      coordinator,
+      "thread-a",
+      "generated",
+      "generation before manual rename",
+    );
     await coordinator.rename("thread-a", "Manual after generation");
     assert.equal(coordinator.snapshot()["thread-a"]?.status, "manual");
     assert.equal(
@@ -89,7 +111,12 @@ test("duplicate first messages launch only one generation", async () => {
     assert.deepEqual(duplicate, first);
     assert.equal(inference.calls, 1);
     inference.resolve("Done");
-    await waitFor(events, "thread-a", "generated");
+    await waitForTitleStatus(
+      coordinator,
+      "thread-a",
+      "generated",
+      "deduplicated title generation",
+    );
   });
 });
 
@@ -113,14 +140,16 @@ test("restart marks in-flight generation failed without automatic retry", async 
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-restart-"),
   );
+  let first: ZenXThreadTitleCoordinator | undefined;
+  let restarted: ZenXThreadTitleCoordinator | undefined;
   try {
     const store = new ZenXThreadTitleStore(path.join(directory, "titles.json"));
     const inference = new ControlledInference();
-    const first = coordinator(store, inference);
+    first = coordinator(store, inference);
     await first.initialize();
     await first.observe("thread-a", "Restart race");
     const restartedInference = new ControlledInference();
-    const restarted = coordinator(store, restartedInference);
+    restarted = coordinator(store, restartedInference);
     await restarted.initialize();
     assert.equal(restarted.snapshot()["thread-a"]?.status, "failed");
     assert.match(
@@ -129,6 +158,8 @@ test("restart marks in-flight generation failed without automatic retry", async 
     );
     assert.equal(restartedInference.calls, 0);
   } finally {
+    await restarted?.close();
+    await first?.close();
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -137,11 +168,12 @@ test("corrupt title metadata disables naming without starting inference", async 
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-corrupt-"),
   );
+  let instance: ZenXThreadTitleCoordinator | undefined;
   try {
     const file = path.join(directory, "titles.json");
     await writeFile(file, "{not-json", "utf8");
     const inference = new ControlledInference();
-    const instance = coordinator(new ZenXThreadTitleStore(file), inference);
+    instance = coordinator(new ZenXThreadTitleStore(file), inference);
     await instance.initialize();
     await assert.rejects(
       instance.observe("thread-a", "Turn must still be allowed by the caller"),
@@ -149,6 +181,9 @@ test("corrupt title metadata disables naming without starting inference", async 
     );
     assert.equal(inference.calls, 0);
   } finally {
+    if (instance !== undefined) {
+      await assert.rejects(instance.close(), /invalid JSON/u);
+    }
     await rm(directory, { recursive: true, force: true });
   }
 });
@@ -162,16 +197,19 @@ async function withCoordinator(
   }) => Promise<void>,
 ): Promise<void> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-title-"));
+  let instanceToClose: ZenXThreadTitleCoordinator | undefined;
   try {
     const store = new ZenXThreadTitleStore(path.join(directory, "titles.json"));
     const inference = new ControlledInference();
     const names: string[] = [];
     const instance = coordinator(store, inference, names);
+    instanceToClose = instance;
     const events: ThreadTitleSnapshot[] = [];
     instance.onChange((snapshot) => events.push(snapshot));
     await instance.initialize();
     await run({ coordinator: instance, inference, events, names });
   } finally {
+    await instanceToClose?.close();
     await rm(directory, { recursive: true, force: true });
   }
 }
@@ -198,11 +236,28 @@ class ControlledInference implements ThreadTitleInference {
     reject(error: Error): void;
   }> = [];
 
-  async generate(): Promise<string> {
+  async generate(
+    _input: string,
+    _model: string,
+    signal: AbortSignal,
+  ): Promise<string> {
     this.calls += 1;
-    return await new Promise<string>((resolve, reject) =>
-      this.#pending.push({ resolve, reject }),
-    );
+    return await new Promise<string>((resolve, reject) => {
+      const abort = (): void => pending.reject(abortError(signal));
+      const pending = {
+        resolve: (value: string): void => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error: Error): void => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) abort();
+      else this.#pending.push(pending);
+    });
   }
 
   resolve(value: string): void {
@@ -213,19 +268,8 @@ class ControlledInference implements ThreadTitleInference {
   }
 }
 
-async function waitFor(
-  events: ThreadTitleSnapshot[],
-  threadId: string,
-  status: string,
-): Promise<void> {
-  for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    if (events.some((snapshot) => snapshot[threadId]?.status === status))
-      return;
-    await tick();
-  }
-  assert.fail(`Timed out waiting for title status ${status}`);
-}
-
-async function tick(): Promise<void> {
-  await new Promise<void>((resolve) => setImmediate(resolve));
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("Title generation aborted", "AbortError");
 }

--- a/apps/zenx/test/thread-title-notification.test.ts
+++ b/apps/zenx/test/thread-title-notification.test.ts
@@ -9,6 +9,10 @@ import { observeCompletedUserMessageTitle } from "../src/main/thread-title-notif
 import { ZenXThreadTitleStore } from "../src/main/thread-title-store.js";
 import type { ThreadTitleInference } from "../src/main/thread-title-types.js";
 import type { ServerNotificationParams } from "../src/protocol-client/index.js";
+import {
+  waitForTitleStage,
+  waitForTitleStatus,
+} from "./fixtures/thread-title-state.js";
 
 test("an externally-originated completed userMessage starts staged naming once", async () => {
   await withCoordinator(async ({ titles, inference }) => {
@@ -31,7 +35,12 @@ test("an externally-originated completed userMessage starts staged naming once",
     );
     assert.equal(inference.calls, 1);
     inference.resolve("Cross-client release workflow");
-    await waitForStatus(titles, "thread-external", "generated");
+    await waitForTitleStatus(
+      titles,
+      "thread-external",
+      "generated",
+      "external user-message title generation",
+    );
   });
 });
 
@@ -54,7 +63,7 @@ test("a canonical duplicate cannot restart generation or overwrite a pre-observe
     assert.equal(inference.calls, 1);
     assert.equal(titles.snapshot()["thread-preobserved"]?.status, "manual");
     inference.resolve("Late semantic title");
-    await tick();
+    await titles.stop();
     assert.equal(
       titles.snapshot()["thread-preobserved"]?.title,
       "Manual authority",
@@ -70,7 +79,7 @@ test("an App Server rename becomes authoritative over pending generation", async
       "Agent-managed name",
     );
     inference.resolve("Late generated name");
-    await tick();
+    await titles.stop();
     assert.deepEqual(titles.snapshot()["thread-agent-renamed"], {
       threadId: "thread-agent-renamed",
       title: "Agent-managed name",
@@ -133,6 +142,7 @@ async function withCoordinator(
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-notification-"),
   );
+  let titlesToClose: ZenXThreadTitleCoordinator | undefined;
   try {
     const inference = new ControlledInference();
     const titles = new ZenXThreadTitleCoordinator({
@@ -141,9 +151,11 @@ async function withCoordinator(
       titleModel: () => "gpt-5.6-luna",
       setNativeName: async () => undefined,
     });
+    titlesToClose = titles;
     await titles.initialize();
     await run({ titles, inference });
   } finally {
+    await titlesToClose?.close();
     await rm(directory, { recursive: true, force: true });
   }
 }
@@ -154,11 +166,19 @@ async function assertRenameWinsGenerationRace(
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-title-authority-race-"),
   );
+  let titlesToClose: ZenXThreadTitleCoordinator | undefined;
   try {
     const inference = new ControlledInference();
     let nativeName = "";
     let synchronization: Promise<unknown> | undefined;
     const synchronizations: Promise<unknown>[] = [];
+    const synchronizationStarted = signal();
+    const secondSynchronizationStarted = signal();
+    const trackSynchronization = (operation: Promise<unknown>): void => {
+      synchronizations.push(operation);
+      synchronizationStarted.resolve();
+      if (synchronizations.length === 2) secondSynchronizationStarted.resolve();
+    };
     let injected = false;
     let titles!: ZenXThreadTitleCoordinator;
     titles = new ZenXThreadTitleCoordinator({
@@ -177,7 +197,7 @@ async function assertRenameWinsGenerationRace(
             "thread-race",
             "Agent authority",
           );
-          synchronizations.push(synchronization);
+          trackSynchronization(synchronization);
           await synchronization;
         }
         nativeName = title;
@@ -185,10 +205,11 @@ async function assertRenameWinsGenerationRace(
           "thread-race",
           title,
         );
-        synchronizations.push(mirrorNotification);
+        trackSynchronization(mirrorNotification);
         await mirrorNotification;
       },
     });
+    titlesToClose = titles;
     if (phase === "after-generated-commit") {
       titles.onChange((snapshot) => {
         if (snapshot["thread-race"]?.status !== "generated" || injected) return;
@@ -198,23 +219,31 @@ async function assertRenameWinsGenerationRace(
           "thread-race",
           "Agent authority",
         );
-        synchronizations.push(synchronization);
+        trackSynchronization(synchronization);
       });
     }
     await titles.initialize();
     await titles.observe("thread-race", "Original title source");
     inference.resolve("Late generated");
-    for (
-      let attempt = 0;
-      attempt < 5_000 && synchronization === undefined;
-      attempt += 1
-    ) {
-      await tick();
-    }
+    await waitForTitleStage(
+      synchronizationStarted.promise,
+      `${phase} authority synchronization start`,
+      () =>
+        `tracked synchronizations=${String(
+          synchronizations.length,
+        )}; projection=${JSON.stringify(titles.snapshot()["thread-race"] ?? null)}`,
+    );
     assert.notEqual(synchronization, undefined);
     await synchronization;
     if (phase === "during-generated-mirror")
-      await until(() => synchronizations.length === 2);
+      await waitForTitleStage(
+        secondSynchronizationStarted.promise,
+        "generated mirror reconciliation start",
+        () =>
+          `tracked synchronizations=${String(synchronizations.length)}; projection=${JSON.stringify(
+            titles.snapshot()["thread-race"] ?? null,
+          )}`,
+      );
     for (let index = 0; index < synchronizations.length; index += 1)
       await synchronizations[index];
     assert.deepEqual(titles.snapshot()["thread-race"], {
@@ -233,49 +262,69 @@ async function assertRenameWinsGenerationRace(
         ? "Late generated"
         : "Agent authority",
     );
-    await titles.stop();
   } finally {
+    await titlesToClose?.close();
     await rm(directory, { recursive: true, force: true });
   }
 }
 
 class ControlledInference implements ThreadTitleInference {
   calls = 0;
-  #resolve: ((value: string) => void) | undefined;
+  #pending:
+    | {
+        resolve(value: string): void;
+        reject(error: Error): void;
+      }
+    | undefined;
 
-  async generate(): Promise<string> {
+  async generate(
+    _input: string,
+    _model: string,
+    signal: AbortSignal,
+  ): Promise<string> {
     this.calls += 1;
-    return await new Promise<string>((resolve) => {
-      this.#resolve = resolve;
+    return await new Promise<string>((resolve, reject) => {
+      const abort = (): void => pending.reject(abortError(signal));
+      const pending = {
+        resolve: (value: string): void => {
+          signal.removeEventListener("abort", abort);
+          resolve(value);
+        },
+        reject: (error: Error): void => {
+          signal.removeEventListener("abort", abort);
+          reject(error);
+        },
+      };
+      signal.addEventListener("abort", abort, { once: true });
+      if (signal.aborted) abort();
+      else this.#pending = pending;
     });
   }
 
   resolve(value: string): void {
-    this.#resolve?.(value);
-    this.#resolve = undefined;
+    this.#pending?.resolve(value);
+    this.#pending = undefined;
   }
 }
 
-async function waitForStatus(
-  titles: ZenXThreadTitleCoordinator,
-  threadId: string,
-  status: string,
-): Promise<void> {
-  for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    if (titles.snapshot()[threadId]?.status === status) return;
-    await tick();
-  }
-  assert.fail(`Timed out waiting for title status ${status}`);
+function signal(): { promise: Promise<void>; resolve(): void } {
+  let resolvePromise!: () => void;
+  let resolved = false;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve: () => {
+      if (resolved) return;
+      resolved = true;
+      resolvePromise();
+    },
+  };
 }
 
-async function until(predicate: () => boolean): Promise<void> {
-  for (let attempt = 0; attempt < 5_000; attempt += 1) {
-    if (predicate()) return;
-    await tick();
-  }
-  assert.fail("Timed out waiting for condition");
-}
-
-async function tick(): Promise<void> {
-  await new Promise<void>((resolve) => setImmediate(resolve));
+function abortError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("Title generation aborted", "AbortError");
 }

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -120,7 +120,7 @@ test(
   "Windows identity adapter rejects a stale identity and terminates the matching handle",
   { skip: process.platform !== "win32" },
   async () => {
-    const { child, identity } = await spawnWindowsIdentityFixture();
+    const { child, identity, settled } = await spawnWindowsIdentityFixture();
     try {
       const stale = await realWindowsProcessOperations.terminateProcessIdentity(
         {
@@ -137,7 +137,7 @@ test(
       );
       await waitForProcessExit(identity.pid);
     } finally {
-      killFixtureProcess(identity.pid);
+      await stopWindowsIdentityFixture(child, settled);
     }
   },
 );
@@ -146,7 +146,7 @@ test(
   "Windows identity adapter accepts exit after matching the open handle",
   { skip: process.platform !== "win32" },
   async () => {
-    const { child, identity } = await spawnWindowsIdentityFixture();
+    const { child, identity, settled } = await spawnWindowsIdentityFixture();
     try {
       const result = await terminateWindowsProcessIdentity(
         identity,
@@ -163,7 +163,7 @@ test(
       assert.deepEqual(result, { ok: true, error: "" });
       await waitForProcessExit(identity.pid);
     } finally {
-      killFixtureProcess(identity.pid);
+      await stopWindowsIdentityFixture(child, settled);
     }
   },
 );
@@ -626,70 +626,95 @@ function killFixtureProcess(pid: number): void {
 async function spawnWindowsIdentityFixture(): Promise<{
   child: ReturnType<typeof spawn>;
   identity: WindowsProcessIdentity & { startTime: string };
+  settled: Promise<void>;
 }> {
-  const script = [
-    "$start = [System.Diagnostics.Process]::GetCurrentProcess().StartTime.ToUniversalTime().Ticks",
-    "$start -= $start % 10",
-    '[Console]::Out.WriteLine("$PID|$start")',
-    "[Console]::Out.Flush()",
-    "while ($true) { Start-Sleep -Seconds 1 }",
-  ].join("; ");
   const child = spawn(
-    "powershell.exe",
-    ["-NoProfile", "-NonInteractive", "-Command", script],
-    { stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
+    process.execPath,
+    [
+      "-e",
+      "process.stdout.write(`${process.pid}|ready\\n`); setInterval(() => undefined, 1000)",
+    ],
+    { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
   );
   assert(child.pid !== undefined);
   assert(child.stdout !== null);
-  const line = await new Promise<string>((resolve, reject) => {
-    let output = "";
-    let settled = false;
-    const finish = (value: string | Error): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      child.stdout?.removeListener("data", onData);
-      child.removeListener("error", onError);
-      child.removeListener("exit", onExit);
-      if (value instanceof Error) {
-        killFixtureProcess(child.pid!);
-        reject(value);
-      } else resolve(value);
-    };
-    const onData = (chunk: string): void => {
-      output += chunk;
-      const newline = output.indexOf("\n");
-      if (newline >= 0) finish(output.slice(0, newline).trim());
-    };
-    const onError = (error: Error): void => finish(error);
-    const onExit = (code: number | null): void =>
-      finish(
-        new Error(
-          `Windows identity fixture exited with code ${String(code)} before reporting its identity`,
-        ),
-      );
-    const timer = setTimeout(
-      () => finish(new Error("Windows identity fixture did not become ready")),
-      10_000,
-    );
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", onData);
-    child.once("error", onError);
-    child.once("exit", onExit);
+  assert(child.stderr !== null);
+  const settled = new Promise<void>((resolve) => {
+    child.once("close", () => resolve());
+    child.once("error", () => resolve());
   });
-  const match = line.match(/^(\d+)\|(\d+)$/u);
-  if (match === null || Number(match[1]) !== child.pid) {
-    killFixtureProcess(child.pid);
-    throw new Error("Windows identity fixture reported an invalid identity");
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    if (stderr.length < 8_192) stderr += chunk;
+  });
+  try {
+    const line = await new Promise<string>((resolve, reject) => {
+      let output = "";
+      let settled = false;
+      const finish = (value: string | Error): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        child.stdout?.removeListener("data", onData);
+        child.removeListener("error", onError);
+        child.removeListener("exit", onExit);
+        if (value instanceof Error) reject(value);
+        else resolve(value);
+      };
+      const onData = (chunk: string): void => {
+        output += chunk;
+        const newline = output.indexOf("\n");
+        if (newline >= 0) finish(output.slice(0, newline).trim());
+      };
+      const onError = (error: Error): void => finish(error);
+      const onExit = (code: number | null): void =>
+        finish(
+          new Error(
+            `Windows identity fixture PID ${String(child.pid)} exited with code ${String(code)} and signal ${String(child.signalCode)} before reporting ready; stdout=${JSON.stringify(output)}; stderr=${JSON.stringify(stderr)}`,
+          ),
+        );
+      const timer = setTimeout(
+        () =>
+          finish(
+            new Error(
+              `Windows identity fixture PID ${String(child.pid)} did not become ready; exitCode=${String(child.exitCode)}; signal=${String(child.signalCode)}; stdout=${JSON.stringify(output)}; stderr=${JSON.stringify(stderr)}`,
+            ),
+          ),
+        10_000,
+      );
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", onData);
+      child.once("error", onError);
+      child.once("exit", onExit);
+    });
+    const match = line.match(/^(\d+)\|ready$/u);
+    if (match === null || Number(match[1]) !== child.pid)
+      throw new Error(
+        `Windows identity fixture PID ${String(child.pid)} reported invalid readiness ${JSON.stringify(line)}`,
+      );
+    const table = await realWindowsProcessOperations.captureProcessTable();
+    const identity = table.entries.find((entry) => entry.pid === child.pid);
+    if (identity?.startTime === null || identity?.startTime === undefined)
+      throw new Error(
+        `Windows identity fixture PID ${String(child.pid)} was ready but had no process-table identity`,
+      );
+    return {
+      child,
+      identity: { ...identity, startTime: identity.startTime },
+      settled,
+    };
+  } catch (error) {
+    await stopWindowsIdentityFixture(child, settled);
+    throw error;
   }
-  return {
-    child,
-    identity: {
-      pid: child.pid,
-      parentPid: process.pid,
-      processGroupId: null,
-      sessionId: null,
-      startTime: match[2]!,
-    },
-  };
+}
+
+async function stopWindowsIdentityFixture(
+  child: ReturnType<typeof spawn>,
+  settled: Promise<void>,
+): Promise<void> {
+  if (child.exitCode === null && child.signalCode === null)
+    child.kill("SIGKILL");
+  await settled;
 }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -387,7 +387,9 @@ export class ZenAppServer {
         // A terminal Item is externally observable before the execution
         // handle's finalizer removes it. Preserve idle => startable semantics
         // by awaiting that exact predecessor instead of racing its finalizer.
-        await predecessor.done;
+        // The predecessor's caller owns its outcome; admission needs only
+        // outcome-neutral writer quiescence after canonical terminal state.
+        await Promise.allSettled([predecessor.done]);
       }
       const pendingReplacement = this.#pendingReplacement(thread);
       if (

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -375,14 +375,20 @@ export class ZenAppServer {
       throw new AppServerError("invalid_request", "Turn input cannot be empty");
     }
     const launch = await this.#withThreadMutation(threadId, async () => {
-      if (this.#activeTurns.has(threadId)) {
-        throw new AppServerError(
-          "thread_busy",
-          `Thread ${threadId} already has a running turn`,
-        );
-      }
-
       const thread = await this.#requireThread(threadId);
+      const predecessor = this.#activeTurns.get(threadId);
+      if (predecessor !== undefined) {
+        if (!this.#isTerminal(thread, predecessor.turnId)) {
+          throw new AppServerError(
+            "thread_busy",
+            `Thread ${threadId} already has a running turn`,
+          );
+        }
+        // A terminal Item is externally observable before the execution
+        // handle's finalizer removes it. Preserve idle => startable semantics
+        // by awaiting that exact predecessor instead of racing its finalizer.
+        await predecessor.done;
+      }
       const pendingReplacement = this.#pendingReplacement(thread);
       if (
         pendingReplacement !== undefined &&

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../src/model.js";
 import { OpenAiCompatibleModel } from "../src/model/openai-compatible.js";
 import { projectThread } from "../src/protocol/codex/mapper.js";
-import { AgentRuntime } from "../src/runtime.js";
+import { AgentRuntime, type RunTurnOptions } from "../src/runtime.js";
 import {
   InMemoryThreadMetadataStore,
   JsonlThreadMetadataStore,
@@ -45,17 +45,20 @@ function createServer(
     tools?: ToolExecutor;
     idFactory?: () => string;
     runtimeIdFactory?: () => string;
+    runtime?: AgentRuntime;
   } = {},
 ): ZenAppServer {
   return new ZenAppServer({
     journal: options.journal ?? new InMemoryThreadJournal(),
-    runtime: new AgentRuntime({
-      model: options.model ?? new FakeModel(),
-      tools: options.tools ?? new ShellToolExecutor(),
-      ...(options.runtimeIdFactory === undefined
-        ? {}
-        : { idFactory: options.runtimeIdFactory }),
-    }),
+    runtime:
+      options.runtime ??
+      new AgentRuntime({
+        model: options.model ?? new FakeModel(),
+        tools: options.tools ?? new ShellToolExecutor(),
+        ...(options.runtimeIdFactory === undefined
+          ? {}
+          : { idFactory: options.runtimeIdFactory }),
+      }),
     modelCatalog:
       options.modelCatalog ??
       new StaticModelCatalog([{ id: "fake", isDefault: true }]),
@@ -1125,6 +1128,65 @@ test("allows only one active turn per thread under concurrent requests", async (
   assert.equal(rejected.length, 1);
   assert.match(String(rejected[0]?.reason), /already has a running turn/);
   await fulfilled[0]?.value.done;
+});
+
+test("waits for a terminal predecessor handle to settle before starting its successor", async () => {
+  const predecessorTerminal = testDeferred<void>();
+  const releasePredecessor = testDeferred<void>();
+  let runs = 0;
+  class DelayedSettlementRuntime extends AgentRuntime {
+    override async runTurn(options: RunTurnOptions): Promise<void> {
+      await super.runTurn(options);
+      runs += 1;
+      if (runs !== 1) return;
+      predecessorTerminal.resolve();
+      await releasePredecessor.promise;
+    }
+  }
+  const runtime = new DelayedSettlementRuntime({
+    model: new FakeModel(),
+    tools: new ShellToolExecutor(),
+  });
+  const server = createServer({ runtime });
+  const thread = await server.startThread();
+  const predecessor = await server.startTurn(thread.id, "first");
+  await testWithin(
+    predecessorTerminal.promise,
+    "predecessor canonical terminal Item before handle settlement",
+  );
+  assert.equal(
+    (await server.readThread(thread.id)).turns[0]?.status,
+    "completed",
+  );
+
+  let earlyOutcome:
+    | PromiseSettledResult<Awaited<ReturnType<typeof server.startTurn>>>
+    | undefined;
+  const successorOutcome = server.startTurn(thread.id, "second").then(
+    (value) => ({ status: "fulfilled", value }) as const,
+    (reason: unknown) => ({ status: "rejected", reason }) as const,
+  );
+  void successorOutcome.then((outcome) => {
+    earlyOutcome = outcome;
+  });
+  try {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(
+      earlyOutcome,
+      undefined,
+      "successor launch must wait while the terminal predecessor handle settles",
+    );
+  } finally {
+    releasePredecessor.resolve();
+  }
+
+  await predecessor.done;
+  const outcome = await testWithin(
+    successorOutcome,
+    "successor launch after predecessor handle settlement",
+  );
+  assert.equal(outcome.status, "fulfilled");
+  if (outcome.status === "fulfilled") await outcome.value.done;
 });
 
 test("deduplicates concurrent cold thread loads before starting a turn", async () => {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1189,6 +1189,69 @@ test("waits for a terminal predecessor handle to settle before starting its succ
   if (outcome.status === "fulfilled") await outcome.value.done;
 });
 
+test("does not let a rejected terminal predecessor handle reject successor admission", async () => {
+  const predecessorTerminal = testDeferred<void>();
+  const releasePredecessor = testDeferred<void>();
+  let runs = 0;
+  class RejectedSettlementRuntime extends AgentRuntime {
+    override async runTurn(options: RunTurnOptions): Promise<void> {
+      await super.runTurn(options);
+      runs += 1;
+      if (runs !== 1) return;
+      predecessorTerminal.resolve();
+      await releasePredecessor.promise;
+      throw new Error("fixture rejection after canonical terminal");
+    }
+  }
+  const runtime = new RejectedSettlementRuntime({
+    model: new FakeModel(),
+    tools: new ShellToolExecutor(),
+  });
+  const server = createServer({ runtime });
+  const thread = await server.startThread();
+  const predecessor = await server.startTurn(thread.id, "first");
+  await testWithin(
+    predecessorTerminal.promise,
+    "predecessor canonical terminal Item before rejected settlement",
+  );
+  assert.equal(
+    (await server.readThread(thread.id)).turns[0]?.status,
+    "completed",
+  );
+
+  let earlyOutcome:
+    | PromiseSettledResult<Awaited<ReturnType<typeof server.startTurn>>>
+    | undefined;
+  const successorOutcome = server.startTurn(thread.id, "second").then(
+    (value) => ({ status: "fulfilled", value }) as const,
+    (reason: unknown) => ({ status: "rejected", reason }) as const,
+  );
+  void successorOutcome.then((outcome) => {
+    earlyOutcome = outcome;
+  });
+  try {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(
+      earlyOutcome,
+      undefined,
+      "successor launch must wait while the terminal predecessor handle settles",
+    );
+  } finally {
+    releasePredecessor.resolve();
+  }
+
+  await assert.rejects(
+    predecessor.done,
+    /fixture rejection after canonical terminal/u,
+  );
+  const outcome = await testWithin(
+    successorOutcome,
+    "successor launch after rejected predecessor settlement",
+  );
+  assert.equal(outcome.status, "fulfilled");
+  if (outcome.status === "fulfilled") await outcome.value.done;
+});
+
 test("deduplicates concurrent cold thread loads before starting a turn", async () => {
   const backing = new InMemoryThreadJournal();
   const threadId = "cold_thread";


### PR DESCRIPTION
## Summary  - rebase onto current `main` (`8f54542`, including PR #113 trigger containment and PR #110 CSP behavior) and preserve those current-main boundaries - wait for the exact canonical-terminal predecessor execution handle before admitting a successor Turn, using outcome-neutral settlement so predecessor rejection remains owned by its caller - replace hosted self-control and title timing polls with owned notification/projection transitions and stage-specific diagnostics - settle title ownership, capability work, and the hosted App Server child before temporary-directory cleanup - add a fail-fast focused hosted-flake stress runner without retries or blanket timeout inflation  ## Lifecycle audit  Current main did not subsume the Issue #96 lifecycle gaps. PR #113 constrains Trigger child-process trees and PR #110 changes the Vite CSP path; neither provides Turn predecessor settlement, title/self-control transition observation, or the affected test teardown ownership. The rebased diff keeps the existing mutation, title ownership, and App Server manager boundaries and adds no coordinator, durable state machine, workflow retry, or global timeout increase.  The successor admission path captures the exact active predecessor handle under the existing Thread mutation boundary. It first requires that predecessor's canonical Turn to be terminal, then awaits `Promise.allSettled([predecessor.done])`. This preserves writer quiescence while ensuring a rejected predecessor handle cannot reject successor admission; the predecessor caller still observes the original rejection.  Title tests subscribe to the coordinator's owned `onChange` projection before checking the current snapshot. Hosted self-control tests subscribe to the exact `turn/completed` notification and expected Turn identity. Failures report the lifecycle stage, Thread/Turn identity, and last observed state.  Teardown now closes title coordinators (retiring tracked generation/store work) and stops the hosted App Server manager (settling accepted capabilities and the exact child process) before deleting their temporary directories.  ## Reproduction evidence  The original PR head `1265e27222c3231fc5b201d9682bbef26c021f2b` failed in three distinct hosted attempts:  - self-control successor raced the still-owned active handle and returned `thread_busy` - title tests timed out waiting for `failed` / `generated` - title teardown hit `ENOTEMPTY` while removing its temporary directory  A fourth attempt passed unchanged, confirming hosted timing sensitivity: https://github.com/albert-zen/zen/actions/runs/32285853964  The deterministic predecessor regression exposes canonical `turn_completed`, holds the exact execution handle unsettled, and then exercises both fulfilled and rejected settlement. Before the rejection follow-up, successor admission inherited the rejected predecessor outcome; the current implementation keeps the predecessor rejection with its original caller and admits the successor only after settlement.  ## Validation  Local Windows validation at exact head `a3e2887c4f855218a1929cbffb5a69182baf1c44`:  - focused predecessor admission: 3 passed (single-active contract plus fulfilled and rejected exact predecessor settlement) - focused hosted lifecycle tests: 4 passed (real self-control host plus title generated/failed/notification transitions) - `ZENX_HOSTED_FLAKE_ITERATIONS=20 ZENX_HOSTED_FLAKE_WORKERS=4 npm --workspace apps/zenx run stress:hosted-flakes`: 20 iterations × 4 focused tests, all passed - `npm run check`: format, lint, typecheck; 99 Node tests (98 passed, 1 platform skip); 38 IMZen tests passed - ZenX: brand generation/check, typecheck, and production build passed; full test run reported 469 passed, 10 skipped, and one unrelated Windows environment failure because symlink creation is not permitted (`package-zenx-portable.test.mjs`, `EPERM` creating the macOS fixture symlink) - `git diff --check`  Fresh GitHub checks are expected on the pushed rebased head; this body does not claim them before completion.  Closes #96 ## R3 merge-gate follow-up  R2 code review passed at `a3e2887c4f855218a1929cbffb5a69182baf1c44`, but that exact head failed both Windows fixture jobs on the original run and failed-job rerun. Those repeated failures were treated as unmet Issue #96 acceptance, not as rerunnable flakes.  The trigger failures had two owned-lifecycle gaps. The real identity fixture used a second cold PowerShell process merely to report readiness, while each termination helper dynamically compiled `Add-Type` inside its existing 4-second deadline. On timeout, the helper was killed but the promise returned before helper close, and fixture cleanup also did not wait for the pre-registered child close. The current head uses a lightweight Node ready fixture, reads its real identity through the production process-table adapter, binds identity check/kill/wait to one opened `.NET Process.Handle`, reports the last helper stage plus bounded stdout/stderr, and settles the exact helper and fixture child before returning.  The attached-browser smoke only polled `DevToolsActivePort` while discarding browser stdout/stderr and ignoring early child exit. Its finally block also waited for the fixture HTTP server before stopping the browser that could still own a connection. The current head registers bounded stdout/stderr/error/close observation immediately after spawn, races `DevToolsActivePort` readiness against child exit/error, reports PID/exit/signal/output/path/last-read diagnostics, then stops and settles the exact browser child before closing fixture connections and deleting the profile.  No readiness, termination, browser, or workflow timeout was increased; the existing 4-second termination, 10-second identity-ready, and 15-second browser-ready bounds remain unchanged. No retry or new coordinator/state machine was added.  Local Windows validation at exact head `fec094ef47b8823da27c74ae7341ecd18e497046`:  - full `trigger-program-runner.test.ts`: 12 passed, 4 platform skips - four parallel focused trigger processes: 8/8 real Windows identity-adapter cases passed - focused trigger cases after final ownership adjustment: 2/2 passed - real attached Chrome user-browser smoke: 3 consecutive passes with child/profile cleanup completing - deterministic invalid-executable probe: failed immediately on child exit with PID, exit code, stderr, DevToolsActivePort path, and last-read diagnostics - ZenX typecheck and production build passed - focused Prettier check and `git diff --check` passed  Fresh GitHub CI run https://github.com/albert-zen/zen/actions/runs/32390628433 passed 8/8 jobs on this exact head. The previously repeated Windows gates passed directly: WinApp/trigger in 45 seconds and attached user-browser smoke in 1 minute 21 seconds.   ## Final R3 settlement correction  R3 identified one remaining ownership error at `fec094ef47b8823da27c74ae7341ecd18e497046`: both new child observations treated every Node `ChildProcess.error` event as terminal, although an error emitted after spawn (including failed signal delivery) does not prove OS-process exit or guarantee `close`.  Exact head `b5ecc5d63a500e0fcdaafb5896a09f1c04f26235` centralizes the narrow owned-child terminal rule used by the trigger helper and browser smoke: a post-spawn error is retained only as diagnostic state; terminal settlement requires `close`, except for an explicit spawn failure with no PID proving that no process was created. DevToolsActivePort readiness now races only that terminal outcome. Trigger and browser teardown use one bounded, PID-targeted owned-child escalation and still wait for exact child close before later server/profile/temp cleanup. No timeout was increased, no retry was added, and no coordinator/state machine or broader lifecycle boundary was introduced.  Final local Windows evidence at this exact head:  - deterministic owned-child regressions: 3/3 passed (post-spawn error remains pending, no-PID spawn failure settles, cleanup stays fenced until close) - full trigger runner suite: 12 passed, 4 existing platform skips - four parallel real Windows identity-fixture workers: 8/8 passed - real attached Chrome user-browser smoke: 3 consecutive passes - invalid-executable browser probe: failed in about 2.5 seconds on child close with PID, exit/signal, stdout/stderr, DevToolsActivePort path, and last-read diagnostics - exact predecessor admission regressions: 3/3 passed, including fulfilled and rejected predecessor settlement - hosted lifecycle stress: 20 iterations across 2 workers, all passed - ZenX typecheck, production build, focused Prettier, and `git diff --check` passed - full ZenX test run: 472 passed, 10 skipped; the sole failure was the unrelated local Windows `EPERM` inability to create the macOS symlink fixture  Fresh exact-head GitHub CI run https://github.com/albert-zen/zen/actions/runs/32393920641 passed 8/8 jobs. The two acceptance-critical Windows gates passed directly: WinApp/trigger in 51 seconds and attached user-browser smoke in 1 minute 30 seconds.