### PR TITLE
Fix remaining trigger containment audit gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Report WinApp CLI version
         run: winapp --version
       - run: npm ci
+      - name: Exercise trigger process containment on Windows
+        run: npm --workspace apps/zenx exec -- tsx --test test/trigger-program-runner.test.ts
       - run: npm --workspace apps/zenx run smoke:windows-computer
 
   zenx-windows-packaged-provider-smoke:

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -21,6 +21,8 @@ const PROGRAM_QUIESCENCE_PASSES = 2;
 const PROGRAM_QUIESCENCE_POLL_MS = 40;
 const MAX_PROGRAM_STDERR_BYTES = 8 * 1_024;
 const PROCESS_TABLE_TIMEOUT_MS = process.platform === "win32" ? 4_000 : 750;
+const MAX_PROCESS_TABLE_BYTES = 128 * 1_024;
+const WINDOWS_IDENTITY_TERMINATION_TIMEOUT_MS = 4_000;
 
 export interface TriggerProgramRunInput {
   invocationId: string;
@@ -171,14 +173,22 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
                 };
           return forced;
         });
-        const terminationResult = await withDeadline(
-          containment,
-          PROGRAM_FORCE_SETTLEMENT_MS,
-          {
+        let terminationResult: TerminationResult;
+        try {
+          terminationResult = await withDeadline(
+            containment,
+            PROGRAM_FORCE_SETTLEMENT_MS,
+            {
+              ok: false,
+              error: "bounded process-tree termination deadline expired",
+            },
+          );
+        } catch (error) {
+          terminationResult = {
             ok: false,
-            error: "bounded process-tree termination deadline expired",
-          },
-        );
+            error: `process-tree termination failed: ${describeError(error)}`,
+          };
+        }
         if (settled || requested === null) return;
         if (terminationResult.ok) finish(requested);
         else
@@ -196,21 +206,24 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         requested = value;
         stopCollection();
         child.stdin.destroy();
-        const treeAtTermination = captureProcessTree(child.pid).catch(
-          () => undefined,
+        const treeAtTermination = captureProcessTree(child.pid).then(
+          (tree) => ({ tree, error: null }),
+          (error: unknown) => ({
+            tree: undefined,
+            error: describeError(error),
+          }),
         );
-        termination = treeAtTermination.then(async (tree) => {
-          if (tree !== undefined) {
-            capturedTree = tree;
-            return await terminateProcessTree(child, false, tree);
+        termination = treeAtTermination.then(async (snapshot) => {
+          if (snapshot.tree !== undefined) {
+            capturedTree = snapshot.tree;
+            return await terminateProcessTree(child, false, snapshot.tree);
           }
           await terminateProcessTree(child, false);
           const exited = await verifyExitedChild(child);
           if (exited.ok) return exited;
           return {
             ok: false as const,
-            error:
-              "process-tree snapshot unavailable; containment was not proven",
+            error: `process-tree snapshot unavailable: ${snapshot.error ?? "unknown discovery failure"}; containment was not proven`,
           };
         });
         forceTimer = setTimeout(() => {
@@ -394,9 +407,8 @@ export interface WindowsProcessTreeSnapshot {
 
 export interface WindowsProcessOperations {
   captureProcessTable(): Promise<WindowsProcessTableSnapshot>;
-  runTaskkill(
-    pid: number,
-    tree: boolean,
+  terminateProcessIdentity(
+    expected: WindowsProcessIdentity,
   ): Promise<{ ok: boolean; error: string }>;
 }
 
@@ -519,7 +531,12 @@ export async function verifyAndTerminateWindowsProcessTree(
   let firstPass = true;
   while (firstPass || Date.now() < deadline) {
     firstPass = false;
-    const table = await operations.captureProcessTable();
+    let table: WindowsProcessTableSnapshot;
+    try {
+      table = await operations.captureProcessTable();
+    } catch (error) {
+      return processTableDiscoveryFailure(error);
+    }
     tracked = addWindowsDescendants(tracked, table.entries);
     const unknownIdentity = tracked.find(
       (identity) => identity.startTime === null,
@@ -543,13 +560,7 @@ export async function verifyAndTerminateWindowsProcessTree(
       stableAbsentPasses = 0;
       for (const identity of live) {
         if (Date.now() >= deadline) return quiescenceDeadlineFailure();
-        const freshTable = await operations.captureProcessTable();
-        const current = freshTable.entries.find(
-          (candidate) => candidate.pid === identity.pid,
-        );
-        if (!identityMatches(identity, current)) continue;
-        if (Date.now() >= deadline) return quiescenceDeadlineFailure();
-        const termination = await operations.runTaskkill(identity.pid, true);
+        const termination = await operations.terminateProcessIdentity(identity);
         if (!termination.ok && termination.error !== "process was not found")
           return {
             ok: false,
@@ -580,9 +591,9 @@ function boundedDuration(value: number | undefined, maximum: number): number {
   return Math.min(maximum, Math.max(0, Math.floor(value)));
 }
 
-const realWindowsProcessOperations: WindowsProcessOperations = {
+export const realWindowsProcessOperations: WindowsProcessOperations = {
   captureProcessTable,
-  runTaskkill,
+  terminateProcessIdentity: terminateWindowsProcessIdentity,
 };
 
 async function verifyAndTerminatePosix(
@@ -593,7 +604,12 @@ async function verifyAndTerminatePosix(
   const deadline = Date.now() + PROGRAM_QUIESCENCE_TIMEOUT_MS;
   let tracked = [tree.root, ...tree.descendants];
   while (Date.now() < deadline) {
-    const table = await captureProcessTable();
+    let table: ProcessTableSnapshot;
+    try {
+      table = await captureProcessTable();
+    } catch (error) {
+      return processTableDiscoveryFailure(error);
+    }
     const beforeExpansion = validateTrackedIdentities(tracked, table.entries);
     if (beforeExpansion !== null) return { ok: false, error: beforeExpansion };
     tracked = addDescendants(tracked, table.entries);
@@ -640,6 +656,13 @@ async function verifyAndTerminatePosix(
     ok: false,
     error:
       "process-tree quiescence could not be proven before the bounded deadline",
+  };
+}
+
+function processTableDiscoveryFailure(error: unknown): TerminationResult {
+  return {
+    ok: false,
+    error: `process-table discovery failed: ${describeError(error)}`,
   };
 }
 
@@ -751,15 +774,86 @@ function windowsIdentityPredates(
   return BigInt(identity.startTime) < BigInt(other.startTime);
 }
 
-async function runTaskkill(
-  pid: number,
-  tree: boolean,
-): Promise<{ ok: boolean; error: string }> {
+async function terminateWindowsProcessIdentity(
+  expected: WindowsProcessIdentity,
+): Promise<TerminationResult> {
+  if (expected.startTime === null || !/^\d+$/u.test(expected.startTime))
+    return {
+      ok: false,
+      error: `PID ${String(expected.pid)} has unknown process identity`,
+    };
+  const script = `
+$ErrorActionPreference = 'Stop'
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+public static class ZenXExpectedProcessTermination
+{
+    [DllImport("kernel32.dll", SetLastError = true)]
+    public static extern IntPtr OpenProcess(uint access, bool inheritHandle, uint processId);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetProcessTimes(IntPtr process, out long creation, out long exit, out long kernel, out long user);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool TerminateProcess(IntPtr process, uint exitCode);
+
+    [DllImport("kernel32.dll")]
+    public static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool CloseHandle(IntPtr handle);
+}
+'@
+
+$handle = [ZenXExpectedProcessTermination]::OpenProcess(0x1001, $false, ${String(expected.pid)})
+if ($handle -eq [IntPtr]::Zero) {
+  $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+  if ($code -eq 87 -or $code -eq 1168) { exit 3 }
+  throw "OpenProcess failed with Win32 error $code"
+}
+
+$matched = $false
+try {
+  $expectedStartTime = [Int64]::Parse('${expected.startTime}')
+  $creation = 0L
+  $exit = 0L
+  $kernel = 0L
+  $user = 0L
+  if (![ZenXExpectedProcessTermination]::GetProcessTimes($handle, [ref]$creation, [ref]$exit, [ref]$kernel, [ref]$user)) {
+    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    throw "GetProcessTimes failed with Win32 error $code"
+  }
+  $actualStartTime = ([DateTime]::FromFileTimeUtc($creation)).Ticks
+  # CIM datetime exposes microseconds while FILETIME exposes 100-nanosecond ticks.
+  $actualStartTime -= $actualStartTime % 10
+  if ($actualStartTime -eq $expectedStartTime) {
+    $matched = $true
+    if ([ZenXExpectedProcessTermination]::WaitForSingleObject($handle, 0) -ne 0) {
+      if (![ZenXExpectedProcessTermination]::TerminateProcess($handle, 1)) {
+        $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        if ([ZenXExpectedProcessTermination]::WaitForSingleObject($handle, 0) -ne 0) {
+          throw "TerminateProcess failed with Win32 error $code"
+        }
+      }
+    }
+  }
+} finally {
+  [void][ZenXExpectedProcessTermination]::CloseHandle($handle)
+}
+if (!$matched) { exit 3 }
+`;
+  const encoded = Buffer.from(script, "utf16le").toString("base64");
   return await new Promise((resolve) => {
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let killer: ReturnType<typeof spawn> | undefined;
-    const finish = (value: { ok: boolean; error: string }): void => {
+    let stderr = "";
+    const finish = (value: TerminationResult): void => {
       if (settled) return;
       settled = true;
       if (timer !== undefined) clearTimeout(timer);
@@ -767,18 +861,25 @@ async function runTaskkill(
     };
     try {
       killer = spawn(
-        "taskkill",
-        tree ? ["/PID", String(pid), "/T", "/F"] : ["/PID", String(pid), "/F"],
-        { windowsHide: true, stdio: "ignore" },
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+        { windowsHide: true, stdio: ["ignore", "ignore", "pipe"] },
       );
+      killer.stderr?.setEncoding("utf8");
+      killer.stderr?.on("data", (chunk: string) => {
+        if (stderr.length < MAX_PROGRAM_STDERR_BYTES) stderr += chunk;
+      });
     } catch (error) {
       finish({ ok: false, error: describeError(error) });
       return;
     }
     timer = setTimeout(() => {
       killer?.kill("SIGKILL");
-      finish({ ok: false, error: "taskkill timed out" });
-    }, 750);
+      finish({
+        ok: false,
+        error: `PID ${String(expected.pid)} identity-aware termination timed out`,
+      });
+    }, WINDOWS_IDENTITY_TERMINATION_TIMEOUT_MS);
     killer.once("error", (error: unknown) =>
       finish({ ok: false, error: describeError(error) }),
     );
@@ -786,9 +887,14 @@ async function runTaskkill(
       finish(
         code === 0
           ? { ok: true, error: "" }
-          : code === 128
+          : code === 3
             ? { ok: false, error: "process was not found" }
-            : { ok: false, error: `taskkill exited with code ${String(code)}` },
+            : {
+                ok: false,
+                error:
+                  boundedError(stderr) ??
+                  `identity-aware termination exited with code ${String(code)}`,
+              },
       ),
     );
   });
@@ -832,7 +938,9 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
         : // Darwin ps has no sid= keyword; session identity is not used here.
           ["-axo", "pid=,ppid=,pgid=,lstart="];
   const output = await new Promise<string>((resolve, reject) => {
-    let text = "";
+    const chunks: Buffer[] = [];
+    let bytes = 0;
+    let overflowed = false;
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
     let processHandle: ReturnType<typeof spawn> | undefined;
@@ -841,16 +949,23 @@ async function captureProcessTable(): Promise<ProcessTableSnapshot> {
       settled = true;
       if (timer !== undefined) clearTimeout(timer);
       if (error !== null) reject(error);
-      else resolve(text);
+      else if (overflowed)
+        reject(new Error("process-table snapshot exceeded its 128 KiB bound"));
+      else resolve(Buffer.concat(chunks).toString("utf8"));
     };
     try {
       processHandle = spawn(command, args, {
         windowsHide: true,
         stdio: ["ignore", "pipe", "ignore"],
       });
-      processHandle.stdout?.setEncoding("utf8");
-      processHandle.stdout?.on("data", (chunk: string) => {
-        if (text.length < 128 * 1024) text += chunk;
+      processHandle.stdout?.on("data", (chunk: Buffer | string) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        if (bytes + buffer.length > MAX_PROCESS_TABLE_BYTES) {
+          overflowed = true;
+          return;
+        }
+        bytes += buffer.length;
+        chunks.push(buffer);
       });
       processHandle.once("error", (error: unknown) =>
         finish(new Error(describeError(error))),
@@ -876,8 +991,10 @@ function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
   const entries: ProcessIdentity[] = [];
   for (const line of output.split(/\r?\n/u)) {
     const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
     const match = trimmed.match(/^(\d+)\|(\d+)\|(\d+)$/u);
-    if (match === null) continue;
+    if (match === null)
+      throw new Error("Windows process-table snapshot was incomplete");
     entries.push({
       pid: Number(match[1]!),
       parentPid: Number(match[2]!),
@@ -895,10 +1012,12 @@ function parsePosixProcessTable(
 ): ProcessTableSnapshot {
   const entries: ProcessIdentity[] = [];
   for (const line of output.split(/\r?\n/u)) {
+    if (line.trim().length === 0) continue;
     const match = includesSessionId
       ? line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u)
       : line.match(/^\s*(\d+)\s+(\d+)\s+(\d+)\s+(.+?)\s*$/u);
-    if (match === null) continue;
+    if (match === null)
+      throw new Error("POSIX process-table snapshot was incomplete");
     entries.push({
       pid: Number(match[1]!),
       parentPid: Number(match[2]!),
@@ -915,7 +1034,7 @@ async function withDeadline<T>(
   milliseconds: number,
   fallback: T,
 ): Promise<T> {
-  return await new Promise<T>((resolve) => {
+  return await new Promise<T>((resolve, reject) => {
     let settled = false;
     const timer = setTimeout(() => {
       if (settled) return;
@@ -929,11 +1048,11 @@ async function withDeadline<T>(
         clearTimeout(timer);
         resolve(value);
       },
-      () => {
+      (error: unknown) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        resolve(fallback);
+        reject(error);
       },
     );
   });

--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -774,8 +774,10 @@ function windowsIdentityPredates(
   return BigInt(identity.startTime) < BigInt(other.startTime);
 }
 
-async function terminateWindowsProcessIdentity(
+export async function terminateWindowsProcessIdentity(
   expected: WindowsProcessIdentity,
+  // Test-only handshake for the real adapter's exit-after-match fixture.
+  identityMatchedFixture?: () => void | Promise<void>,
 ): Promise<TerminationResult> {
   if (expected.startTime === null || !/^\d+$/u.test(expected.startTime))
     return {
@@ -801,7 +803,7 @@ public static class ZenXExpectedProcessTermination
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool TerminateProcess(IntPtr process, uint exitCode);
 
-    [DllImport("kernel32.dll")]
+    [DllImport("kernel32.dll", SetLastError = true)]
     public static extern uint WaitForSingleObject(IntPtr handle, uint milliseconds);
 
     [DllImport("kernel32.dll", SetLastError = true)]
@@ -810,7 +812,19 @@ public static class ZenXExpectedProcessTermination
 }
 '@
 
-$handle = [ZenXExpectedProcessTermination]::OpenProcess(0x1001, $false, ${String(expected.pid)})
+function Test-ProcessExited([IntPtr]$process, [string]$context) {
+  $wait = [ZenXExpectedProcessTermination]::WaitForSingleObject($process, 0)
+  if ($wait -eq 0) { return $true }
+  if ($wait -eq 258) { return $false }
+  if ($wait -eq [UInt32]::MaxValue) {
+    $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    throw "WaitForSingleObject ($context) failed with Win32 error $code"
+  }
+  throw "WaitForSingleObject ($context) returned unexpected status $wait"
+}
+
+# PROCESS_TERMINATE | PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE
+$handle = [ZenXExpectedProcessTermination]::OpenProcess(0x101001, $false, ${String(expected.pid)})
 if ($handle -eq [IntPtr]::Zero) {
   $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
   if ($code -eq 87 -or $code -eq 1168) { exit 3 }
@@ -833,10 +847,19 @@ try {
   $actualStartTime -= $actualStartTime % 10
   if ($actualStartTime -eq $expectedStartTime) {
     $matched = $true
-    if ([ZenXExpectedProcessTermination]::WaitForSingleObject($handle, 0) -ne 0) {
+${
+  identityMatchedFixture === undefined
+    ? ""
+    : `    [Console]::Out.WriteLine('ZENX_IDENTITY_MATCHED')
+    [Console]::Out.Flush()
+    if ([Console]::In.ReadLine() -ne 'continue') {
+      throw "identity-match fixture did not continue"
+    }
+`
+}    if (!(Test-ProcessExited $handle 'before termination')) {
       if (![ZenXExpectedProcessTermination]::TerminateProcess($handle, 1)) {
         $code = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
-        if ([ZenXExpectedProcessTermination]::WaitForSingleObject($handle, 0) -ne 0) {
+        if (!(Test-ProcessExited $handle 'after TerminateProcess failure')) {
           throw "TerminateProcess failed with Win32 error $code"
         }
       }
@@ -853,6 +876,8 @@ if (!$matched) { exit 3 }
     let timer: ReturnType<typeof setTimeout> | undefined;
     let killer: ReturnType<typeof spawn> | undefined;
     let stderr = "";
+    let stdout = "";
+    let identityHookStarted = false;
     const finish = (value: TerminationResult): void => {
       if (settled) return;
       settled = true;
@@ -863,12 +888,41 @@ if (!$matched) { exit 3 }
       killer = spawn(
         "powershell.exe",
         ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
-        { windowsHide: true, stdio: ["ignore", "ignore", "pipe"] },
+        {
+          windowsHide: true,
+          stdio:
+            identityMatchedFixture === undefined
+              ? ["ignore", "ignore", "pipe"]
+              : ["pipe", "pipe", "pipe"],
+        },
       );
       killer.stderr?.setEncoding("utf8");
       killer.stderr?.on("data", (chunk: string) => {
         if (stderr.length < MAX_PROGRAM_STDERR_BYTES) stderr += chunk;
       });
+      if (identityMatchedFixture !== undefined) {
+        killer.stdout?.setEncoding("utf8");
+        killer.stdout?.on("data", (chunk: string) => {
+          if (identityHookStarted) return;
+          stdout += chunk;
+          if (!stdout.includes("ZENX_IDENTITY_MATCHED")) return;
+          identityHookStarted = true;
+          void Promise.resolve()
+            .then(identityMatchedFixture)
+            .then(
+              () => {
+                if (!settled) killer?.stdin?.end("continue\n");
+              },
+              (error: unknown) => {
+                killer?.kill("SIGKILL");
+                finish({
+                  ok: false,
+                  error: `identity-match fixture failed: ${describeError(error)}`,
+                });
+              },
+            );
+        });
+      }
     } catch (error) {
       finish({ ok: false, error: describeError(error) });
       return;

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -1,11 +1,20 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import {
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
 import {
   ZenXTriggerProgramRunner,
+  realWindowsProcessOperations,
   type TriggerProgramRunInput,
   verifyAndTerminateWindowsProcessTree,
   type WindowsProcessIdentity,
@@ -32,15 +41,20 @@ test("Windows containment never reuses stale identity evidence for a second tree
   let table: WindowsProcessTableSnapshot = {
     entries: [root, descendant],
   };
-  const taskkills: Array<[number, boolean]> = [];
+  const terminatedIdentities: string[] = [];
 
   const result = await verifyAndTerminateWindowsProcessTree(
     root.pid,
     { root, descendants: [descendant] },
     {
       captureProcessTable: async () => structuredClone(table),
-      runTaskkill: async (pid, tree) => {
-        taskkills.push([pid, tree]);
+      terminateProcessIdentity: async (expected) => {
+        const actual = table.entries.find(
+          (entry) => entry.pid === expected.pid,
+        );
+        if (actual?.startTime !== expected.startTime)
+          return { ok: false, error: "process was not found" };
+        terminatedIdentities.push(expected.startTime ?? "unknown");
         table = {
           entries: [
             {
@@ -60,8 +74,79 @@ test("Windows containment never reuses stale identity evidence for a second tree
   );
 
   assert.deepEqual(result, { ok: true, error: "" });
-  assert.deepEqual(taskkills, [[root.pid, true]]);
+  assert.deepEqual(terminatedIdentities, [root.startTime]);
 });
+
+test("Windows containment does not kill a replacement created at termination dispatch", async () => {
+  const root: WindowsProcessIdentity = {
+    pid: 101,
+    parentPid: 1,
+    processGroupId: null,
+    sessionId: null,
+    startTime: "root-original",
+  };
+  const replacement: WindowsProcessIdentity = {
+    ...root,
+    startTime: "root-reused-at-dispatch",
+  };
+  let table: WindowsProcessTableSnapshot = { entries: [root] };
+  const killedIdentities: string[] = [];
+
+  const result = await verifyAndTerminateWindowsProcessTree(
+    root.pid,
+    { root, descendants: [] },
+    {
+      captureProcessTable: async () => structuredClone(table),
+      terminateProcessIdentity: async (expected) => {
+        table = { entries: [replacement] };
+        const actual = table.entries.find(
+          (entry) => entry.pid === expected.pid,
+        );
+        if (actual?.startTime !== expected.startTime)
+          return { ok: false, error: "process was not found" };
+        if (actual.startTime !== null) killedIdentities.push(actual.startTime);
+        return { ok: true, error: "" };
+      },
+    },
+    { quiescencePollMs: 0 },
+  );
+
+  assert.deepEqual(result, { ok: true, error: "" });
+  assert.deepEqual(killedIdentities, []);
+});
+
+test(
+  "Windows identity adapter rejects a stale identity and terminates the matching handle",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const child = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    assert(child.pid !== undefined);
+    try {
+      const table = await realWindowsProcessOperations.captureProcessTable();
+      const identity = table.entries.find((entry) => entry.pid === child.pid);
+      assert(identity?.startTime !== null && identity?.startTime !== undefined);
+      const stale = await realWindowsProcessOperations.terminateProcessIdentity(
+        {
+          ...identity,
+          startTime: String(BigInt(identity.startTime) + 1n),
+        },
+      );
+      assert.deepEqual(stale, { ok: false, error: "process was not found" });
+      process.kill(child.pid, 0);
+
+      assert.deepEqual(
+        await realWindowsProcessOperations.terminateProcessIdentity(identity),
+        { ok: true, error: "" },
+      );
+      await waitForProcessExit(child.pid);
+    } finally {
+      killFixtureProcess(child.pid);
+    }
+  },
+);
 
 test("Windows containment discovers and kills a descendant born during termination", async () => {
   const root: WindowsProcessIdentity = {
@@ -86,10 +171,12 @@ test("Windows containment discovers and kills a descendant born during terminati
     { root, descendants: [] },
     {
       captureProcessTable: async () => structuredClone(table),
-      runTaskkill: async (pid, tree) => {
-        taskkills.push([pid, tree]);
+      terminateProcessIdentity: async (expected) => {
+        taskkills.push([expected.pid, true]);
         table =
-          pid === root.pid ? { entries: [lateDescendant] } : { entries: [] };
+          expected.pid === root.pid
+            ? { entries: [lateDescendant] }
+            : { entries: [] };
         return { ok: true, error: "" };
       },
     },
@@ -122,8 +209,8 @@ test("Windows containment fails when the deadline finds a non-empty tree", async
         captures += 1;
         return { entries: [root] };
       },
-      runTaskkill: async (pid, tree) => {
-        taskkills.push([pid, tree]);
+      terminateProcessIdentity: async (expected) => {
+        taskkills.push([expected.pid, true]);
         return { ok: true, error: "" };
       },
     },
@@ -359,6 +446,77 @@ test("program runner contains descendants when the direct child exits", async ()
   }
 });
 
+test(
+  "program runner rejects an overflowed process-table snapshot instead of proving false quiescence",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixture = await installProcessTableFixture("overflow");
+    const ready = path.join(fixture.directory, "ready");
+    const program = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));process.on('SIGTERM',()=>{});setInterval(()=>{},1000);`;
+    const controller = new AbortController();
+    let pid = 0;
+    try {
+      const running = runner.run(
+        { command: process.execPath, args: ["-e", program] },
+        {
+          invocationId: "overflowed-process-table",
+          stage: "action",
+          event: {},
+        },
+        controller.signal,
+      );
+      pid = Number(await waitForFile(ready));
+      controller.abort(new Error("overflow fixture"));
+      const result = await running;
+      assert.equal(result.status, "failed");
+      assert.match(
+        result.error ?? "",
+        /process-table snapshot exceeded its 128 KiB bound/u,
+      );
+      assert.doesNotMatch(
+        result.error ?? "",
+        /bounded process-tree termination deadline expired/u,
+      );
+    } finally {
+      fixture.restorePath();
+      killFixtureProcess(pid);
+      await rm(fixture.directory, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "program runner preserves process discovery failure instead of reporting a deadline",
+  { skip: process.platform === "win32" },
+  async () => {
+    const fixture = await installProcessTableFixture("failure");
+    const ready = path.join(fixture.directory, "ready");
+    const program = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(ready)},String(process.pid));process.on('SIGTERM',()=>{});setInterval(()=>{},1000);`;
+    const controller = new AbortController();
+    let pid = 0;
+    try {
+      const running = runner.run(
+        { command: process.execPath, args: ["-e", program] },
+        { invocationId: "failed-process-table", stage: "action", event: {} },
+        controller.signal,
+      );
+      pid = Number(await waitForFile(ready));
+      controller.abort(new Error("discovery failure fixture"));
+      const result = await running;
+      assert.equal(result.status, "failed");
+      assert.match(result.error ?? "", /ps exited with code 7/u);
+      assert.doesNotMatch(
+        result.error ?? "",
+        /bounded process-tree termination deadline expired/u,
+      );
+    } finally {
+      fixture.restorePath();
+      killFixtureProcess(pid);
+      await rm(fixture.directory, { recursive: true, force: true });
+    }
+  },
+);
+
 function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
@@ -388,4 +546,59 @@ async function waitForProcessExit(pid: number): Promise<void> {
     await delay(10);
   }
   throw new Error(`Fixture process ${String(pid)} did not exit`);
+}
+
+async function installProcessTableFixture(
+  mode: "overflow" | "failure",
+): Promise<{
+  directory: string;
+  restorePath(): void;
+}> {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-process-table-fixture-"),
+  );
+  const state = path.join(directory, "captured-once");
+  const ready = path.join(directory, "ready");
+  const overflowOutput = path.join(directory, "overflow-output");
+  const executable = path.join(directory, "ps");
+  const originalPath = process.env.PATH;
+  const source = `#!/bin/sh
+state=${JSON.stringify(state)}
+ready=${JSON.stringify(ready)}
+if [ ! -f "$state" ]; then
+  : > "$state"
+  IFS= read -r pid < "$ready"
+  case "$*" in
+    *sid=*) printf '%s 1 %s %s Thu Jan  1 00:00:00 1970\\n' "$pid" "$pid" "$pid" ;;
+    *) printf '%s 1 %s Thu Jan  1 00:00:00 1970\\n' "$pid" "$pid" ;;
+  esac
+  exit 0
+fi
+if [ ${JSON.stringify(mode)} = failure ]; then exit 7; fi
+exec /bin/cat ${JSON.stringify(overflowOutput)}
+`;
+  await writeFile(
+    overflowOutput,
+    "900000 1 900000 900000 Thu Jan  1 00:00:00 1970\n".repeat(8_000),
+    "utf8",
+  );
+  await writeFile(executable, source, "utf8");
+  await chmod(executable, 0o755);
+  process.env.PATH = `${directory}${path.delimiter}${originalPath ?? ""}`;
+  return {
+    directory,
+    restorePath: () => {
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+    },
+  };
+}
+
+function killFixtureProcess(pid: number): void {
+  if (!Number.isInteger(pid) || pid <= 0) return;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
 }

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -15,6 +15,7 @@ import test from "node:test";
 import {
   ZenXTriggerProgramRunner,
   realWindowsProcessOperations,
+  terminateWindowsProcessIdentity,
   type TriggerProgramRunInput,
   verifyAndTerminateWindowsProcessTree,
   type WindowsProcessIdentity,
@@ -141,6 +142,40 @@ test(
         await realWindowsProcessOperations.terminateProcessIdentity(identity),
         { ok: true, error: "" },
       );
+      await waitForProcessExit(child.pid);
+    } finally {
+      killFixtureProcess(child.pid);
+    }
+  },
+);
+
+test(
+  "Windows identity adapter accepts exit after matching the open handle",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const child = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    assert(child.pid !== undefined);
+    try {
+      const table = await realWindowsProcessOperations.captureProcessTable();
+      const identity = table.entries.find((entry) => entry.pid === child.pid);
+      assert(identity?.startTime !== null && identity?.startTime !== undefined);
+
+      const result = await terminateWindowsProcessIdentity(
+        identity,
+        async () => {
+          const exited = new Promise<void>((resolve, reject) => {
+            child.once("exit", () => resolve());
+            child.once("error", reject);
+          });
+          assert.equal(child.kill("SIGKILL"), true);
+          await exited;
+        },
+      );
+
+      assert.deepEqual(result, { ok: true, error: "" });
       await waitForProcessExit(child.pid);
     } finally {
       killFixtureProcess(child.pid);

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -120,15 +120,8 @@ test(
   "Windows identity adapter rejects a stale identity and terminates the matching handle",
   { skip: process.platform !== "win32" },
   async () => {
-    const child = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    assert(child.pid !== undefined);
+    const { child, identity } = await spawnWindowsIdentityFixture();
     try {
-      const table = await realWindowsProcessOperations.captureProcessTable();
-      const identity = table.entries.find((entry) => entry.pid === child.pid);
-      assert(identity?.startTime !== null && identity?.startTime !== undefined);
       const stale = await realWindowsProcessOperations.terminateProcessIdentity(
         {
           ...identity,
@@ -136,15 +129,15 @@ test(
         },
       );
       assert.deepEqual(stale, { ok: false, error: "process was not found" });
-      process.kill(child.pid, 0);
+      process.kill(identity.pid, 0);
 
       assert.deepEqual(
         await realWindowsProcessOperations.terminateProcessIdentity(identity),
         { ok: true, error: "" },
       );
-      await waitForProcessExit(child.pid);
+      await waitForProcessExit(identity.pid);
     } finally {
-      killFixtureProcess(child.pid);
+      killFixtureProcess(identity.pid);
     }
   },
 );
@@ -153,16 +146,8 @@ test(
   "Windows identity adapter accepts exit after matching the open handle",
   { skip: process.platform !== "win32" },
   async () => {
-    const child = spawn(process.execPath, ["-e", "setInterval(()=>{},1000)"], {
-      stdio: "ignore",
-      windowsHide: true,
-    });
-    assert(child.pid !== undefined);
+    const { child, identity } = await spawnWindowsIdentityFixture();
     try {
-      const table = await realWindowsProcessOperations.captureProcessTable();
-      const identity = table.entries.find((entry) => entry.pid === child.pid);
-      assert(identity?.startTime !== null && identity?.startTime !== undefined);
-
       const result = await terminateWindowsProcessIdentity(
         identity,
         async () => {
@@ -176,9 +161,9 @@ test(
       );
 
       assert.deepEqual(result, { ok: true, error: "" });
-      await waitForProcessExit(child.pid);
+      await waitForProcessExit(identity.pid);
     } finally {
-      killFixtureProcess(child.pid);
+      killFixtureProcess(identity.pid);
     }
   },
 );
@@ -636,4 +621,75 @@ function killFixtureProcess(pid: number): void {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
   }
+}
+
+async function spawnWindowsIdentityFixture(): Promise<{
+  child: ReturnType<typeof spawn>;
+  identity: WindowsProcessIdentity & { startTime: string };
+}> {
+  const script = [
+    "$start = [System.Diagnostics.Process]::GetCurrentProcess().StartTime.ToUniversalTime().Ticks",
+    "$start -= $start % 10",
+    '[Console]::Out.WriteLine("$PID|$start")',
+    "[Console]::Out.Flush()",
+    "while ($true) { Start-Sleep -Seconds 1 }",
+  ].join("; ");
+  const child = spawn(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", script],
+    { stdio: ["ignore", "pipe", "ignore"], windowsHide: true },
+  );
+  assert(child.pid !== undefined);
+  assert(child.stdout !== null);
+  const line = await new Promise<string>((resolve, reject) => {
+    let output = "";
+    let settled = false;
+    const finish = (value: string | Error): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.stdout?.removeListener("data", onData);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+      if (value instanceof Error) {
+        killFixtureProcess(child.pid!);
+        reject(value);
+      } else resolve(value);
+    };
+    const onData = (chunk: string): void => {
+      output += chunk;
+      const newline = output.indexOf("\n");
+      if (newline >= 0) finish(output.slice(0, newline).trim());
+    };
+    const onError = (error: Error): void => finish(error);
+    const onExit = (code: number | null): void =>
+      finish(
+        new Error(
+          `Windows identity fixture exited with code ${String(code)} before reporting its identity`,
+        ),
+      );
+    const timer = setTimeout(
+      () => finish(new Error("Windows identity fixture did not become ready")),
+      10_000,
+    );
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", onData);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+  const match = line.match(/^(\d+)\|(\d+)$/u);
+  if (match === null || Number(match[1]) !== child.pid) {
+    killFixtureProcess(child.pid);
+    throw new Error("Windows identity fixture reported an invalid identity");
+  }
+  return {
+    child,
+    identity: {
+      pid: child.pid,
+      parentPid: process.pid,
+      processGroupId: null,
+      sessionId: null,
+      startTime: match[2]!,
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- move Windows expected process identity and termination behind one adapter operation that opens, verifies, and terminates the same OS process handle instead of crossing a naked-PID `taskkill` seam
- make bounded process-table collection reject overflow and incomplete rows, and keep discovery failures distinct from a deadline that actually wins
- add deterministic regressions for dispatch-time PID reuse, truncated false-empty snapshots, and discovery error reporting, plus a real Windows handle fixture in CI

Fixes #98

## Red regression evidence

Before the implementation changes, the focused runner suite produced 11 passes and these 3 failures:

- dispatch-time reuse terminated `root-reused-at-dispatch`
- an overflowed process table returned `cancelled` instead of containment failure
- `ps` exit 7 was reported as `bounded process-tree termination deadline expired`

## Validation

- Trigger runner/service focused: 37 passed, 1 platform skip
- `npm run check`: 97 Node tests and 38 IMZen tests passed
- ZenX typecheck: passed
- ZenX production build: passed
- ZenX full tests: 394 passed, 4 platform skips, 1 known #96 hosted timing flake; the failing `repeated isolated-context invalidations remain bounded and recover` test passed in isolated rerun
- format check and `git diff --check`: passed

## Exact-head CI evidence

All 8 CI jobs passed on `7dbc5b17962e80529711a2bd302d631b7fa93cb6`.

The Windows WinApp smoke job ran `trigger-program-runner.test.ts` with 11 passes and 4 platform skips. Its Windows-only fixture proved that a stale creation identity leaves the process alive and a matching identity terminates the same handle. Linux ZenX/root checks, macOS capability/Playwright smokes, and the remaining Windows packaging/browser smokes also passed.
