### PR TITLE
fix(zenx): use canonical cwd as Project identity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -18,8 +18,9 @@
 - **ZenXThreadSummaryAdapter** — ZenX Electron main 通过既有 host-local 进程边界查询
   ZAS 原生 summary，并以 typed IPC 暴露给产品层，不拥有 Thread 语义或新增 wire method。
 - **ZenXProjectProjection** — ZenX main 的同一个实例把 host-profile workspace 与 ZAS
-  原生 Thread cwd 投影为 UI 和 Agent self-control 共用的 Project 读模型；Windows 路径折叠大小写，
-  POSIX 路径保留大小写，最近使用项由同一 host profile 持有且失效时不隐式回退，
+  原生 Thread cwd 按最近存在祖先的异步 realpath 归一为 UI 和 Agent self-control 共用的
+  Project 读模型；Windows 路径折叠大小写，POSIX 路径保留大小写，配置保留用户选择的展示路径，
+  realpath 不可用时退回 lexical absolute path，最近使用项由同一 host profile 持有且失效时不隐式回退，
   它不拥有 Project、Thread 或 journal 状态。
 - **ZenXDirectoryBrowser** — ZenX main 把 home、documents、Windows drive / POSIX root 与
   canonical 只读目录枚举投影给内部 picker；symlink/junction 只解析为目录目标，不修改文件系统。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -43,7 +43,8 @@ provider 与 skill/prompt 均由 ZenX 持有，不进入 Zen Core 或 Codex 协�
 
 ZenX Agent 的自控工具同样属于产品层：bundled capability package 经现有 registry
 显式授权 workspace/local-device 权限后才向 Agent 暴露；Project 列表只按已配置
-workspace 与 Thread 实际 cwd 派生；Thread 的创建、读取、状态、重命名、归档与取消归档，以及
+workspace 与 Thread 实际 cwd 的 canonical filesystem identity 派生，symlink/junction alias
+合并但保留用户选择的展示路径；Thread 的创建、读取、状态、重命名、归档与取消归档，以及
 `start | steer | replace` 发送全部经由 App Server。工具调用和目标 Thread 的结果分别
 进入各自权威 ItemList，不另建委派记录、消息队列或 transcript；互相监听
 `turn_completed` 后继续发起普通 Turn 是允许的。

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -3,9 +3,13 @@
 ## Desktop shell policy
 
 Projects are ZenX host-profile workspace entries grouped with ZAS native Thread
-`cwd`; they are not Core runtime objects. Add Project uses ZenX's read-only
-directory picker. Removing an entry only changes the host profile and never
-deletes the directory, its files, or Thread journals.
+`cwd` by canonical filesystem identity; symlink/junction aliases share one
+Project while the configured user-selected path remains its display path. The
+projection resolves the nearest existing ancestor asynchronously and falls back
+to the lexical absolute path when realpath is unavailable, so missing or denied
+paths remain usable. Projects are not Core runtime objects. Add Project uses
+ZenX's read-only directory picker. Removing an entry only changes the host
+profile and never deletes the directory, its files, or Thread journals.
 New Thread always carries an explicit configured Project `cwd`. The top-level
 action reuses the last Project used for a Thread; if that record is missing or
 the Project was removed, ZenX asks the user to choose and never falls back to

--- a/apps/zenx/src/main/capabilities/self-control-package.ts
+++ b/apps/zenx/src/main/capabilities/self-control-package.ts
@@ -9,10 +9,7 @@ import type {
   ThreadItem,
 } from "../../protocol-client/index.js";
 import type { ZenXCapabilityManifest, ZenXCapabilityPackage } from "./types.js";
-import {
-  projectPathKey,
-  ZenXProjectProjection,
-} from "../project-projection.js";
+import { ZenXProjectProjection } from "../project-projection.js";
 
 export const ZENX_SELF_CONTROL_CAPABILITY_ID = "zenx-self-control";
 export const ZENX_SELF_CONTROL_WORKSPACE_PERMISSION =
@@ -56,14 +53,14 @@ export class MutableAppServerRequestPort implements AppServerRequestPort {
     this.projectProjection = projectProjection;
   }
 
-  attach(
+  async attach(
     target: AppServerRequestTarget,
     configuredWorkspace?: string | null,
     configuredWorkspaces: readonly string[] = [],
-  ): void {
+  ): Promise<void> {
     this.#target = target;
     if (configuredWorkspace !== undefined) {
-      this.projectProjection.updateConfiguration(
+      await this.projectProjection.updateConfiguration(
         configuredWorkspaces,
         configuredWorkspace,
       );
@@ -353,7 +350,7 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
       MAX_LIST_LIMIT,
     );
     const threads = (await this.#appServer.request("thread/list", {})).data;
-    const snapshot = this.#appServer.projectProjection.project(
+    const snapshot = await this.#appServer.projectProjection.project(
       threads.map((thread) => ({
         id: thread.id,
         cwd: thread.status.type === "systemError" ? null : thread.cwd,
@@ -381,15 +378,20 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     const workspace = optionalString(args.workspace, "workspace");
     const cwd = optionalString(args.cwd, "cwd");
     if (workspace !== undefined && cwd !== undefined) {
-      if (projectPathKey(workspace) !== projectPathKey(cwd)) {
+      if (
+        (await this.#appServer.projectProjection.canonicalKey(workspace)) !==
+        (await this.#appServer.projectProjection.canonicalKey(cwd))
+      ) {
         throw new Error(
           "workspace and cwd filters must identify the same path",
         );
       }
     }
     const cwdFilter = workspace ?? cwd;
-    const resolvedFilter =
-      cwdFilter === undefined ? undefined : path.resolve(cwdFilter);
+    const filterKey =
+      cwdFilter === undefined
+        ? undefined
+        : await this.#appServer.projectProjection.canonicalKey(cwdFilter);
     const query = optionalString(args.query, "query")?.toLocaleLowerCase();
     const archived = optionalBoolean(args.archived, "archived") ?? false;
     const limit = boundedInteger(
@@ -398,15 +400,23 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
       DEFAULT_LIST_LIMIT,
       MAX_LIST_LIMIT,
     );
+    const listed = (await this.#appServer.request("thread/list", { archived }))
+      .data;
     const threads = (
-      await this.#appServer.request("thread/list", { archived })
-    ).data
-      .filter(
-        (thread) =>
-          resolvedFilter === undefined ||
-          (thread.cwd.length > 0 &&
-            projectPathKey(thread.cwd) === projectPathKey(resolvedFilter)),
+      await Promise.all(
+        listed.map(async (thread) => ({
+          thread,
+          matches:
+            filterKey === undefined ||
+            (thread.cwd.length > 0 &&
+              (await this.#appServer.projectProjection.canonicalKey(
+                thread.cwd,
+              )) === filterKey),
+        })),
       )
+    )
+      .filter(({ matches }) => matches)
+      .map(({ thread }) => thread)
       .filter((thread) => query === undefined || matchesQuery(thread, query))
       .sort((left, right) => right.updatedAt - left.updatedAt);
     return {
@@ -422,7 +432,7 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     assertOnly(args, ["cwd", "model", "approvalPolicy", "sandbox"]);
     const requestedCwd = path.resolve(requiredString(args.cwd, "cwd"));
     const cwd =
-      this.#appServer.projectProjection.configuredWorkspace(requestedCwd);
+      await this.#appServer.projectProjection.configuredWorkspace(requestedCwd);
     if (cwd === null)
       throw new Error("Configure the workspace as a ZenX Project first");
     const model = optionalString(args.model, "model");

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -159,7 +159,7 @@ app.whenReady().then(async () => {
       execPath: process.execPath,
       capabilityHost: capabilityService,
     });
-    selfControlPort.attach(appServerManager);
+    await selfControlPort.attach(appServerManager);
     titleCoordinator = new ZenXThreadTitleCoordinator({
       store: new ZenXThreadTitleStore(
         join(userDataDirectory, "thread-title-projections.json"),
@@ -214,10 +214,10 @@ app.whenReady().then(async () => {
           execPath: process.execPath,
           capabilityHost: capabilityService,
         });
-        selfControlPort.attach(appServerManager);
+        await selfControlPort.attach(appServerManager);
         await appServerManager.start();
       } else {
-        selfControlPort.attach(appServerManager);
+        await selfControlPort.attach(appServerManager);
         const restartErrors: Error[] = [];
         let hostStopped = false;
         try {
@@ -339,7 +339,7 @@ function installProtocolIpc(
     const threads = await manager.listThreadSummaries(
       readThreadSummaryListOptions(options),
     );
-    return projects.project(
+    return await projects.project(
       threads.map((thread) => ({
         id: thread.threadId,
         cwd:
@@ -565,7 +565,7 @@ async function syncProjectProjection(
   settings: ZenXSettingsService,
 ): Promise<void> {
   const profile = (await settings.publicSettings()).profile;
-  projectProjection.updateConfiguration(
+  await projectProjection.updateConfiguration(
     profile.workspaces,
     profile.workspace,
     profile.lastUsedWorkspace,

--- a/apps/zenx/src/main/project-projection.ts
+++ b/apps/zenx/src/main/project-projection.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 
 export interface ProjectProjectionThread {
@@ -19,106 +20,196 @@ export interface ZenXProjectProjectionSnapshot {
   lastUsedWorkspace: string | null;
 }
 
+type ProjectRealpath = (candidate: string) => Promise<string>;
+
+interface ProjectPathIdentity {
+  displayPath: string;
+  key: string;
+}
+
+const nodeProjectRealpath: ProjectRealpath = async (candidate) =>
+  await realpath(candidate);
+
 /** Shared ZenX product projection; it owns workspace configuration, never Project or Thread state. */
 export class ZenXProjectProjection {
   readonly #platform: NodeJS.Platform;
-  #workspaces: string[] = [];
-  #defaultWorkspace: string | null = null;
+  readonly #realpath: ProjectRealpath;
+  #workspaces: ProjectPathIdentity[] = [];
+  #defaultKey: string | null = null;
   #lastUsedWorkspace: string | null = null;
 
-  constructor(platform: NodeJS.Platform = process.platform) {
+  constructor(
+    platform: NodeJS.Platform = process.platform,
+    resolveRealpath: ProjectRealpath = nodeProjectRealpath,
+  ) {
     this.#platform = platform;
+    this.#realpath = resolveRealpath;
   }
 
-  updateConfiguration(
+  async updateConfiguration(
     workspaces: readonly string[],
     defaultWorkspace: string | null,
     lastUsedWorkspace: string | null = null,
-  ): void {
-    const unique = new Map<string, string>();
+  ): Promise<void> {
+    const unique = new Map<string, ProjectPathIdentity>();
     const candidates =
       defaultWorkspace === null
         ? workspaces
         : [defaultWorkspace, ...workspaces];
-    for (const workspace of candidates) {
-      const resolved = projectPath(workspace, this.#platform);
-      const key = projectPathKey(resolved, this.#platform);
-      if (!unique.has(key)) unique.set(key, resolved);
+    for (const workspace of await Promise.all(
+      candidates.map(
+        async (candidate) =>
+          await projectPathIdentity(candidate, this.#platform, this.#realpath),
+      ),
+    )) {
+      if (!unique.has(workspace.key)) unique.set(workspace.key, workspace);
     }
-    this.#workspaces = [...unique.values()];
-    this.#defaultWorkspace =
+    const nextWorkspaces = [...unique.values()];
+    const nextDefaultKey =
       defaultWorkspace === null
         ? null
-        : projectPath(defaultWorkspace, this.#platform);
-    this.#lastUsedWorkspace =
+        : (
+            await projectPathIdentity(
+              defaultWorkspace,
+              this.#platform,
+              this.#realpath,
+            )
+          ).key;
+    const lastUsedKey =
       lastUsedWorkspace === null
         ? null
-        : this.configuredWorkspace(lastUsedWorkspace);
+        : (
+            await projectPathIdentity(
+              lastUsedWorkspace,
+              this.#platform,
+              this.#realpath,
+            )
+          ).key;
+    const nextLastUsedWorkspace =
+      lastUsedKey === null
+        ? null
+        : (nextWorkspaces.find((workspace) => workspace.key === lastUsedKey)
+            ?.displayPath ?? null);
+    this.#workspaces = nextWorkspaces;
+    this.#defaultKey = nextDefaultKey;
+    this.#lastUsedWorkspace = nextLastUsedWorkspace;
   }
 
-  project(
+  async project(
     threads: readonly ProjectProjectionThread[],
-  ): ZenXProjectProjectionSnapshot {
+  ): Promise<ZenXProjectProjectionSnapshot> {
+    const configuredWorkspaces = this.#workspaces;
+    const defaultKey = this.#defaultKey;
+    const lastUsedWorkspace = this.#lastUsedWorkspace;
     const projects = new Map<string, ZenXProjectProjectionEntry>();
-    const defaultKey =
-      this.#defaultWorkspace === null
-        ? null
-        : projectPathKey(this.#defaultWorkspace, this.#platform);
-    for (const workspace of this.#workspaces) {
-      const key = projectPathKey(workspace, this.#platform);
-      projects.set(key, {
-        key,
-        workspace,
+    for (const workspace of configuredWorkspaces) {
+      projects.set(workspace.key, {
+        key: workspace.key,
+        workspace: workspace.displayPath,
         configured: true,
-        isDefault: key === defaultKey,
+        isDefault: workspace.key === defaultKey,
         threadIds: [],
       });
     }
     const unavailableThreadIds: string[] = [];
-    for (const thread of threads) {
-      if (thread.cwd === null || thread.cwd.trim().length === 0) {
+    const resolvedThreads = await Promise.all(
+      threads.map(async (thread) => ({
+        thread,
+        identity:
+          thread.cwd === null || thread.cwd.trim().length === 0
+            ? null
+            : await projectPathIdentity(
+                thread.cwd,
+                this.#platform,
+                this.#realpath,
+              ),
+      })),
+    );
+    for (const { thread, identity } of resolvedThreads) {
+      if (identity === null) {
         unavailableThreadIds.push(thread.id);
         continue;
       }
-      const workspace = projectPath(thread.cwd, this.#platform);
-      const key = projectPathKey(workspace, this.#platform);
-      const project = projects.get(key) ?? {
-        key,
-        workspace,
+      const project = projects.get(identity.key) ?? {
+        key: identity.key,
+        workspace: identity.displayPath,
         configured: false,
-        isDefault: key === defaultKey,
+        isDefault: identity.key === defaultKey,
         threadIds: [],
       };
       project.threadIds.push(thread.id);
-      projects.set(key, project);
+      projects.set(identity.key, project);
     }
     return {
       projects: [...projects.values()].sort((left, right) =>
         left.workspace.localeCompare(right.workspace),
       ),
       unavailableThreadIds,
-      lastUsedWorkspace: this.#lastUsedWorkspace,
+      lastUsedWorkspace,
     };
   }
 
-  configuredWorkspace(value: string): string | null {
-    const key = projectPathKey(value, this.#platform);
+  async configuredWorkspace(value: string): Promise<string | null> {
+    const key = await this.canonicalKey(value);
     return (
-      this.#workspaces.find(
-        (workspace) => projectPathKey(workspace, this.#platform) === key,
-      ) ?? null
+      this.#workspaces.find((workspace) => workspace.key === key)
+        ?.displayPath ?? null
     );
+  }
+
+  async canonicalKey(value: string): Promise<string> {
+    return (await projectPathIdentity(value, this.#platform, this.#realpath))
+      .key;
   }
 }
 
-export function projectPathKey(
+export async function projectPathKey(
   value: string,
   platform: NodeJS.Platform = process.platform,
-): string {
-  const resolved = projectPath(value, platform);
-  return platform === "win32" ? resolved.toLocaleLowerCase("en-US") : resolved;
+  resolveRealpath: ProjectRealpath = nodeProjectRealpath,
+): Promise<string> {
+  return (await projectPathIdentity(value, platform, resolveRealpath)).key;
 }
 
-function projectPath(value: string, platform: NodeJS.Platform): string {
-  return platform === "win32" ? path.win32.resolve(value) : path.resolve(value);
+async function projectPathIdentity(
+  value: string,
+  platform: NodeJS.Platform,
+  resolveRealpath: ProjectRealpath,
+): Promise<ProjectPathIdentity> {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const displayPath = pathApi.resolve(value);
+  const unresolved: string[] = [];
+  let cursor = displayPath;
+  let canonicalPath: string | undefined;
+
+  while (canonicalPath === undefined) {
+    try {
+      canonicalPath = await resolveRealpath(cursor);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") {
+        canonicalPath = displayPath;
+        unresolved.length = 0;
+        break;
+      }
+      const parent = pathApi.dirname(cursor);
+      if (parent === cursor) {
+        canonicalPath = cursor;
+        break;
+      }
+      unresolved.unshift(pathApi.basename(cursor));
+      cursor = parent;
+    }
+  }
+
+  const physicalPath = pathApi.normalize(
+    pathApi.join(canonicalPath, ...unresolved),
+  );
+  return {
+    displayPath,
+    key:
+      platform === "win32"
+        ? physicalPath.toLocaleLowerCase("en-US")
+        : physicalPath,
+  };
 }

--- a/apps/zenx/src/main/real-smoke.ts
+++ b/apps/zenx/src/main/real-smoke.ts
@@ -174,7 +174,7 @@ void app.whenReady().then(async () => {
       capabilityHost: capabilities,
       startupTimeoutMs: 20_000,
     });
-    port.attach(manager, workspace);
+    await port.attach(manager, workspace);
 
     await check("hosted-app-server", async () => {
       await manager!.start();

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -11,10 +11,10 @@ import {
   type ZenXHostProfile,
   ZenXHostProfileStore,
   validateHostProfile,
-  workspaceKey,
 } from "./host-profile.js";
 import { ZenXCredentialVault } from "./credential-vault.js";
 import { resolveZenXHostConfig } from "./host-config.js";
+import { projectPathKey } from "./project-projection.js";
 
 export class ZenXSettingsService {
   readonly #dataDirectory: string;
@@ -64,7 +64,7 @@ export class ZenXSettingsService {
   async initialize(environment: NodeJS.ProcessEnv): Promise<void> {
     const existing = await this.#profileStore.readOptional();
     if (existing !== undefined) {
-      this.#profile = existing;
+      this.#profile = await normalizeCanonicalWorkspaces(existing);
       return;
     }
     const configureWorkspace = environment.ZENX_CWD !== undefined;
@@ -73,7 +73,7 @@ export class ZenXSettingsService {
     if (legacy.provider.type === "openai-compatible") {
       await this.#vault.writeApiKey(legacy.provider.apiKey);
     }
-    this.#profile = fallback;
+    this.#profile = await normalizeCanonicalWorkspaces(fallback);
     await this.#profileStore.write(this.#profile);
   }
 
@@ -135,8 +135,11 @@ export class ZenXSettingsService {
   }
 
   async save(profile: ZenXHostProfile, apiKey?: string): Promise<void> {
-    const validated = validateHostProfile(profile);
+    const structurallyValidated = validateHostProfile(profile);
     await this.#queueProfileOperation(async () => {
+      const validated = await normalizeCanonicalWorkspaces(
+        structurallyValidated,
+      );
       if (apiKey !== undefined && apiKey.length > 0)
         await this.#vault.writeApiKey(apiKey);
       if (
@@ -155,19 +158,20 @@ export class ZenXSettingsService {
     if (candidate.length === 0) throw new Error("Workspace is required");
     const resolved = path.resolve(candidate);
     return await this.#queueProfileOperation(async () => {
-      const current = this.#requireProfile();
-      if (
-        current.workspaces.some(
-          (entry) => workspaceKey(entry) === workspaceKey(resolved),
-        )
-      )
-        return false;
+      const current = await normalizeCanonicalWorkspaces(
+        this.#requireProfile(),
+      );
+      const candidateKey = await projectPathKey(resolved);
+      const entries = await canonicalWorkspaceEntries(current.workspaces);
+      if (entries.some((entry) => entry.key === candidateKey)) return false;
       const isFirst = current.workspace === null;
-      const next = validateHostProfile({
-        ...current,
-        workspace: isFirst ? resolved : current.workspace,
-        workspaces: [...current.workspaces, resolved],
-      });
+      const next = await normalizeCanonicalWorkspaces(
+        validateHostProfile({
+          ...current,
+          workspace: isFirst ? resolved : current.workspace,
+          workspaces: [...current.workspaces, resolved],
+        }),
+      );
       await this.#profileStore.write(next);
       this.#profile = next;
       return isFirst;
@@ -175,22 +179,28 @@ export class ZenXSettingsService {
   }
 
   async removeWorkspace(workspace: string): Promise<boolean> {
-    const key = workspaceKey(workspace);
+    const key = await projectPathKey(workspace);
     return await this.#queueProfileOperation(async () => {
-      const current = this.#requireProfile();
-      const nextWorkspaces = current.workspaces.filter(
-        (entry) => workspaceKey(entry) !== key,
+      const current = await normalizeCanonicalWorkspaces(
+        this.#requireProfile(),
       );
+      const entries = await canonicalWorkspaceEntries(current.workspaces);
+      const nextWorkspaces = entries
+        .filter((entry) => entry.key !== key)
+        .map((entry) => entry.workspace);
       if (nextWorkspaces.length === current.workspaces.length) return false;
       const defaultRemoved =
-        current.workspace !== null && workspaceKey(current.workspace) === key;
-      const next = validateHostProfile({
-        ...current,
-        workspace: defaultRemoved
-          ? (nextWorkspaces[0] ?? null)
-          : current.workspace,
-        workspaces: nextWorkspaces,
-      });
+        current.workspace !== null &&
+        (await projectPathKey(current.workspace)) === key;
+      const next = await normalizeCanonicalWorkspaces(
+        validateHostProfile({
+          ...current,
+          workspace: defaultRemoved
+            ? (nextWorkspaces[0] ?? null)
+            : current.workspace,
+          workspaces: nextWorkspaces,
+        }),
+      );
       await this.#profileStore.write(next);
       this.#profile = next;
       return defaultRemoved;
@@ -198,20 +208,24 @@ export class ZenXSettingsService {
   }
 
   async setDefaultWorkspace(workspace: string): Promise<boolean> {
-    const key = workspaceKey(workspace);
+    const key = await projectPathKey(workspace);
     return await this.#queueProfileOperation(async () => {
-      const current = this.#requireProfile();
-      const selected = current.workspaces.find(
-        (entry) => workspaceKey(entry) === key,
+      const current = await normalizeCanonicalWorkspaces(
+        this.#requireProfile(),
       );
+      const selected = (
+        await canonicalWorkspaceEntries(current.workspaces)
+      ).find((entry) => entry.key === key)?.workspace;
       if (selected === undefined)
         throw new Error("Workspace is not configured");
       if (
         current.workspace !== null &&
-        workspaceKey(selected) === workspaceKey(current.workspace)
+        (await projectPathKey(current.workspace)) === key
       )
         return false;
-      const next = validateHostProfile({ ...current, workspace: selected });
+      const next = await normalizeCanonicalWorkspaces(
+        validateHostProfile({ ...current, workspace: selected }),
+      );
       await this.#profileStore.write(next);
       this.#profile = next;
       return true;
@@ -219,23 +233,27 @@ export class ZenXSettingsService {
   }
 
   async markWorkspaceUsed(workspace: string): Promise<void> {
-    const key = workspaceKey(workspace);
+    const key = await projectPathKey(workspace);
     await this.#queueProfileOperation(async () => {
-      const current = this.#requireProfile();
-      const selected = current.workspaces.find(
-        (entry) => workspaceKey(entry) === key,
+      const current = await normalizeCanonicalWorkspaces(
+        this.#requireProfile(),
       );
+      const selected = (
+        await canonicalWorkspaceEntries(current.workspaces)
+      ).find((entry) => entry.key === key)?.workspace;
       if (selected === undefined)
         throw new Error("Workspace is not configured");
       if (
         current.lastUsedWorkspace !== null &&
-        workspaceKey(current.lastUsedWorkspace) === key
+        (await projectPathKey(current.lastUsedWorkspace)) === key
       )
         return;
-      const next = validateHostProfile({
-        ...current,
-        lastUsedWorkspace: selected,
-      });
+      const next = await normalizeCanonicalWorkspaces(
+        validateHostProfile({
+          ...current,
+          lastUsedWorkspace: selected,
+        }),
+      );
       await this.#profileStore.write(next);
       this.#profile = next;
     });
@@ -306,6 +324,43 @@ export class ZenXSettingsService {
     );
     return result;
   }
+}
+
+async function normalizeCanonicalWorkspaces(
+  profile: ZenXHostProfile,
+): Promise<ZenXHostProfile> {
+  const candidates =
+    profile.workspace === null
+      ? profile.workspaces
+      : [profile.workspace, ...profile.workspaces];
+  const unique = new Map<string, string>();
+  for (const entry of await canonicalWorkspaceEntries(candidates)) {
+    if (!unique.has(entry.key)) unique.set(entry.key, entry.workspace);
+  }
+  const defaultKey =
+    profile.workspace === null ? null : await projectPathKey(profile.workspace);
+  const lastUsedKey =
+    profile.lastUsedWorkspace === null
+      ? null
+      : await projectPathKey(profile.lastUsedWorkspace);
+  return {
+    ...profile,
+    workspace: defaultKey === null ? null : (unique.get(defaultKey) ?? null),
+    workspaces: [...unique.values()],
+    lastUsedWorkspace:
+      lastUsedKey === null ? null : (unique.get(lastUsedKey) ?? null),
+  };
+}
+
+async function canonicalWorkspaceEntries(
+  workspaces: readonly string[],
+): Promise<Array<{ workspace: string; key: string }>> {
+  return await Promise.all(
+    workspaces.map(async (workspace) => ({
+      workspace: path.resolve(workspace),
+      key: await projectPathKey(workspace),
+    })),
+  );
 }
 
 function profileFromLegacy(

--- a/apps/zenx/test/project-projection.test.ts
+++ b/apps/zenx/test/project-projection.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -6,14 +9,14 @@ import {
   ZenXProjectProjection,
 } from "../src/main/project-projection.js";
 
-test("projects share Windows case-insensitive identity and keep empty configured workspaces", () => {
+test("projects share Windows case-insensitive identity and keep empty configured workspaces", async () => {
   const projection = new ZenXProjectProjection("win32");
-  projection.updateConfiguration(
+  await projection.updateConfiguration(
     ["C:\\Work\\Zen", "D:\\Empty"],
     "c:\\work\\zen",
     "C:\\WORK\\ZEN",
   );
-  const snapshot = projection.project([
+  const snapshot = await projection.project([
     { id: "thread-a", cwd: "C:\\WORK\\ZEN" },
     { id: "broken", cwd: null },
   ]);
@@ -44,26 +47,136 @@ test("projects share Windows case-insensitive identity and keep empty configured
   assert.equal(snapshot.lastUsedWorkspace, "c:\\work\\zen");
 });
 
-test("POSIX project identity preserves case", () => {
+test("POSIX project identity preserves case", async () => {
   assert.notEqual(
-    projectPathKey("/Work/Zen", "linux"),
-    projectPathKey("/work/zen", "linux"),
+    await projectPathKey("/Work/Zen", "linux"),
+    await projectPathKey("/work/zen", "linux"),
   );
 });
 
-test("does not invent a Project when host configuration is empty", () => {
+test("does not invent a Project when host configuration is empty", async () => {
   const projection = new ZenXProjectProjection("win32");
-  projection.updateConfiguration([], null);
-  assert.deepEqual(projection.project([]), {
+  await projection.updateConfiguration([], null);
+  assert.deepEqual(await projection.project([]), {
     projects: [],
     unavailableThreadIds: [],
     lastUsedWorkspace: null,
   });
-  assert.equal(projection.configuredWorkspace("C:\\unconfigured"), null);
+  assert.equal(await projection.configuredWorkspace("C:\\unconfigured"), null);
 });
 
-test("drops a last-used workspace that is no longer configured", () => {
+test("drops a last-used workspace that is no longer configured", async () => {
   const projection = new ZenXProjectProjection("linux");
-  projection.updateConfiguration(["/work/remaining"], null, "/work/removed");
-  assert.equal(projection.project([]).lastUsedWorkspace, null);
+  await projection.updateConfiguration(
+    ["/work/remaining"],
+    null,
+    "/work/removed",
+  );
+  assert.equal((await projection.project([])).lastUsedWorkspace, null);
 });
+
+test(
+  "POSIX symlink aliases share one Project and preserve the configured display path",
+  { skip: process.platform === "win32" },
+  async () => {
+    await withAliasedDirectory("dir", async ({ physical, alias }) => {
+      const projection = new ZenXProjectProjection();
+      await projection.updateConfiguration([alias], alias, physical);
+
+      const snapshot = await projection.project([
+        { id: "physical-thread", cwd: physical },
+        { id: "alias-thread", cwd: alias },
+      ]);
+
+      assert.equal(snapshot.projects.length, 1);
+      assert.equal(snapshot.projects[0]?.workspace, path.resolve(alias));
+      assert.deepEqual(snapshot.projects[0]?.threadIds, [
+        "physical-thread",
+        "alias-thread",
+      ]);
+      assert.equal(snapshot.lastUsedWorkspace, path.resolve(alias));
+    });
+  },
+);
+
+test(
+  "Windows junction aliases share one Project and preserve the configured display path",
+  { skip: process.platform !== "win32" },
+  async () => {
+    await withAliasedDirectory("junction", async ({ physical, alias }) => {
+      const projection = new ZenXProjectProjection();
+      await projection.updateConfiguration([alias], alias, physical);
+
+      const snapshot = await projection.project([
+        { id: "physical-thread", cwd: physical },
+        { id: "junction-thread", cwd: alias },
+      ]);
+
+      assert.equal(snapshot.projects.length, 1);
+      assert.equal(snapshot.projects[0]?.workspace, path.resolve(alias));
+      assert.deepEqual(snapshot.projects[0]?.threadIds, [
+        "physical-thread",
+        "junction-thread",
+      ]);
+      assert.equal(snapshot.lastUsedWorkspace, path.resolve(alias));
+    });
+  },
+);
+
+test(
+  "resolves aliases through the nearest existing ancestor for missing cwd paths",
+  { skip: process.platform === "win32" },
+  async () => {
+    await withAliasedDirectory("dir", async ({ physical, alias }) => {
+      const physicalMissing = path.join(physical, "missing", "workspace");
+      const aliasMissing = path.join(alias, "missing", "workspace");
+      const projection = new ZenXProjectProjection();
+      await projection.updateConfiguration([aliasMissing], aliasMissing);
+
+      const snapshot = await projection.project([
+        { id: "missing-physical", cwd: physicalMissing },
+      ]);
+
+      assert.equal(snapshot.projects.length, 1);
+      assert.equal(snapshot.projects[0]?.workspace, aliasMissing);
+      assert.deepEqual(snapshot.projects[0]?.threadIds, ["missing-physical"]);
+    });
+  },
+);
+
+test("falls back to the lexical absolute path when realpath is unavailable", async () => {
+  const permissionDenied = Object.assign(new Error("permission denied"), {
+    code: "EACCES",
+  });
+  const projection = new ZenXProjectProjection("linux", async () => {
+    throw permissionDenied;
+  });
+  const workspace = path.resolve("unreadable-workspace");
+
+  await projection.updateConfiguration([workspace], workspace, workspace);
+  const snapshot = await projection.project([
+    { id: "still-usable", cwd: workspace },
+  ]);
+
+  assert.equal(snapshot.projects[0]?.workspace, workspace);
+  assert.deepEqual(snapshot.projects[0]?.threadIds, ["still-usable"]);
+  assert.equal(snapshot.lastUsedWorkspace, workspace);
+});
+
+async function withAliasedDirectory(
+  type: "dir" | "junction",
+  run: (paths: { physical: string; alias: string }) => Promise<void>,
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-project-alias-"),
+  );
+  const physical = path.join(directory, "physical");
+  const alias = path.join(directory, "alias");
+  try {
+    await mkdir(physical);
+    await symlink(physical, alias, type);
+    await run({ physical, alias });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}

--- a/apps/zenx/test/self-control-capability.test.ts
+++ b/apps/zenx/test/self-control-capability.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -40,6 +40,7 @@ import {
   type ClientRequestParams,
   type ClientRequestResults,
   type ServerNotificationParams,
+  type Thread,
 } from "../src/protocol-client/index.js";
 import { ZenXProjectProjection } from "../src/main/project-projection.js";
 
@@ -60,7 +61,7 @@ test("real ZenX host control tools make active semantics explicit", async () => 
   const requestPort = new MutableAppServerRequestPort();
   const capabilities = await grantedSelfControl(directory, requestPort);
   const manager = managerFor(directory, capabilities);
-  requestPort.attach(manager, directory);
+  await requestPort.attach(manager, directory);
   const tools = capabilityTools(capabilities);
   try {
     await manager.start();
@@ -282,7 +283,7 @@ test("an Agent drives the complete bounded tracer bullet through App Server wire
       version: "0.1.0",
     },
   });
-  requestPort.attach(client, workspace);
+  await requestPort.attach(client, workspace);
   const approvals: string[] = [];
   client.onServerRequest(
     "item/commandExecution/requestApproval",
@@ -451,6 +452,94 @@ test("bounded reads omit command output and truncate message text", async () => 
     assert.match(serialized, /"outputOmitted":true/u);
   } finally {
     await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("self-control Project and Thread filters reconcile filesystem aliases", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-control-alias-"),
+  );
+  const physical = path.join(directory, "physical");
+  const alias = path.join(directory, "alias");
+  try {
+    await mkdir(physical);
+    await symlink(
+      physical,
+      alias,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    const projection = new ZenXProjectProjection();
+    await projection.updateConfiguration([alias], alias);
+    const thread: Thread = {
+      id: "thread-alias",
+      sessionId: "thread-alias",
+      forkedFromId: null,
+      parentThreadId: null,
+      preview: "Alias reconciliation",
+      ephemeral: false,
+      isPinned: false,
+      modelProvider: "fake",
+      createdAt: 1,
+      updatedAt: 2,
+      recencyAt: null,
+      status: { type: "idle" },
+      path: null,
+      cwd: physical,
+      cliVersion: "zen/0.1.0",
+      source: "appServer",
+      threadSource: null,
+      agentNickname: null,
+      agentRole: null,
+      gitInfo: null,
+      name: null,
+      turns: [],
+    };
+    const port: AppServerRequestPort = {
+      projectProjection: projection,
+      async request<M extends ClientRequestMethod>(
+        method: M,
+        _params: ClientRequestParams[M],
+      ): Promise<ClientRequestResults[M]> {
+        assert.equal(method, "thread/list");
+        return {
+          data: [thread],
+          nextCursor: null,
+          backwardsCursor: null,
+        } as ClientRequestResults[M];
+      },
+    };
+    const capabilities = await grantedSelfControl(directory, port);
+    try {
+      const tools = capabilityTools(capabilities);
+      const projects = await invoke(tools, "zenx_projects_list", {
+        limit: 10,
+      });
+      assert.deepEqual(projects.projects, [
+        {
+          workspace: path.resolve(alias),
+          cwd: path.resolve(alias),
+          configured: true,
+          isDefault: true,
+          threadCount: 1,
+          threadIds: [thread.id],
+          threadIdsTruncated: false,
+        },
+      ]);
+
+      const listed = await invoke(tools, "zenx_threads_list", {
+        workspace: alias,
+        cwd: physical,
+        limit: 10,
+      });
+      assert.equal(
+        (listed.threads as Array<{ threadId: string }>)[0]?.threadId,
+        thread.id,
+      );
+    } finally {
+      await capabilities.close();
+    }
+  } finally {
     await rm(directory, { recursive: true, force: true });
   }
 });

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -169,6 +176,18 @@ test("serializes concurrent workspace mutations without losing either update", a
   }
 });
 
+test(
+  "POSIX symlink aliases drive add, mark-used, default, and remove by one canonical key",
+  { skip: process.platform === "win32" },
+  async () => await exerciseAliasWorkspaceMutations("dir"),
+);
+
+test(
+  "Windows junction aliases drive add, mark-used, default, and remove by one canonical key",
+  { skip: process.platform !== "win32" },
+  async () => await exerciseAliasWorkspaceMutations("junction"),
+);
+
 test("clears the OAuth concurrency guard after failure so login can retry", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-oauth-retry-"));
   let attempts = 0;
@@ -202,6 +221,48 @@ test("clears the OAuth concurrency guard after failure so login can retry", asyn
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+async function exerciseAliasWorkspaceMutations(
+  type: "dir" | "junction",
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-settings-alias-"),
+  );
+  const physical = path.join(directory, "physical");
+  const alias = path.join(directory, "alias");
+  const other = path.join(directory, "other");
+  const marker = path.join(physical, "keep-me.txt");
+  try {
+    await Promise.all([mkdir(physical), mkdir(other)]);
+    await symlink(physical, alias, type);
+    await writeFile(marker, "keep");
+    const service = settingsFor(directory, {
+      login: async () => undefined,
+      logout: async () => undefined,
+      status: async () => ({ authenticated: false, expired: false }),
+    });
+    await service.initialize({ ZENX_CWD: physical });
+
+    assert.equal(await service.addWorkspace(alias), false);
+    await service.addWorkspace(other);
+    assert.equal(await service.setDefaultWorkspace(other), true);
+    await service.markWorkspaceUsed(alias);
+    let profile = (await service.publicSettings()).profile;
+    assert.equal(profile.lastUsedWorkspace, path.resolve(physical));
+    assert.equal(await service.setDefaultWorkspace(alias), true);
+    profile = (await service.publicSettings()).profile;
+    assert.equal(profile.workspace, path.resolve(physical));
+
+    assert.equal(await service.removeWorkspace(alias), true);
+    profile = (await service.publicSettings()).profile;
+    assert.deepEqual(profile.workspaces, [path.resolve(other)]);
+    assert.equal(profile.workspace, path.resolve(other));
+    assert.equal(profile.lastUsedWorkspace, null);
+    assert.equal(await readFile(marker, "utf8"), "keep");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
 
 test("cleans an aborted manual OAuth wait and accepts a later login", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-oauth-abort-"));


### PR DESCRIPTION
## Summary

- resolve Project identity through the nearest existing realpath ancestor while preserving the configured display path
- use the same canonical key for workspace mutations, Thread grouping, and self-control filters/creation
- fall back to lexical absolute paths when realpath is unavailable, with real symlink/junction coverage

## Validation

- npm run check
- npm --workspace apps/zenx run typecheck
- npm --workspace apps/zenx test (382 passed, 3 skipped)
- npm --workspace apps/zenx run build
- Prettier check and git diff --check

Closes #104