### PR TITLE
fix(zenx): target development CSP rewrite

### DIFF
--- a/apps/zenx/electron.vite.config.ts
+++ b/apps/zenx/electron.vite.config.ts
@@ -6,11 +6,71 @@ import type { Plugin } from "vite";
 const productionStylePolicy = "style-src 'self'";
 const developmentStylePolicy = "style-src 'self' 'unsafe-inline'";
 
+function quotedAttribute(markup: string, name: string) {
+  const match = new RegExp(
+    `(?:^|\\s)${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`,
+    "iu",
+  ).exec(markup);
+  if (match === null) return undefined;
+
+  const value = match[1] ?? match[2];
+  if (value === undefined) return undefined;
+  const quote = match[1] === undefined ? "'" : '"';
+  const valueStart = match.index + match[0].indexOf(quote) + 1;
+  return { value, valueStart, valueEnd: valueStart + value.length };
+}
+
 function allowViteDevelopmentStyles(html: string): string {
-  if (!html.includes(productionStylePolicy)) {
-    throw new Error("ZenX renderer CSP is missing its production style policy");
+  const cspMetas = [...html.matchAll(/<!--[\s\S]*?-->|<meta\b[^>]*>/giu)]
+    .filter((match) => !match[0].startsWith("<!--"))
+    .flatMap((match) => {
+      const httpEquiv = quotedAttribute(match[0], "http-equiv");
+      return httpEquiv?.value.toLowerCase() === "content-security-policy"
+        ? [{ markup: match[0], start: match.index }]
+        : [];
+    });
+  const cspMeta = cspMetas[0];
+  if (cspMetas.length !== 1 || cspMeta === undefined) {
+    throw new Error(
+      `ZenX renderer must contain exactly one CSP meta; found ${cspMetas.length}`,
+    );
   }
-  return html.replace(productionStylePolicy, developmentStylePolicy);
+
+  const content = quotedAttribute(cspMeta.markup, "content");
+  if (content === undefined) {
+    throw new Error("ZenX renderer CSP meta is missing its content attribute");
+  }
+
+  const directives = content.value.split(";");
+  const styleDirectiveIndexes = directives.flatMap((directive, index) =>
+    /^\s*style-src(?:\s|$)/iu.test(directive) ? [index] : [],
+  );
+  const styleDirectiveIndex = styleDirectiveIndexes[0];
+  if (styleDirectiveIndexes.length !== 1 || styleDirectiveIndex === undefined) {
+    throw new Error(
+      `ZenX renderer CSP must contain exactly one style-src directive; found ${styleDirectiveIndexes.length}`,
+    );
+  }
+
+  const styleDirective = directives[styleDirectiveIndex];
+  if (
+    styleDirective === undefined ||
+    styleDirective.trim().replace(/\s+/gu, " ") !== productionStylePolicy
+  ) {
+    throw new Error(
+      "ZenX renderer CSP has an unexpected production style policy",
+    );
+  }
+  const leadingWhitespace = /^\s*/u.exec(styleDirective)?.[0] ?? "";
+  const trailingWhitespace = /\s*$/u.exec(styleDirective)?.[0] ?? "";
+  directives[styleDirectiveIndex] =
+    leadingWhitespace + developmentStylePolicy + trailingWhitespace;
+
+  const valueStart = cspMeta.start + content.valueStart;
+  const valueEnd = cspMeta.start + content.valueEnd;
+  return (
+    html.slice(0, valueStart) + directives.join(";") + html.slice(valueEnd)
+  );
 }
 
 const viteDevelopmentCsp: Plugin = {

--- a/apps/zenx/test/renderer-csp.test.ts
+++ b/apps/zenx/test/renderer-csp.test.ts
@@ -13,7 +13,9 @@ const rendererIndexPath = new URL(
 const rendererRootPath = fileURLToPath(
   new URL("../src/renderer", import.meta.url),
 );
-const configPath = new URL("../electron.vite.config.ts", import.meta.url);
+const configFilePath = fileURLToPath(
+  new URL("../electron.vite.config.ts", import.meta.url),
+);
 
 test("development Vite pipeline only relaxes the renderer CSP meta", async () => {
   const productionHtml = await readFile(rendererIndexPath, "utf8");
@@ -25,7 +27,7 @@ test("development Vite pipeline only relaxes the renderer CSP meta", async () =>
   );
   const loaded = await loadConfigFromFile(
     { command: "serve", mode: "development" },
-    configPath.pathname,
+    configFilePath,
   );
   const server = await createServer({
     ...loaded.config.renderer,
@@ -91,7 +93,7 @@ test("production Vite build keeps the renderer CSP strict", async () => {
 
   const loaded = await loadConfigFromFile(
     { command: "build", mode: "production" },
-    configPath.pathname,
+    configFilePath,
   );
   const result = await build({
     ...loaded.config.renderer,

--- a/apps/zenx/test/renderer-csp.test.ts
+++ b/apps/zenx/test/renderer-csp.test.ts
@@ -1,42 +1,115 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import { loadConfigFromFile } from "electron-vite";
-import type { Plugin } from "vite";
+import { build, createServer } from "vite";
 
 const rendererIndexPath = new URL(
   "../src/renderer/index.html",
   import.meta.url,
 );
+const rendererRootPath = fileURLToPath(
+  new URL("../src/renderer", import.meta.url),
+);
 const configPath = new URL("../electron.vite.config.ts", import.meta.url);
 
-test("keeps production styles strict while allowing Vite development injection", async () => {
+test("development Vite pipeline only relaxes the renderer CSP meta", async () => {
   const productionHtml = await readFile(rendererIndexPath, "utf8");
-
-  assert.match(productionHtml, /style-src 'self';/u);
-  assert.doesNotMatch(productionHtml, /style-src[^;]*'unsafe-inline'/u);
+  const developmentFixture = productionHtml.replace(
+    "<head>",
+    `<head>
+    <!-- style-src 'self' -->
+    <meta name="csp-decoy" content="style-src 'self'" />`,
+  );
   const loaded = await loadConfigFromFile(
     { command: "serve", mode: "development" },
     configPath.pathname,
   );
-  const plugin = loaded.config.renderer?.plugins?.find(
-    (candidate) =>
-      candidate !== false &&
-      candidate !== null &&
-      candidate !== undefined &&
-      typeof candidate === "object" &&
-      "name" in candidate &&
-      candidate.name === "zenx-vite-development-csp",
-  ) as Plugin | undefined;
-  assert.ok(plugin && typeof plugin === "object");
-  assert.equal(plugin.apply, "serve");
-  const transformIndexHtml = plugin.transformIndexHtml;
-  assert.equal(typeof transformIndexHtml, "function");
+  const server = await createServer({
+    ...loaded.config.renderer,
+    configFile: false,
+    logLevel: "silent",
+    root: rendererRootPath,
+    server: { middlewareMode: true },
+  });
 
-  const developmentHtml = await (
-    transformIndexHtml as (html: string) => string | Promise<string>
-  )(productionHtml);
-  assert.match(developmentHtml, /style-src 'self' 'unsafe-inline';/u);
-  assert.match(developmentHtml, /script-src 'self';/u);
+  try {
+    const developmentHtml = await server.transformIndexHtml(
+      "/index.html",
+      developmentFixture,
+    );
+
+    assert.match(developmentHtml, /<!-- style-src 'self' -->/u);
+    assert.match(
+      developmentHtml,
+      /<meta name="csp-decoy" content="style-src 'self'" \/>/u,
+    );
+    assert.match(
+      developmentHtml,
+      /http-equiv="Content-Security-Policy"[\s\S]*?content="[^"]*style-src 'self' 'unsafe-inline';/u,
+    );
+    assert.equal(
+      developmentHtml.match(/style-src 'self' 'unsafe-inline'/gu)?.length,
+      1,
+    );
+    assert.match(developmentHtml, /script-src 'self';/u);
+
+    await assert.rejects(
+      server.transformIndexHtml(
+        "/index.html",
+        productionHtml.replace(
+          "style-src 'self';",
+          "style-src 'self'; style-src 'self';",
+        ),
+      ),
+      /exactly one style-src directive/u,
+    );
+
+    const cspMeta = productionHtml.match(
+      /<meta\s+http-equiv="Content-Security-Policy"[\s\S]*?\/>/u,
+    )?.[0];
+    assert.ok(cspMeta);
+    await assert.rejects(
+      server.transformIndexHtml(
+        "/index.html",
+        productionHtml.replace(cspMeta, `${cspMeta}\n${cspMeta}`),
+      ),
+      /exactly one CSP meta/u,
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+test("production Vite build keeps the renderer CSP strict", async () => {
+  const productionHtml = await readFile(rendererIndexPath, "utf8");
+
+  assert.match(productionHtml, /style-src 'self';/u);
+  assert.doesNotMatch(productionHtml, /style-src[^;]*'unsafe-inline'/u);
+
+  const loaded = await loadConfigFromFile(
+    { command: "build", mode: "production" },
+    configPath.pathname,
+  );
+  const result = await build({
+    ...loaded.config.renderer,
+    configFile: false,
+    logLevel: "silent",
+    root: rendererRootPath,
+    build: { ...loaded.config.renderer?.build, write: false },
+  });
+  const outputs = (Array.isArray(result) ? result : [result]).flatMap(
+    (entry) => ("output" in entry ? entry.output : []),
+  );
+  const indexHtml = outputs.find(
+    (entry) => entry.type === "asset" && entry.fileName === "index.html",
+  );
+
+  assert.ok(indexHtml && indexHtml.type === "asset");
+  const builtHtml = String(indexHtml.source);
+  assert.match(builtHtml, /style-src 'self';/u);
+  assert.doesNotMatch(builtHtml, /style-src[^;]*'unsafe-inline'/u);
+  assert.match(builtHtml, /script-src 'self';/u);
 });


### PR DESCRIPTION
## Summary

- locate the unique `Content-Security-Policy` meta while ignoring earlier HTML comments and unrelated duplicate tokens
- require one strict `style-src 'self'` directive, then add `'unsafe-inline'` only in the serve-only transform
- exercise the real Vite development transform and production build boundaries, including ambiguous CSP rejection
- convert the electron-vite config URL with `fileURLToPath`, so the focused pipeline tests run on Windows as well as POSIX

Closes #99

## Verification

- Windows focused regression: `npx tsx --test --test-name-pattern "development Vite pipeline|production Vite build" apps/zenx/test/renderer-csp.test.ts` — 2 passed
- `npm --workspace apps/zenx run typecheck` — passed
- `npm --workspace apps/zenx run build` — passed; the production renderer build retained strict `style-src 'self'` and `script-src 'self'`
- `npm --workspace apps/zenx test` — CSP tests passed; suite total 469 passed, 10 skipped, 1 unrelated Windows `EPERM` while creating the macOS symlink fixture in `package-zenx-portable.test.mjs`
- `npm --workspace apps/zenx run check` — stopped before task code at `brand:check` because six generated SVGs already present on the rebased `origin/main` baseline are reported stale
- `npx prettier --check apps/zenx/test/renderer-csp.test.ts` and `git diff --check` — passed

Rebased onto `origin/main` containing PR #113. CI for the updated exact head is running.