### PR TITLE
fix(zenx): serialize verified artifact cache transactions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -137,7 +137,7 @@
 - **ZenXPlaywrightSessionFence** — Playwright provider 在一个瞬时 CLI session 内串行执行操作，并用稳定 tab/document identity 与 lifecycle revision 围住选择、观察、截图、摘要和关闭；该 fence 不进入 Core 或 durable journal。
 - **ZenXProviderLaunchVerification** — 外部 provider 在实际 spawn 前再次验证绑定的 canonical executable、browser payload、shim companion、manifest digest 与 pinned semantic version；失败只产生显式诊断，不自动改用未验证资产。
 - **ZenXPackagedProviderSmoke** — ZenX 构建验证用真实 resources/providers manifest、asset hash、version pin 与 bundled-only catalog path 检查离线 packaged provisioning；它是一次性测试流程，不是运行时 coordinator 或 durable state。
-- **VerifiedArtifactAcquisition** — ZenX release assembly 只以 artifact name、URL、SHA-256、deadline 与 cache location 取得 digest-addressed immutable file，并在内部收口 proxy-aware bounded transport、stream size、partial cleanup、cache revalidation 与 atomic publication；它不成为运行时下载器或第二条 packaging pipeline。
+- **VerifiedArtifactAcquisition** — ZenX release assembly 只以 artifact name、URL、SHA-256、deadline 与 cache location 取得 digest-addressed immutable file，并在内部以 per-digest 跨进程 transaction 收口 proxy-aware bounded transport、stream size、partial cleanup、no-follow cache revalidation 与 atomic publication；它不成为运行时下载器或第二条 packaging pipeline。
 - **ZenXPackagingRunStaging** — portable app 与 packaged smoke 继续复用同一 provider assembly、digest injection 与 Electron packager，但每次只在私有 run directory 内写 build/resources/app/artifact，以 target lock 拒绝同目标并发并在完整 staging 后发布稳定产物；它不复制 release pipeline。
 - **ZenXSelfControlCapabilityPackage** — ZenX 产品层通过 capability registry 暴露 Project/Thread 自控工具，
   只从 workspace 与 canonical Thread 投影派生结果，并经进程内可替换的 typed App Server request port 执行操作，

--- a/apps/zenx/test/playwright-browser-assembly.test.mjs
+++ b/apps/zenx/test/playwright-browser-assembly.test.mjs
@@ -228,9 +228,12 @@ test("browser assembly fails closed on digest and reuses verified cache offline"
       deadline: Date.now() + 5_000,
     });
     assert.equal(offline.assets[0].sha256, online.assets[0].sha256);
-    assert.deepEqual(await readdir(path.join(cacheLocation, "sha256")), [
-      archiveSha256,
-    ]);
+    assert.deepEqual(
+      (await readdir(path.join(cacheLocation, "sha256"))).filter(
+        (entry) => !entry.startsWith("."),
+      ),
+      [archiveSha256],
+    );
   } finally {
     await server?.close();
     await rm(directory, { recursive: true, force: true });

--- a/apps/zenx/test/verified-artifact-acquisition.test.mjs
+++ b/apps/zenx/test/verified-artifact-acquisition.test.mjs
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   chmod,
+  lstat,
+  mkdir,
   mkdtemp,
   readFile,
   readdir,
   rm,
   stat,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { createServer } from "node:http";
@@ -159,6 +162,187 @@ test("re-verifies a cache hit before reuse", async () => {
     assert.deepEqual(await readFile(cached), bytes);
     assert.equal(requests, 2);
   } finally {
+    await fixture.close();
+  }
+});
+
+test("serializes invalid-cache cleanup with a competing publish", async () => {
+  const bytes = Buffer.from("transaction winner bytes");
+  const digest = sha256(bytes);
+  let releaseRequest;
+  const requestReceived = new Promise((resolve) => {
+    releaseRequest = resolve;
+  });
+  const fixture = await createFixture((_request, response) => {
+    response.end(bytes, releaseRequest);
+  });
+  const cacheFile = path.join(fixture.cacheLocation, "sha256", digest);
+  const readyFile = path.join(fixture.cacheLocation, "slow-ready");
+  const releaseFile = path.join(fixture.cacheLocation, "release-slow");
+  await mkdir(path.dirname(cacheFile), { recursive: true });
+  await writeFile(cacheFile, "invalid predecessor");
+
+  const slow = acquirePausedAfterCacheSnapshot(
+    {
+      artifactName: "slow invalid-cache contender",
+      url: "http://127.0.0.1:1/unavailable",
+      digest,
+      deadline: Date.now() + 5_000,
+      cacheLocation: fixture.cacheLocation,
+    },
+    { cacheFile, readyFile, releaseFile },
+  );
+  try {
+    await waitForPath(readyFile);
+    const fast = acquireInChild({
+      artifactName: "publishing contender",
+      url: `${fixture.url}/winner`,
+      digest,
+      deadline: Date.now() + 5_000,
+      cacheLocation: fixture.cacheLocation,
+    });
+    const publishedBeforeRelease = await Promise.race([
+      requestReceived.then(async () => {
+        await fast;
+        return true;
+      }),
+      delay(500).then(() => false),
+    ]);
+    await writeFile(releaseFile, "release");
+
+    const slowResult = await slow;
+    assert.equal(slowResult.ok, false);
+    const fastResult = await fast;
+    assert.equal(fastResult, cacheFile);
+    assert.deepEqual(await readFile(cacheFile), bytes);
+    assert.equal(
+      publishedBeforeRelease,
+      false,
+      "a contender must not publish while the invalid-cache transaction is held",
+    );
+  } finally {
+    await writeFile(releaseFile, "release").catch(() => {});
+    await fixture.close();
+  }
+});
+
+test(
+  "removes a cache-path symlink without changing its target",
+  { skip: process.platform === "win32" ? "POSIX mode contract" : false },
+  async () => {
+    const bytes = Buffer.from("replacement artifact bytes");
+    const digest = sha256(bytes);
+    const fixture = await createFixture((_request, response) => {
+      response.end(bytes);
+    });
+    const cacheFile = path.join(fixture.cacheLocation, "sha256", digest);
+    const target = path.join(fixture.cacheLocation, "symlink-target");
+    try {
+      await mkdir(path.dirname(cacheFile), { recursive: true });
+      await writeFile(target, "do not mutate this target", { mode: 0o444 });
+      await chmod(target, 0o444);
+      const targetMode = (await stat(target)).mode & 0o777;
+      await symlink(target, cacheFile);
+
+      assert.equal(
+        await acquireVerifiedArtifact({
+          artifactName: "symlinked cache fixture",
+          url: `${fixture.url}/replacement`,
+          digest,
+          deadline: Date.now() + 2_000,
+          cacheLocation: fixture.cacheLocation,
+        }),
+        cacheFile,
+      );
+
+      assert.deepEqual(await readFile(cacheFile), bytes);
+      assert.equal((await lstat(cacheFile)).isFile(), true);
+      assert.equal(await readFile(target, "utf8"), "do not mutate this target");
+      assert.equal((await stat(target)).mode & 0o777, targetMode);
+    } finally {
+      await fixture.close();
+    }
+  },
+);
+
+test("converges cross-process contenders through one download", async () => {
+  const bytes = Buffer.from("one serialized download");
+  let requests = 0;
+  const fixture = await createFixture((_request, response) => {
+    requests += 1;
+    setTimeout(() => response.end(bytes), 50);
+  });
+  try {
+    const options = {
+      artifactName: "cross-process stress fixture",
+      url: `${fixture.url}/serialized`,
+      digest: sha256(bytes),
+      deadline: Date.now() + 10_000,
+      cacheLocation: fixture.cacheLocation,
+    };
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => acquireInChild(options)),
+    );
+
+    assert.equal(new Set(results).size, 1);
+    assert.deepEqual(await readFile(results[0]), bytes);
+    assert.equal(requests, 1);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("reclaims a dead contender without leaving the digest blocked", async () => {
+  const bytes = Buffer.from("recovered after dead owner");
+  const digest = sha256(bytes);
+  const fixture = await createFixture((_request, response) => {
+    response.end(bytes);
+  });
+  const cacheFile = path.join(fixture.cacheLocation, "sha256", digest);
+  const readyFile = path.join(fixture.cacheLocation, "dead-owner-ready");
+  const releaseFile = path.join(fixture.cacheLocation, "never-release-owner");
+  await mkdir(path.dirname(cacheFile), { recursive: true });
+  await writeFile(cacheFile, "invalid predecessor");
+
+  const deadOwner = acquirePausedAfterCacheSnapshot(
+    {
+      artifactName: "dead cache transaction owner",
+      url: `${fixture.url}/unused`,
+      digest,
+      deadline: Date.now() + 30_000,
+      cacheLocation: fixture.cacheLocation,
+    },
+    { cacheFile, readyFile, releaseFile },
+  );
+  try {
+    await waitForPath(readyFile);
+    assert.equal(deadOwner.child.kill(), true);
+    await assert.rejects(deadOwner, /paused acquisition exited/u);
+
+    const started = Date.now();
+    assert.equal(
+      await acquireVerifiedArtifact({
+        artifactName: "dead-owner recovery fixture",
+        url: `${fixture.url}/recovery`,
+        digest,
+        deadline: Date.now() + 2_000,
+        cacheLocation: fixture.cacheLocation,
+      }),
+      cacheFile,
+    );
+    assert.ok(
+      Date.now() - started < 1_500,
+      "dead owner cleanup must be bounded",
+    );
+    assert.deepEqual(await readFile(cacheFile), bytes);
+    assert.deepEqual(
+      await readdir(
+        path.join(fixture.cacheLocation, "sha256", ".transactions", digest),
+      ),
+      [],
+    );
+  } finally {
+    deadOwner.child.kill();
     await fixture.close();
   }
 });
@@ -358,6 +542,110 @@ async function acquireInChild(options, environment) {
     },
   );
   return result.stdout;
+}
+
+function acquirePausedAfterCacheSnapshot(options, gate) {
+  const source = `
+    import fs from "node:fs";
+    const originalOpen = fs.promises.open;
+    const originalWriteFile = fs.promises.writeFile;
+    const originalAccess = fs.promises.access;
+    let paused = false;
+    fs.promises.open = async (...arguments_) => {
+      const handle = await originalOpen(...arguments_);
+      if (!paused && String(arguments_[0]) === process.env.ZENX_CACHE_FILE) {
+        paused = true;
+        const metadata = await handle.stat();
+        const snapshot = await handle.readFile();
+        await handle.close();
+        await originalWriteFile(process.env.ZENX_READY_FILE, "ready");
+        while (true) {
+          try {
+            await originalAccess(process.env.ZENX_RELEASE_FILE);
+            break;
+          } catch (error) {
+            if (error?.code !== "ENOENT") throw error;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        let position = 0;
+        return {
+          stat: async () => metadata,
+          read: async (buffer, offset, length) => {
+            const bytesRead = Math.min(length, snapshot.byteLength - position);
+            if (bytesRead > 0) {
+              snapshot.copy(buffer, offset, position, position + bytesRead);
+              position += bytesRead;
+            }
+            return { bytesRead, buffer };
+          },
+          close: async () => {},
+        };
+      }
+      return handle;
+    };
+    const { acquireVerifiedArtifact } = await import(${JSON.stringify(acquisitionModule)});
+    try {
+      const result = await acquireVerifiedArtifact(JSON.parse(process.env.ZENX_ARTIFACT_OPTIONS));
+      process.stdout.write(JSON.stringify({ ok: true, result }));
+    } catch (error) {
+      process.stdout.write(JSON.stringify({ ok: false, message: error.message }));
+    }
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--input-type=module", "--eval", source],
+    {
+      env: {
+        ...process.env,
+        ZENX_ARTIFACT_OPTIONS: JSON.stringify(options),
+        ZENX_CACHE_FILE: gate.cacheFile,
+        ZENX_READY_FILE: gate.readyFile,
+        ZENX_RELEASE_FILE: gate.releaseFile,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk) => (stdout += chunk));
+  child.stderr.on("data", (chunk) => (stderr += chunk));
+  const completion = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `paused acquisition exited ${String(code)} ${signal ?? ""}: ${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(JSON.parse(stdout));
+    });
+  });
+  completion.child = child;
+  return completion;
+}
+
+async function waitForPath(file) {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    try {
+      await stat(file);
+      return;
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    await delay(10);
+  }
+  throw new Error(`Timed out waiting for ${file}`);
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 async function cacheFiles(root) {

--- a/apps/zenx/test/verified-artifact-acquisition.test.mjs
+++ b/apps/zenx/test/verified-artifact-acquisition.test.mjs
@@ -11,6 +11,7 @@ import {
   rm,
   stat,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import { createServer } from "node:http";
@@ -292,6 +293,94 @@ test("converges cross-process contenders through one download", async () => {
   }
 });
 
+test("ignores a participant atomically retired while it is observed", async () => {
+  const bytes = Buffer.from("retirement race recovery");
+  const digest = sha256(bytes);
+  const fixture = await createFixture((_request, response) => {
+    response.end(bytes);
+  });
+  const record = await seedParticipant(fixture.cacheLocation, digest, {
+    token: "retiring-observer-fixture",
+    createdAt: Date.now(),
+    deadline: Date.now() + 30_000,
+    ticket: 1,
+  });
+  try {
+    const result = await acquireAfterRetiringObservedParticipant(
+      {
+        artifactName: "retirement observer fixture",
+        url: `${fixture.url}/retired-observer`,
+        digest,
+        deadline: Date.now() + 5_000,
+        cacheLocation: fixture.cacheLocation,
+      },
+      record,
+    );
+
+    assert.deepEqual(await readFile(result), bytes);
+    assert.deepEqual(await readdir(record.transactionRoot), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("quarantines a live participant with future-skewed timestamps", async () => {
+  const bytes = Buffer.from("future timestamp recovery");
+  const digest = sha256(bytes);
+  const fixture = await createFixture((_request, response) => {
+    response.end(bytes);
+  });
+  const future = Date.now() + 24 * 60 * 60_000;
+  const record = await seedParticipant(fixture.cacheLocation, digest, {
+    token: "future-owner-fixture",
+    createdAt: future,
+    deadline: future + 30_000,
+    ticket: 1,
+    modifiedAt: future,
+  });
+  try {
+    const result = await acquireVerifiedArtifact({
+      artifactName: "future owner fixture",
+      url: `${fixture.url}/future-owner`,
+      digest,
+      deadline: Date.now() + 2_000,
+      cacheLocation: fixture.cacheLocation,
+    });
+
+    assert.deepEqual(await readFile(result), bytes);
+    assert.deepEqual(await readdir(record.transactionRoot), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test("quarantines a published participant without a ticket", async () => {
+  const bytes = Buffer.from("invalid participant recovery");
+  const digest = sha256(bytes);
+  const fixture = await createFixture((_request, response) => {
+    response.end(bytes);
+  });
+  const record = await seedParticipant(fixture.cacheLocation, digest, {
+    token: "missing-ticket-fixture",
+    createdAt: Date.now(),
+    deadline: Date.now() + 30_000,
+  });
+  try {
+    const result = await acquireVerifiedArtifact({
+      artifactName: "invalid participant fixture",
+      url: `${fixture.url}/invalid-participant`,
+      digest,
+      deadline: Date.now() + 2_000,
+      cacheLocation: fixture.cacheLocation,
+    });
+
+    assert.deepEqual(await readFile(result), bytes);
+    assert.deepEqual(await readdir(record.transactionRoot), []);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test("reclaims a dead contender without leaving the digest blocked", async () => {
   const bytes = Buffer.from("recovered after dead owner");
   const digest = sha256(bytes);
@@ -544,6 +633,54 @@ async function acquireInChild(options, environment) {
   return result.stdout;
 }
 
+async function acquireAfterRetiringObservedParticipant(options, record) {
+  const source = `
+    import fs from "node:fs";
+    import { syncBuiltinESMExports } from "node:module";
+    const originalReadFile = fs.promises.readFile;
+    let ownerObservations = 0;
+    fs.promises.readFile = async (...arguments_) => {
+      const result = await originalReadFile(...arguments_);
+      if (String(arguments_[0]) === process.env.ZENX_OBSERVED_OWNER) {
+        ownerObservations += 1;
+        if (ownerObservations === 2) {
+          await fs.promises.rename(
+            process.env.ZENX_OBSERVED_PARTICIPANT,
+            process.env.ZENX_RETIRED_PARTICIPANT,
+          );
+          await fs.promises.rm(process.env.ZENX_RETIRED_PARTICIPANT, {
+            recursive: true,
+            force: true,
+          });
+        }
+      }
+      return result;
+    };
+    syncBuiltinESMExports();
+    const { acquireVerifiedArtifact } = await import(${JSON.stringify(acquisitionModule)});
+    const result = await acquireVerifiedArtifact(JSON.parse(process.env.ZENX_ARTIFACT_OPTIONS));
+    process.stdout.write(result);
+  `;
+  const retiredParticipant = path.join(
+    record.transactionRoot,
+    `retired-${path.basename(record.directory)}-fixture`,
+  );
+  const result = await run(
+    process.execPath,
+    ["--input-type=module", "--eval", source],
+    {
+      env: {
+        ...process.env,
+        ZENX_ARTIFACT_OPTIONS: JSON.stringify(options),
+        ZENX_OBSERVED_OWNER: path.join(record.directory, "owner.json"),
+        ZENX_OBSERVED_PARTICIPANT: record.directory,
+        ZENX_RETIRED_PARTICIPANT: retiredParticipant,
+      },
+    },
+  );
+  return result.stdout;
+}
+
 function acquirePausedAfterCacheSnapshot(options, gate) {
   const source = `
     import fs from "node:fs";
@@ -628,6 +765,41 @@ function acquirePausedAfterCacheSnapshot(options, gate) {
   });
   completion.child = child;
   return completion;
+}
+
+async function seedParticipant(cacheLocation, digest, options) {
+  const transactionRoot = path.join(
+    cacheLocation,
+    "sha256",
+    ".transactions",
+    digest,
+  );
+  const directory = path.join(transactionRoot, `participant-${options.token}`);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await writeFile(
+    path.join(directory, "owner.json"),
+    `${JSON.stringify({
+      version: 1,
+      token: options.token,
+      pid: process.pid,
+      createdAt: options.createdAt,
+      deadline: options.deadline,
+    })}\n`,
+    { mode: 0o600 },
+  );
+  if (options.choosing === true) {
+    await writeFile(path.join(directory, "choosing"), "", { mode: 0o600 });
+  }
+  if (options.ticket !== undefined) {
+    await writeFile(path.join(directory, "ticket"), `${options.ticket}\n`, {
+      mode: 0o600,
+    });
+  }
+  if (options.modifiedAt !== undefined) {
+    const modifiedAt = new Date(options.modifiedAt);
+    await utimes(directory, modifiedAt, modifiedAt);
+  }
+  return { transactionRoot, directory };
 }
 
 async function waitForPath(file) {

--- a/apps/zenx/test/verified-artifact-acquisition.test.mjs
+++ b/apps/zenx/test/verified-artifact-acquisition.test.mjs
@@ -281,9 +281,15 @@ test("converges cross-process contenders through one download", async () => {
       deadline: Date.now() + 10_000,
       cacheLocation: fixture.cacheLocation,
     };
-    const results = await Promise.all(
+    const settled = await Promise.allSettled(
       Array.from({ length: 12 }, () => acquireInChild(options)),
     );
+    const failures = settled.filter((result) => result.status === "rejected");
+    assert.deepEqual(
+      failures.map((result) => result.reason?.message ?? String(result.reason)),
+      [],
+    );
+    const results = settled.map((result) => result.value);
 
     assert.equal(new Set(results).size, 1);
     assert.deepEqual(await readFile(results[0]), bytes);

--- a/scripts/verified-artifact-acquisition.mjs
+++ b/scripts/verified-artifact-acquisition.mjs
@@ -467,32 +467,57 @@ async function readParticipant(directory, name) {
     if (error?.code !== "ENOENT" && !(error instanceof SyntaxError))
       throw error;
   }
+  const observedAt = Date.now();
   const token = name.replace(/^(?:candidate|participant)-/u, "");
-  const validOwner =
+  const ownerFieldsAreValid =
     owner?.version === 1 &&
     owner.token === token &&
     Number.isSafeInteger(owner.pid) &&
     owner.pid > 0 &&
     Number.isSafeInteger(owner.createdAt) &&
-    Number.isSafeInteger(owner.deadline);
-  const age = Date.now() - directoryMetadata.mtimeMs;
+    owner.createdAt >= 0 &&
+    Number.isSafeInteger(owner.deadline) &&
+    owner.deadline >= owner.createdAt;
+  const ownerTimeIsFuture =
+    ownerFieldsAreValid &&
+    owner.createdAt > observedAt + transactionInitializationGraceMilliseconds;
+  const validOwner = ownerFieldsAreValid && !ownerTimeIsFuture;
+  const directoryTimeIsFuture =
+    directoryMetadata.mtimeMs >
+    observedAt + transactionInitializationGraceMilliseconds;
+  const age = Math.max(0, observedAt - directoryMetadata.mtimeMs);
   if (!validOwner) {
-    return {
+    return await returnIfParticipantPathUnchanged(
       directory,
-      token,
-      choosing: true,
-      ticket: undefined,
-      stale: age >= transactionInitializationGraceMilliseconds,
-    };
+      directoryMetadata,
+      {
+        directory,
+        token,
+        choosing: true,
+        ticket: undefined,
+        // candidate-* can be observed between mkdir and owner publication.
+        // participant-* is published only after owner + choosing are present,
+        // so malformed published state is safe to quarantine immediately.
+        stale:
+          name.startsWith("participant-") ||
+          ownerTimeIsFuture ||
+          directoryTimeIsFuture ||
+          age >= transactionInitializationGraceMilliseconds,
+      },
+    );
   }
 
   const retirementDeadline = Math.min(
     owner.deadline + transactionRetirementGraceMilliseconds,
     owner.createdAt + maxTransactionLeaseMilliseconds,
   );
-  const stale = !processIsAlive(owner.pid) || Date.now() >= retirementDeadline;
+  const stale = !processIsAlive(owner.pid) || observedAt >= retirementDeadline;
   if (stale) {
-    return { directory, token, choosing: true, ticket: undefined, stale };
+    return await returnIfParticipantPathUnchanged(
+      directory,
+      directoryMetadata,
+      { directory, token, choosing: true, ticket: undefined, stale },
+    );
   }
 
   const choosing =
@@ -507,7 +532,37 @@ async function readParticipant(directory, name) {
   } catch (error) {
     if (error?.code !== "ENOENT") throw error;
   }
-  return { directory, token, choosing, ticket, stale: false };
+  return await returnIfParticipantPathUnchanged(directory, directoryMetadata, {
+    directory,
+    token,
+    choosing,
+    ticket,
+    // A published participant without either an in-progress choosing marker or
+    // a valid ticket cannot become valid. Quarantine it instead of allowing it
+    // to reject every later acquisition.
+    stale: name.startsWith("participant-") && !choosing && ticket === undefined,
+  });
+}
+
+async function returnIfParticipantPathUnchanged(
+  directory,
+  directoryMetadata,
+  participant,
+) {
+  let currentMetadata;
+  try {
+    currentMetadata = await lstat(directory);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (
+    !currentMetadata.isDirectory() ||
+    !sameFile(directoryMetadata, currentMetadata)
+  ) {
+    return undefined;
+  }
+  return participant;
 }
 
 async function assertTransactionOwner(transaction) {

--- a/scripts/verified-artifact-acquisition.mjs
+++ b/scripts/verified-artifact-acquisition.mjs
@@ -1,5 +1,18 @@
 import { createHash, randomUUID } from "node:crypto";
-import { chmod, link, lstat, mkdir, open, rm, unlink } from "node:fs/promises";
+import { constants } from "node:fs";
+import {
+  access,
+  link,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 
 import { EnvHttpProxyAgent, fetch } from "undici";
@@ -7,12 +20,21 @@ import { EnvHttpProxyAgent, fetch } from "undici";
 const digestPattern = /^[a-f0-9]{64}$/u;
 const maxArtifactBytes = 512 * 1024 * 1024;
 const maxConnectMilliseconds = 10_000;
+// Production acquisitions use a two-minute deadline. A dead owner is reaped
+// immediately by PID; PID reuse or a corrupt future deadline can delay cleanup
+// only until this lease bound, and an owner revalidates its ticket before
+// invalid cleanup and atomic publish.
+const maxTransactionLeaseMilliseconds = 5 * 60_000;
 const readBufferBytes = 64 * 1024;
+const transactionInitializationGraceMilliseconds = 2_000;
+const transactionRetirementGraceMilliseconds = 5_000;
+const transactionWaitMilliseconds = 25;
 
 /**
  * Acquire one digest-addressed immutable file. Cache verification, proxy-aware
- * transport, timeouts, streaming bounds, partial cleanup, and atomic cache
- * publication stay behind this interface.
+ * transport, timeouts, streaming bounds, partial cleanup, no-follow cache
+ * handling, and the per-digest cross-process transaction stay behind this
+ * interface.
  */
 export async function acquireVerifiedArtifact(options) {
   const artifactName = requiredString(options?.artifactName, "artifactName");
@@ -26,17 +48,26 @@ export async function acquireVerifiedArtifact(options) {
   try {
     ensureBeforeDeadline(deadline);
     await mkdir(cacheDirectory, { recursive: true, mode: 0o700 });
-    if (await isVerifiedFile(cacheFile, digest, deadline)) {
-      await makeImmutable(cacheFile);
-      return cacheFile;
-    }
-    await removeInvalidCacheEntry(cacheFile);
-    return await downloadAndPublish({
-      url: options.url,
+    return await withDigestTransaction({
+      cacheDirectory,
       digest,
       deadline,
-      cacheDirectory,
-      cacheFile,
+      action: async (transaction) => {
+        if (await isVerifiedFile(cacheFile, digest, deadline)) {
+          return cacheFile;
+        }
+        await assertTransactionOwner(transaction);
+        await removeInvalidCacheEntry(cacheFile);
+        await assertTransactionOwner(transaction);
+        return await downloadAndPublish({
+          url: options.url,
+          digest,
+          deadline,
+          cacheDirectory,
+          cacheFile,
+          transaction,
+        });
+      },
     });
   } catch (error) {
     const reason = acquisitionReason(error);
@@ -114,6 +145,7 @@ async function downloadAndPublish(options) {
     }
 
     ensureBeforeDeadline(options.deadline);
+    await assertTransactionOwner(options.transaction);
     try {
       await link(partialFile, options.cacheFile);
     } catch (error) {
@@ -130,7 +162,6 @@ async function downloadAndPublish(options) {
         );
       }
     }
-    await makeImmutable(options.cacheFile);
     return options.cacheFile;
   } catch (error) {
     if (controller.signal.aborted) {
@@ -145,20 +176,36 @@ async function downloadAndPublish(options) {
 }
 
 async function isVerifiedFile(file, expectedDigest, deadline) {
-  let metadata;
+  let pathMetadata;
   try {
-    metadata = await lstat(file);
+    pathMetadata = await lstat(file);
   } catch (error) {
     if (error?.code === "ENOENT") return false;
     throw error;
   }
-  if (!metadata.isFile() || metadata.size > maxArtifactBytes) return false;
+  if (!pathMetadata.isFile() || pathMetadata.size > maxArtifactBytes) {
+    return false;
+  }
 
-  const handle = await open(file, "r");
+  let handle;
+  try {
+    handle = await openRegularFileNoFollow(file);
+  } catch (error) {
+    if (isMissingOrSymlinkError(error)) return false;
+    throw error;
+  }
   const hash = createHash("sha256");
   const buffer = Buffer.allocUnsafe(readBufferBytes);
   let position = 0;
   try {
+    const handleMetadata = await handle.stat();
+    if (
+      !handleMetadata.isFile() ||
+      !sameFile(pathMetadata, handleMetadata) ||
+      handleMetadata.size > maxArtifactBytes
+    ) {
+      return false;
+    }
     while (true) {
       ensureBeforeDeadline(deadline);
       const { bytesRead } = await handle.read(
@@ -172,29 +219,350 @@ async function isVerifiedFile(file, expectedDigest, deadline) {
       position += bytesRead;
       if (position > maxArtifactBytes) return false;
     }
+    ensureBeforeDeadline(deadline);
+    const currentPathMetadata = await lstat(file).catch((error) => {
+      if (error?.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (
+      currentPathMetadata === undefined ||
+      !sameFile(currentPathMetadata, handleMetadata) ||
+      hash.digest("hex") !== expectedDigest
+    ) {
+      return false;
+    }
+    await handle.chmod(0o444);
+    return true;
   } finally {
     await handle.close();
   }
-  ensureBeforeDeadline(deadline);
-  return hash.digest("hex") === expectedDigest;
 }
 
 async function removeInvalidCacheEntry(file) {
+  const quarantine = path.join(
+    path.dirname(file),
+    `.${path.basename(file)}.${randomUUID()}.invalid`,
+  );
   try {
-    await chmod(file, 0o600);
+    await rename(file, quarantine);
   } catch (error) {
     if (error?.code === "ENOENT") return;
     throw error;
   }
+
+  let shouldRestore = true;
   try {
-    await unlink(file);
-  } catch (error) {
-    if (error?.code !== "ENOENT") throw error;
+    const pathMetadata = await lstat(quarantine);
+    if (pathMetadata.isSymbolicLink()) {
+      await unlink(quarantine);
+      shouldRestore = false;
+      return;
+    }
+    if (!pathMetadata.isFile()) {
+      throw acquisitionFailure("invalid cache entry is not a regular file");
+    }
+
+    const handle = await openRegularFileNoFollow(quarantine);
+    try {
+      const handleMetadata = await handle.stat();
+      if (!handleMetadata.isFile() || !sameFile(pathMetadata, handleMetadata)) {
+        throw acquisitionFailure("invalid cache entry changed during cleanup");
+      }
+      await handle.chmod(0o600);
+    } finally {
+      await handle.close();
+    }
+    await unlink(quarantine);
+    shouldRestore = false;
+  } finally {
+    if (shouldRestore) {
+      await rename(quarantine, file).catch(() => {});
+    }
   }
 }
 
-async function makeImmutable(file) {
-  await chmod(file, 0o444);
+async function openRegularFileNoFollow(file) {
+  const flags =
+    constants.O_RDONLY |
+    (typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0);
+  return await open(file, flags);
+}
+
+async function withDigestTransaction(options) {
+  const transactionRoot = path.join(
+    options.cacheDirectory,
+    ".transactions",
+    options.digest,
+  );
+  await mkdir(transactionRoot, { recursive: true, mode: 0o700 });
+  const transaction = await acquireTransaction({
+    transactionRoot,
+    deadline: options.deadline,
+  });
+  try {
+    await assertTransactionOwner(transaction);
+    return await options.action(transaction);
+  } finally {
+    await retireTransactionDirectory(
+      transaction.transactionRoot,
+      transaction.directory,
+    );
+  }
+}
+
+async function acquireTransaction(options) {
+  // Unique contender directories avoid a fixed lock pathname's stale-cleanup
+  // ABA race. Each contender chooses one ticket, then waits for every lower
+  // (ticket, token) pair; newcomers observe the published ticket and queue later.
+  const token = randomUUID();
+  const createdAt = Date.now();
+  const candidateDirectory = path.join(
+    options.transactionRoot,
+    `candidate-${token}`,
+  );
+  const directory = path.join(options.transactionRoot, `participant-${token}`);
+  const owner = {
+    version: 1,
+    token,
+    pid: process.pid,
+    createdAt,
+    deadline: options.deadline,
+  };
+  await mkdir(candidateDirectory, { mode: 0o700 });
+  try {
+    await Promise.all([
+      writeFile(
+        path.join(candidateDirectory, "owner.json"),
+        `${JSON.stringify(owner)}\n`,
+        { mode: 0o600 },
+      ),
+      writeFile(path.join(candidateDirectory, "choosing"), "", {
+        mode: 0o600,
+      }),
+    ]);
+    await rename(candidateDirectory, directory);
+
+    const participants = await activeParticipants(options.transactionRoot);
+    const ticket =
+      participants.reduce(
+        (maximum, participant) =>
+          participant.ticket === undefined
+            ? maximum
+            : Math.max(maximum, participant.ticket),
+        0,
+      ) + 1;
+    if (!Number.isSafeInteger(ticket)) {
+      throw acquisitionFailure("cache transaction ticket space exhausted");
+    }
+    await writeFile(path.join(directory, "ticket"), `${String(ticket)}\n`, {
+      mode: 0o600,
+    });
+    await unlink(path.join(directory, "choosing"));
+
+    const transaction = {
+      transactionRoot: options.transactionRoot,
+      directory,
+      token,
+      ticket,
+      deadline: options.deadline,
+    };
+    while (true) {
+      ensureBeforeDeadline(options.deadline);
+      if (!(await hasPrecedingParticipant(transaction))) return transaction;
+      await waitForTransaction(options.deadline);
+    }
+  } catch (error) {
+    await retireTransactionDirectory(
+      options.transactionRoot,
+      candidateDirectory,
+    );
+    await retireTransactionDirectory(options.transactionRoot, directory);
+    throw error;
+  }
+}
+
+async function hasPrecedingParticipant(transaction) {
+  const participants = await activeParticipants(transaction.transactionRoot);
+  for (const participant of participants) {
+    if (participant.token === transaction.token) continue;
+    if (participant.choosing) return true;
+    if (participant.ticket === undefined) {
+      throw acquisitionFailure("cache transaction state is invalid");
+    }
+    if (
+      participant.ticket < transaction.ticket ||
+      (participant.ticket === transaction.ticket &&
+        participant.token < transaction.token)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function activeParticipants(transactionRoot) {
+  const result = [];
+  for (const entry of await readdir(transactionRoot, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith("retired-")) {
+      await rm(path.join(transactionRoot, entry.name), {
+        recursive: true,
+        force: true,
+      });
+      continue;
+    }
+    if (
+      !entry.isDirectory() ||
+      (!entry.name.startsWith("candidate-") &&
+        !entry.name.startsWith("participant-"))
+    ) {
+      continue;
+    }
+    const participant = await readParticipant(
+      path.join(transactionRoot, entry.name),
+      entry.name,
+    );
+    if (participant === undefined) continue;
+    if (participant.stale) {
+      await retireTransactionDirectory(transactionRoot, participant.directory);
+      continue;
+    }
+    result.push(participant);
+  }
+  return result;
+}
+
+async function retireTransactionDirectory(transactionRoot, directory) {
+  // Removing the active name atomically keeps observers from reading a
+  // half-deleted owner/ticket pair. A crash after rename leaves only inert state
+  // that the next scan removes.
+  const retiredDirectory = path.join(
+    transactionRoot,
+    `retired-${path.basename(directory)}-${randomUUID()}`,
+  );
+  try {
+    await rename(directory, retiredDirectory);
+  } catch (error) {
+    if (error?.code === "ENOENT") return;
+    throw error;
+  }
+  await rm(retiredDirectory, { recursive: true, force: true });
+}
+
+async function readParticipant(directory, name) {
+  let directoryMetadata;
+  try {
+    directoryMetadata = await lstat(directory);
+  } catch (error) {
+    if (error?.code === "ENOENT") return undefined;
+    throw error;
+  }
+  if (!directoryMetadata.isDirectory()) return undefined;
+
+  let owner;
+  try {
+    owner = JSON.parse(
+      await readFile(path.join(directory, "owner.json"), "utf8"),
+    );
+  } catch (error) {
+    if (error?.code !== "ENOENT" && !(error instanceof SyntaxError))
+      throw error;
+  }
+  const token = name.replace(/^(?:candidate|participant)-/u, "");
+  const validOwner =
+    owner?.version === 1 &&
+    owner.token === token &&
+    Number.isSafeInteger(owner.pid) &&
+    owner.pid > 0 &&
+    Number.isSafeInteger(owner.createdAt) &&
+    Number.isSafeInteger(owner.deadline);
+  const age = Date.now() - directoryMetadata.mtimeMs;
+  if (!validOwner) {
+    return {
+      directory,
+      token,
+      choosing: true,
+      ticket: undefined,
+      stale: age >= transactionInitializationGraceMilliseconds,
+    };
+  }
+
+  const retirementDeadline = Math.min(
+    owner.deadline + transactionRetirementGraceMilliseconds,
+    owner.createdAt + maxTransactionLeaseMilliseconds,
+  );
+  const stale = !processIsAlive(owner.pid) || Date.now() >= retirementDeadline;
+  if (stale) {
+    return { directory, token, choosing: true, ticket: undefined, stale };
+  }
+
+  const choosing =
+    name.startsWith("candidate-") ||
+    (await pathExists(path.join(directory, "choosing")));
+  let ticket;
+  try {
+    const value = Number(
+      (await readFile(path.join(directory, "ticket"), "utf8")).trim(),
+    );
+    if (Number.isSafeInteger(value) && value > 0) ticket = value;
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+  return { directory, token, choosing, ticket, stale: false };
+}
+
+async function assertTransactionOwner(transaction) {
+  ensureBeforeDeadline(transaction.deadline);
+  const participant = await readParticipant(
+    transaction.directory,
+    `participant-${transaction.token}`,
+  );
+  if (
+    participant === undefined ||
+    participant.stale ||
+    participant.choosing ||
+    participant.ticket !== transaction.ticket
+  ) {
+    throw acquisitionFailure("cache transaction ownership expired");
+  }
+}
+
+async function waitForTransaction(deadline) {
+  const wait = Math.min(
+    transactionWaitMilliseconds,
+    remainingMilliseconds(deadline),
+  );
+  await new Promise((resolve) => setTimeout(resolve, wait));
+}
+
+function processIsAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code === "EPERM";
+  }
+}
+
+async function pathExists(file) {
+  try {
+    await access(file);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+function sameFile(left, right) {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function isMissingOrSymlinkError(error) {
+  return (
+    error?.code === "ENOENT" ||
+    error?.code === "ELOOP" ||
+    error?.code === "EMLINK"
+  );
 }
 
 function normalizeTransportFailure(error) {

--- a/scripts/verified-artifact-acquisition.mjs
+++ b/scripts/verified-artifact-acquisition.mjs
@@ -28,6 +28,7 @@ const maxTransactionLeaseMilliseconds = 5 * 60_000;
 const readBufferBytes = 64 * 1024;
 const transactionInitializationGraceMilliseconds = 2_000;
 const transactionRetirementGraceMilliseconds = 5_000;
+const transactionRenameRetryMilliseconds = 5_000;
 const transactionWaitMilliseconds = 25;
 
 /**
@@ -306,6 +307,7 @@ async function withDigestTransaction(options) {
     await retireTransactionDirectory(
       transaction.transactionRoot,
       transaction.directory,
+      transaction.deadline,
     );
   }
 }
@@ -340,9 +342,16 @@ async function acquireTransaction(options) {
         mode: 0o600,
       }),
     ]);
-    await rename(candidateDirectory, directory);
+    await renameTransactionPath(
+      candidateDirectory,
+      directory,
+      options.deadline,
+    );
 
-    const participants = await activeParticipants(options.transactionRoot);
+    const participants = await activeParticipants(
+      options.transactionRoot,
+      options.deadline,
+    );
     const ticket =
       participants.reduce(
         (maximum, participant) =>
@@ -375,14 +384,22 @@ async function acquireTransaction(options) {
     await retireTransactionDirectory(
       options.transactionRoot,
       candidateDirectory,
+      options.deadline,
     );
-    await retireTransactionDirectory(options.transactionRoot, directory);
+    await retireTransactionDirectory(
+      options.transactionRoot,
+      directory,
+      options.deadline,
+    );
     throw error;
   }
 }
 
 async function hasPrecedingParticipant(transaction) {
-  const participants = await activeParticipants(transaction.transactionRoot);
+  const participants = await activeParticipants(
+    transaction.transactionRoot,
+    transaction.deadline,
+  );
   for (const participant of participants) {
     if (participant.token === transaction.token) continue;
     if (participant.choosing) return true;
@@ -400,14 +417,11 @@ async function hasPrecedingParticipant(transaction) {
   return false;
 }
 
-async function activeParticipants(transactionRoot) {
+async function activeParticipants(transactionRoot, deadline) {
   const result = [];
   for (const entry of await readdir(transactionRoot, { withFileTypes: true })) {
     if (entry.isDirectory() && entry.name.startsWith("retired-")) {
-      await rm(path.join(transactionRoot, entry.name), {
-        recursive: true,
-        force: true,
-      });
+      await removeRetiredDirectory(path.join(transactionRoot, entry.name));
       continue;
     }
     if (
@@ -423,7 +437,11 @@ async function activeParticipants(transactionRoot) {
     );
     if (participant === undefined) continue;
     if (participant.stale) {
-      await retireTransactionDirectory(transactionRoot, participant.directory);
+      await retireTransactionDirectory(
+        transactionRoot,
+        participant.directory,
+        deadline,
+      );
       continue;
     }
     result.push(participant);
@@ -431,7 +449,11 @@ async function activeParticipants(transactionRoot) {
   return result;
 }
 
-async function retireTransactionDirectory(transactionRoot, directory) {
+async function retireTransactionDirectory(
+  transactionRoot,
+  directory,
+  deadline,
+) {
   // Removing the active name atomically keeps observers from reading a
   // half-deleted owner/ticket pair. A crash after rename leaves only inert state
   // that the next scan removes.
@@ -440,12 +462,65 @@ async function retireTransactionDirectory(transactionRoot, directory) {
     `retired-${path.basename(directory)}-${randomUUID()}`,
   );
   try {
-    await rename(directory, retiredDirectory);
+    await renameTransactionPath(
+      directory,
+      retiredDirectory,
+      Math.min(deadline, Date.now() + transactionRenameRetryMilliseconds),
+    );
   } catch (error) {
     if (error?.code === "ENOENT") return;
+    try {
+      await lstat(directory);
+    } catch (observationError) {
+      if (observationError?.code === "ENOENT") return;
+      throw observationError;
+    }
     throw error;
   }
-  await rm(retiredDirectory, { recursive: true, force: true });
+  await removeRetiredDirectory(retiredDirectory);
+}
+
+async function removeRetiredDirectory(directory) {
+  try {
+    await rm(directory, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: transactionWaitMilliseconds,
+    });
+  } catch (error) {
+    // A retired name is already inert. Windows may keep it briefly busy while
+    // another contender is observing or deleting it; a later scan can finish
+    // this non-authoritative cleanup without blocking artifact acquisition.
+    if (
+      error?.code === "ENOENT" ||
+      error?.code === "EPERM" ||
+      error?.code === "EBUSY" ||
+      error?.code === "ENOTEMPTY"
+    ) {
+      return;
+    }
+    throw error;
+  }
+}
+
+async function renameTransactionPath(source, destination, deadline) {
+  while (true) {
+    try {
+      await rename(source, destination);
+      return;
+    } catch (error) {
+      if (
+        error?.code !== "EPERM" &&
+        error?.code !== "EBUSY" &&
+        error?.code !== "EACCES"
+      ) {
+        throw error;
+      }
+      ensureBeforeDeadline(deadline);
+      await waitForTransaction(deadline);
+    }
+  }
 }
 
 async function readParticipant(directory, name) {


### PR DESCRIPTION
Fixes #92.

## Summary

- preserve the provider-lock SHA-256 as the only cache authority while serializing verify, invalid-entry cleanup, download, and atomic publication in one per-digest cross-process transaction
- quarantine invalid cache pathnames and use no-follow regular-file identity checks so a symlink entry is removed without chmod or mutation of its target
- converge concurrent callers on one verified immutable digest file, reclaim bounded dead owners, and tolerate bounded Windows directory-rename contention without adding retries to provider transport
- retain the existing single provider assembly path used by both package:portable and smoke:packaged; no provider-lock contents or fallback policy changed
- cover hanging/partial/digest failures, proxy vs direct routing, credential-redacted diagnostics, verified offline reuse, invalid-cache/publish races, symlink safety, 12-process convergence, observed-retirement races, malformed/future participants, and dead-owner recovery

## Red signal

The pre-fix acquisition source and fixture blobs remain identical on audited base abe48db and current main 245ab2b. On that source, the deterministic invalid-cleanup/publish fixture left the digest cache path missing, the POSIX symlink fixture changed target mode from 0444 to 0600, and 12 contenders performed 11 downloads.

## Verification at exact head b7ba50beb154a6b3fed86d74f943628dc125a8e2

- rebased cleanly onto origin/main 245ab2b13fd945ee1846c9e534b6a5db98ce5d88, preserving the independently reviewed #131 Windows process-observation lifecycle fix
- integration-focused acquisition, browser assembly, Windows trigger containment, and WinApp provider tests: 41 passed, 5 intentional platform skips
- both Windows identity/process-tree tests that timed out before #131 now pass locally
- ZenX typecheck: passed
- ZenX production build: passed
- committed-blob Prettier checks and git diff --check: passed
- real local WinApp smoke unavailable because WinApp CLI is not installed; it fails immediately with the expected install diagnostic, while exact-head CI provisions WinApp CLI
- exact-head CI: 8/8 green, including Windows WinApp adapter smoke, Windows packaged bundled-provider smoke, and ZenX typecheck/tests/build

Prior #92-head evidence, unchanged by this rebase:

- focused acquisition + browser assembly: 16 passed, 1 expected Windows POSIX-contract skip
- 10 repeated 12-process convergence runs passed (120 contenders, one download per run)
- full ZenX suite: 484 passed, 11 platform skips; one Windows symlink fixture lacked local symlink privilege
- root lint/typecheck passed; root tests 98 passed + 1 platform skip; IMZen 38 passed
- real package:portable passed and produced a 619,693,550-byte Windows artifact through the shared verified provider path
- real smoke:packaged completed acquisition and packaging, then hit this host's unrelated GPU-process fatal baseline

Out of scope: Playwright payload/provider-lock expansion, fallback runtimes, a second packaging path, global proxy mutation, and durable recovery machinery.

