### PR TITLE
fix(zenx): make settings persistence transactional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm --workspace apps/zenx run test:project-identity
       - run: npm --workspace apps/zenx run smoke:windows-projects
 
   zenx-windows-user-browser-smoke:

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,8 +20,10 @@
 - **ZenXProjectProjection** — ZenX main 的同一个实例把 host-profile workspace 与 ZAS
   原生 Thread cwd 按最近存在祖先的异步 realpath 归一为 UI 和 Agent self-control 共用的
   Project 读模型；Windows 路径折叠大小写，POSIX 路径保留大小写，配置保留用户选择的展示路径，
-  realpath 不可用时退回 lexical absolute path，最近使用项由同一 host profile 持有且失效时不隐式回退，
-  它不拥有 Project、Thread 或 journal 状态。
+  realpath 不可用时退回 lexical absolute path，配置刷新按 latest-wins 发布且不长期缓存 filesystem identity，
+  每次投影、筛选、创建或 workspace mutation 从一份不可变的 canonicalization snapshot 派生，mutation
+  在既有队列内有界重验；最近使用项由同一 host profile 持有且失效时不隐式回退，
+  它不拥有 Project、Thread、journal 或 durable coordination 状态。
 - **ZenXDirectoryBrowser** — ZenX main 把 home、documents、Windows drive / POSIX root 与
   canonical 只读目录枚举投影给内部 picker；symlink/junction 只解析为目录目标，不修改文件系统。
 - **ZenXApplicationMenuPolicy** — ZenX 在 Windows/Linux 移除 Electron 默认菜单，在 macOS

--- a/apps/zenx/README.md
+++ b/apps/zenx/README.md
@@ -7,9 +7,12 @@ Projects are ZenX host-profile workspace entries grouped with ZAS native Thread
 Project while the configured user-selected path remains its display path. The
 projection resolves the nearest existing ancestor asynchronously and falls back
 to the lexical absolute path when realpath is unavailable, so missing or denied
-paths remain usable. Projects are not Core runtime objects. Add Project uses
-ZenX's read-only directory picker. Removing an entry only changes the host
-profile and never deletes the directory, its files, or Thread journals.
+paths remain usable. It publishes configuration refreshes latest-wins and
+re-canonicalizes immutable per-operation snapshots, so filesystem identity may
+recover or change without becoming a permanently cached Project key. Projects
+are not Core runtime objects. Add Project uses ZenX's read-only directory picker.
+Removing an entry only changes the host profile and never deletes the directory,
+its files, or Thread journals.
 New Thread always carries an explicit configured Project `cwd`. The top-level
 action reuses the last Project used for a Thread; if that record is missing or
 the Project was removed, ZenX asks the user to choose and never falls back to

--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -9,6 +9,7 @@
     "build": "electron-vite build",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "test": "tsx --test test/**/*.test.ts test/**/*.test.mjs",
+    "test:project-identity": "tsx --test test/project-projection.test.ts test/settings-service.test.ts test/self-control-capability.test.ts",
     "smoke:capabilities": "npm run smoke:packaged",
     "smoke:unit-capabilities": "npm run build && electron ./out/main/capability-smoke.js",
     "assemble:providers": "node ../../scripts/assemble-zenx-providers.mjs",

--- a/apps/zenx/src/main/capabilities/self-control-package.ts
+++ b/apps/zenx/src/main/capabilities/self-control-package.ts
@@ -377,21 +377,7 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     assertOnly(args, ["workspace", "cwd", "query", "archived", "limit"]);
     const workspace = optionalString(args.workspace, "workspace");
     const cwd = optionalString(args.cwd, "cwd");
-    if (workspace !== undefined && cwd !== undefined) {
-      if (
-        (await this.#appServer.projectProjection.canonicalKey(workspace)) !==
-        (await this.#appServer.projectProjection.canonicalKey(cwd))
-      ) {
-        throw new Error(
-          "workspace and cwd filters must identify the same path",
-        );
-      }
-    }
     const cwdFilter = workspace ?? cwd;
-    const filterKey =
-      cwdFilter === undefined
-        ? undefined
-        : await this.#appServer.projectProjection.canonicalKey(cwdFilter);
     const query = optionalString(args.query, "query")?.toLocaleLowerCase();
     const archived = optionalBoolean(args.archived, "archived") ?? false;
     const limit = boundedInteger(
@@ -402,21 +388,39 @@ export class ZenXSelfControlCapabilityPackage implements ZenXCapabilityPackage {
     );
     const listed = (await this.#appServer.request("thread/list", { archived }))
       .data;
-    const threads = (
-      await Promise.all(
-        listed.map(async (thread) => ({
-          thread,
-          matches:
-            filterKey === undefined ||
-            (thread.cwd.length > 0 &&
-              (await this.#appServer.projectProjection.canonicalKey(
-                thread.cwd,
-              )) === filterKey),
-        })),
-      )
-    )
-      .filter(({ matches }) => matches)
-      .map(({ thread }) => thread)
+    let filtered = listed;
+    if (cwdFilter !== undefined) {
+      const filterPaths = [
+        ...(workspace === undefined ? [] : [workspace]),
+        ...(cwd === undefined ? [] : [cwd]),
+      ];
+      const threadsWithCwd = listed.filter((thread) => thread.cwd.length > 0);
+      const keys = await this.#appServer.projectProjection.canonicalKeys([
+        ...filterPaths,
+        ...threadsWithCwd.map((thread) => thread.cwd),
+      ]);
+      const workspaceKey = workspace === undefined ? undefined : keys[0];
+      const cwdKey =
+        cwd === undefined ? undefined : keys[workspace === undefined ? 0 : 1];
+      if (
+        workspaceKey !== undefined &&
+        cwdKey !== undefined &&
+        workspaceKey !== cwdKey
+      ) {
+        throw new Error(
+          "workspace and cwd filters must identify the same path",
+        );
+      }
+      const filterKey = workspaceKey ?? cwdKey;
+      const threadOffset = filterPaths.length;
+      const matchingIds = new Set(
+        threadsWithCwd
+          .filter((_thread, index) => keys[threadOffset + index] === filterKey)
+          .map((thread) => thread.id),
+      );
+      filtered = listed.filter((thread) => matchingIds.has(thread.id));
+    }
+    const threads = filtered
       .filter((thread) => query === undefined || matchesQuery(thread, query))
       .sort((left, right) => right.updatedAt - left.updatedAt);
     return {

--- a/apps/zenx/src/main/credential-vault.ts
+++ b/apps/zenx/src/main/credential-vault.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, open, rename, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -76,12 +77,18 @@ export class ZenXCredentialVault {
       version: 1,
       apiKey: this.#encryption.encryptString(apiKey).toString("base64"),
     };
-    const temporary = `${this.#filePath}.${process.pid}.tmp`;
-    await writeFile(temporary, `${JSON.stringify(stored)}\n`, {
-      mode: 0o600,
-      encoding: "utf8",
-    });
-    await rename(temporary, this.#filePath);
+    const temporary = `${this.#filePath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, `${JSON.stringify(stored)}\n`, {
+        mode: 0o600,
+        encoding: "utf8",
+      });
+      await rename(temporary, this.#filePath);
+    } finally {
+      await unlink(temporary).catch((error: unknown) => {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      });
+    }
   }
 
   async clearApiKey(): Promise<void> {

--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -27,6 +27,16 @@ export interface ZenXHostProfile {
   approvalPolicy: "always" | "never";
 }
 
+export type ZenXSettingsUpdate = Pick<
+  ZenXHostProfile,
+  | "onboardingComplete"
+  | "provider"
+  | "defaultModel"
+  | "titleModel"
+  | "models"
+  | "approvalPolicy"
+>;
+
 export interface PublicHostSettings {
   profile: ZenXHostProfile;
   hasApiKey: boolean;

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -18,7 +18,7 @@ import { ipcChannels } from "../preload/ipc.js";
 import { AppServerManager } from "./app-server-manager.js";
 import type { ApprovalDecision } from "./app-server-manager.js";
 import { ZenXCredentialVault } from "./credential-vault.js";
-import type { ZenXHostProfile } from "./host-profile.js";
+import type { ZenXSettingsUpdate } from "./host-profile.js";
 import { ZenXSettingsService } from "./settings-service.js";
 import { zenXProviderTransport } from "./system-proxy.js";
 import { ZenXTriggerService } from "./trigger-service.js";
@@ -522,11 +522,11 @@ function installSettingsIpc(
   );
   ipcMain.handle(
     ipcChannels.settingsSave,
-    async (_event, profile: ZenXHostProfile, apiKey?: unknown) => {
+    async (_event, update: ZenXSettingsUpdate, apiKey?: unknown) => {
       if (apiKey !== undefined && typeof apiKey !== "string") {
         throw new Error("Invalid API key");
       }
-      await settings.save(profile, apiKey);
+      await settings.save(update, apiKey);
       await refreshProjects();
       await restartHost();
       return await settings.publicSettings();

--- a/apps/zenx/src/main/project-projection.ts
+++ b/apps/zenx/src/main/project-projection.ts
@@ -20,11 +20,19 @@ export interface ZenXProjectProjectionSnapshot {
   lastUsedWorkspace: string | null;
 }
 
-type ProjectRealpath = (candidate: string) => Promise<string>;
+export type ProjectRealpath = (candidate: string) => Promise<string>;
 
-interface ProjectPathIdentity {
-  displayPath: string;
-  key: string;
+export interface ProjectPathIdentity {
+  readonly displayPath: string;
+  readonly key: string;
+}
+
+export type ProjectPathSnapshot = readonly ProjectPathIdentity[];
+
+interface ProjectConfigurationSnapshot {
+  readonly workspaces: readonly string[];
+  readonly defaultWorkspace: string | null;
+  readonly lastUsedWorkspace: string | null;
 }
 
 const nodeProjectRealpath: ProjectRealpath = async (candidate) =>
@@ -34,9 +42,12 @@ const nodeProjectRealpath: ProjectRealpath = async (candidate) =>
 export class ZenXProjectProjection {
   readonly #platform: NodeJS.Platform;
   readonly #realpath: ProjectRealpath;
-  #workspaces: ProjectPathIdentity[] = [];
-  #defaultKey: string | null = null;
-  #lastUsedWorkspace: string | null = null;
+  #configuration: ProjectConfigurationSnapshot = Object.freeze({
+    workspaces: Object.freeze([]),
+    defaultWorkspace: null,
+    lastUsedWorkspace: null,
+  });
+  #configurationRevision = 0;
 
   constructor(
     platform: NodeJS.Platform = process.platform,
@@ -51,58 +62,88 @@ export class ZenXProjectProjection {
     defaultWorkspace: string | null,
     lastUsedWorkspace: string | null = null,
   ): Promise<void> {
+    const revision = ++this.#configurationRevision;
     const unique = new Map<string, ProjectPathIdentity>();
     const candidates =
       defaultWorkspace === null
         ? workspaces
         : [defaultWorkspace, ...workspaces];
-    for (const workspace of await Promise.all(
-      candidates.map(
-        async (candidate) =>
-          await projectPathIdentity(candidate, this.#platform, this.#realpath),
-      ),
-    )) {
+    const values = [
+      ...candidates,
+      ...(lastUsedWorkspace === null ? [] : [lastUsedWorkspace]),
+    ];
+    const identities = await this.#canonicalSnapshot(values);
+    const workspaceIdentities = identities.slice(0, candidates.length);
+    for (const workspace of workspaceIdentities) {
       if (!unique.has(workspace.key)) unique.set(workspace.key, workspace);
     }
-    const nextWorkspaces = [...unique.values()];
+    const nextWorkspaces = [...unique.values()].map(
+      (workspace) => workspace.displayPath,
+    );
     const nextDefaultKey =
-      defaultWorkspace === null
+      defaultWorkspace === null ? null : workspaceIdentities[0]?.key;
+    const nextDefaultWorkspace =
+      nextDefaultKey === null || nextDefaultKey === undefined
         ? null
-        : (
-            await projectPathIdentity(
-              defaultWorkspace,
-              this.#platform,
-              this.#realpath,
-            )
-          ).key;
+        : (unique.get(nextDefaultKey)?.displayPath ?? null);
+    const lastUsedIdentity =
+      lastUsedWorkspace === null ? undefined : identities.at(-1);
     const lastUsedKey =
-      lastUsedWorkspace === null
-        ? null
-        : (
-            await projectPathIdentity(
-              lastUsedWorkspace,
-              this.#platform,
-              this.#realpath,
-            )
-          ).key;
+      lastUsedWorkspace === null ? null : (lastUsedIdentity?.key ?? null);
     const nextLastUsedWorkspace =
       lastUsedKey === null
         ? null
-        : (nextWorkspaces.find((workspace) => workspace.key === lastUsedKey)
-            ?.displayPath ?? null);
-    this.#workspaces = nextWorkspaces;
-    this.#defaultKey = nextDefaultKey;
-    this.#lastUsedWorkspace = nextLastUsedWorkspace;
+        : (unique.get(lastUsedKey)?.displayPath ?? null);
+    if (revision !== this.#configurationRevision) return;
+    this.#configuration = Object.freeze({
+      workspaces: Object.freeze(nextWorkspaces),
+      defaultWorkspace: nextDefaultWorkspace,
+      lastUsedWorkspace: nextLastUsedWorkspace,
+    });
   }
 
   async project(
     threads: readonly ProjectProjectionThread[],
   ): Promise<ZenXProjectProjectionSnapshot> {
-    const configuredWorkspaces = this.#workspaces;
-    const defaultKey = this.#defaultKey;
-    const lastUsedWorkspace = this.#lastUsedWorkspace;
+    const configuration = this.#configuration;
+    const availableThreads = threads.filter(
+      (thread): thread is ProjectProjectionThread & { cwd: string } =>
+        thread.cwd !== null && thread.cwd.trim().length > 0,
+    );
+    const defaultIndex =
+      configuration.defaultWorkspace === null
+        ? undefined
+        : configuration.workspaces.length;
+    const lastUsedIndex =
+      configuration.lastUsedWorkspace === null
+        ? undefined
+        : configuration.workspaces.length +
+          (defaultIndex === undefined ? 0 : 1);
+    const threadOffset =
+      configuration.workspaces.length +
+      (defaultIndex === undefined ? 0 : 1) +
+      (lastUsedIndex === undefined ? 0 : 1);
+    const identities = await this.#canonicalSnapshot([
+      ...configuration.workspaces,
+      ...(configuration.defaultWorkspace === null
+        ? []
+        : [configuration.defaultWorkspace]),
+      ...(configuration.lastUsedWorkspace === null
+        ? []
+        : [configuration.lastUsedWorkspace]),
+      ...availableThreads.map((thread) => thread.cwd),
+    ]);
+    const configuredWorkspaces = identities.slice(
+      0,
+      configuration.workspaces.length,
+    );
+    const defaultKey =
+      defaultIndex === undefined
+        ? null
+        : (identities[defaultIndex]?.key ?? null);
     const projects = new Map<string, ZenXProjectProjectionEntry>();
     for (const workspace of configuredWorkspaces) {
+      if (projects.has(workspace.key)) continue;
       projects.set(workspace.key, {
         key: workspace.key,
         workspace: workspace.displayPath,
@@ -112,19 +153,15 @@ export class ZenXProjectProjection {
       });
     }
     const unavailableThreadIds: string[] = [];
-    const resolvedThreads = await Promise.all(
-      threads.map(async (thread) => ({
-        thread,
-        identity:
-          thread.cwd === null || thread.cwd.trim().length === 0
-            ? null
-            : await projectPathIdentity(
-                thread.cwd,
-                this.#platform,
-                this.#realpath,
-              ),
-      })),
-    );
+    let availableThreadIndex = 0;
+    const resolvedThreads = threads.map((thread) => {
+      if (thread.cwd === null || thread.cwd.trim().length === 0) {
+        return { thread, identity: null };
+      }
+      const identity = identities[threadOffset + availableThreadIndex] ?? null;
+      availableThreadIndex += 1;
+      return { thread, identity };
+    });
     for (const { thread, identity } of resolvedThreads) {
       if (identity === null) {
         unavailableThreadIds.push(thread.id);
@@ -140,26 +177,53 @@ export class ZenXProjectProjection {
       project.threadIds.push(thread.id);
       projects.set(identity.key, project);
     }
+    const lastUsedKey =
+      lastUsedIndex === undefined
+        ? null
+        : (identities[lastUsedIndex]?.key ?? null);
+    const resolvedLastUsedWorkspace =
+      lastUsedKey === null || !projects.get(lastUsedKey)?.configured
+        ? null
+        : (projects.get(lastUsedKey)?.workspace ?? null);
     return {
       projects: [...projects.values()].sort((left, right) =>
         left.workspace.localeCompare(right.workspace),
       ),
       unavailableThreadIds,
-      lastUsedWorkspace,
+      lastUsedWorkspace: resolvedLastUsedWorkspace,
     };
   }
 
   async configuredWorkspace(value: string): Promise<string | null> {
-    const key = await this.canonicalKey(value);
+    const configuration = this.#configuration;
+    const identities = await this.#canonicalSnapshot([
+      ...configuration.workspaces,
+      value,
+    ]);
+    const requested = identities.at(-1);
+    if (requested === undefined) return null;
     return (
-      this.#workspaces.find((workspace) => workspace.key === key)
-        ?.displayPath ?? null
+      identities
+        .slice(0, configuration.workspaces.length)
+        .find((workspace) => workspace.key === requested.key)?.displayPath ??
+      null
     );
   }
 
   async canonicalKey(value: string): Promise<string> {
-    return (await projectPathIdentity(value, this.#platform, this.#realpath))
-      .key;
+    return (await this.canonicalKeys([value]))[0]!;
+  }
+
+  async canonicalKeys(values: readonly string[]): Promise<readonly string[]> {
+    return Object.freeze(
+      (await this.#canonicalSnapshot(values)).map((identity) => identity.key),
+    );
+  }
+
+  async #canonicalSnapshot(
+    values: readonly string[],
+  ): Promise<ProjectPathSnapshot> {
+    return await projectPathSnapshot(values, this.#platform, this.#realpath);
   }
 }
 
@@ -168,7 +232,35 @@ export async function projectPathKey(
   platform: NodeJS.Platform = process.platform,
   resolveRealpath: ProjectRealpath = nodeProjectRealpath,
 ): Promise<string> {
-  return (await projectPathIdentity(value, platform, resolveRealpath)).key;
+  return (await projectPathSnapshot([value], platform, resolveRealpath))[0]!
+    .key;
+}
+
+export async function projectPathSnapshot(
+  values: readonly string[],
+  platform: NodeJS.Platform = process.platform,
+  resolveRealpath: ProjectRealpath = nodeProjectRealpath,
+): Promise<ProjectPathSnapshot> {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const pending = new Map<string, Promise<string>>();
+  const identities = await Promise.all(
+    values.map(async (value) => {
+      const displayPath = pathApi.resolve(value);
+      const lexicalKey =
+        platform === "win32"
+          ? displayPath.toLocaleLowerCase("en-US")
+          : displayPath;
+      let key = pending.get(lexicalKey);
+      if (key === undefined) {
+        key = projectPathIdentity(displayPath, platform, resolveRealpath).then(
+          (identity) => identity.key,
+        );
+        pending.set(lexicalKey, key);
+      }
+      return Object.freeze({ displayPath, key: await key });
+    }),
+  );
+  return Object.freeze(identities);
 }
 
 async function projectPathIdentity(
@@ -181,6 +273,7 @@ async function projectPathIdentity(
   const unresolved: string[] = [];
   let cursor = displayPath;
   let canonicalPath: string | undefined;
+  let shouldRecheck = false;
 
   while (canonicalPath === undefined) {
     try {
@@ -190,6 +283,7 @@ async function projectPathIdentity(
       if (code !== "ENOENT" && code !== "ENOTDIR") {
         canonicalPath = displayPath;
         unresolved.length = 0;
+        shouldRecheck = true;
         break;
       }
       const parent = pathApi.dirname(cursor);
@@ -199,17 +293,27 @@ async function projectPathIdentity(
       }
       unresolved.unshift(pathApi.basename(cursor));
       cursor = parent;
+      shouldRecheck = true;
+    }
+  }
+
+  if (shouldRecheck) {
+    try {
+      canonicalPath = await resolveRealpath(displayPath);
+      unresolved.length = 0;
+    } catch {
+      // Keep the bounded first result; a later operation will canonicalize again.
     }
   }
 
   const physicalPath = pathApi.normalize(
     pathApi.join(canonicalPath, ...unresolved),
   );
-  return {
+  return Object.freeze({
     displayPath,
     key:
       platform === "win32"
         ? physicalPath.toLocaleLowerCase("en-US")
         : physicalPath,
-  };
+  });
 }

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -14,7 +14,23 @@ import {
 } from "./host-profile.js";
 import { ZenXCredentialVault } from "./credential-vault.js";
 import { resolveZenXHostConfig } from "./host-config.js";
-import { projectPathKey } from "./project-projection.js";
+import {
+  type ProjectPathIdentity,
+  type ProjectPathSnapshot,
+  type ProjectRealpath,
+  projectPathSnapshot,
+} from "./project-projection.js";
+
+const MAX_WORKSPACE_IDENTITY_ATTEMPTS = 2;
+
+interface CanonicalWorkspaceSnapshot {
+  readonly profile: ZenXHostProfile;
+  readonly entries: readonly ProjectPathIdentity[];
+  readonly requested: readonly ProjectPathIdentity[];
+  readonly identities: ProjectPathSnapshot;
+  readonly defaultKey: string | null;
+  readonly lastUsedKey: string | null;
+}
 
 export class ZenXSettingsService {
   readonly #dataDirectory: string;
@@ -26,6 +42,8 @@ export class ZenXSettingsService {
   > &
     Partial<Pick<OpenAiSubscriptionAuthProfile, "acquireAccessLease">>;
   readonly #vault: ZenXCredentialVault;
+  readonly #projectPlatform: NodeJS.Platform;
+  readonly #projectRealpath: ProjectRealpath | undefined;
   #profile: ZenXHostProfile | undefined;
   #profileOperations: Promise<void> = Promise.resolve();
   #loginInProgress = false;
@@ -46,6 +64,8 @@ export class ZenXSettingsService {
       OpenAiSubscriptionAuthProfile,
       "login" | "logout" | "status"
     >;
+    projectPlatform?: NodeJS.Platform;
+    projectRealpath?: ProjectRealpath;
   }) {
     this.#dataDirectory = options.zenDataDirectory;
     this.#profilePath = path.join(
@@ -59,12 +79,18 @@ export class ZenXSettingsService {
       options.subscription ??
       new OpenAiSubscriptionAuthProfile(this.#profilePath);
     this.#vault = options.vault;
+    this.#projectPlatform = options.projectPlatform ?? process.platform;
+    this.#projectRealpath = options.projectRealpath;
   }
 
   async initialize(environment: NodeJS.ProcessEnv): Promise<void> {
     const existing = await this.#profileStore.readOptional();
     if (existing !== undefined) {
-      this.#profile = await normalizeCanonicalWorkspaces(existing);
+      this.#profile = await normalizeCanonicalWorkspaces(
+        existing,
+        this.#projectPlatform,
+        this.#projectRealpath,
+      );
       return;
     }
     const configureWorkspace = environment.ZENX_CWD !== undefined;
@@ -73,7 +99,11 @@ export class ZenXSettingsService {
     if (legacy.provider.type === "openai-compatible") {
       await this.#vault.writeApiKey(legacy.provider.apiKey);
     }
-    this.#profile = await normalizeCanonicalWorkspaces(fallback);
+    this.#profile = await normalizeCanonicalWorkspaces(
+      fallback,
+      this.#projectPlatform,
+      this.#projectRealpath,
+    );
     await this.#profileStore.write(this.#profile);
   }
 
@@ -137,9 +167,9 @@ export class ZenXSettingsService {
   async save(profile: ZenXHostProfile, apiKey?: string): Promise<void> {
     const structurallyValidated = validateHostProfile(profile);
     await this.#queueProfileOperation(async () => {
-      const validated = await normalizeCanonicalWorkspaces(
-        structurallyValidated,
-      );
+      const validated = (
+        await this.#stableWorkspaceSnapshot(structurallyValidated, [])
+      ).profile;
       if (apiKey !== undefined && apiKey.length > 0)
         await this.#vault.writeApiKey(apiKey);
       if (
@@ -158,20 +188,21 @@ export class ZenXSettingsService {
     if (candidate.length === 0) throw new Error("Workspace is required");
     const resolved = path.resolve(candidate);
     return await this.#queueProfileOperation(async () => {
-      const current = await normalizeCanonicalWorkspaces(
+      const snapshot = await this.#stableWorkspaceSnapshot(
         this.#requireProfile(),
+        [resolved],
       );
-      const candidateKey = await projectPathKey(resolved);
-      const entries = await canonicalWorkspaceEntries(current.workspaces);
+      const current = snapshot.profile;
+      const candidateIdentity = snapshot.requested[0]!;
+      const candidateKey = candidateIdentity.key;
+      const entries = snapshot.entries;
       if (entries.some((entry) => entry.key === candidateKey)) return false;
       const isFirst = current.workspace === null;
-      const next = await normalizeCanonicalWorkspaces(
-        validateHostProfile({
-          ...current,
-          workspace: isFirst ? resolved : current.workspace,
-          workspaces: [...current.workspaces, resolved],
-        }),
-      );
+      const next = validateHostProfile({
+        ...current,
+        workspace: isFirst ? candidateIdentity.displayPath : current.workspace,
+        workspaces: [...current.workspaces, candidateIdentity.displayPath],
+      });
       await this.#profileStore.write(next);
       this.#profile = next;
       return isFirst;
@@ -179,28 +210,27 @@ export class ZenXSettingsService {
   }
 
   async removeWorkspace(workspace: string): Promise<boolean> {
-    const key = await projectPathKey(workspace);
     return await this.#queueProfileOperation(async () => {
-      const current = await normalizeCanonicalWorkspaces(
+      const snapshot = await this.#stableWorkspaceSnapshot(
         this.#requireProfile(),
+        [workspace],
       );
-      const entries = await canonicalWorkspaceEntries(current.workspaces);
+      const current = snapshot.profile;
+      const key = snapshot.requested[0]!.key;
+      const entries = snapshot.entries;
       const nextWorkspaces = entries
         .filter((entry) => entry.key !== key)
-        .map((entry) => entry.workspace);
+        .map((entry) => entry.displayPath);
       if (nextWorkspaces.length === current.workspaces.length) return false;
       const defaultRemoved =
-        current.workspace !== null &&
-        (await projectPathKey(current.workspace)) === key;
-      const next = await normalizeCanonicalWorkspaces(
-        validateHostProfile({
-          ...current,
-          workspace: defaultRemoved
-            ? (nextWorkspaces[0] ?? null)
-            : current.workspace,
-          workspaces: nextWorkspaces,
-        }),
-      );
+        current.workspace !== null && snapshot.defaultKey === key;
+      const next = validateHostProfile({
+        ...current,
+        workspace: defaultRemoved
+          ? (nextWorkspaces[0] ?? null)
+          : current.workspace,
+        workspaces: nextWorkspaces,
+      });
       await this.#profileStore.write(next);
       this.#profile = next;
       return defaultRemoved;
@@ -208,24 +238,21 @@ export class ZenXSettingsService {
   }
 
   async setDefaultWorkspace(workspace: string): Promise<boolean> {
-    const key = await projectPathKey(workspace);
     return await this.#queueProfileOperation(async () => {
-      const current = await normalizeCanonicalWorkspaces(
+      const snapshot = await this.#stableWorkspaceSnapshot(
         this.#requireProfile(),
+        [workspace],
       );
-      const selected = (
-        await canonicalWorkspaceEntries(current.workspaces)
-      ).find((entry) => entry.key === key)?.workspace;
+      const current = snapshot.profile;
+      const key = snapshot.requested[0]!.key;
+      const selected = snapshot.entries.find(
+        (entry) => entry.key === key,
+      )?.displayPath;
       if (selected === undefined)
         throw new Error("Workspace is not configured");
-      if (
-        current.workspace !== null &&
-        (await projectPathKey(current.workspace)) === key
-      )
+      if (current.workspace !== null && snapshot.defaultKey === key)
         return false;
-      const next = await normalizeCanonicalWorkspaces(
-        validateHostProfile({ ...current, workspace: selected }),
-      );
+      const next = validateHostProfile({ ...current, workspace: selected });
       await this.#profileStore.write(next);
       this.#profile = next;
       return true;
@@ -233,27 +260,24 @@ export class ZenXSettingsService {
   }
 
   async markWorkspaceUsed(workspace: string): Promise<void> {
-    const key = await projectPathKey(workspace);
     await this.#queueProfileOperation(async () => {
-      const current = await normalizeCanonicalWorkspaces(
+      const snapshot = await this.#stableWorkspaceSnapshot(
         this.#requireProfile(),
+        [workspace],
       );
-      const selected = (
-        await canonicalWorkspaceEntries(current.workspaces)
-      ).find((entry) => entry.key === key)?.workspace;
+      const current = snapshot.profile;
+      const key = snapshot.requested[0]!.key;
+      const selected = snapshot.entries.find(
+        (entry) => entry.key === key,
+      )?.displayPath;
       if (selected === undefined)
         throw new Error("Workspace is not configured");
-      if (
-        current.lastUsedWorkspace !== null &&
-        (await projectPathKey(current.lastUsedWorkspace)) === key
-      )
+      if (current.lastUsedWorkspace !== null && snapshot.lastUsedKey === key)
         return;
-      const next = await normalizeCanonicalWorkspaces(
-        validateHostProfile({
-          ...current,
-          lastUsedWorkspace: selected,
-        }),
-      );
+      const next = validateHostProfile({
+        ...current,
+        lastUsedWorkspace: selected,
+      });
       await this.#profileStore.write(next);
       this.#profile = next;
     });
@@ -324,43 +348,109 @@ export class ZenXSettingsService {
     );
     return result;
   }
+
+  async #stableWorkspaceSnapshot(
+    profile: ZenXHostProfile,
+    requested: readonly string[],
+  ): Promise<CanonicalWorkspaceSnapshot> {
+    for (
+      let attempt = 0;
+      attempt < MAX_WORKSPACE_IDENTITY_ATTEMPTS;
+      attempt += 1
+    ) {
+      const snapshot = await canonicalWorkspaceSnapshot(
+        profile,
+        requested,
+        this.#projectPlatform,
+        this.#projectRealpath,
+      );
+      const revalidated = await projectPathSnapshot(
+        snapshot.identities.map((identity) => identity.displayPath),
+        this.#projectPlatform,
+        this.#projectRealpath,
+      );
+      if (
+        revalidated.every(
+          (identity, index) => identity.key === snapshot.identities[index]?.key,
+        )
+      ) {
+        return snapshot;
+      }
+    }
+    throw new Error(
+      "Workspace filesystem identity changed during the operation; try again",
+    );
+  }
 }
 
 async function normalizeCanonicalWorkspaces(
   profile: ZenXHostProfile,
+  platform: NodeJS.Platform,
+  resolveRealpath: ProjectRealpath | undefined,
 ): Promise<ZenXHostProfile> {
-  const candidates =
-    profile.workspace === null
-      ? profile.workspaces
-      : [profile.workspace, ...profile.workspaces];
-  const unique = new Map<string, string>();
-  for (const entry of await canonicalWorkspaceEntries(candidates)) {
-    if (!unique.has(entry.key)) unique.set(entry.key, entry.workspace);
-  }
-  const defaultKey =
-    profile.workspace === null ? null : await projectPathKey(profile.workspace);
-  const lastUsedKey =
-    profile.lastUsedWorkspace === null
-      ? null
-      : await projectPathKey(profile.lastUsedWorkspace);
-  return {
-    ...profile,
-    workspace: defaultKey === null ? null : (unique.get(defaultKey) ?? null),
-    workspaces: [...unique.values()],
-    lastUsedWorkspace:
-      lastUsedKey === null ? null : (unique.get(lastUsedKey) ?? null),
-  };
+  return (
+    await canonicalWorkspaceSnapshot(profile, [], platform, resolveRealpath)
+  ).profile;
 }
 
-async function canonicalWorkspaceEntries(
-  workspaces: readonly string[],
-): Promise<Array<{ workspace: string; key: string }>> {
-  return await Promise.all(
-    workspaces.map(async (workspace) => ({
-      workspace: path.resolve(workspace),
-      key: await projectPathKey(workspace),
-    })),
+async function canonicalWorkspaceSnapshot(
+  profile: ZenXHostProfile,
+  requested: readonly string[],
+  platform: NodeJS.Platform,
+  resolveRealpath: ProjectRealpath | undefined,
+): Promise<CanonicalWorkspaceSnapshot> {
+  const validated = validateHostProfile(profile);
+  const candidates =
+    validated.workspace === null
+      ? validated.workspaces
+      : [validated.workspace, ...validated.workspaces];
+  const defaultIndex = validated.workspace === null ? undefined : 0;
+  const lastUsedIndex =
+    validated.lastUsedWorkspace === null ? undefined : candidates.length;
+  const requestedOffset =
+    candidates.length + (lastUsedIndex === undefined ? 0 : 1);
+  const identities = await projectPathSnapshot(
+    [
+      ...candidates,
+      ...(validated.lastUsedWorkspace === null
+        ? []
+        : [validated.lastUsedWorkspace]),
+      ...requested,
+    ],
+    platform,
+    resolveRealpath,
   );
+  const unique = new Map<string, ProjectPathIdentity>();
+  for (const entry of identities.slice(0, candidates.length)) {
+    if (!unique.has(entry.key)) unique.set(entry.key, entry);
+  }
+  const entries = Object.freeze([...unique.values()]);
+  const defaultKey =
+    defaultIndex === undefined ? null : (identities[defaultIndex]?.key ?? null);
+  const lastUsedKey =
+    lastUsedIndex === undefined
+      ? null
+      : (identities[lastUsedIndex]?.key ?? null);
+  const normalized = validateHostProfile({
+    ...validated,
+    workspace:
+      defaultKey === null
+        ? null
+        : (unique.get(defaultKey)?.displayPath ?? null),
+    workspaces: entries.map((entry) => entry.displayPath),
+    lastUsedWorkspace:
+      lastUsedKey === null
+        ? null
+        : (unique.get(lastUsedKey)?.displayPath ?? null),
+  });
+  return Object.freeze({
+    profile: normalized,
+    entries,
+    requested: Object.freeze(identities.slice(requestedOffset)),
+    identities,
+    defaultKey,
+    lastUsedKey,
+  });
 }
 
 function profileFromLegacy(

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -10,6 +10,7 @@ import {
   type PublicHostSettings,
   type ZenXHostProfile,
   ZenXHostProfileStore,
+  type ZenXSettingsUpdate,
   validateHostProfile,
 } from "./host-profile.js";
 import { ZenXCredentialVault } from "./credential-vault.js";
@@ -42,6 +43,7 @@ export class ZenXSettingsService {
     userDataDirectory: string;
     zenDataDirectory: string;
     vault: ZenXCredentialVault;
+    profileStore?: ZenXHostProfileStore;
     subscription?: Pick<
       OpenAiSubscriptionAuthProfile,
       "login" | "logout" | "status"
@@ -52,9 +54,11 @@ export class ZenXSettingsService {
       options.userDataDirectory,
       "openai-subscription-auth.json",
     );
-    this.#profileStore = new ZenXHostProfileStore(
-      path.join(options.userDataDirectory, "host-profile.json"),
-    );
+    this.#profileStore =
+      options.profileStore ??
+      new ZenXHostProfileStore(
+        path.join(options.userDataDirectory, "host-profile.json"),
+      );
     this.#subscription =
       options.subscription ??
       new OpenAiSubscriptionAuthProfile(this.#profilePath);
@@ -62,19 +66,25 @@ export class ZenXSettingsService {
   }
 
   async initialize(environment: NodeJS.ProcessEnv): Promise<void> {
-    const existing = await this.#profileStore.readOptional();
-    if (existing !== undefined) {
-      this.#profile = await normalizeCanonicalWorkspaces(existing);
-      return;
-    }
-    const configureWorkspace = environment.ZENX_CWD !== undefined;
-    const legacy = resolveZenXHostConfig(environment);
-    const fallback = profileFromLegacy(legacy, configureWorkspace);
-    if (legacy.provider.type === "openai-compatible") {
-      await this.#vault.writeApiKey(legacy.provider.apiKey);
-    }
-    this.#profile = await normalizeCanonicalWorkspaces(fallback);
-    await this.#profileStore.write(this.#profile);
+    await this.#queueProfileOperation(async () => {
+      const existing = await this.#profileStore.readOptional();
+      if (existing !== undefined) {
+        this.#profile = await normalizeCanonicalWorkspaces(existing);
+        return;
+      }
+      const configureWorkspace = environment.ZENX_CWD !== undefined;
+      const legacy = resolveZenXHostConfig(environment);
+      const fallback = await normalizeCanonicalWorkspaces(
+        profileFromLegacy(legacy, configureWorkspace),
+      );
+      await this.#persistProfile(
+        fallback,
+        legacy.provider.type === "openai-compatible"
+          ? legacy.provider.apiKey
+          : undefined,
+      );
+      this.#profile = fallback;
+    });
   }
 
   async publicSettings(): Promise<PublicHostSettings> {
@@ -134,21 +144,28 @@ export class ZenXSettingsService {
     };
   }
 
-  async save(profile: ZenXHostProfile, apiKey?: string): Promise<void> {
-    const structurallyValidated = validateHostProfile(profile);
+  async save(settings: ZenXSettingsUpdate, apiKey?: string): Promise<void> {
     await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
       const validated = await normalizeCanonicalWorkspaces(
-        structurallyValidated,
+        validateHostProfile({
+          ...current,
+          onboardingComplete: settings.onboardingComplete,
+          provider: settings.provider,
+          defaultModel: settings.defaultModel,
+          titleModel: settings.titleModel,
+          models: settings.models,
+          approvalPolicy: settings.approvalPolicy,
+        }),
       );
-      if (apiKey !== undefined && apiKey.length > 0)
-        await this.#vault.writeApiKey(apiKey);
       if (
         validated.provider.type === "openai-compatible" &&
+        !(apiKey !== undefined && apiKey.length > 0) &&
         !(await this.#vault.hasApiKey())
       ) {
         throw new Error("Add an API key before activating this provider");
       }
-      await this.#profileStore.write(validated);
+      await this.#persistProfile(validated, apiKey);
       this.#profile = validated;
     });
   }
@@ -323,6 +340,32 @@ export class ZenXSettingsService {
       () => undefined,
     );
     return result;
+  }
+
+  async #persistProfile(
+    profile: ZenXHostProfile,
+    apiKey?: string,
+  ): Promise<void> {
+    const rotatesCredential = apiKey !== undefined && apiKey.length > 0;
+    const previousApiKey = rotatesCredential
+      ? await this.#vault.readApiKey()
+      : undefined;
+    if (rotatesCredential) await this.#vault.writeApiKey(apiKey);
+    try {
+      await this.#profileStore.write(profile);
+    } catch (persistenceError) {
+      if (!rotatesCredential) throw persistenceError;
+      try {
+        if (previousApiKey === undefined) await this.#vault.clearApiKey();
+        else await this.#vault.writeApiKey(previousApiKey);
+      } catch (compensationError) {
+        throw new AggregateError(
+          [persistenceError, compensationError],
+          "ZenX settings were partially saved: host profile persistence failed and the previous credential could not be restored",
+        );
+      }
+      throw persistenceError;
+    }
   }
 }
 

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -16,7 +16,7 @@ import type {
 import { ipcChannels } from "./ipc.js";
 import type {
   PublicHostSettings,
-  ZenXHostProfile,
+  ZenXSettingsUpdate,
 } from "../main/host-profile.js";
 import type {
   CreateRoomInput,
@@ -123,10 +123,10 @@ contextBridge.exposeInMainWorld("zenx", {
     get: async (): Promise<PublicHostSettings> =>
       await ipcRenderer.invoke(ipcChannels.settingsGet),
     save: async (
-      profile: ZenXHostProfile,
+      settings: ZenXSettingsUpdate,
       apiKey?: string,
     ): Promise<PublicHostSettings> =>
-      await ipcRenderer.invoke(ipcChannels.settingsSave, profile, apiKey),
+      await ipcRenderer.invoke(ipcChannels.settingsSave, settings, apiKey),
     addWorkspace: async (workspace: string): Promise<PublicHostSettings> =>
       await ipcRenderer.invoke(ipcChannels.workspaceAdd, workspace),
     removeWorkspace: async (workspace: string): Promise<PublicHostSettings> =>

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -82,7 +82,14 @@ export function SettingsView({
         .map((value) => value.trim())
         .filter(Boolean);
       const value = await window.zenx.settings.save(
-        { ...draft, onboardingComplete: true, models: modelList },
+        {
+          onboardingComplete: true,
+          provider: draft.provider,
+          defaultModel: draft.defaultModel,
+          titleModel: draft.titleModel,
+          models: modelList,
+          approvalPolicy: draft.approvalPolicy,
+        },
         apiKey.trim().length > 0 ? apiKey : undefined,
       );
       setSettings(value);

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   PublicHostSettings,
   ZenXHostProfile,
+  ZenXSettingsUpdate,
 } from "../../main/host-profile.js";
 import type {
   CreateRoomInput,
@@ -81,7 +82,7 @@ declare global {
       settings: {
         get(): Promise<PublicHostSettings>;
         save(
-          profile: ZenXHostProfile,
+          settings: ZenXSettingsUpdate,
           apiKey?: string,
         ): Promise<PublicHostSettings>;
         addWorkspace(workspace: string): Promise<PublicHostSettings>;

--- a/apps/zenx/test/credential-vault.test.ts
+++ b/apps/zenx/test/credential-vault.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -42,6 +42,49 @@ test("refuses to persist a secret when system encryption is unavailable", async 
     await assert.rejects(
       vault.writeApiKey("secret"),
       /encryption is unavailable/u,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("uses independent staging files for concurrent credential writes and cleans them", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-vault-concurrent-"),
+  );
+  const file = path.join(directory, "credentials.vault");
+  try {
+    const vault = new ZenXCredentialVault(file, encryption);
+    await Promise.all([
+      vault.writeApiKey("first-secret"),
+      vault.writeApiKey("second-secret"),
+    ]);
+    assert.ok(
+      ["first-secret", "second-secret"].includes(
+        (await vault.readApiKey()) ?? "",
+      ),
+    );
+    assert.deepEqual(
+      (await readdir(directory)).filter((entry) => entry.endsWith(".tmp")),
+      [],
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("cleans credential staging when atomic replacement fails", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-vault-cleanup-"),
+  );
+  const file = path.join(directory, "credentials.vault");
+  try {
+    await mkdir(file);
+    const vault = new ZenXCredentialVault(file, encryption);
+    await assert.rejects(vault.writeApiKey("secret"));
+    assert.deepEqual(
+      (await readdir(directory)).filter((entry) => entry.endsWith(".tmp")),
+      [],
     );
   } finally {
     await rm(directory, { recursive: true, force: true });

--- a/apps/zenx/test/project-projection.test.ts
+++ b/apps/zenx/test/project-projection.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, unlink } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -52,6 +52,23 @@ test("POSIX project identity preserves case", async () => {
     await projectPathKey("/Work/Zen", "linux"),
     await projectPathKey("/work/zen", "linux"),
   );
+});
+
+test("Windows case aliases share one resolution per operation", async () => {
+  let resolutions = 0;
+  const projection = new ZenXProjectProjection("win32", async (candidate) => {
+    resolutions += 1;
+    return candidate;
+  });
+
+  await projection.updateConfiguration(
+    ["C:\\Work\\Zen"],
+    "c:\\work\\zen",
+    "C:\\WORK\\ZEN",
+  );
+  await projection.project([]);
+
+  assert.equal(resolutions, 2);
 });
 
 test("does not invent a Project when host configuration is empty", async () => {
@@ -163,6 +180,126 @@ test("falls back to the lexical absolute path when realpath is unavailable", asy
   assert.equal(snapshot.lastUsedWorkspace, workspace);
 });
 
+test("a slower obsolete configuration refresh cannot replace a newer one", async () => {
+  const slowWorkspace = path.resolve("slow-workspace");
+  const fastWorkspace = path.resolve("fast-workspace");
+  let announceSlow!: () => void;
+  const slowStarted = new Promise<void>((resolve) => {
+    announceSlow = resolve;
+  });
+  let releaseSlow!: () => void;
+  const slowGate = new Promise<void>((resolve) => {
+    releaseSlow = resolve;
+  });
+  const projection = new ZenXProjectProjection("linux", async (candidate) => {
+    if (candidate === slowWorkspace) {
+      announceSlow();
+      await slowGate;
+    }
+    return candidate;
+  });
+
+  const slow = projection.updateConfiguration([slowWorkspace], slowWorkspace);
+  await slowStarted;
+  await projection.updateConfiguration([fastWorkspace], fastWorkspace);
+  releaseSlow();
+  await slow;
+
+  const snapshot = await projection.project([]);
+  assert.deepEqual(
+    snapshot.projects.map((project) => project.workspace),
+    [fastWorkspace],
+  );
+});
+
+test("configuration, default, and last-used share one identity snapshot", async () => {
+  const alias = path.resolve("single-snapshot-alias");
+  const first = path.resolve("single-snapshot-first");
+  const retargeted = path.resolve("single-snapshot-retargeted");
+  let aliasResolutions = 0;
+  const projection = new ZenXProjectProjection("linux", async (candidate) => {
+    if (candidate !== alias) return candidate;
+    aliasResolutions += 1;
+    return aliasResolutions === 1 ? first : retargeted;
+  });
+
+  await projection.updateConfiguration([alias], alias, alias);
+  const snapshot = await projection.project([]);
+
+  assert.equal(snapshot.projects.length, 1);
+  assert.equal(snapshot.projects[0]?.workspace, alias);
+  assert.equal(snapshot.projects[0]?.isDefault, true);
+  assert.equal(snapshot.lastUsedWorkspace, alias);
+  assert.equal(aliasResolutions, 2);
+});
+
+test(
+  "POSIX missing paths reconcile after becoming symlink aliases",
+  { skip: process.platform === "win32" },
+  async () => await exerciseMissingAliasAppearance("dir"),
+);
+
+test(
+  "Windows missing paths reconcile after becoming junction aliases",
+  { skip: process.platform !== "win32" },
+  async () => await exerciseMissingAliasAppearance("junction"),
+);
+
+test(
+  "POSIX configured aliases follow retargeted filesystem identity",
+  { skip: process.platform === "win32" },
+  async () => await exerciseAliasRetarget("dir"),
+);
+
+test(
+  "Windows configured junctions follow retargeted filesystem identity",
+  { skip: process.platform !== "win32" },
+  async () => await exerciseAliasRetarget("junction"),
+);
+
+test("configured paths reconcile after realpath fallback recovers", async () => {
+  const alias = path.resolve("temporarily-unavailable-alias");
+  const physical = path.resolve("physical-after-recovery");
+  const permissionDenied = Object.assign(new Error("permission denied"), {
+    code: "EACCES",
+  });
+  let unavailable = true;
+  const projection = new ZenXProjectProjection("linux", async (candidate) => {
+    if (candidate === alias) {
+      if (unavailable) throw permissionDenied;
+      return physical;
+    }
+    return candidate;
+  });
+
+  await projection.updateConfiguration([alias], alias, alias);
+  unavailable = false;
+
+  const snapshot = await projection.project([
+    { id: "recovered-thread", cwd: physical },
+  ]);
+  assert.equal(snapshot.projects.length, 1);
+  assert.equal(snapshot.projects[0]?.workspace, alias);
+  assert.deepEqual(snapshot.projects[0]?.threadIds, ["recovered-thread"]);
+  assert.equal(await projection.configuredWorkspace(physical), alias);
+});
+
+test("nearest-ancestor resolution rechecks a path that appears mid-flight", async () => {
+  const alias = path.resolve("appearing-alias");
+  const physical = path.resolve("appearing-physical");
+  let missing = true;
+  const key = await projectPathKey(alias, "linux", async (candidate) => {
+    if (candidate === alias && missing) {
+      missing = false;
+      throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    }
+    if (candidate === alias) return physical;
+    return candidate;
+  });
+
+  assert.equal(key, physical);
+});
+
 async function withAliasedDirectory(
   type: "dir" | "junction",
   run: (paths: { physical: string; alias: string }) => Promise<void>,
@@ -176,6 +313,59 @@ async function withAliasedDirectory(
     await mkdir(physical);
     await symlink(physical, alias, type);
     await run({ physical, alias });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function exerciseMissingAliasAppearance(
+  type: "dir" | "junction",
+): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-project-missing-alias-"),
+  );
+  const physical = path.join(directory, "physical");
+  const alias = path.join(directory, "later-alias");
+  try {
+    await mkdir(physical);
+    const projection = new ZenXProjectProjection();
+    await projection.updateConfiguration([alias], alias);
+    await symlink(physical, alias, type);
+
+    const snapshot = await projection.project([
+      { id: "physical-thread", cwd: physical },
+    ]);
+    assert.equal(snapshot.projects.length, 1);
+    assert.equal(snapshot.projects[0]?.workspace, alias);
+    assert.deepEqual(snapshot.projects[0]?.threadIds, ["physical-thread"]);
+    assert.equal(await projection.configuredWorkspace(physical), alias);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+async function exerciseAliasRetarget(type: "dir" | "junction"): Promise<void> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-project-retarget-"),
+  );
+  const first = path.join(directory, "first");
+  const second = path.join(directory, "second");
+  const alias = path.join(directory, "alias");
+  try {
+    await Promise.all([mkdir(first), mkdir(second)]);
+    await symlink(first, alias, type);
+    const projection = new ZenXProjectProjection();
+    await projection.updateConfiguration([alias], alias);
+    await unlink(alias);
+    await symlink(second, alias, type);
+
+    const snapshot = await projection.project([
+      { id: "retargeted-thread", cwd: second },
+    ]);
+    assert.equal(snapshot.projects.length, 1);
+    assert.equal(snapshot.projects[0]?.workspace, alias);
+    assert.deepEqual(snapshot.projects[0]?.threadIds, ["retargeted-thread"]);
+    assert.equal(await projection.configuredWorkspace(second), alias);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/self-control-capability.test.ts
+++ b/apps/zenx/test/self-control-capability.test.ts
@@ -544,6 +544,80 @@ test("self-control Project and Thread filters reconcile filesystem aliases", asy
   }
 });
 
+test("self-control Thread filters use one canonicalization snapshot", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-control-filter-snapshot-"),
+  );
+  const alias = path.join(directory, "alias");
+  const physical = path.join(directory, "physical");
+  const retargeted = path.join(directory, "retargeted");
+  let aliasResolutions = 0;
+  const projection = new ZenXProjectProjection("linux", async (candidate) => {
+    if (candidate !== alias) return candidate;
+    aliasResolutions += 1;
+    return aliasResolutions === 1 ? physical : retargeted;
+  });
+  const thread: Thread = {
+    id: "thread-filter-snapshot",
+    sessionId: "thread-filter-snapshot",
+    forkedFromId: null,
+    parentThreadId: null,
+    preview: "Canonical filter snapshot",
+    ephemeral: false,
+    isPinned: false,
+    modelProvider: "fake",
+    createdAt: 1,
+    updatedAt: 2,
+    recencyAt: null,
+    status: { type: "idle" },
+    path: null,
+    cwd: physical,
+    cliVersion: "zen/0.1.0",
+    source: "appServer",
+    threadSource: null,
+    agentNickname: null,
+    agentRole: null,
+    gitInfo: null,
+    name: null,
+    turns: [],
+  };
+  const port: AppServerRequestPort = {
+    projectProjection: projection,
+    async request<M extends ClientRequestMethod>(
+      method: M,
+      _params: ClientRequestParams[M],
+    ): Promise<ClientRequestResults[M]> {
+      assert.equal(method, "thread/list");
+      return {
+        data: [thread],
+        nextCursor: null,
+        backwardsCursor: null,
+      } as ClientRequestResults[M];
+    },
+  };
+  const capabilities = await grantedSelfControl(directory, port);
+  try {
+    const listed = await invoke(
+      capabilityTools(capabilities),
+      "zenx_threads_list",
+      {
+        workspace: alias,
+        cwd: alias,
+        limit: 10,
+      },
+    );
+
+    assert.equal(
+      (listed.threads as Array<{ threadId: string }>)[0]?.threadId,
+      thread.id,
+    );
+    assert.equal(aliasResolutions, 1);
+  } finally {
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("all hosted tool definitions serialize through the OpenAI subscription boundary", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-control-openai-"),

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -5,6 +5,7 @@ import {
   readFile,
   rm,
   symlink,
+  unlink,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -188,6 +189,97 @@ test(
   async () => await exerciseAliasWorkspaceMutations("junction"),
 );
 
+test(
+  "POSIX queued mutations resolve aliases after a symlink retarget",
+  { skip: process.platform === "win32" },
+  async () => await exerciseQueuedAliasRetarget("dir"),
+);
+
+test(
+  "Windows queued mutations resolve aliases after a junction retarget",
+  { skip: process.platform !== "win32" },
+  async () => await exerciseQueuedAliasRetarget("junction"),
+);
+
+test("workspace mutations retry one filesystem identity change", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-settings-identity-retry-"),
+  );
+  const first = path.join(directory, "first");
+  const second = path.join(directory, "second");
+  const alias = path.join(directory, "alias");
+  let aliasResolutions = 0;
+  try {
+    const service = new ZenXSettingsService({
+      userDataDirectory: directory,
+      zenDataDirectory: path.join(directory, "zen"),
+      vault: new ZenXCredentialVault(
+        path.join(directory, "credentials.vault"),
+        encryption,
+      ),
+      subscription: idleSubscription(),
+      projectPlatform: "linux",
+      projectRealpath: async (candidate) => {
+        if (candidate !== alias) return candidate;
+        aliasResolutions += 1;
+        return aliasResolutions === 1 ? first : second;
+      },
+    });
+    await service.initialize({ ZENX_CWD: second });
+
+    await service.markWorkspaceUsed(alias);
+
+    assert.equal(
+      (await service.publicSettings()).profile.lastUsedWorkspace,
+      second,
+    );
+    assert.equal(aliasResolutions, 4);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("workspace mutations fail after bounded identity revalidation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-settings-identity-unstable-"),
+  );
+  const first = path.join(directory, "first");
+  const second = path.join(directory, "second");
+  const alias = path.join(directory, "alias");
+  let aliasResolutions = 0;
+  try {
+    const service = new ZenXSettingsService({
+      userDataDirectory: directory,
+      zenDataDirectory: path.join(directory, "zen"),
+      vault: new ZenXCredentialVault(
+        path.join(directory, "credentials.vault"),
+        encryption,
+      ),
+      subscription: idleSubscription(),
+      projectPlatform: "linux",
+      projectRealpath: async (candidate) => {
+        if (candidate !== alias) return candidate;
+        aliasResolutions += 1;
+        return aliasResolutions % 2 === 1 ? first : second;
+      },
+    });
+    await service.initialize({ ZENX_CWD: second });
+
+    await assert.rejects(
+      async () => await service.markWorkspaceUsed(alias),
+      /filesystem identity changed/u,
+    );
+
+    assert.equal(
+      (await service.publicSettings()).profile.lastUsedWorkspace,
+      null,
+    );
+    assert.equal(aliasResolutions, 4);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("clears the OAuth concurrency guard after failure so login can retry", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-oauth-retry-"));
   let attempts = 0;
@@ -262,6 +354,107 @@ async function exerciseAliasWorkspaceMutations(
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+}
+
+async function exerciseQueuedAliasRetarget(
+  type: "dir" | "junction",
+): Promise<void> {
+  for (const operation of ["mark-used", "default", "remove"] as const) {
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), `zenx-settings-retarget-${operation}-`),
+    );
+    const first = path.join(directory, "first");
+    const second = path.join(directory, "second");
+    const other = path.join(directory, "other");
+    const alias = path.join(directory, "alias");
+    try {
+      await Promise.all([mkdir(first), mkdir(second), mkdir(other)]);
+      await symlink(first, alias, type);
+      const vault = new BlockingCredentialVault(
+        path.join(directory, "credentials.vault"),
+        encryption,
+      );
+      const service = new ZenXSettingsService({
+        userDataDirectory: directory,
+        zenDataDirectory: path.join(directory, "zen"),
+        vault,
+        subscription: idleSubscription(),
+      });
+      await service.initialize({ ZENX_CWD: other });
+      await service.addWorkspace(second);
+      const profile = (await service.publicSettings()).profile;
+
+      const blocker = vault.blockNextWrite();
+      const queuedSave = service.save(profile, "queued-secret");
+      await blocker.started;
+      const mutation =
+        operation === "mark-used"
+          ? service.markWorkspaceUsed(alias)
+          : operation === "default"
+            ? service.setDefaultWorkspace(alias)
+            : service.removeWorkspace(alias);
+      await unlink(alias);
+      await symlink(second, alias, type);
+      blocker.release();
+      await queuedSave;
+      await mutation;
+
+      const updated = (await service.publicSettings()).profile;
+      if (operation === "mark-used") {
+        assert.equal(updated.lastUsedWorkspace, second);
+      } else if (operation === "default") {
+        assert.equal(updated.workspace, second);
+      } else {
+        assert.deepEqual(updated.workspaces, [other]);
+        assert.equal(updated.workspace, other);
+      }
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+}
+
+class BlockingCredentialVault extends ZenXCredentialVault {
+  #nextWrite:
+    | {
+        readonly started: () => void;
+        readonly gate: Promise<void>;
+      }
+    | undefined;
+
+  blockNextWrite(): { started: Promise<void>; release(): void } {
+    let announceStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      announceStarted = resolve;
+    });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.#nextWrite = { started: announceStarted, gate };
+    return { started, release };
+  }
+
+  override async writeApiKey(apiKey: string): Promise<void> {
+    const blocker = this.#nextWrite;
+    this.#nextWrite = undefined;
+    if (blocker !== undefined) {
+      blocker.started();
+      await blocker.gate;
+    }
+    await super.writeApiKey(apiKey);
+  }
+}
+
+function idleSubscription(): Pick<
+  OpenAiSubscriptionAuthProfile,
+  "login" | "logout" | "status"
+> {
+  return {
+    login: async () => undefined,
+    logout: async () => undefined,
+    status: async () => ({ authenticated: false, expired: false }),
+  };
 }
 
 test("cleans an aborted manual OAuth wait and accepts a later login", async () => {

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -15,6 +15,10 @@ import {
   ZenXCredentialVault,
   type LocalEncryption,
 } from "../src/main/credential-vault.js";
+import {
+  type ZenXHostProfile,
+  ZenXHostProfileStore,
+} from "../src/main/host-profile.js";
 import { ZenXSettingsService } from "../src/main/settings-service.js";
 import type { OpenAiSubscriptionAuthProfile } from "../../cli/src/subscription-auth.js";
 
@@ -171,6 +175,217 @@ test("serializes concurrent workspace mutations without losing either update", a
       new Set(persisted.workspaces),
       new Set([path.resolve(firstWorkspace), path.resolve(secondWorkspace)]),
     );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("keeps inverse-completing initialize and save writes in invocation order", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-inverse-profile-writes-"),
+  );
+  const store = new InverseCompletionProfileStore(
+    path.join(directory, "host-profile.json"),
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    profileStore: store,
+    vault: new ZenXCredentialVault(
+      path.join(directory, "credentials.vault"),
+      encryption,
+    ),
+  });
+  try {
+    const initialization = service.initialize({ ZENX_PROVIDER: "fake" });
+    await store.firstWriteStarted;
+    const saved = fakeProfile("saved-model");
+    const save = service.save(saved);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const writesBeforeRelease = store.writeCalls;
+    store.releaseFirstWrite();
+    const results = await Promise.allSettled([initialization, save]);
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ["fulfilled", "fulfilled"],
+    );
+
+    assert.equal(writesBeforeRelease, 1);
+    assert.equal(
+      (await service.publicSettings()).profile.defaultModel,
+      "saved-model",
+    );
+    assert.equal(
+      JSON.parse(
+        await readFile(path.join(directory, "host-profile.json"), "utf8"),
+      ).defaultModel,
+      "saved-model",
+    );
+  } finally {
+    store.releaseFirstWrite();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("serializes initialize followed by save across vault and profile persistence", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-initialize-save-"),
+  );
+  const vault = new ZenXCredentialVault(
+    path.join(directory, "credentials.vault"),
+    encryption,
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    vault,
+  });
+  try {
+    const initialization = service.initialize(compatibleEnvironment("first"));
+    const save = service.save(compatibleProfile("second"), "second-key");
+
+    const results = await Promise.allSettled([initialization, save]);
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ["fulfilled", "fulfilled"],
+    );
+
+    assert.equal(await vault.readApiKey(), "second-key");
+    assert.equal(
+      (await service.publicSettings()).profile.defaultModel,
+      "second-model",
+    );
+    assert.equal(
+      JSON.parse(
+        await readFile(path.join(directory, "host-profile.json"), "utf8"),
+      ).defaultModel,
+      "second-model",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("serializes concurrent initialize calls so the first migration remains authoritative", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-initialize-initialize-"),
+  );
+  const vault = new ZenXCredentialVault(
+    path.join(directory, "credentials.vault"),
+    encryption,
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    vault,
+  });
+  try {
+    const results = await Promise.allSettled([
+      service.initialize(compatibleEnvironment("first")),
+      service.initialize(compatibleEnvironment("second")),
+    ]);
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ["fulfilled", "fulfilled"],
+    );
+
+    assert.equal(await vault.readApiKey(), "first-key");
+    assert.equal(
+      (await service.publicSettings()).profile.defaultModel,
+      "first-model",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("merges stale Settings fields without overwriting a newer Project mutation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-stale-settings-"),
+  );
+  const workspace = path.join(directory, "project");
+  try {
+    const service = settingsFor(directory, inactiveSubscription());
+    await service.initialize({});
+    const stale = (await service.publicSettings()).profile;
+    await service.addWorkspace(workspace);
+
+    await service.save({
+      ...stale,
+      defaultModel: "saved-model",
+      models: ["saved-model"],
+    });
+
+    const profile = (await service.publicSettings()).profile;
+    assert.equal(profile.defaultModel, "saved-model");
+    assert.equal(profile.workspace, path.resolve(workspace));
+    assert.deepEqual(profile.workspaces, [path.resolve(workspace)]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("restores the previous credential when profile persistence fails", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-profile-persistence-failure-"),
+  );
+  const vault = new ZenXCredentialVault(
+    path.join(directory, "credentials.vault"),
+    encryption,
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    vault,
+  });
+  try {
+    await service.initialize(compatibleEnvironment("first"));
+    const before = (await service.publicSettings()).profile;
+    const profilePath = path.join(directory, "host-profile.json");
+    await rm(profilePath);
+    await mkdir(profilePath);
+
+    await assert.rejects(
+      service.save(compatibleProfile("second"), "second-key"),
+    );
+
+    assert.deepEqual((await service.publicSettings()).profile, before);
+    assert.equal(await vault.readApiKey(), "first-key");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("reports an explicit partial save when credential compensation fails", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-credential-compensation-failure-"),
+  );
+  const vault = new FailingCompensationVault(
+    path.join(directory, "credentials.vault"),
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    vault,
+  });
+  try {
+    await service.initialize(compatibleEnvironment("first"));
+    const before = (await service.publicSettings()).profile;
+    const profilePath = path.join(directory, "host-profile.json");
+    await rm(profilePath);
+    await mkdir(profilePath);
+    vault.failCompensation = true;
+
+    await assert.rejects(
+      service.save(compatibleProfile("second"), "second-key"),
+      (error: unknown) =>
+        error instanceof AggregateError &&
+        /partially saved/u.test(error.message) &&
+        error.errors.length === 2,
+    );
+
+    assert.deepEqual((await service.publicSettings()).profile, before);
+    assert.equal(await vault.readApiKey(), "second-key");
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -374,4 +589,100 @@ function settingsFor(
     ),
     subscription,
   });
+}
+
+function inactiveSubscription(): Pick<
+  OpenAiSubscriptionAuthProfile,
+  "login" | "logout" | "status"
+> {
+  return {
+    login: async () => undefined,
+    logout: async () => undefined,
+    status: async () => ({ authenticated: false, expired: false }),
+  };
+}
+
+function fakeProfile(model: string): ZenXHostProfile {
+  return {
+    version: 1,
+    onboardingComplete: true,
+    provider: { type: "fake", displayName: "Local demo" },
+    defaultModel: model,
+    titleModel: model,
+    models: [model],
+    workspace: null,
+    workspaces: [],
+    lastUsedWorkspace: null,
+    approvalPolicy: "always",
+  };
+}
+
+function compatibleProfile(name: string): ZenXHostProfile {
+  return {
+    ...fakeProfile(`${name}-model`),
+    provider: {
+      type: "openai-compatible",
+      name,
+      displayName: name,
+      baseUrl: `https://${name}.example.test/v1`,
+    },
+  };
+}
+
+function compatibleEnvironment(name: string): NodeJS.ProcessEnv {
+  return {
+    ZENX_PROVIDER: "openai-compatible",
+    ZENX_API_KEY_ENV: `${name.toUpperCase()}_KEY`,
+    [`${name.toUpperCase()}_KEY`]: `${name}-key`,
+    ZENX_BASE_URL: `https://${name}.example.test/v1`,
+    ZENX_PROVIDER_NAME: name,
+    ZENX_MODEL: `${name}-model`,
+    ZENX_MODELS: `${name}-model`,
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
+
+class InverseCompletionProfileStore extends ZenXHostProfileStore {
+  readonly #firstWriteStarted = deferred();
+  readonly #releaseFirstWrite = deferred();
+  writeCalls = 0;
+
+  get firstWriteStarted(): Promise<void> {
+    return this.#firstWriteStarted.promise;
+  }
+
+  releaseFirstWrite(): void {
+    this.#releaseFirstWrite.resolve();
+  }
+
+  override async write(profile: ZenXHostProfile): Promise<void> {
+    this.writeCalls += 1;
+    if (this.writeCalls === 1) {
+      this.#firstWriteStarted.resolve();
+      await this.#releaseFirstWrite.promise;
+    }
+    await super.write(profile);
+  }
+}
+
+class FailingCompensationVault extends ZenXCredentialVault {
+  failCompensation = false;
+
+  constructor(filePath: string) {
+    super(filePath, encryption);
+  }
+
+  override async writeApiKey(apiKey: string): Promise<void> {
+    if (this.failCompensation && apiKey === "first-key") {
+      throw new Error("credential compensation failed");
+    }
+    await super.writeApiKey(apiKey);
+  }
 }


### PR DESCRIPTION
## Summary

- serialize the complete Settings initialize/save profile mutation sequence
- make the renderer save contract own only Settings fields and merge them with current Project/workspace state inside the queue
- use unique credential-vault staging with cleanup on success and failure
- restore the previous credential when profile persistence fails, with an explicit partial-save error if compensation also fails
- integrate PR #114 exact reviewed head so Project refreshes are latest-wins and each projection/mutation uses one canonical identity snapshot with bounded retry
- preserve configured display paths across aliases, missing paths, fallback recovery, and retargeting; run Project identity coverage in Windows CI
- cover inverse completion, initialize/save, initialize/initialize, stale Settings, credential failure/compensation, alias retargeting, and identity instability

## Validation

- `npm --prefix apps/zenx run test:project-identity` — 37 passed, 5 platform-specific skips
- focused Project/Settings/profile/vault suite — 46 passed, 5 platform-specific skips
- `npm --prefix apps/zenx run typecheck`
- `npm --prefix apps/zenx run build`
- `npm --prefix apps/zenx test` — 411 passed, 6 platform-specific skips
- Prettier check on all changed files
- `git diff --check origin/main...HEAD`

Closes #100
Closes #104