### PR TITLE
fix(zenx): complete sidebar interaction fixes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -62,9 +62,12 @@
 - **IMZen Gateway state file** — SDK SQLite repository 持久化 inbound/outbound
   幂等 claim 等可重建 bridge state，使 `side_effect_started` 在进程重启后仍不被
   重新授权；它不是 Zen Thread、transcript、queue 或 Agent state。
-- **ZenXHostProfile** — ZenX 主进程持久化的 Provider、ModelCatalog、workspace 与
-  审批默认值；它只用于组合本机 App Server host，不包含 credential，也不覆盖已存
-  Thread 的生效设置。
+- **ZenXHostProfile** — ZenX 主进程持久化的 Provider、ModelCatalog、workspace、
+  审批默认值与本地产品偏好；其中 host 配置只用于组合本机 App Server，不包含
+  credential，也不覆盖已存 Thread 的生效设置。
+- **ZenXThreadPinProjection** — ZenXHostProfile 按本机 threadId 顺序持久化 Sidebar Pin，
+  renderer 只把仍存在的 active Thread 投影到独立 Pinned section；Pin 不同步、不进入
+  canonical ItemList，也不改变 Runtime、调度或 Inbox 优先级。
 - **ZenXCredentialVault** — ZenX 通过操作系统安全存储保护的 Provider credential
   存放点；解密后的 secret 只在主进程内存中交给 host，绝不进入 renderer、进程环境、
   App Server 协议或 canonical ItemList。

--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -25,6 +25,7 @@ export interface ZenXHostProfile {
   workspaces: string[];
   lastUsedWorkspace: string | null;
   approvalPolicy: "always" | "never";
+  pinnedThreadIds: string[];
 }
 
 export interface PublicHostSettings {
@@ -121,6 +122,7 @@ export function validateHostProfile(value: unknown): ZenXHostProfile {
     value.lastUsedWorkspace,
     workspaces,
   );
+  const pinnedThreadIds = normalizePinnedThreadIds(value.pinnedThreadIds);
   return {
     version: 1,
     onboardingComplete: value.onboardingComplete === true,
@@ -132,7 +134,27 @@ export function validateHostProfile(value: unknown): ZenXHostProfile {
     workspaces,
     lastUsedWorkspace,
     approvalPolicy: value.approvalPolicy,
+    pinnedThreadIds,
   };
+}
+
+function normalizePinnedThreadIds(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > 4_096) {
+    throw new Error("ZenX pinned Thread list is invalid");
+  }
+  return [
+    ...new Set(
+      value.map((entry) => {
+        if (typeof entry !== "string")
+          throw new Error("ZenX pinned Thread id is invalid");
+        const threadId = entry.trim();
+        if (threadId.length === 0 || threadId.length > 512)
+          throw new Error("ZenX pinned Thread id is invalid");
+        return threadId;
+      }),
+    ),
+  ];
 }
 
 function normalizeLastUsedWorkspace(

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -509,6 +509,15 @@ function installSettingsIpc(
     },
   );
   ipcMain.handle(
+    ipcChannels.pinnedThreadsSet,
+    async (_event, threadIds: unknown) => {
+      if (!Array.isArray(threadIds))
+        throw new Error("Invalid pinned Thread list");
+      await settings.setPinnedThreadIds(threadIds);
+      return await settings.publicSettings();
+    },
+  );
+  ipcMain.handle(
     ipcChannels.directorySnapshot,
     async () => await directoryBrowser.snapshot(),
   );

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -241,6 +241,25 @@ export class ZenXSettingsService {
     });
   }
 
+  async setPinnedThreadIds(threadIds: readonly string[]): Promise<void> {
+    await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      const next = validateHostProfile({
+        ...current,
+        pinnedThreadIds: [...threadIds],
+      });
+      if (
+        next.pinnedThreadIds.length === current.pinnedThreadIds.length &&
+        next.pinnedThreadIds.every(
+          (threadId, index) => threadId === current.pinnedThreadIds[index],
+        )
+      )
+        return;
+      await this.#profileStore.write(next);
+      this.#profile = next;
+    });
+  }
+
   async login(
     openBrowser: (url: string) => void,
     manualCodeRequested: () => void,
@@ -337,5 +356,6 @@ function profileFromLegacy(
     workspaces: configureWorkspace ? [config.cwd] : [],
     lastUsedWorkspace: null,
     approvalPolicy: config.approvalPolicy,
+    pinnedThreadIds: [],
   };
 }

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -137,6 +137,10 @@ contextBridge.exposeInMainWorld("zenx", {
       await ipcRenderer.invoke(ipcChannels.workspaceDefault, workspace),
     markWorkspaceUsed: async (workspace: string): Promise<PublicHostSettings> =>
       await ipcRenderer.invoke(ipcChannels.workspaceUse, workspace),
+    setPinnedThreadIds: async (
+      threadIds: readonly string[],
+    ): Promise<PublicHostSettings> =>
+      await ipcRenderer.invoke(ipcChannels.pinnedThreadsSet, threadIds),
     getDirectoryBrowser: async (): Promise<DirectoryBrowserSnapshot> =>
       await ipcRenderer.invoke(ipcChannels.directorySnapshot),
     listDirectory: async (directory: string): Promise<DirectoryListing> =>

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -15,6 +15,7 @@ export const ipcChannels = {
   workspaceRemove: "zenx:settings:workspace-remove",
   workspaceDefault: "zenx:settings:workspace-default",
   workspaceUse: "zenx:settings:workspace-use",
+  pinnedThreadsSet: "zenx:settings:pinned-threads-set",
   directorySnapshot: "zenx:directory:snapshot",
   directoryList: "zenx:directory:list",
   subscriptionLogin: "zenx:settings:subscription-login",

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -73,6 +73,8 @@ export function App() {
   const projectLoadEpoch = useRef(0);
   const selectedThreadIdRef = useRef<string | null>(null);
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
+  const pinnedThreadIdsRef = useRef<string[]>([]);
+  const pinMutationQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
@@ -140,6 +142,26 @@ export function App() {
   const [composerStates, setComposerStates] = useState<
     Record<string, ComposerState>
   >({});
+
+  const confirmPinnedThreadIds = (threadIds: readonly string[]) => {
+    const confirmed = [...threadIds];
+    pinnedThreadIdsRef.current = confirmed;
+    setPinnedThreadIds(confirmed);
+  };
+
+  const queuePinMutation = (
+    update: (current: readonly string[]) => readonly string[],
+  ): Promise<void> => {
+    const result = pinMutationQueueRef.current.then(async () => {
+      const current = pinnedThreadIdsRef.current;
+      const next = update(current);
+      if (next === current) return;
+      const value = await window.zenx.settings.setPinnedThreadIds(next);
+      confirmPinnedThreadIds(value.profile.pinnedThreadIds);
+    });
+    pinMutationQueueRef.current = result.catch(() => undefined);
+    return result;
+  };
 
   const loadThreadSummaries = async (showLoading = false) => {
     const epoch = ++threadSummaryLoadEpoch.current;
@@ -337,13 +359,12 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    void window.zenx.settings
-      .get()
-      .then((value) => {
-        setPinnedThreadIds(value.profile.pinnedThreadIds);
-        if (!value.profile.onboardingComplete) setPage("settings");
-      })
-      .catch(() => undefined);
+    const result = pinMutationQueueRef.current.then(async () => {
+      const value = await window.zenx.settings.get();
+      confirmPinnedThreadIds(value.profile.pinnedThreadIds);
+      if (!value.profile.onboardingComplete) setPage("settings");
+    });
+    pinMutationQueueRef.current = result.catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -561,17 +582,15 @@ export function App() {
   };
 
   const changeThreadPinned = async (summary: NativeThreadSummary) => {
-    const pinned = pinnedThreadIds.includes(summary.threadId);
-    const next = pinned
-      ? pinnedThreadIds.filter((threadId) => threadId !== summary.threadId)
-      : [
-          summary.threadId,
-          ...pinnedThreadIds.filter(
-            (threadId) => threadId !== summary.threadId,
-          ),
-        ];
-    const value = await window.zenx.settings.setPinnedThreadIds(next);
-    setPinnedThreadIds(value.profile.pinnedThreadIds);
+    const shouldPin = !pinnedThreadIds.includes(summary.threadId);
+    await queuePinMutation((current) =>
+      shouldPin
+        ? [
+            summary.threadId,
+            ...current.filter((threadId) => threadId !== summary.threadId),
+          ]
+        : current.filter((threadId) => threadId !== summary.threadId),
+    );
   };
 
   const performThreadLifecycle = async (summary: NativeThreadSummary) => {
@@ -582,12 +601,13 @@ export function App() {
       summary.archived ? "thread/unarchive" : "thread/archive",
       { threadId: summary.threadId },
     );
-    if (!summary.archived && pinnedThreadIds.includes(summary.threadId)) {
+    if (!summary.archived) {
       try {
-        const value = await window.zenx.settings.setPinnedThreadIds(
-          pinnedThreadIds.filter((threadId) => threadId !== summary.threadId),
+        await queuePinMutation((current) =>
+          current.includes(summary.threadId)
+            ? current.filter((threadId) => threadId !== summary.threadId)
+            : current,
         );
-        setPinnedThreadIds(value.profile.pinnedThreadIds);
       } catch (error) {
         setRequestError(
           `Thread archived, but its local Pin could not be cleared: ${describeError(error)}`,

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -49,19 +49,17 @@ import {
 import { loadedPluginContributions } from "./plugin-contributions.js";
 import { RoomView } from "./RoomView.js";
 import { ScheduledView } from "./ScheduledView.js";
-import { SettingsView } from "./SettingsView.js";
+import { SettingsView, type SettingsTab } from "./SettingsView.js";
 import { Sidebar } from "./Sidebar.js";
 import {
+  derivePinnedThreads,
   readSidebarMode,
-  readThreadScope,
   threadHasActiveTurn,
   lastUsedProjectWorkspace,
   startProjectThread,
   threadTitle,
   writeSidebarMode,
-  writeThreadScope,
   type SidebarMode,
-  type ThreadScope,
 } from "./thread-list.js";
 import { applyThreadViewNotification } from "./thread-view-state.js";
 import { ThreadLifecycleAction } from "./ThreadLifecycleAction.js";
@@ -77,6 +75,7 @@ export function App() {
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
@@ -96,6 +95,7 @@ export function App() {
   const [threadSummaries, setThreadSummaries] = useState<NativeThreadSummary[]>(
     [],
   );
+  const [pinnedThreadIds, setPinnedThreadIds] = useState<string[]>([]);
   const [archivedThreadSummaries, setArchivedThreadSummaries] = useState<
     NativeThreadSummary[]
   >([]);
@@ -132,14 +132,6 @@ export function App() {
       return "projects";
     }
   });
-  const [threadScope, setThreadScope] = useState<ThreadScope>(() => {
-    try {
-      return readThreadScope(window.localStorage);
-    } catch {
-      return "active";
-    }
-  });
-  const threadScopeRef = useRef(threadScope);
   const [requestError, setRequestError] = useState<string | null>(null);
   const [threadLifecycleBusy, setThreadLifecycleBusy] = useState(false);
   const [threadLifecycleError, setThreadLifecycleError] = useState<
@@ -178,12 +170,10 @@ export function App() {
     setThreadListLoaded({ active: true, archived: true });
   };
 
-  const loadProjects = async (scope = threadScopeRef.current) => {
+  const loadProjects = async () => {
     const epoch = ++projectLoadEpoch.current;
     try {
-      const snapshot = await window.zenx.projects.get({
-        archived: scope === "archived",
-      });
+      const snapshot = await window.zenx.projects.get({ archived: false });
       if (projectLoadEpoch.current === epoch) setProjects(snapshot);
     } catch (error) {
       if (projectLoadEpoch.current === epoch)
@@ -350,6 +340,7 @@ export function App() {
     void window.zenx.settings
       .get()
       .then((value) => {
+        setPinnedThreadIds(value.profile.pinnedThreadIds);
         if (!value.profile.onboardingComplete) setPage("settings");
       })
       .catch(() => undefined);
@@ -387,8 +378,7 @@ export function App() {
       ? summary
       : { ...summary, name: titleSnapshot[summary.threadId]!.title },
   );
-  const visibleSummaries =
-    threadScope === "active" ? activeSummaries : archivedSummaries;
+  const pinnedSummaries = derivePinnedThreads(activeSummaries, pinnedThreadIds);
   const selectedSummary =
     [...activeSummaries, ...archivedSummaries].find(
       (summary) => summary.threadId === selectedThreadId,
@@ -410,19 +400,12 @@ export function App() {
         (startedWorkspace) => {
           void window.zenx.settings
             .markWorkspaceUsed(startedWorkspace)
-            .then(() => loadProjects("active"))
+            .then(() => loadProjects())
             .catch((error: unknown) => setRequestError(describeError(error)));
         },
       );
       if (selectionEpoch.current !== epoch) return;
       selectedThreadIdRef.current = result.thread.id;
-      threadScopeRef.current = "active";
-      setThreadScope("active");
-      try {
-        writeThreadScope(window.localStorage, "active");
-      } catch {
-        // The view remains active for this window.
-      }
       setPage("agent");
       setSidebarOpen(false);
       setSelectedThreadId(result.thread.id);
@@ -577,6 +560,20 @@ export function App() {
     }));
   };
 
+  const changeThreadPinned = async (summary: NativeThreadSummary) => {
+    const pinned = pinnedThreadIds.includes(summary.threadId);
+    const next = pinned
+      ? pinnedThreadIds.filter((threadId) => threadId !== summary.threadId)
+      : [
+          summary.threadId,
+          ...pinnedThreadIds.filter(
+            (threadId) => threadId !== summary.threadId,
+          ),
+        ];
+    const value = await window.zenx.settings.setPinnedThreadIds(next);
+    setPinnedThreadIds(value.profile.pinnedThreadIds);
+  };
+
   const performThreadLifecycle = async (summary: NativeThreadSummary) => {
     if (!summary.archived && threadHasActiveTurn(summary, threadDetail)) {
       throw new Error("Wait for the active Turn to finish before archiving.");
@@ -585,26 +582,36 @@ export function App() {
       summary.archived ? "thread/unarchive" : "thread/archive",
       { threadId: summary.threadId },
     );
+    if (!summary.archived && pinnedThreadIds.includes(summary.threadId)) {
+      try {
+        const value = await window.zenx.settings.setPinnedThreadIds(
+          pinnedThreadIds.filter((threadId) => threadId !== summary.threadId),
+        );
+        setPinnedThreadIds(value.profile.pinnedThreadIds);
+      } catch (error) {
+        setRequestError(
+          `Thread archived, but its local Pin could not be cleared: ${describeError(error)}`,
+        );
+      }
+    }
     await loadThreadSummaries();
     await loadProjects();
   };
 
   const changeThreadLifecycle = async () => {
     if (selectedSummary === null) return;
-    const nextScope: ThreadScope = selectedSummary.archived
-      ? "active"
-      : "archived";
     setThreadLifecycleBusy(true);
     setThreadLifecycleError(null);
     try {
       await performThreadLifecycle(selectedSummary);
-      threadScopeRef.current = nextScope;
-      setThreadScope(nextScope);
-      await loadProjects(nextScope);
-      try {
-        writeThreadScope(window.localStorage, nextScope);
-      } catch {
-        // The view remains valid for this window.
+      if (!selectedSummary.archived) {
+        selectionEpoch.current += 1;
+        selectedThreadIdRef.current = null;
+        setSelectedThreadId(null);
+        setThreadDetail(null);
+        setSelectedSettings(null);
+        setSettingsTab("archived");
+        openPage("settings");
       }
     } catch (error) {
       setThreadLifecycleError(describeError(error));
@@ -621,6 +628,7 @@ export function App() {
         open={sidebarOpen}
         onClose={() => setSidebarOpen(false)}
         onChangeThreadLifecycle={performThreadLifecycle}
+        onChangeThreadPinned={changeThreadPinned}
         onModeChange={(mode) => {
           setSidebarMode(mode);
           try {
@@ -650,34 +658,30 @@ export function App() {
         onRetryThreads={() => void loadThreadSummaries(true)}
         onRenameThread={renameThread}
         onSelectThread={(threadId) => void resumeThread(threadId)}
-        onThreadScopeChange={(scope) => {
-          threadScopeRef.current = scope;
-          setThreadScope(scope);
-          void loadProjects(scope);
-          try {
-            writeThreadScope(window.localStorage, scope);
-          } catch {
-            // The preference remains valid for this window.
-          }
-        }}
         pendingApprovalThreadIds={pendingThreadIds}
         pluginContributions={pluginContributions}
         selectedPage={page}
         selectedThreadId={selectedThreadId}
         serverReady={serverStatus.type === "ready"}
         projects={projects}
-        threadError={threadListErrors[threadScope]}
-        threadLoading={!threadListLoaded[threadScope]}
-        threadScope={threadScope}
-        threads={visibleSummaries}
+        pinnedThreads={pinnedSummaries}
+        threadError={threadListErrors.active}
+        threadLoading={!threadListLoaded.active}
+        threads={activeSummaries}
         triggerSnapshot={triggerSnapshot}
       />
 
       <main className="workspace">
         {page === "settings" ? (
           <SettingsView
-            onClose={() => openPage("agent")}
+            archivedError={threadListErrors.archived}
+            archivedLoading={!threadListLoaded.archived}
+            archivedThreads={archivedSummaries}
+            onRetryArchived={() => void loadThreadSummaries(true)}
+            onTabChange={setSettingsTab}
+            onUnarchive={performThreadLifecycle}
             onOpenSidebar={() => setSidebarOpen(true)}
+            tab={settingsTab}
           />
         ) : page === "triggers" ? (
           <ScheduledView
@@ -729,7 +733,7 @@ export function App() {
             onAddProject={() => setProjectPickerOpen(true)}
             onNewThread={() => {
               if (lastUsedWorkspace !== null) void newThread(lastUsedWorkspace);
-              else setSidebarOpen(true);
+              else setProjectPickerOpen(true);
             }}
             onOpenSidebar={() => setSidebarOpen(true)}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
@@ -901,7 +905,8 @@ function AgentSurface({
         </div>
         <div className="top-actions">
           {selectedSummary === null ||
-          selectedSummary.status === "systemError" ? null : (
+          selectedSummary.status === "systemError" ||
+          selectedSummary.archived ? null : (
             <ThreadLifecycleAction
               archived={selectedSummary.archived}
               busy={threadLifecycleBusy}

--- a/apps/zenx/src/renderer/src/DirectoryPicker.tsx
+++ b/apps/zenx/src/renderer/src/DirectoryPicker.tsx
@@ -102,9 +102,12 @@ export function DirectoryPicker({
     } else if (event.key === "End" && count > 0) {
       event.preventDefault();
       setActiveIndex(count - 1);
-    } else if (event.key === "Backspace" && listing?.parent !== null) {
-      event.preventDefault();
-      void open(listing!.parent!);
+    } else if (event.key === "Backspace") {
+      const parent = listing?.parent;
+      if (parent !== null && parent !== undefined) {
+        event.preventDefault();
+        void open(parent);
+      }
     }
   };
 

--- a/apps/zenx/src/renderer/src/ProviderLogo.tsx
+++ b/apps/zenx/src/renderer/src/ProviderLogo.tsx
@@ -1,0 +1,55 @@
+import { Icon } from "./icons.js";
+
+export type ProviderLogoKind =
+  "openai" | "deepseek" | "qwen" | "local" | "generic";
+
+export function ProviderLogo({ kind }: { kind: ProviderLogoKind }) {
+  return (
+    <span className={`provider-logo ${kind}`} aria-hidden="true">
+      {kind === "openai" ? (
+        <svg viewBox="0 0 18 18">
+          <path
+            d="M9 2.7a3 3 0 0 1 2.8 1.8 3 3 0 0 1 3.2 4.8 3 3 0 0 1-2.7 4.8A3 3 0 0 1 7 15.3a3 3 0 0 1-3.2-4.8 3 3 0 0 1 2.7-4.8A3 3 0 0 1 9 2.7Z"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.2"
+          />
+          <path
+            d="m6.4 5.8 5.2 3v5.3M11.6 12.2l-5.2-3V4.8m.1 6.1L9 9.5l2.5-1.4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.15"
+          />
+        </svg>
+      ) : kind === "deepseek" ? (
+        <svg viewBox="0 0 18 18">
+          <path
+            d="M3 10.5c1.8 2.9 5.2 4.4 8.2 3.4 2.4-.8 3.6-2.7 3.8-5.2-1.8 1-3.9.8-5.5-.6C7.4 6.2 5.6 7 3 10.5Z"
+            fill="currentColor"
+          />
+          <circle cx="11.8" cy="9.7" r=".8" fill="var(--surface-2)" />
+        </svg>
+      ) : kind === "qwen" ? (
+        <svg viewBox="0 0 18 18">
+          <path
+            d="M9 2.8a6.2 6.2 0 1 0 4.2 10.8l2 1.7v-4.6h-4.5l1.8 1.6A4.5 4.5 0 1 1 13.5 9h1.7A6.2 6.2 0 0 0 9 2.8Z"
+            fill="currentColor"
+          />
+          <circle cx="9" cy="9" r="1.3" fill="var(--surface-2)" />
+        </svg>
+      ) : kind === "local" ? (
+        <Icon name="terminal" size={13} />
+      ) : (
+        <svg viewBox="0 0 18 18">
+          <path
+            d="M9 3.1 14.9 9 9 14.9 3.1 9 9 3.1Z"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.2"
+          />
+          <circle cx="9" cy="9" r="1.4" fill="currentColor" />
+        </svg>
+      )}
+    </span>
+  );
+}

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type {
   PublicHostSettings,
   ZenXHostProfile,
@@ -7,17 +8,31 @@ import type {
 } from "../../main/host-profile.js";
 import { CapabilitySettings } from "./CapabilitySettings.js";
 import { Icon } from "./icons.js";
+import { ProviderLogo } from "./ProviderLogo.js";
+import { threadModelIdentity, threadTitle } from "./thread-list.js";
 
-type SettingsTab = "account" | "models" | "plugins" | "general";
+export type SettingsTab =
+  "account" | "models" | "plugins" | "general" | "archived";
 
 export function SettingsView({
-  onClose,
+  archivedError,
+  archivedLoading,
+  archivedThreads,
   onOpenSidebar,
+  onRetryArchived,
+  onTabChange,
+  onUnarchive,
+  tab,
 }: {
-  onClose(): void;
+  archivedError: string | null;
+  archivedLoading: boolean;
+  archivedThreads: readonly NativeThreadSummary[];
   onOpenSidebar?(): void;
+  onRetryArchived(): void;
+  onTabChange(tab: SettingsTab): void;
+  onUnarchive(thread: NativeThreadSummary): Promise<void>;
+  tab: SettingsTab;
 }) {
-  const [tab, setTab] = useState<SettingsTab>("account");
   const [settings, setSettings] = useState<PublicHostSettings | null>(null);
   const [draft, setDraft] = useState<ZenXHostProfile | null>(null);
   const [apiKey, setApiKey] = useState("");
@@ -77,18 +92,16 @@ export function SettingsView({
     setError(null);
     setStatus(null);
     try {
-      const modelList = models
-        .split(/[\n,]/u)
-        .map((value) => value.trim())
-        .filter(Boolean);
+      const modelList = normalizedModels(models);
       const value = await window.zenx.settings.save(
         { ...draft, onboardingComplete: true, models: modelList },
         apiKey.trim().length > 0 ? apiKey : undefined,
       );
       setSettings(value);
       setDraft(value.profile);
+      setModels(value.profile.models.join("\n"));
       setApiKey("");
-      setStatus("Settings saved · local host ready");
+      setStatus("Changes applied · local host restarted");
     } catch (reason) {
       setError(describeError(reason));
     } finally {
@@ -107,15 +120,24 @@ export function SettingsView({
     );
   }
   const provider = draft.provider;
+  const pendingProfile: ZenXHostProfile = {
+    ...draft,
+    onboardingComplete: true,
+    models: normalizedModels(models),
+  };
+  const hostDirty =
+    apiKey.trim().length > 0 ||
+    JSON.stringify(pendingProfile) !== JSON.stringify(settings.profile);
   const tabs: Array<{
     id: SettingsTab;
     label: string;
-    icon: "users" | "layers" | "trigger" | "settings";
+    icon: "users" | "layers" | "trigger" | "settings" | "archive";
   }> = [
     { id: "account", label: "Account", icon: "users" },
     { id: "models", label: "Models & provider", icon: "layers" },
     { id: "plugins", label: "Plugins", icon: "trigger" },
     { id: "general", label: "General", icon: "settings" },
+    { id: "archived", label: "Archived threads", icon: "archive" },
   ];
   return (
     <section className="product-page settings-view" aria-label="ZenX settings">
@@ -133,19 +155,6 @@ export function SettingsView({
             <h1>Settings</h1>
             <p>Account, models, plugins, and local host</p>
           </div>
-        </div>
-        <div className="page-header-actions">
-          <button className="quiet-button" type="button" onClick={onClose}>
-            Done
-          </button>
-          <button
-            className="primary-button"
-            type="button"
-            disabled={busy !== null}
-            onClick={() => void save()}
-          >
-            {busy === "save" ? "Restarting host…" : "Save and restart host"}
-          </button>
         </div>
       </header>
       <div className="page-scroll">
@@ -184,7 +193,7 @@ export function SettingsView({
               if (event.key === "End") next = buttons.length - 1;
               buttons[next]?.focus();
               const id = buttons[next]?.dataset.tab as SettingsTab | undefined;
-              if (id) setTab(id);
+              if (id) onTabChange(id);
             }}
           >
             {tabs.map((item) => (
@@ -194,7 +203,7 @@ export function SettingsView({
                 type="button"
                 role="tab"
                 aria-selected={tab === item.id}
-                onClick={() => setTab(item.id)}
+                onClick={() => onTabChange(item.id)}
               >
                 <Icon name={item.icon} />
                 <span>{item.label}</span>
@@ -241,6 +250,22 @@ export function SettingsView({
             {tab === "general" ? (
               <GeneralPanel draft={draft} setDraft={setDraft} />
             ) : null}
+            {tab === "archived" ? (
+              <ArchivedThreadsPanel
+                error={archivedError}
+                loading={archivedLoading}
+                onRetry={onRetryArchived}
+                onUnarchive={onUnarchive}
+                threads={archivedThreads}
+              />
+            ) : null}
+            {tab === "models" || tab === "general" ? (
+              <SettingsApplyBar
+                busy={busy === "save"}
+                dirty={hostDirty}
+                onApply={() => void save()}
+              />
+            ) : null}
             {error ? (
               <div className="settings-error" role="alert">
                 <Icon name="warning" />
@@ -257,6 +282,131 @@ export function SettingsView({
         </div>
       </div>
     </section>
+  );
+}
+
+export function SettingsApplyBar({
+  busy,
+  dirty,
+  onApply,
+}: {
+  busy: boolean;
+  dirty: boolean;
+  onApply(): void;
+}) {
+  return (
+    <div className={`settings-apply-bar${dirty ? " dirty" : ""}`}>
+      <div>
+        <strong>Local host configuration</strong>
+        <span>
+          {dirty
+            ? "Apply these changes when you are ready. ZenX will restart the local host."
+            : "No unapplied host changes."}
+        </span>
+      </div>
+      <button
+        className={dirty ? "primary-button" : "quiet-button"}
+        type="button"
+        disabled={!dirty || busy}
+        onClick={onApply}
+      >
+        {busy ? "Applying & restarting…" : "Apply & restart"}
+      </button>
+    </div>
+  );
+}
+
+export function ArchivedThreadsPanel({
+  error,
+  loading,
+  onRetry,
+  onUnarchive,
+  threads,
+}: {
+  error: string | null;
+  loading: boolean;
+  onRetry(): void;
+  onUnarchive(thread: NativeThreadSummary): Promise<void>;
+  threads: readonly NativeThreadSummary[];
+}) {
+  const [busyThreadId, setBusyThreadId] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const unarchive = async (thread: NativeThreadSummary) => {
+    setBusyThreadId(thread.threadId);
+    setActionError(null);
+    try {
+      await onUnarchive(thread);
+    } catch (reason) {
+      setActionError(describeError(reason));
+    } finally {
+      setBusyThreadId(null);
+    }
+  };
+  return (
+    <>
+      <header>
+        <h2>Archived threads</h2>
+        <p>
+          Archived conversations remain canonical Threads. Restore one to return
+          it to the active Sidebar.
+        </p>
+      </header>
+      {loading ? (
+        <div className="settings-empty" role="status">
+          Loading archived Threads…
+        </div>
+      ) : error !== null ? (
+        <div className="settings-empty settings-error" role="alert">
+          <span>{error}</span>
+          <button className="quiet-button" type="button" onClick={onRetry}>
+            Try again
+          </button>
+        </div>
+      ) : threads.length === 0 ? (
+        <div className="settings-empty">
+          No archived Threads. Conversations you archive will appear here.
+        </div>
+      ) : (
+        <div className="archived-thread-list">
+          {threads.map((thread) => {
+            const identity = threadModelIdentity(thread);
+            const busy = busyThreadId === thread.threadId;
+            const workspace =
+              thread.status === "systemError"
+                ? "Unavailable journal"
+                : thread.currentMetadata.cwd;
+            return (
+              <article className="archived-thread-row" key={thread.threadId}>
+                <div className="archived-thread-copy">
+                  <strong>{threadTitle(thread)}</strong>
+                  <span title={workspace}>{workspace}</span>
+                  {identity === null ? null : (
+                    <small>
+                      <ProviderLogo kind={identity.providerKind} />
+                      {identity.label}
+                    </small>
+                  )}
+                </div>
+                <button
+                  className="quiet-button"
+                  type="button"
+                  disabled={busyThreadId !== null}
+                  onClick={() => void unarchive(thread)}
+                >
+                  {busy ? "Restoring…" : "Unarchive"}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      )}
+      {actionError === null ? null : (
+        <div className="settings-error" role="alert">
+          <Icon name="warning" />
+          {actionError}
+        </div>
+      )}
+    </>
   );
 }
 
@@ -560,8 +710,8 @@ function GeneralPanel({
           <div>
             <strong>Zen App Server</strong>
             <span>
-              Saving restarts the local host with these defaults. Existing
-              Thread settings remain authoritative.
+              Applying changes restarts the local host with these defaults.
+              Existing Thread settings remain authoritative.
             </span>
           </div>
           <span className="status-good">Local</span>
@@ -623,4 +773,11 @@ function ManualCode() {
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function normalizedModels(value: string): string[] {
+  return value
+    .split(/[\n,]/u)
+    .map((model) => model.trim())
+    .filter(Boolean);
 }

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { TriggerSnapshot } from "../../main/trigger-types.js";
@@ -6,6 +13,7 @@ import type { Thread } from "../../protocol-client/index.js";
 import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
 import { Icon } from "./icons.js";
 import type { LoadedPluginContribution } from "./plugin-contributions.js";
+import { ProviderLogo } from "./ProviderLogo.js";
 import {
   deriveInboxSections,
   deriveProjectGroups,
@@ -14,7 +22,6 @@ import {
   threadProject,
   threadTitle,
   type SidebarMode,
-  type ThreadScope,
 } from "./thread-list.js";
 
 interface SidebarProps {
@@ -22,6 +29,7 @@ interface SidebarProps {
   open: boolean;
   onClose(): void;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onModeChange(mode: SidebarMode): void;
   onNewThread(workspace?: string): void;
   onAddProject(): void;
@@ -32,7 +40,6 @@ interface SidebarProps {
   onRetryThreads(): void;
   onRenameThread(threadId: string, title: string): Promise<void>;
   onSelectThread(threadId: string): void;
-  onThreadScopeChange(scope: ThreadScope): void;
   pendingApprovalThreadIds: ReadonlySet<string>;
   pluginContributions: readonly LoadedPluginContribution[];
   selectedPage: "agent" | "triggers" | "rooms" | "settings";
@@ -41,8 +48,8 @@ interface SidebarProps {
   liveThread: Thread | null;
   threadError: string | null;
   threadLoading: boolean;
-  threadScope: ThreadScope;
   projects: ZenXProjectProjectionSnapshot;
+  pinnedThreads: readonly NativeThreadSummary[];
   threads: readonly NativeThreadSummary[];
   triggerSnapshot: TriggerSnapshot;
 }
@@ -52,6 +59,7 @@ export function Sidebar({
   open,
   onClose,
   onChangeThreadLifecycle,
+  onChangeThreadPinned,
   onModeChange,
   onNewThread,
   onAddProject,
@@ -62,7 +70,6 @@ export function Sidebar({
   onRetryThreads,
   onRenameThread,
   onSelectThread,
-  onThreadScopeChange,
   pendingApprovalThreadIds,
   pluginContributions,
   selectedPage,
@@ -71,8 +78,8 @@ export function Sidebar({
   liveThread,
   threadError,
   threadLoading,
-  threadScope,
   projects,
+  pinnedThreads,
   threads,
   triggerSnapshot,
 }: SidebarProps) {
@@ -89,6 +96,29 @@ export function Sidebar({
   const configuredProjects = projects.projects.filter(
     (project) => project.configured,
   );
+  const pinnedThreadIds = useMemo(
+    () => new Set(pinnedThreads.map((thread) => thread.threadId)),
+    [pinnedThreads],
+  );
+  const [pendingPinFocus, setPendingPinFocus] = useState<
+    "pinned" | "list" | null
+  >(null);
+  const changeThreadPinned = async (thread: NativeThreadSummary) => {
+    const willPin = !pinnedThreadIds.has(thread.threadId);
+    await onChangeThreadPinned(thread);
+    setPendingPinFocus(willPin && mode === "projects" ? "pinned" : "list");
+  };
+  useLayoutEffect(() => {
+    if (pendingPinFocus === null) return;
+    const target = document.getElementById(
+      pendingPinFocus === "pinned"
+        ? "sidebar-pinned-heading"
+        : "sidebar-thread-list-heading",
+    );
+    if (target === null) return;
+    target.focus();
+    setPendingPinFocus(null);
+  }, [mode, pendingPinFocus, pinnedThreads]);
   const watchingThreadIds = useMemo(
     () =>
       new Set(
@@ -111,24 +141,22 @@ export function Sidebar({
               <span>ZENX</span>
             </div>
             <div className="brand-actions">
-              {threadScope === "active" ? (
-                <button
-                  className="icon-button inbox-button"
-                  type="button"
-                  aria-label={
-                    mode === "inbox" ? "Return to projects" : "Open inbox"
-                  }
-                  aria-pressed={mode === "inbox"}
-                  onClick={() =>
-                    onModeChange(mode === "inbox" ? "projects" : "inbox")
-                  }
-                >
-                  <Icon name="inbox" />
-                  {pendingApprovalThreadIds.size > 0 ? (
-                    <span className="inbox-dot" aria-hidden="true" />
-                  ) : null}
-                </button>
-              ) : null}
+              <button
+                className="icon-button inbox-button"
+                type="button"
+                aria-label={
+                  mode === "inbox" ? "Return to projects" : "Open inbox"
+                }
+                aria-pressed={mode === "inbox"}
+                onClick={() =>
+                  onModeChange(mode === "inbox" ? "projects" : "inbox")
+                }
+              >
+                <Icon name="inbox" />
+                {pendingApprovalThreadIds.size > 0 ? (
+                  <span className="inbox-dot" aria-hidden="true" />
+                ) : null}
+              </button>
             </div>
           </div>
 
@@ -163,26 +191,6 @@ export function Sidebar({
               ))}
             </section>
           )}
-
-          <div
-            className="thread-scope-tabs"
-            role="tablist"
-            aria-label="Thread views"
-          >
-            {(["active", "archived"] as const).map((scope) => (
-              <button
-                aria-controls="thread-scope-panel"
-                id={`thread-scope-${scope}`}
-                key={scope}
-                type="button"
-                role="tab"
-                aria-selected={threadScope === scope}
-                onClick={() => onThreadScopeChange(scope)}
-              >
-                {scope === "active" ? "Active" : "Archived"}
-              </button>
-            ))}
-          </div>
 
           <div className="new-thread-control">
             <button
@@ -238,10 +246,9 @@ export function Sidebar({
           </div>
 
           <div className="sidebar-view-head">
-            {threadScope === "archived" ? (
-              <strong>Archived</strong>
-            ) : mode === "projects" ? (
+            {mode === "projects" ? (
               <button
+                id="sidebar-thread-list-heading"
                 className="projects-section-toggle"
                 type="button"
                 aria-expanded={projectsOpen}
@@ -255,15 +262,19 @@ export function Sidebar({
                 <strong>Projects</strong>
               </button>
             ) : (
-              <strong>Inbox</strong>
+              <strong id="sidebar-thread-list-heading" tabIndex={-1}>
+                Inbox
+              </strong>
             )}
             {mode === "projects" ? (
               <button
                 className="sidebar-inline-action"
                 type="button"
+                aria-label="Add project"
+                title="Add project"
                 onClick={onAddProject}
               >
-                Add project
+                <Icon name="folder-plus" size={14} />
               </button>
             ) : (
               <span>{threads.length}</span>
@@ -273,16 +284,13 @@ export function Sidebar({
 
         <div
           className="sidebar-scroll"
-          id="thread-scope-panel"
-          role="tabpanel"
-          aria-labelledby={`thread-scope-${threadScope}`}
+          aria-labelledby="sidebar-thread-list-heading"
         >
           {!serverReady ? (
             <p className="sidebar-empty">Waiting for the local App Server.</p>
           ) : threadLoading ? (
             <p className="sidebar-empty" role="status">
-              Loading {threadScope === "active" ? "active" : "archived"}{" "}
-              Threads…
+              Loading active Threads…
             </p>
           ) : threadError !== null ? (
             <div className="sidebar-empty sidebar-error" role="alert">
@@ -291,60 +299,76 @@ export function Sidebar({
                 Try again
               </button>
             </div>
-          ) : threadScope === "archived" && threads.length === 0 ? (
-            <p className="sidebar-empty">
-              No archived Threads yet. Archived conversations stay safe here
-              until you restore them.
-            </p>
-          ) : threadScope === "active" &&
-            mode === "inbox" &&
-            threads.length === 0 ? (
+          ) : mode === "inbox" && threads.length === 0 ? (
             <p className="sidebar-empty">
               Your conversations will appear here.
             </p>
-          ) : threadScope === "active" && mode === "inbox" ? (
+          ) : mode === "inbox" ? (
             <InboxView
               onSelectThread={onSelectThread}
               onChangeThreadLifecycle={onChangeThreadLifecycle}
+              onChangeThreadPinned={changeThreadPinned}
               onRenameThread={onRenameThread}
               pendingApprovalThreadIds={pendingApprovalThreadIds}
               selectedThreadId={selectedThreadId}
               threads={threads}
               liveThread={liveThread}
+              pinnedThreadIds={pinnedThreadIds}
               watchingThreadIds={watchingThreadIds}
             />
-          ) : !projectsOpen ? null : (
-            <ProjectsView
-              projects={projects}
-              onNewThread={onNewThread}
-              onRemoveProject={onRemoveProject}
-              onSetDefaultProject={onSetDefaultProject}
-              onSelectThread={onSelectThread}
-              onChangeThreadLifecycle={onChangeThreadLifecycle}
-              onRenameThread={onRenameThread}
-              pendingApprovalThreadIds={pendingApprovalThreadIds}
-              selectedThreadId={selectedThreadId}
-              threads={threads}
-              liveThread={liveThread}
-              watchingThreadIds={watchingThreadIds}
-            />
+          ) : (
+            <>
+              {pinnedThreads.length === 0 ? null : (
+                <PinnedThreadsView
+                  liveThread={liveThread}
+                  onChangeThreadLifecycle={onChangeThreadLifecycle}
+                  onChangeThreadPinned={changeThreadPinned}
+                  onRenameThread={onRenameThread}
+                  onSelectThread={onSelectThread}
+                  pendingApprovalThreadIds={pendingApprovalThreadIds}
+                  selectedThreadId={selectedThreadId}
+                  threads={pinnedThreads}
+                  watchingThreadIds={watchingThreadIds}
+                />
+              )}
+              {!projectsOpen ? null : (
+                <ProjectsView
+                  projects={projects}
+                  onNewThread={onNewThread}
+                  onRemoveProject={onRemoveProject}
+                  onSetDefaultProject={onSetDefaultProject}
+                  onSelectThread={onSelectThread}
+                  onChangeThreadLifecycle={onChangeThreadLifecycle}
+                  onChangeThreadPinned={changeThreadPinned}
+                  onRenameThread={onRenameThread}
+                  pendingApprovalThreadIds={pendingApprovalThreadIds}
+                  selectedThreadId={selectedThreadId}
+                  threads={threads.filter(
+                    (thread) => !pinnedThreadIds.has(thread.threadId),
+                  )}
+                  liveThread={liveThread}
+                  pinnedThreadIds={pinnedThreadIds}
+                  watchingThreadIds={watchingThreadIds}
+                />
+              )}
+            </>
           )}
         </div>
 
         <footer className="sidebar-footer">
+          <button
+            className="settings-nav-row"
+            type="button"
+            aria-current={selectedPage === "settings" ? "page" : undefined}
+            onClick={onOpenSettings}
+          >
+            <Icon name="settings" />
+            <span>Settings</span>
+          </button>
           <div className="service-status">
             <span className={`live-dot${serverReady ? " ready" : ""}`} />
             <span>{serverReady ? "Local service ready" : "Connecting…"}</span>
           </div>
-          <button
-            className="icon-button"
-            type="button"
-            aria-current={selectedPage === "settings" ? "page" : undefined}
-            aria-label="Settings"
-            onClick={onOpenSettings}
-          >
-            <Icon name="settings" />
-          </button>
         </footer>
       </aside>
       <button
@@ -362,19 +386,23 @@ function InboxView({
   selectedThreadId,
   onSelectThread,
   onChangeThreadLifecycle,
+  onChangeThreadPinned,
   onRenameThread,
   pendingApprovalThreadIds,
   liveThread,
   watchingThreadIds,
+  pinnedThreadIds,
 }: {
   threads: readonly NativeThreadSummary[];
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
+  pinnedThreadIds: ReadonlySet<string>;
 }) {
   return deriveInboxSections(
     threads,
@@ -390,9 +418,11 @@ function InboxView({
             key={thread.threadId}
             hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
             onChangeThreadLifecycle={onChangeThreadLifecycle}
+            onChangeThreadPinned={onChangeThreadPinned}
             onRenameThread={onRenameThread}
             onSelectThread={onSelectThread}
             pendingApproval={pendingApprovalThreadIds.has(thread.threadId)}
+            pinned={pinnedThreadIds.has(thread.threadId)}
             selected={thread.threadId === selectedThreadId}
             thread={thread}
             watching={watchingThreadIds.has(thread.threadId)}
@@ -400,6 +430,54 @@ function InboxView({
         ))}
       </section>
     ),
+  );
+}
+
+function PinnedThreadsView({
+  liveThread,
+  onChangeThreadLifecycle,
+  onChangeThreadPinned,
+  onRenameThread,
+  onSelectThread,
+  pendingApprovalThreadIds,
+  selectedThreadId,
+  threads,
+  watchingThreadIds,
+}: {
+  liveThread: Thread | null;
+  onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
+  onRenameThread(threadId: string, title: string): Promise<void>;
+  onSelectThread(threadId: string): void;
+  pendingApprovalThreadIds: ReadonlySet<string>;
+  selectedThreadId: string | null;
+  threads: readonly NativeThreadSummary[];
+  watchingThreadIds: ReadonlySet<string>;
+}) {
+  return (
+    <section
+      className="pinned-thread-group"
+      aria-labelledby="sidebar-pinned-heading"
+    >
+      <h2 id="sidebar-pinned-heading" tabIndex={-1}>
+        Pinned
+      </h2>
+      {threads.map((thread) => (
+        <ThreadRow
+          hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
+          key={thread.threadId}
+          onChangeThreadLifecycle={onChangeThreadLifecycle}
+          onChangeThreadPinned={onChangeThreadPinned}
+          onRenameThread={onRenameThread}
+          onSelectThread={onSelectThread}
+          pendingApproval={pendingApprovalThreadIds.has(thread.threadId)}
+          pinned
+          selected={thread.threadId === selectedThreadId}
+          thread={thread}
+          watching={watchingThreadIds.has(thread.threadId)}
+        />
+      ))}
+    </section>
   );
 }
 
@@ -412,10 +490,12 @@ function ProjectsView({
   selectedThreadId,
   onSelectThread,
   onChangeThreadLifecycle,
+  onChangeThreadPinned,
   onRenameThread,
   pendingApprovalThreadIds,
   liveThread,
   watchingThreadIds,
+  pinnedThreadIds,
 }: {
   projects: ZenXProjectProjectionSnapshot;
   onNewThread(workspace?: string): void;
@@ -425,10 +505,12 @@ function ProjectsView({
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
+  pinnedThreadIds: ReadonlySet<string>;
 }) {
   if (
     projects.projects.length === 0 &&
@@ -448,6 +530,7 @@ function ProjectsView({
       key={group.key}
       liveThread={liveThread}
       onChangeThreadLifecycle={onChangeThreadLifecycle}
+      onChangeThreadPinned={onChangeThreadPinned}
       onRenameThread={onRenameThread}
       onNewThread={onNewThread}
       onRemoveProject={onRemoveProject}
@@ -455,6 +538,7 @@ function ProjectsView({
       onSelectThread={onSelectThread}
       pendingApprovalThreadIds={pendingApprovalThreadIds}
       selectedThreadId={selectedThreadId}
+      pinnedThreadIds={pinnedThreadIds}
       watchingThreadIds={watchingThreadIds}
     />
   ));
@@ -473,10 +557,12 @@ function ProjectRows({
   selectedThreadId,
   onSelectThread,
   onChangeThreadLifecycle,
+  onChangeThreadPinned,
   onRenameThread,
   pendingApprovalThreadIds,
   liveThread,
   watchingThreadIds,
+  pinnedThreadIds,
 }: {
   group: ReturnType<typeof deriveProjectGroups>[number];
   onNewThread(workspace?: string): void;
@@ -485,10 +571,12 @@ function ProjectRows({
   selectedThreadId: string | null;
   onSelectThread(threadId: string): void;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onRenameThread(threadId: string, title: string): Promise<void>;
   pendingApprovalThreadIds: ReadonlySet<string>;
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
+  pinnedThreadIds: ReadonlySet<string>;
 }) {
   const [open, setOpen] = useState(true);
   return (
@@ -549,9 +637,11 @@ function ProjectRows({
             hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
             key={thread.threadId}
             onChangeThreadLifecycle={onChangeThreadLifecycle}
+            onChangeThreadPinned={onChangeThreadPinned}
             onRenameThread={onRenameThread}
             onSelectThread={onSelectThread}
             pendingApproval={pendingApprovalThreadIds.has(thread.threadId)}
+            pinned={pinnedThreadIds.has(thread.threadId)}
             selected={thread.threadId === selectedThreadId}
             thread={thread}
             watching={watchingThreadIds.has(thread.threadId)}
@@ -567,9 +657,11 @@ function ThreadRow({
   selected,
   hasActiveTurn,
   onChangeThreadLifecycle,
+  onChangeThreadPinned,
   onRenameThread,
   onSelectThread,
   pendingApproval,
+  pinned,
   watching,
   inbox = false,
 }: {
@@ -577,9 +669,11 @@ function ThreadRow({
   selected: boolean;
   hasActiveTurn: boolean;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
+  onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onRenameThread(threadId: string, title: string): Promise<void>;
   onSelectThread(threadId: string): void;
   pendingApproval: boolean;
+  pinned: boolean;
   watching: boolean;
   inbox?: boolean;
 }) {
@@ -591,7 +685,7 @@ function ThreadRow({
   const [renaming, setRenaming] = useState(false);
   const [renameDraft, setRenameDraft] = useState(threadTitle(thread));
   const [busyAction, setBusyAction] = useState<
-    "rename" | "archive" | "unarchive" | null
+    "rename" | "pin" | "unpin" | "archive" | "unarchive" | null
   >(null);
   const [menuError, setMenuError] = useState<string | null>(null);
   const restoreMenuTriggerFocus = () => {
@@ -602,9 +696,11 @@ function ThreadRow({
     setRenaming(false);
     if (restoreFocus) restoreMenuTriggerFocus();
   };
-  const focusThreadScope = () => {
+  const focusThreadListHeading = (nextPinned = pinned) => {
     document
-      .getElementById(`thread-scope-${thread.archived ? "archived" : "active"}`)
+      .getElementById(
+        nextPinned ? "sidebar-pinned-heading" : "sidebar-thread-list-heading",
+      )
       ?.focus();
   };
   useEffect(() => {
@@ -644,22 +740,23 @@ function ThreadRow({
       </span>
       {identity === null ? null : (
         <span className="model-line">
-          <ProviderMark kind={identity.providerKind} />
+          <ProviderLogo kind={identity.providerKind} />
           <span>{identity.label}</span>
         </span>
       )}
     </>
   );
   const runAction = async (
-    action: "rename" | "archive" | "unarchive",
+    action: "rename" | "pin" | "unpin" | "archive" | "unarchive",
     operation: () => Promise<void>,
   ) => {
     setBusyAction(action);
     setMenuError(null);
     try {
-      if (action !== "rename") focusThreadScope();
+      if (action !== "rename") focusThreadListHeading();
       await operation();
-      if (action !== "rename") focusThreadScope();
+      if (action !== "rename" && action !== "pin" && action !== "unpin")
+        focusThreadListHeading();
       closeMenu(action === "rename");
     } catch (error) {
       setMenuError(error instanceof Error ? error.message : String(error));
@@ -681,7 +778,7 @@ function ThreadRow({
       ref={rowRef}
       className="thread-row-shell"
       onKeyDown={(event) => {
-        if (event.key === "Escape") {
+        if (menuOpen && event.key === "Escape") {
           event.preventDefault();
           closeMenu();
         }
@@ -710,6 +807,7 @@ function ThreadRow({
         aria-haspopup="menu"
         aria-expanded={menuOpen}
         aria-controls={menuOpen ? `thread-menu-${thread.threadId}` : undefined}
+        title={`Manage ${threadTitle(thread)}`}
         onClick={() => {
           if (menuOpen) {
             closeMenu();
@@ -732,7 +830,7 @@ function ThreadRow({
           setMenuOpen(true);
         }}
       >
-        <Icon name="more" />
+        <Icon name="more" size={18} />
       </button>
       <ThreadItemMenu
         archived={thread.archived}
@@ -743,6 +841,7 @@ function ThreadRow({
         menuId={`thread-menu-${thread.threadId}`}
         menuRef={menuRef}
         open={menuOpen}
+        pinned={pinned}
         renaming={renaming}
         renameDraft={renameDraft}
         onArchive={() =>
@@ -752,6 +851,11 @@ function ThreadRow({
         onCancelRename={() => setRenaming(false)}
         onRequestClose={() => closeMenu()}
         onDraftChange={setRenameDraft}
+        onPin={() =>
+          void runAction(pinned ? "unpin" : "pin", () =>
+            onChangeThreadPinned(thread),
+          )
+        }
         onRename={() =>
           void runAction("rename", () =>
             onRenameThread(thread.threadId, renameDraft),
@@ -774,6 +878,7 @@ export function ThreadItemMenu({
   menuId,
   menuRef,
   open,
+  pinned,
   renaming,
   renameDraft,
   onArchive,
@@ -781,17 +886,19 @@ export function ThreadItemMenu({
   onCancelRename,
   onRequestClose,
   onDraftChange,
+  onPin,
   onRename,
   onUnarchive,
 }: {
   archived: boolean;
-  busyAction: "rename" | "archive" | "unarchive" | null;
+  busyAction: "rename" | "pin" | "unpin" | "archive" | "unarchive" | null;
   error: string | null;
   hasActiveTurn: boolean;
   labelledBy?: string;
   menuId?: string;
   menuRef?: RefObject<HTMLDivElement | null>;
   open: boolean;
+  pinned: boolean;
   renaming: boolean;
   renameDraft: string;
   onArchive(): void;
@@ -799,6 +906,7 @@ export function ThreadItemMenu({
   onCancelRename(): void;
   onRequestClose?(): void;
   onDraftChange(value: string): void;
+  onPin(): void;
   onRename(): void;
   onUnarchive(): void;
 }) {
@@ -896,6 +1004,23 @@ export function ThreadItemMenu({
             type="button"
             role="menuitem"
             tabIndex={-1}
+            data-thread-action={pinned ? "unpin" : "pin"}
+            disabled={busy}
+            onClick={onPin}
+          >
+            <Icon name={pinned ? "pin-off" : "pin"} />
+            {busyAction === "pin"
+              ? "Pinning…"
+              : busyAction === "unpin"
+                ? "Unpinning…"
+                : pinned
+                  ? "Unpin"
+                  : "Pin"}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            tabIndex={-1}
             data-thread-action="archive"
             disabled={busy || hasActiveTurn}
             title={
@@ -926,26 +1051,6 @@ function enabledMenuItems(container: HTMLElement | null): HTMLButtonElement[] {
     container.querySelectorAll<HTMLButtonElement>(
       'button[role="menuitem"]:not(:disabled)',
     ),
-  );
-}
-
-function ProviderMark({
-  kind,
-}: {
-  kind: "openai" | "anthropic" | "google" | "local" | "generic";
-}) {
-  return (
-    <span className={`provider-mark ${kind}`} aria-hidden="true">
-      {kind === "openai"
-        ? "◎"
-        : kind === "anthropic"
-          ? "A"
-          : kind === "google"
-            ? "✦"
-            : kind === "local"
-              ? "⌂"
-              : "◇"}
-    </span>
   );
 }
 

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -680,6 +680,7 @@ function ThreadRow({
   const rowRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuTriggerRef = useRef<HTMLButtonElement>(null);
+  const restoreMenuFocusRef = useRef(false);
   const initialMenuFocusRef = useRef<"first" | "last">("first");
   const [menuOpen, setMenuOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
@@ -688,13 +689,10 @@ function ThreadRow({
     "rename" | "pin" | "unpin" | "archive" | "unarchive" | null
   >(null);
   const [menuError, setMenuError] = useState<string | null>(null);
-  const restoreMenuTriggerFocus = () => {
-    queueMicrotask(() => menuTriggerRef.current?.focus());
-  };
   const closeMenu = (restoreFocus = true) => {
+    restoreMenuFocusRef.current = restoreFocus;
     setMenuOpen(false);
     setRenaming(false);
-    if (restoreFocus) restoreMenuTriggerFocus();
   };
   const focusThreadListHeading = (nextPinned = pinned) => {
     document
@@ -720,6 +718,11 @@ function ThreadRow({
       initialMenuFocusRef.current === "last" ? items.at(-1) : items.at(0);
     item?.focus();
   }, [menuOpen, renaming]);
+  useLayoutEffect(() => {
+    if (menuOpen || !restoreMenuFocusRef.current) return;
+    restoreMenuFocusRef.current = false;
+    menuTriggerRef.current?.focus();
+  }, [menuOpen]);
   const identity = threadModelIdentity(thread);
   const contents = (
     <>

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -88,6 +88,9 @@ declare global {
         removeWorkspace(workspace: string): Promise<PublicHostSettings>;
         setDefaultWorkspace(workspace: string): Promise<PublicHostSettings>;
         markWorkspaceUsed(workspace: string): Promise<PublicHostSettings>;
+        setPinnedThreadIds(
+          threadIds: readonly string[],
+        ): Promise<PublicHostSettings>;
         getDirectoryBrowser(): Promise<DirectoryBrowserSnapshot>;
         listDirectory(directory: string): Promise<DirectoryListing>;
         loginSubscription(): Promise<PublicHostSettings>;

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -11,12 +11,15 @@ type IconName =
   | "folder"
   | "file"
   | "inbox"
+  | "folder-plus"
   | "layers"
   | "lock"
   | "moon"
   | "more"
   | "paperclip"
   | "panel-right"
+  | "pin"
+  | "pin-off"
   | "reasoning"
   | "restore"
   | "settings"
@@ -57,6 +60,12 @@ const paths: Record<IconName, ReactNode> = {
   folder: (
     <path d="M1.8 4.2C1.8 3.5 2.3 3 3 3h3l1.4 1.6H13c.7 0 1.2.5 1.2 1.2v6c0 .7-.5 1.2-1.2 1.2H3c-.7 0-1.2-.5-1.2-1.2V4.2Z" />
   ),
+  "folder-plus": (
+    <>
+      <path d="M1.8 4.2C1.8 3.5 2.3 3 3 3h3l1.4 1.6H13c.7 0 1.2.5 1.2 1.2v6c0 .7-.5 1.2-1.2 1.2H3c-.7 0-1.2-.5-1.2-1.2V4.2Z" />
+      <path d="M8 7v4M6 9h4" />
+    </>
+  ),
   file: (
     <>
       <path d="M4 1.8h5.2l2.8 2.8v9.6H4z" />
@@ -70,7 +79,7 @@ const paths: Record<IconName, ReactNode> = {
     </>
   ),
   moon: <path d="M13.4 9.4A5.8 5.8 0 0 1 6.6 2.6a5.8 5.8 0 1 0 6.8 6.8Z" />,
-  more: <path d="M3 8h.01M8 8h.01M13 8h.01" />,
+  more: <path d="M3 8h.01M8 8h.01M13 8h.01" strokeWidth="2.8" />,
   layers: (
     <>
       <path d="m8 2 6 3.2-6 3.2-6-3.2Z" />
@@ -90,6 +99,17 @@ const paths: Record<IconName, ReactNode> = {
     <>
       <rect x="1.8" y="2.2" width="12.4" height="11.6" rx="1.5" />
       <path d="M10.2 2.2v11.6" />
+    </>
+  ),
+  pin: (
+    <>
+      <path d="m5 2 6 6M4.2 7.2l4.6 4.6M3 10l3 3M6.2 3.2l6.6 6.6-2.7.3-3.9-3.9.3-2.7Z" />
+      <path d="m6 12-3 3" />
+    </>
+  ),
+  "pin-off": (
+    <>
+      <path d="m4 2 10 12M6.2 3.2l6.6 6.6-2.1.2M4.2 7.2l4.6 4.6M3 10l3 3M6 12l-3 3" />
     </>
   ),
   reasoning: (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -345,35 +345,13 @@ a:focus-visible {
 .sidebar-view-head span {
   font-size: 10px;
 }
-.thread-scope-tabs {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 3px;
-  margin-top: 8px;
-  padding: 3px;
-  border: 1px solid var(--border-soft);
-  border-radius: 9px;
-  background: #0d0f13;
-}
-.thread-scope-tabs button {
-  min-height: 32px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-3);
-  font-size: 11px;
-  transition:
-    color 160ms ease,
-    background 160ms ease;
-}
-.thread-scope-tabs button:hover,
-.thread-scope-tabs button[aria-selected="true"] {
-  color: var(--text);
-  background: var(--surface-2);
-}
 .sidebar-inline-action {
+  width: 28px;
+  height: 28px;
   min-height: 28px;
-  padding: 0 8px;
+  display: grid;
+  place-items: center;
+  padding: 0;
   border: 1px solid var(--border-soft);
   border-radius: 7px;
   background: rgb(255 255 255 / 2%);
@@ -428,6 +406,19 @@ a:focus-visible {
 .project-group + .project-group,
 .inbox-group + .inbox-group {
   margin-top: 16px;
+}
+.pinned-thread-group {
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border-soft);
+}
+.pinned-thread-group h2 {
+  margin: 4px 10px 8px;
+  color: var(--text-3);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
 }
 .project-header {
   width: 100%;
@@ -552,9 +543,20 @@ a:focus-visible {
   border-radius: 8px;
   background: transparent;
   color: var(--text-3);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
   transition:
+    opacity 140ms ease,
     color 160ms ease,
     background 160ms ease;
+}
+.thread-row-shell:hover .thread-menu-trigger,
+.thread-row-shell:focus-within .thread-menu-trigger,
+.thread-menu-trigger[aria-expanded="true"] {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 .thread-menu-trigger:hover,
 .thread-menu-trigger[aria-expanded="true"] {
@@ -703,7 +705,7 @@ a:focus-visible {
   background: var(--good);
   box-shadow: 0 0 0 4px rgb(115 210 173 / 10%);
 }
-.provider-mark {
+.provider-logo {
   width: 18px;
   height: 18px;
   flex: 0 0 auto;
@@ -712,37 +714,67 @@ a:focus-visible {
   border-radius: 5px;
   background: #23262d;
   color: #dfe1e6;
-  font-size: 10px;
-  font-weight: 600;
+  overflow: hidden;
 }
-.provider-mark.openai {
+.provider-logo svg {
+  width: 14px;
+  height: 14px;
+}
+.provider-logo.openai {
   background: #26342f;
   color: #d7e9e1;
 }
-.provider-mark.anthropic {
-  background: #3a2d27;
-  color: #ead3c7;
-}
-.provider-mark.google {
+.provider-logo.deepseek {
   background: #272f47;
   color: #aabfff;
 }
-.provider-mark.local {
+.provider-logo.qwen {
   background: #2f2948;
   color: #cbbcff;
 }
+.provider-logo.local {
+  background: #252831;
+  color: #c6cad5;
+}
+.provider-logo.generic {
+  background: #23262d;
+  color: #aeb2bd;
+}
 .sidebar-footer {
-  min-height: 58px;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 8px 10px 8px 16px;
+  min-height: 76px;
+  display: grid;
+  align-content: center;
+  gap: 2px;
+  padding: 7px 8px;
   border-top: 1px solid var(--border-soft);
   color: var(--text-3);
 }
+.settings-nav-row {
+  width: 100%;
+  min-height: 38px;
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 12px;
+  text-align: left;
+}
+.settings-nav-row:hover,
+.settings-nav-row[aria-current="page"] {
+  color: var(--text);
+  background: #202228;
+}
 .service-status {
   min-width: 0;
-  gap: 8px;
-  font-size: 11px;
+  gap: 7px;
+  padding: 2px 10px 0;
+  font-size: 9px;
+  opacity: 0.68;
 }
 .sidebar-scrim {
   display: none;
@@ -2075,6 +2107,91 @@ a:focus-visible {
   background: rgb(115 210 173 / 10%);
   color: var(--good);
 }
+.settings-apply-bar {
+  min-height: 66px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: #121419;
+}
+.settings-apply-bar.dirty {
+  border-color: #4d5d8d;
+  background: rgb(115 139 214 / 8%);
+}
+.settings-apply-bar > div {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+.settings-apply-bar strong {
+  color: var(--text-2);
+  font-size: 11px;
+  font-weight: 520;
+}
+.settings-apply-bar span,
+.settings-empty {
+  color: var(--text-3);
+  font-size: 10px;
+  line-height: 1.5;
+}
+.settings-empty {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+  padding: 22px;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: #121419;
+}
+.archived-thread-list {
+  overflow: hidden;
+  border: 1px solid var(--border-soft);
+  border-radius: 10px;
+  background: #121419;
+}
+.archived-thread-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 13px 14px;
+}
+.archived-thread-row + .archived-thread-row {
+  border-top: 1px solid var(--border-soft);
+}
+.archived-thread-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+.archived-thread-copy strong,
+.archived-thread-copy > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.archived-thread-copy strong {
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 520;
+}
+.archived-thread-copy > span {
+  color: var(--text-3);
+  font-size: 9px;
+}
+.archived-thread-copy small {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--text-3);
+  font-size: 9px;
+}
 .plugin-boundary {
   display: grid;
   grid-template-columns: 36px minmax(0, 1fr) auto;
@@ -2577,7 +2694,7 @@ a:focus-visible {
     padding-inline: 9px;
   }
   .thread-row {
-    padding-inline: 10px 8px;
+    padding: 10px 46px 10px 10px;
   }
   .workspace-header {
     padding-left: 16px;
@@ -2658,7 +2775,6 @@ a:focus-visible {
     width: 44px;
     height: 44px;
   }
-  .thread-scope-tabs button,
   .sidebar-error button {
     min-height: 44px;
   }
@@ -2666,6 +2782,9 @@ a:focus-visible {
   .thread-item-menu > button {
     min-width: 44px;
     min-height: 44px;
+  }
+  .thread-row {
+    padding-right: 52px;
   }
   .thread-lifecycle-action {
     width: 44px;

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -3,7 +3,6 @@ import type { Thread } from "../../protocol-client/index.js";
 import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
 
 export type SidebarMode = "inbox" | "projects";
-export type ThreadScope = "active" | "archived";
 
 interface SidebarStorage {
   getItem(key: string): string | null;
@@ -27,7 +26,22 @@ export interface ProjectGroup {
 
 export interface ThreadModelIdentity {
   label: string;
-  providerKind: "openai" | "anthropic" | "google" | "local" | "generic";
+  providerKind: "openai" | "deepseek" | "qwen" | "local" | "generic";
+}
+
+export function derivePinnedThreads(
+  threads: readonly NativeThreadSummary[],
+  pinnedThreadIds: readonly string[],
+): NativeThreadSummary[] {
+  const activeById = new Map(
+    threads
+      .filter((thread) => !thread.archived)
+      .map((thread) => [thread.threadId, thread] as const),
+  );
+  return pinnedThreadIds.flatMap((threadId) => {
+    const thread = activeById.get(threadId);
+    return thread === undefined ? [] : [thread];
+  });
 }
 
 export function lastUsedProjectWorkspace(
@@ -74,21 +88,6 @@ export function writeSidebarMode(
   mode: SidebarMode,
 ): void {
   storage.setItem("zenx-sidebar-mode", mode);
-}
-
-export function readThreadScope(
-  storage: Pick<SidebarStorage, "getItem">,
-): ThreadScope {
-  return storage.getItem("zenx-thread-scope") === "archived"
-    ? "archived"
-    : "active";
-}
-
-export function writeThreadScope(
-  storage: Pick<SidebarStorage, "setItem">,
-  scope: ThreadScope,
-): void {
-  storage.setItem("zenx-thread-scope", scope);
 }
 
 export function threadHasActiveTurn(
@@ -230,10 +229,10 @@ export function threadModelIdentity(
   const providerKind =
     provider.includes("openai") || /^gpt-/iu.test(model)
       ? "openai"
-      : provider.includes("anthropic") || /^claude/iu.test(model)
-        ? "anthropic"
-        : provider.includes("google") || /^gemini/iu.test(model)
-          ? "google"
+      : provider.includes("deepseek") || /^deepseek/iu.test(model)
+        ? "deepseek"
+        : provider.includes("qwen") || /^qwen/iu.test(model)
+          ? "qwen"
           : provider.includes("local")
             ? "local"
             : "generic";

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -134,11 +134,84 @@ test("archiving an active Thread opens its Settings restore entry", async () => 
   }
 });
 
+test("serializes cross-row Pin mutations against the latest confirmed order", async () => {
+  const requests: Array<{
+    threadIds: readonly string[];
+    response: ReturnType<typeof deferred<ReturnType<typeof publicSettings>>>;
+  }> = [];
+  const threads = [
+    summary(false, "thread-1", "Thread one"),
+    summary(false, "thread-2", "Thread two"),
+  ];
+  const harness = await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: threads.map((thread) => thread.threadId),
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      threads: async (archived) => (archived ? [] : threads),
+      setPinnedThreadIds: async (threadIds) => {
+        const response = deferred<ReturnType<typeof publicSettings>>();
+        requests.push({ threadIds: [...threadIds], response });
+        return await response.promise;
+      },
+    },
+  );
+  try {
+    await act(async () => threadMenuButton("Thread one").click());
+    await act(async () => exactButton("Pin")?.click());
+    await act(async () => threadMenuButton("Thread two").click());
+    await act(async () => exactButton("Pin")?.click());
+
+    assert.equal(requests.length, 1);
+    assert.deepEqual(requests[0]?.threadIds, ["thread-1"]);
+
+    await act(async () => {
+      requests[0]?.response.resolve(publicSettings(["thread-1"]));
+      await Promise.resolve();
+    });
+    await waitFor(() => requests.length === 2);
+    assert.deepEqual(requests[1]?.threadIds, ["thread-2", "thread-1"]);
+
+    await act(async () => {
+      requests[1]?.response.resolve(publicSettings(["thread-2", "thread-1"]));
+      await Promise.resolve();
+    });
+    await waitFor(
+      () =>
+        document.querySelectorAll(".pinned-thread-group .thread-row").length ===
+        2,
+    );
+    assert.deepEqual(
+      [
+        ...document.querySelectorAll(
+          ".pinned-thread-group .thread-title > span:first-child",
+        ),
+      ].map((title) => title.textContent),
+      ["Thread two", "Thread one"],
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 async function mountApp(
   projects: ZenXProjectProjectionSnapshot,
   options: {
     initialPinnedThreadIds?: string[];
     onPinnedThreadIds?(threadIds: readonly string[]): void;
+    setPinnedThreadIds?(
+      threadIds: readonly string[],
+    ): Promise<ReturnType<typeof publicSettings>>;
     request?(method: string): Promise<unknown>;
     threads?(archived: boolean): Promise<NativeThreadSummary[]>;
   } = {},
@@ -181,6 +254,8 @@ async function mountApp(
     settings: {
       get: async () => currentSettings,
       setPinnedThreadIds: async (threadIds: readonly string[]) => {
+        if (options.setPinnedThreadIds !== undefined)
+          return await options.setPinnedThreadIds(threadIds);
         options.onPinnedThreadIds?.(threadIds);
         currentSettings = publicSettings([...threadIds]);
         return currentSettings;
@@ -243,9 +318,13 @@ function publicSettings(pinnedThreadIds: string[]) {
   };
 }
 
-function summary(archived: boolean): NativeThreadSummary {
+function summary(
+  archived: boolean,
+  threadId = "thread-1",
+  name = "Thread one",
+): NativeThreadSummary {
   return {
-    threadId: "thread-1",
+    threadId,
     currentMetadata: {
       model: "fake",
       provider: "fake",
@@ -256,10 +335,18 @@ function summary(archived: boolean): NativeThreadSummary {
     archived,
     createdAt: new Date(1_000).toISOString(),
     updatedAt: new Date(2_000).toISOString(),
-    name: "Thread one",
+    name,
     preview: "",
     status: "idle",
   };
+}
+
+function threadMenuButton(threadName: string): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(
+    `[aria-label="Manage ${threadName}"]`,
+  );
+  assert.ok(button, `Expected menu trigger for ${threadName}`);
+  return button;
 }
 
 function liveThread(): Thread {
@@ -312,4 +399,15 @@ async function waitFor<T>(read: () => T | null | undefined): Promise<T> {
     });
   }
   throw new Error("Timed out waiting for App interaction state");
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
 }

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -1,0 +1,315 @@
+/// <reference path="../src/renderer/src/env.d.ts" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import type { ZenXProjectProjectionSnapshot } from "../src/main/project-projection.js";
+import type { Thread } from "../src/protocol-client/index.js";
+const { act, createElement } = React;
+Object.assign(globalThis, { React });
+const { App } = await import("../src/renderer/src/App.js");
+
+interface AppHarness {
+  dom: JSDOM;
+  root: Root;
+}
+
+test("desktop Choose project opens the existing directory picker", async () => {
+  const harness = await mountApp({
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  });
+  try {
+    const chooseProject = await waitFor(() => exactButton("Choose project"));
+    await act(async () => chooseProject.click());
+    await waitFor(() => document.querySelector('[role="dialog"]'));
+    assert.match(
+      document.querySelector('[role="dialog"]')?.textContent ?? "",
+      /Add a project folder/u,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("zero-Project New thread opens the existing directory picker", async () => {
+  const harness = await mountApp({
+    projects: [],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  });
+  try {
+    const newThread = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action"),
+    );
+    assert.match(newThread.textContent ?? "", /Add project first/u);
+    await act(async () => newThread.click());
+    await waitFor(() => document.querySelector('[role="dialog"]'));
+    assert.match(
+      document.querySelector('[role="dialog"]')?.textContent ?? "",
+      /Add a project folder/u,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("archiving an active Thread opens its Settings restore entry", async () => {
+  let archived = false;
+  let persistedPins = ["thread-1"];
+  const harness = await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: ["thread-1"],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      request: async (method) => {
+        if (method === "thread/resume")
+          return {
+            thread: liveThread(),
+            model: "fake",
+            modelProvider: "fake",
+          };
+        if (method === "thread/archive") {
+          archived = true;
+          return {};
+        }
+        if (method === "thread/unarchive") {
+          archived = false;
+          return {};
+        }
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+      threads: async (requestedArchived) =>
+        requestedArchived === archived ? [summary(archived)] : [],
+      initialPinnedThreadIds: persistedPins,
+      onPinnedThreadIds: (threadIds) => {
+        persistedPins = [...threadIds];
+      },
+    },
+  );
+  try {
+    const row = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(".thread-row"),
+    );
+    await act(async () => row.click());
+    const archive = await waitFor(() => exactButton("Archive"));
+    await act(async () => {
+      archive.click();
+      await Promise.resolve();
+    });
+    await waitFor(() => exactButton("Unarchive"));
+    assert.match(document.body.textContent ?? "", /Archived threads/u);
+    assert.match(document.body.textContent ?? "", /Thread one/u);
+    assert.equal(document.querySelector('[aria-label="Thread views"]'), null);
+    assert.deepEqual(persistedPins, []);
+
+    await act(async () => exactButton("Unarchive")?.click());
+    await waitFor(() => document.querySelector(".thread-row"));
+    assert.equal(document.getElementById("sidebar-pinned-heading"), null);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+async function mountApp(
+  projects: ZenXProjectProjectionSnapshot,
+  options: {
+    initialPinnedThreadIds?: string[];
+    onPinnedThreadIds?(threadIds: readonly string[]): void;
+    request?(method: string): Promise<unknown>;
+    threads?(archived: boolean): Promise<NativeThreadSummary[]>;
+  } = {},
+): Promise<AppHarness> {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    KeyboardEvent: dom.window.KeyboardEvent,
+    MouseEvent: dom.window.MouseEvent,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  let currentSettings = publicSettings(options.initialPinnedThreadIds ?? []);
+  const zenx = {
+    platform: "darwin",
+    protocol: {
+      getStatus: async () => ({ type: "ready", reconnected: false }),
+      getPendingApprovals: async () => [],
+      request: async (method: string) => {
+        if (method === "model/list") return { data: [] };
+        if (options.request !== undefined) return await options.request(method);
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+      respondToApproval: async () => undefined,
+      onApprovalRequest: () => () => undefined,
+      onApprovalResolved: () => () => undefined,
+      onStatus: () => () => undefined,
+      onNotification: () => () => undefined,
+    },
+    threads: {
+      list: async ({ archived }: { archived: boolean }) =>
+        options.threads === undefined ? [] : await options.threads(archived),
+    },
+    projects: { get: async () => projects },
+    settings: {
+      get: async () => currentSettings,
+      setPinnedThreadIds: async (threadIds: readonly string[]) => {
+        options.onPinnedThreadIds?.(threadIds);
+        currentSettings = publicSettings([...threadIds]);
+        return currentSettings;
+      },
+      onManualCodeRequested: () => () => undefined,
+      addWorkspace: async () => ({ profile: { onboardingComplete: true } }),
+      getDirectoryBrowser: async () => ({
+        locations: [{ label: "Root", path: "/" }],
+        initialPath: "/",
+      }),
+      listDirectory: async () => ({
+        path: "/",
+        parent: null,
+        breadcrumbs: [{ label: "/", path: "/" }],
+        directories: [],
+      }),
+    },
+    titles: {
+      get: async () => ({}),
+      onChange: () => () => undefined,
+    },
+    triggers: {
+      get: async () => ({ triggers: [], history: [], rooms: [] }),
+      onChange: () => () => undefined,
+    },
+    capabilities: {
+      get: async () => ({ capabilities: [], audit: [], providers: [] }),
+      onChange: () => () => undefined,
+    },
+    plugins: {
+      get: async () => ({ plugins: [], sidebar: [], pages: [] }),
+      onChange: () => () => undefined,
+    },
+  } as unknown as Window["zenx"];
+  Object.defineProperty(dom.window, "zenx", { value: zenx });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+  await act(async () => root.render(createElement(App)));
+  return { dom, root };
+}
+
+function publicSettings(pinnedThreadIds: string[]) {
+  return {
+    profile: {
+      version: 1 as const,
+      onboardingComplete: true,
+      provider: { type: "fake" as const, displayName: "Local demo" },
+      defaultModel: "fake",
+      titleModel: "gpt-5.6-luna",
+      models: ["fake"],
+      workspace: "/work/zen",
+      workspaces: ["/work/zen"],
+      lastUsedWorkspace: "/work/zen",
+      approvalPolicy: "never" as const,
+      pinnedThreadIds,
+    },
+    hasApiKey: false,
+    subscription: { authenticated: false, expired: false },
+  };
+}
+
+function summary(archived: boolean): NativeThreadSummary {
+  return {
+    threadId: "thread-1",
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    name: "Thread one",
+    preview: "",
+    status: "idle",
+  };
+}
+
+function liveThread(): Thread {
+  return {
+    id: "thread-1",
+    sessionId: "thread-1",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "fake",
+    createdAt: 1,
+    updatedAt: 2,
+    recencyAt: null,
+    status: { type: "idle" },
+    path: null,
+    cwd: "/work/zen",
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: "Thread one",
+    turns: [],
+  };
+}
+
+async function unmountApp(harness: AppHarness): Promise<void> {
+  await act(async () => harness.root.unmount());
+  Object.assign(globalThis, {
+    IS_REACT_ACT_ENVIRONMENT: undefined,
+  });
+  harness.dom.window.close();
+}
+
+function exactButton(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+    (button) => button.textContent?.trim() === label,
+  );
+}
+
+async function waitFor<T>(read: () => T | null | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const value = read();
+    if (value !== null && value !== undefined && value !== false) return value;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+  }
+  throw new Error("Timed out waiting for App interaction state");
+}

--- a/apps/zenx/test/app-request-freshness.test.ts
+++ b/apps/zenx/test/app-request-freshness.test.ts
@@ -59,7 +59,9 @@ test("ignores an older Thread summary response after a newer refresh", async () 
       }),
     },
     settings: {
-      get: async () => ({ profile: { onboardingComplete: true } }),
+      get: async () => ({
+        profile: { onboardingComplete: true, pinnedThreadIds: [] },
+      }),
     },
     titles: {
       get: async () => ({}),

--- a/apps/zenx/test/directory-picker-ui.test.ts
+++ b/apps/zenx/test/directory-picker-ui.test.ts
@@ -122,8 +122,46 @@ test("directory picker exposes failure, retries, and cancels with Escape", async
   }
 });
 
+test("directory picker ignores Backspace before a root listing is available", async () => {
+  const pending = deferred<DirectoryListing>();
+  const harness = await mountPicker(async () => await pending.promise, {
+    locations: [{ label: "Root", path: "/" }],
+    initialPath: "/",
+  });
+  try {
+    await waitFor(() => harness.listCalls.length === 1);
+    await pressKey(
+      harness.dom,
+      harness.container.querySelector(".directory-picker-list")!,
+      "Backspace",
+    );
+    assert.deepEqual(harness.listCalls, ["/"]);
+
+    pending.resolve(listing("/", null, []));
+    await waitFor(() => currentSelection() === "/");
+    await pressKey(
+      harness.dom,
+      harness.container.querySelector(".directory-picker-list")!,
+      "Backspace",
+    );
+    assert.deepEqual(harness.listCalls, ["/"]);
+  } finally {
+    pending.resolve(listing("/", null, []));
+    await unmountPicker(harness);
+    harness.dom.window.close();
+  }
+});
+
 async function mountPicker(
   listDirectory: (directory: string) => Promise<DirectoryListing>,
+  snapshot: DirectoryBrowserSnapshot = {
+    locations: [
+      { label: "Home", path: "/home" },
+      { label: "Documents", path: "/docs" },
+      { label: "Root", path: "/" },
+    ],
+    initialPath: "/docs",
+  },
 ): Promise<PickerHarness> {
   const dom = new JSDOM("<!doctype html><body></body>", {
     url: "https://zenx.local/",
@@ -142,14 +180,6 @@ async function mountPicker(
   dom.window.document.body.append(previous);
   previous.focus();
 
-  const snapshot: DirectoryBrowserSnapshot = {
-    locations: [
-      { label: "Home", path: "/home" },
-      { label: "Documents", path: "/docs" },
-      { label: "Root", path: "/" },
-    ],
-    initialPath: "/docs",
-  };
   const listCalls: string[] = [];
   Object.assign(dom.window, {
     zenx: {
@@ -274,4 +304,15 @@ async function waitFor<T>(read: () => T | null | undefined): Promise<T> {
     });
   }
   throw new Error("Timed out waiting for picker interaction state");
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((finish) => {
+    resolve = finish;
+  });
+  return { promise, resolve };
 }

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -26,6 +26,7 @@ const profile = {
   workspaces: [path.join(os.tmpdir(), "workspace")],
   lastUsedWorkspace: null,
   approvalPolicy: "always" as const,
+  pinnedThreadIds: [],
 };
 
 test("round-trips credential-free host settings and builds the ModelCatalog config", async () => {
@@ -79,12 +80,14 @@ test("defaults legacy profiles to the independent Luna title model", () => {
     titleModel: _titleModel,
     workspaces: _workspaces,
     lastUsedWorkspace: _lastUsedWorkspace,
+    pinnedThreadIds: _pinnedThreadIds,
     ...legacy
   } = profile;
   const validated = validateHostProfile(legacy);
   assert.equal(validated.titleModel, "gpt-5.6-luna");
   assert.deepEqual(validated.workspaces, [path.resolve(profile.workspace)]);
   assert.equal(validated.lastUsedWorkspace, null);
+  assert.deepEqual(validated.pinnedThreadIds, []);
 });
 
 test("reports a corrupt persisted host profile instead of silently replacing it", async () => {

--- a/apps/zenx/test/projects-ui.test.ts
+++ b/apps/zenx/test/projects-ui.test.ts
@@ -14,6 +14,7 @@ const baseProps = {
   onRemoveProject: () => undefined,
   onSetDefaultProject: () => undefined,
   onChangeThreadLifecycle: async () => undefined,
+  onChangeThreadPinned: async () => undefined,
   onRenameThread: async () => undefined,
   onRetryThreads: () => undefined,
   onOpenContribution: () => undefined,
@@ -26,8 +27,7 @@ const baseProps = {
   serverReady: true,
   threadError: null,
   threadLoading: false,
-  threadScope: "active" as const,
-  onThreadScopeChange: () => undefined,
+  pinnedThreads: [],
   threads: [],
   triggerSnapshot: { triggers: [], history: [], rooms: [] },
 };
@@ -47,7 +47,9 @@ test("no-project sidebar keeps explicit Add project and non-creating New thread 
   );
   assert.match(html, />New thread</u);
   assert.match(html, /Add project first/u);
-  assert.match(html, />Add project</u);
+  assert.match(html, /aria-label="Add project"/u);
+  assert.match(html, /title="Add project"/u);
+  assert.doesNotMatch(html, />Add project<\/button>/u);
   assert.match(html, /aria-expanded="true"/u);
   assert.match(html, /No projects yet/u);
 });

--- a/apps/zenx/test/settings-interaction.test.ts
+++ b/apps/zenx/test/settings-interaction.test.ts
@@ -1,0 +1,223 @@
+/// <reference path="../src/renderer/src/env.d.ts" />
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import type {
+  PublicHostSettings,
+  ZenXHostProfile,
+} from "../src/main/host-profile.js";
+import type { SettingsTab } from "../src/renderer/src/SettingsView.js";
+
+const { act, createElement, useState } = React;
+Object.assign(globalThis, { React });
+const { SettingsView } = await import("../src/renderer/src/SettingsView.js");
+
+const settings: PublicHostSettings = {
+  profile: {
+    version: 1,
+    onboardingComplete: true,
+    provider: { type: "fake", displayName: "Local demo" },
+    defaultModel: "fake",
+    titleModel: "gpt-5.6-luna",
+    models: ["fake"],
+    workspace: "/work/zen",
+    workspaces: ["/work/zen"],
+    lastUsedWorkspace: "/work/zen",
+    approvalPolicy: "never",
+    pinnedThreadIds: [],
+  },
+  hasApiKey: false,
+  subscription: { authenticated: false, expired: false },
+};
+
+test("Settings keeps restart contextual and enables it only for edits", async () => {
+  const saved: ZenXHostProfile[] = [];
+  const harness = await mountSettings("models", async (profile) => {
+    saved.push(profile);
+    return { ...settings, profile };
+  });
+  try {
+    await waitFor(() => exactButton("Apply & restart"));
+    assert.equal(document.querySelector(".page-header-actions"), null);
+    assert.equal(exactButton("Done"), undefined);
+    assert.equal(exactButton("Save and restart host"), undefined);
+
+    const apply = exactButton("Apply & restart");
+    assert.ok(apply);
+    assert.equal(apply.disabled, true);
+    const apiProvider = exactButton("API provider");
+    assert.ok(apiProvider);
+    await act(async () => apiProvider.click());
+    assert.equal(apply.disabled, false);
+    await act(async () => {
+      apply.click();
+      await Promise.resolve();
+    });
+    assert.equal(saved.length, 1);
+    assert.equal(saved[0]?.defaultModel, "gpt-5.4");
+    assert.match(document.body.textContent ?? "", /local host restarted/u);
+    assert.equal(apply.disabled, true);
+  } finally {
+    await unmount(harness);
+  }
+});
+
+test("Archived threads is a Settings section with keyboard-reachable Unarchive", async () => {
+  let restored: string | null = null;
+  const harness = await mountSettings(
+    "account",
+    async (profile) => ({ ...settings, profile }),
+    {
+      archivedThreads: [archivedSummary()],
+      onUnarchive: async (thread) => {
+        restored = thread.threadId;
+      },
+    },
+  );
+  try {
+    const archivedTab = await waitFor(() => exactButton("Archived threads"));
+    archivedTab.focus();
+    await act(async () => archivedTab.click());
+    assert.match(document.body.textContent ?? "", /Archived conversation/u);
+    assert.ok(document.querySelector(".provider-logo.deepseek svg"));
+    const unarchive = exactButton("Unarchive");
+    assert.ok(unarchive);
+    assert.equal(unarchive.disabled, false);
+    await act(async () => {
+      unarchive.click();
+      await Promise.resolve();
+    });
+    assert.equal(restored, "archived-thread");
+  } finally {
+    await unmount(harness);
+  }
+});
+
+interface Harness {
+  dom: JSDOM;
+  root: Root;
+  previous: Record<string, unknown>;
+}
+
+async function mountSettings(
+  initialTab: SettingsTab,
+  save: (
+    profile: ZenXHostProfile,
+    apiKey?: string,
+  ) => Promise<PublicHostSettings>,
+  options: {
+    archivedThreads?: NativeThreadSummary[];
+    onUnarchive?(thread: NativeThreadSummary): Promise<void>;
+  } = {},
+): Promise<Harness> {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previous = {
+    document: globalThis.document,
+    Event: globalThis.Event,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    window: globalThis.window,
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    Event: dom.window.Event,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const zenx = {
+    settings: {
+      get: async () => settings,
+      save,
+      onManualCodeRequested: () => () => undefined,
+    },
+  } as unknown as Window["zenx"];
+  Object.defineProperty(dom.window, "zenx", { value: zenx });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(
+      createElement(SettingsHarness, {
+        archivedThreads: options.archivedThreads ?? [],
+        initialTab,
+        onUnarchive: options.onUnarchive ?? (async () => undefined),
+      }),
+    );
+  });
+  return { dom, previous, root };
+}
+
+function SettingsHarness({
+  archivedThreads,
+  initialTab,
+  onUnarchive,
+}: {
+  archivedThreads: NativeThreadSummary[];
+  initialTab: SettingsTab;
+  onUnarchive(thread: NativeThreadSummary): Promise<void>;
+}) {
+  const [tab, setTab] = useState(initialTab);
+  return createElement(SettingsView, {
+    archivedError: null,
+    archivedLoading: false,
+    archivedThreads,
+    onRetryArchived: () => undefined,
+    onTabChange: setTab,
+    onUnarchive,
+    tab,
+  });
+}
+
+async function unmount(harness: Harness): Promise<void> {
+  await act(async () => harness.root.unmount());
+  Object.assign(globalThis, harness.previous, {
+    IS_REACT_ACT_ENVIRONMENT: undefined,
+  });
+  harness.dom.window.close();
+}
+
+function exactButton(label: string): HTMLButtonElement | undefined {
+  return [...document.querySelectorAll<HTMLButtonElement>("button")].find(
+    (button) => button.textContent?.trim() === label,
+  );
+}
+
+async function waitFor<T>(read: () => T | null | undefined): Promise<T> {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const value = read();
+    if (value !== null && value !== undefined) return value;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    });
+  }
+  throw new Error("Timed out waiting for Settings interaction state");
+}
+
+function archivedSummary(): NativeThreadSummary {
+  return {
+    threadId: "archived-thread",
+    currentMetadata: {
+      model: "deepseek-chat",
+      provider: "deepseek",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: true,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    name: "Archived conversation",
+    preview: "",
+    status: "idle",
+  };
+}

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -169,6 +169,40 @@ test("serializes concurrent workspace mutations without losing either update", a
   }
 });
 
+test("persists bounded local Thread Pins in explicit Sidebar order", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-pins-"));
+  try {
+    const first = settingsFor(directory, {
+      login: async () => undefined,
+      logout: async () => undefined,
+      status: async () => ({ authenticated: false, expired: false }),
+    });
+    await first.initialize({});
+    await first.setPinnedThreadIds(["thread-b", "thread-a", "thread-b"]);
+    assert.deepEqual((await first.publicSettings()).profile.pinnedThreadIds, [
+      "thread-b",
+      "thread-a",
+    ]);
+
+    const second = settingsFor(directory, {
+      login: async () => undefined,
+      logout: async () => undefined,
+      status: async () => ({ authenticated: false, expired: false }),
+    });
+    await second.initialize({});
+    assert.deepEqual((await second.publicSettings()).profile.pinnedThreadIds, [
+      "thread-b",
+      "thread-a",
+    ]);
+    assert.match(
+      await readFile(path.join(directory, "host-profile.json"), "utf8"),
+      /"pinnedThreadIds": \[\s*"thread-b",\s*"thread-a"/u,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("clears the OAuth concurrency guard after failure so login can retry", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-oauth-retry-"));
   let attempts = 0;

--- a/apps/zenx/test/sidebar-pinning-interaction.test.ts
+++ b/apps/zenx/test/sidebar-pinning-interaction.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+
+const { act, createElement, useState } = React;
+Object.assign(globalThis, { React });
+const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
+const noop = () => undefined;
+
+test("Pin and Unpin move one Thread through the independent Pinned section", async () => {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previous = {
+    document: globalThis.document,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    window: globalThis.window,
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+  try {
+    await act(async () => root.render(createElement(PinSidebar)));
+    await act(async () => requiredButton(".thread-menu-trigger").click());
+    await act(async () => exactMenuButton("Pin").click());
+
+    assert.match(document.body.textContent ?? "", /Pinned/u);
+    assert.equal(document.querySelectorAll(".thread-row-shell").length, 1);
+    assert.equal(
+      document.activeElement,
+      document.getElementById("sidebar-pinned-heading"),
+    );
+
+    const projectsToggle = requiredButton(".projects-section-toggle");
+    await act(async () => projectsToggle.click());
+    assert.equal(document.querySelectorAll(".thread-row-shell").length, 1);
+    assert.ok(document.getElementById("sidebar-pinned-heading"));
+    await act(async () => projectsToggle.click());
+
+    await act(async () => requiredButton(".thread-menu-trigger").click());
+    await act(async () => exactMenuButton("Unpin").click());
+
+    assert.equal(document.getElementById("sidebar-pinned-heading"), null);
+    assert.equal(document.querySelectorAll(".thread-row-shell").length, 1);
+    assert.equal(
+      document.activeElement,
+      document.getElementById("sidebar-thread-list-heading"),
+    );
+  } finally {
+    await act(async () => root.unmount());
+    Object.assign(globalThis, previous, {
+      IS_REACT_ACT_ENVIRONMENT: undefined,
+    });
+    dom.window.close();
+  }
+});
+
+function PinSidebar() {
+  const [pinned, setPinned] = useState(false);
+  const threads = [summary()];
+  return createElement(Sidebar, {
+    liveThread: null,
+    mode: "projects",
+    open: true,
+    onClose: noop,
+    onModeChange: noop,
+    onNewThread: noop,
+    onAddProject: noop,
+    onRemoveProject: noop,
+    onSetDefaultProject: noop,
+    onOpenContribution: noop,
+    onOpenSettings: noop,
+    onChangeThreadLifecycle: async () => undefined,
+    onChangeThreadPinned: async () => setPinned((value) => !value),
+    onRenameThread: async () => undefined,
+    onRetryThreads: noop,
+    onSelectThread: noop,
+    pendingApprovalThreadIds: new Set<string>(),
+    pinnedThreads: pinned ? threads : [],
+    pluginContributions: [],
+    projects: {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: ["thread-1"],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    selectedPage: "agent",
+    selectedThreadId: null,
+    serverReady: true,
+    threadError: null,
+    threadLoading: false,
+    threads,
+    triggerSnapshot: { triggers: [], history: [], rooms: [] },
+  });
+}
+
+function requiredButton(selector: string): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(selector);
+  assert.ok(button, `Expected ${selector}`);
+  return button;
+}
+
+function exactMenuButton(label: string): HTMLButtonElement {
+  const button = [
+    ...document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+  ].find((candidate) => candidate.textContent?.trim() === label);
+  assert.ok(button, `Expected ${label} menu item`);
+  return button;
+}
+
+function summary(): NativeThreadSummary {
+  return {
+    threadId: "thread-1",
+    currentMetadata: {
+      model: "gpt-5.6-terra",
+      provider: "openai",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: false,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    name: "Pinned candidate",
+    preview: "",
+    status: "idle",
+  };
+}

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("narrow desktop Thread rows reserve the overflow menu column", async () => {
+  const styles = await readFile(
+    new URL("../src/renderer/src/styles.css", import.meta.url),
+    "utf8",
+  );
+  const mediumStart = styles.indexOf("@media (max-width: 820px)");
+  const mobileStart = styles.indexOf("@media (max-width: 640px)");
+  assert.notEqual(mediumStart, -1);
+  assert.ok(mobileStart > mediumStart);
+  assert.match(
+    styles.slice(mediumStart, mobileStart),
+    /\.thread-row\s*\{\s*padding: 10px 46px 10px 10px;/u,
+  );
+  assert.match(
+    styles.slice(mobileStart),
+    /\.thread-row\s*\{\s*padding-right: 52px;/u,
+  );
+});
+
+test("Thread overflow stays inert until hover, focus, or an open menu", async () => {
+  const styles = await readFile(
+    new URL("../src/renderer/src/styles.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    styles,
+    /\.thread-menu-trigger\s*\{[^}]*opacity: 0;[^}]*visibility: hidden;[^}]*pointer-events: none;/su,
+  );
+  assert.match(styles, /\.thread-row-shell:hover \.thread-menu-trigger/u);
+  assert.match(
+    styles,
+    /\.thread-row-shell:focus-within \.thread-menu-trigger/u,
+  );
+  assert.match(
+    styles,
+    /\.thread-menu-trigger\[aria-expanded="true"\]\s*\{[^}]*opacity: 1;[^}]*visibility: visible;[^}]*pointer-events: auto;/su,
+  );
+  assert.doesNotMatch(
+    styles,
+    /\.thread-row\.selected[^}]*\.thread-menu-trigger/su,
+  );
+});

--- a/apps/zenx/test/sidebar-state-transitions.test.ts
+++ b/apps/zenx/test/sidebar-state-transitions.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+const { act, createElement } = React;
+Object.assign(globalThis, { React });
+const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
+
+const noop = () => undefined;
+
+test("collapsed Projects remain recoverable without an Archived scope", async () => {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previousGlobals = {
+    document: globalThis.document,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    window: globalThis.window,
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+
+  try {
+    await act(async () => root.render(createElement(ActiveSidebar)));
+    const projectsToggle = requiredButton(".projects-section-toggle");
+    await act(async () => projectsToggle.click());
+    assert.equal(document.querySelector(".thread-row"), null);
+    assert.equal(projectsToggle.getAttribute("aria-expanded"), "false");
+    assert.equal(document.querySelector('[aria-label="Thread views"]'), null);
+    assert.ok(document.querySelector(".settings-nav-row"));
+
+    await act(async () => projectsToggle.click());
+    assert.equal(projectsToggle.getAttribute("aria-expanded"), "true");
+    assert.match(document.body.textContent ?? "", /Active Thread/u);
+  } finally {
+    await act(async () => root.unmount());
+    Object.assign(globalThis, previousGlobals, {
+      IS_REACT_ACT_ENVIRONMENT: undefined,
+    });
+    dom.window.close();
+  }
+});
+
+function ActiveSidebar() {
+  const threads = [summary("active-thread", "Active Thread", false)];
+  return createElement(Sidebar, {
+    liveThread: null,
+    mode: "projects",
+    open: true,
+    onClose: noop,
+    onModeChange: noop,
+    onNewThread: noop,
+    onAddProject: noop,
+    onRemoveProject: noop,
+    onSetDefaultProject: noop,
+    onOpenContribution: noop,
+    onOpenSettings: noop,
+    onChangeThreadLifecycle: async () => undefined,
+    onChangeThreadPinned: async () => undefined,
+    onRenameThread: async () => undefined,
+    onRetryThreads: noop,
+    onSelectThread: noop,
+    pendingApprovalThreadIds: new Set<string>(),
+    pluginContributions: [],
+    projects: {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: threads.map((thread) => thread.threadId),
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    selectedPage: "agent",
+    selectedThreadId: null,
+    serverReady: true,
+    threadError: null,
+    threadLoading: false,
+    pinnedThreads: [],
+    threads,
+    triggerSnapshot: { triggers: [], history: [], rooms: [] },
+  });
+}
+
+function requiredButton(selector: string): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(selector);
+  assert.ok(button, `Expected ${selector}`);
+  return button;
+}
+
+function summary(
+  threadId: string,
+  name: string,
+  archived: boolean,
+): NativeThreadSummary {
+  return {
+    threadId,
+    currentMetadata: {
+      model: "fake",
+      provider: "fake",
+      cwd: "/work/zen",
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived,
+    createdAt: new Date(1_000).toISOString(),
+    updatedAt: new Date(2_000).toISOString(),
+    name,
+    preview: "",
+    status: "idle",
+  };
+}

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -4,8 +4,8 @@ import test from "node:test";
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
 import {
   deriveInboxSections,
+  derivePinnedThreads,
   deriveProjectGroups,
-  readThreadScope,
   projectThreadStartParams,
   readSidebarMode,
   startProjectThread,
@@ -13,7 +13,6 @@ import {
   threadModelIdentity,
   threadPreview,
   threadTitle,
-  writeThreadScope,
   writeSidebarMode,
 } from "../src/renderer/src/thread-list.js";
 
@@ -28,19 +27,6 @@ test("persists the selected sidebar mode and defaults invalid values to projects
   assert.equal(readSidebarMode(storage), "inbox");
   values.set("zenx-sidebar-mode", "unexpected");
   assert.equal(readSidebarMode(storage), "projects");
-});
-
-test("persists Active or Archived without accepting unknown Thread scopes", () => {
-  const values = new Map<string, string>();
-  const storage = {
-    getItem: (key: string) => values.get(key) ?? null,
-    setItem: (key: string, value: string) => values.set(key, value),
-  };
-  assert.equal(readThreadScope(storage), "active");
-  writeThreadScope(storage, "archived");
-  assert.equal(readThreadScope(storage), "archived");
-  values.set("zenx-thread-scope", "deleted");
-  assert.equal(readThreadScope(storage), "active");
 });
 
 test("derives inbox groups from native summary status", () => {
@@ -64,6 +50,19 @@ test("derives inbox groups from native summary status", () => {
       ["watching", ["watching"]],
       ["settled", ["settled"]],
     ],
+  );
+});
+
+test("projects local Pins in persisted order while filtering archived and missing Threads", () => {
+  const first = summary("first", "idle", 20);
+  const second = summary("second", "idle", 30);
+  const archived = { ...summary("archived", "idle", 40), archived: true };
+  assert.deepEqual(
+    derivePinnedThreads(
+      [first, second, archived],
+      ["second", "missing", "archived", "first"],
+    ).map((thread) => thread.threadId),
+    ["second", "first"],
   );
 });
 
@@ -232,6 +231,18 @@ test("shows only logo category and friendly model identity", () => {
     label: "Local demo",
     providerKind: "local",
   });
+  const deepseek = summary("deepseek", "idle", 20);
+  deepseek.currentMetadata.model = "deepseek-chat";
+  deepseek.currentMetadata.provider = "deepseek";
+  assert.equal(threadModelIdentity(deepseek)?.providerKind, "deepseek");
+  const qwen = summary("qwen", "idle", 20);
+  qwen.currentMetadata.model = "qwen-max";
+  qwen.currentMetadata.provider = "dashscope";
+  assert.equal(threadModelIdentity(qwen)?.providerKind, "qwen");
+  const unknown = summary("unknown", "idle", 20);
+  unknown.currentMetadata.model = "custom-model";
+  unknown.currentMetadata.provider = "private-provider";
+  assert.equal(threadModelIdentity(unknown)?.providerKind, "generic");
 });
 
 function summary(

--- a/apps/zenx/test/thread-management-component.test.ts
+++ b/apps/zenx/test/thread-management-component.test.ts
@@ -1,29 +1,30 @@
 import assert from "node:assert/strict";
-import { createElement } from "react";
+import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import test from "node:test";
 
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
-import { ThreadLifecycleAction } from "../src/renderer/src/ThreadLifecycleAction.js";
-import { Sidebar, ThreadItemMenu } from "../src/renderer/src/Sidebar.js";
+const { createElement } = React;
+Object.assign(globalThis, { React });
+const { ThreadLifecycleAction } =
+  await import("../src/renderer/src/ThreadLifecycleAction.js");
+const { Sidebar, ThreadItemMenu } =
+  await import("../src/renderer/src/Sidebar.js");
 
 const noop = () => undefined;
 
-test("sidebar exposes distinct Active and Archived Thread views", () => {
-  const active = renderSidebar("active", [summary(false)]);
-  assert.match(active, /role="tablist" aria-label="Thread views"/u);
-  assert.match(active, />Active</u);
-  assert.match(active, />Archived</u);
-  assert.match(active, /aria-selected="true"[^>]*>Active/u);
+test("sidebar shows only active Threads and routes Settings as navigation", () => {
+  const active = renderSidebar([summary(false)]);
+  assert.doesNotMatch(active, /aria-label="Thread views"/u);
+  assert.doesNotMatch(active, />Active<\/button>/u);
+  assert.doesNotMatch(active, />Archived<\/button>/u);
   assert.match(active, /aria-haspopup="menu"/u);
-
-  const archived = renderSidebar("archived", []);
-  assert.match(archived, /aria-selected="true"[^>]*>Archived/u);
-  assert.match(archived, /No archived Threads yet/u);
+  assert.match(active, /class="settings-nav-row"/u);
+  assert.match(active, />Settings<\/span>/u);
 });
 
 test("sidebar announces Thread query failures with a retry action", () => {
-  const html = renderSidebar("archived", [], {
+  const html = renderSidebar([], {
     error: "summary projection unavailable",
   });
   assert.match(html, /role="alert"/u);
@@ -31,10 +32,10 @@ test("sidebar announces Thread query failures with a retry action", () => {
   assert.match(html, />Try again</u);
 });
 
-test("sidebar announces which Thread view is loading", () => {
-  const html = renderSidebar("archived", [], { loading: true });
+test("sidebar announces active Thread loading", () => {
+  const html = renderSidebar([], { loading: true });
   assert.match(html, /role="status"/u);
-  assert.match(html, /Loading archived Threads…/u);
+  assert.match(html, /Loading active Threads…/u);
 });
 
 test("Thread lifecycle action is reversible and honest about active Turns", () => {
@@ -79,18 +80,21 @@ test("active Thread menu offers Rename and a safely disabled Archive", () => {
       error: null,
       hasActiveTurn: true,
       open: true,
+      pinned: false,
       renaming: false,
       renameDraft: "Active Thread",
       onArchive: noop,
       onBeginRename: noop,
       onCancelRename: noop,
       onDraftChange: noop,
+      onPin: noop,
       onRename: noop,
       onUnarchive: noop,
     }),
   );
   assert.match(html, /role="menu"/u);
   assert.match(html, />Rename</u);
+  assert.match(html, />Pin<\/button>/u);
   assert.match(
     html,
     /role="menuitem"[^>]*disabled=""[^>]*>[\s\S]*?Archive<\/button>/u,
@@ -106,12 +110,14 @@ test("archived Thread menu offers Unarchive without inventing Delete", () => {
       error: null,
       hasActiveTurn: false,
       open: true,
+      pinned: false,
       renaming: false,
       renameDraft: "Archived Thread",
       onArchive: noop,
       onBeginRename: noop,
       onCancelRename: noop,
       onDraftChange: noop,
+      onPin: noop,
       onRename: noop,
       onUnarchive: noop,
     }),
@@ -119,10 +125,10 @@ test("archived Thread menu offers Unarchive without inventing Delete", () => {
   assert.match(html, />Unarchiving…</u);
   assert.doesNotMatch(html, />Delete</u);
   assert.doesNotMatch(html, />Rename</u);
+  assert.doesNotMatch(html, />Pin<\/button>/u);
 });
 
 function renderSidebar(
-  scope: "active" | "archived",
   threads: NativeThreadSummary[],
   state: { error?: string; loading?: boolean } = {},
 ): string {
@@ -140,10 +146,10 @@ function renderSidebar(
       onOpenContribution: noop,
       onOpenSettings: noop,
       onChangeThreadLifecycle: async () => undefined,
+      onChangeThreadPinned: async () => undefined,
       onRenameThread: async () => undefined,
       onRetryThreads: noop,
       onSelectThread: noop,
-      onThreadScopeChange: noop,
       pendingApprovalThreadIds: new Set<string>(),
       pluginContributions: [],
       projects: {
@@ -159,12 +165,12 @@ function renderSidebar(
         unavailableThreadIds: [],
         lastUsedWorkspace: "/work/zen",
       },
+      pinnedThreads: [],
       selectedPage: "agent",
       selectedThreadId: null,
       serverReady: true,
       threadError: state.error ?? null,
       threadLoading: state.loading ?? false,
-      threadScope: scope,
       threads,
       triggerSnapshot: { triggers: [], history: [], rooms: [] },
     }),

--- a/apps/zenx/test/thread-menu-interaction.test.ts
+++ b/apps/zenx/test/thread-menu-interaction.test.ts
@@ -54,6 +54,13 @@ test("Thread menu manages keyboard focus through close and row removal", async (
 
     await act(async () => trigger.click());
     assert.equal(document.activeElement?.textContent?.trim(), "Rename");
+    let menuPresentWhenTriggerFocusRestored: boolean | undefined;
+    const focusTrigger = trigger.focus.bind(trigger);
+    trigger.focus = () => {
+      menuPresentWhenTriggerFocusRestored =
+        document.querySelector('[role="menu"]') !== null;
+      focusTrigger();
+    };
 
     await act(async () => {
       document.activeElement?.dispatchEvent(
@@ -105,6 +112,7 @@ test("Thread menu manages keyboard focus through close and row removal", async (
       await Promise.resolve();
     });
     assert.equal(document.activeElement, trigger);
+    assert.equal(menuPresentWhenTriggerFocusRestored, false);
     assert.equal(document.querySelector('[role="menu"]'), null);
 
     await act(async () => trigger.click());

--- a/apps/zenx/test/thread-menu-interaction.test.ts
+++ b/apps/zenx/test/thread-menu-interaction.test.ts
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { JSDOM } from "jsdom";
-import { act, createElement, useState } from "react";
+import * as React from "react";
 import { createRoot } from "react-dom/client";
 
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
-import { Sidebar } from "../src/renderer/src/Sidebar.js";
+const { act, createElement, useState } = React;
+Object.assign(globalThis, { React });
+const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
 
 const noop = () => undefined;
 
@@ -34,6 +36,21 @@ test("Thread menu manages keyboard focus through close and row removal", async (
   try {
     await act(async () => root.render(createElement(TestSidebar)));
     const trigger = requiredElement<HTMLButtonElement>(".thread-menu-trigger");
+    const threadRow = requiredElement<HTMLButtonElement>(".thread-row");
+
+    threadRow.focus();
+    await act(async () => {
+      threadRow.dispatchEvent(
+        new dom.window.KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Escape",
+        }),
+      );
+      await Promise.resolve();
+    });
+    assert.equal(document.activeElement, threadRow);
+    assert.equal(document.querySelector('[role="menu"]'), null);
 
     await act(async () => trigger.click());
     assert.equal(document.activeElement?.textContent?.trim(), "Rename");
@@ -46,7 +63,7 @@ test("Thread menu manages keyboard focus through close and row removal", async (
         }),
       );
     });
-    assert.equal(document.activeElement?.textContent?.trim(), "Archive");
+    assert.equal(document.activeElement?.textContent?.trim(), "Pin");
 
     await act(async () => {
       document.activeElement?.dispatchEvent(
@@ -76,7 +93,7 @@ test("Thread menu manages keyboard focus through close and row removal", async (
         }),
       );
     });
-    assert.equal(document.activeElement?.textContent?.trim(), "Rename");
+    assert.equal(document.activeElement?.textContent?.trim(), "Pin");
 
     await act(async () => {
       document.activeElement?.dispatchEvent(
@@ -112,7 +129,7 @@ test("Thread menu manages keyboard focus through close and row removal", async (
     assert.equal(document.querySelector(".thread-row-shell"), null);
     assert.equal(
       document.activeElement,
-      document.getElementById("thread-scope-active"),
+      document.getElementById("sidebar-thread-list-heading"),
     );
   } finally {
     await act(async () => root.unmount());
@@ -140,10 +157,10 @@ function TestSidebar() {
     onOpenContribution: noop,
     onOpenSettings: noop,
     onChangeThreadLifecycle: async () => setThreads([]),
+    onChangeThreadPinned: async () => undefined,
     onRenameThread: async () => undefined,
     onRetryThreads: noop,
     onSelectThread: noop,
-    onThreadScopeChange: noop,
     pendingApprovalThreadIds: new Set<string>(),
     pluginContributions: [],
     projects: {
@@ -164,7 +181,7 @@ function TestSidebar() {
     serverReady: true,
     threadError: null,
     threadLoading: false,
-    threadScope: "active",
+    pinnedThreads: [],
     threads,
     triggerSnapshot: { triggers: [], history: [], rooms: [] },
   });


### PR DESCRIPTION
## Summary

- route desktop and zero-Project Thread creation through the existing DirectoryPicker, including the root Backspace guard
- make the Sidebar active-only, move archive restore into Settings, compact Add project and Settings navigation, and use local provider logos
- persist local-only ordered Thread Pins, project them into an independent Pinned section, and filter or clear stale/archive Pins without touching canonical Items
- serialize Pin mutations against the latest main-confirmed order so concurrent cross-row actions cannot overwrite one another
- fix narrow Thread overflow spacing, hover/focus/menu visibility, Escape focus semantics, and contextual Apply & restart feedback

## Boundaries

- preserves the ZAS archive gate and summary freshness from #102
- does not change Project cwd identity or projection (#104)
- adds no router, command bus, protocol, or durable state machine

## Verification

- 51 focused ZenX tests, including a deferred cross-row Pin concurrency regression
- npm --workspace apps/zenx run typecheck
- npm --workspace apps/zenx run build
- npm run format:check and git diff --check
- real Electron smoke at 1440, 1024, and 736px, including keyboard focus, DirectoryPicker, archive/unarchive, contextual restart state, and zero renderer console events

Depends on #102.
Refs #91.