### PR TITLE
fix(zenx): remove assistant identity row

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -153,6 +153,7 @@ Tool 状态统一投影为 `queued / running / success / failed / cancelled / ap
 以下是 visual guidance，不是协议或状态要求：
 
 - 用户消息使用右对齐气泡；Agent Message 左侧自然排版，不使用气泡或重复头像轨道。
+- Conversation stream 中的 Agent Message 不显示重复的 assistant logo/avatar + “ZenX” identity row；Completed Turn 的 **Worked for** disclosure 或 Running Turn 的 **Working** 状态直接成为首条 metadata，正文与 inline Trace / Tool affordance 紧随其后。此规则不影响产品壳/Sidebar 的 ZenX 品牌，也不影响 Thread row 的 Provider logo + model identity。
 - Agent Message 与 Trace Group 位于 Turn 的同一一级流中，不制造错误缩进。
 - 正文优先可读宽度、行高和段落节奏；Trace 比正文更小、更弱。
 - Trace Group 保持轻量，不使用厚边框或每一步一个大卡片。

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -324,12 +324,6 @@ function TurnBlock({
           <WakeupCard entry={wakeup} key={item.id} />
         );
       })}
-      <div className="agent-meta">
-        <span className="agent-glyph" aria-hidden="true">
-          Z
-        </span>
-        <strong>ZenX</strong>
-      </div>
       {complete ? (
         <button
           className="turn-toggle"

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1045,28 +1045,6 @@ a:focus-visible {
   line-height: 1.55;
   box-shadow: inset 0 1px rgb(255 255 255 / 2.5%);
 }
-.agent-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-3);
-  font-size: 11px;
-}
-.agent-glyph {
-  width: 20px;
-  height: 20px;
-  display: grid;
-  place-items: center;
-  border: 1px solid #343743;
-  border-radius: 7px;
-  background: #191b20;
-  color: #b3bfff;
-  font-size: 9px;
-}
-.agent-meta strong {
-  color: var(--text-2);
-  font-weight: 500;
-}
 .turn-running-label,
 .turn-toggle {
   width: fit-content;

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -3,7 +3,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import test from "node:test";
 
-import type { Thread, Turn } from "../src/protocol-client/index.js";
+import type { Thread, ThreadItem, Turn } from "../src/protocol-client/index.js";
 import type { ApprovalCardState } from "../src/renderer/src/approval-state.js";
 import {
   editComposer,
@@ -55,16 +55,56 @@ test("pending approvals render in the bottom zone next to the composer", () => {
   assert.match(html, /Allow once/u);
 });
 
+test("assistant messages omit the identity row while preserving metadata and content", () => {
+  const html = renderTurns([
+    turnWithItems("completed", [user("request"), agent("Final answer")], 1_000),
+  ]);
+
+  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
+  assert.match(
+    html,
+    /class="user-row"[\s\S]*<\/article><button class="turn-toggle"[^>]*><span>Worked for 1s<\/span>/u,
+  );
+  assert.match(html, /class="agent-copy"[\s\S]*Final answer/u);
+});
+
+test("assistant messages retain running reasoning and tool disclosure affordances", () => {
+  const html = renderTurns([
+    turnWithItems("inProgress", [
+      user("Inspect the project"),
+      agent("Checking the relevant files."),
+      reasoning("Mapped the rendering path"),
+      command("rg ThreadView"),
+    ]),
+  ]);
+
+  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
+  assert.match(html, /class="turn-running-label"[\s\S]*Working/u);
+  assert.match(html, /Checking the relevant files\./u);
+  assert.match(
+    html,
+    /class="trace-toggle"[^>]*aria-expanded="false"[\s\S]*Reasoned and used rg[\s\S]*2 items/u,
+  );
+});
+
 function render(
   active: boolean,
   approvals: readonly ApprovalCardState[],
+  composer: ComposerState = emptyComposerState(),
+) {
+  return renderTurns(active ? [turn()] : [], approvals, composer);
+}
+
+function renderTurns(
+  turns: Turn[],
+  approvals: readonly ApprovalCardState[] = [],
   composer: ComposerState = emptyComposerState(),
 ) {
   return renderToStaticMarkup(
     createElement(ThreadView, {
       approvals,
       composer,
-      thread: thread(active ? [turn()] : []),
+      thread: thread(turns),
       onDraftChange: () => undefined,
       onInterrupt: noop,
       onRespondToApproval: noop,
@@ -104,14 +144,68 @@ function thread(turns: Turn[]): Thread {
 }
 
 function turn(): Turn {
+  return turnWithItems("inProgress", []);
+}
+
+function turnWithItems(
+  status: Turn["status"],
+  items: ThreadItem[],
+  durationMs: number | null = null,
+): Turn {
   return {
     id: "turn-1",
-    items: [],
+    items,
     itemsView: "full",
-    status: "inProgress",
+    status,
     error: null,
     startedAt: 10,
-    completedAt: null,
+    completedAt: status === "inProgress" ? null : 11,
+    durationMs,
+  };
+}
+
+function user(text: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id: "user-1",
+    clientId: null,
+    content: [{ type: "text", text, text_elements: [] }],
+  };
+}
+
+function agent(text: string): ThreadItem {
+  return {
+    type: "agentMessage",
+    id: `agent-${text}`,
+    text,
+    phase: "final_answer",
+    memoryCitation: null,
+  };
+}
+
+function reasoning(summary: string): ThreadItem {
+  return {
+    type: "reasoning",
+    id: "reasoning-1",
+    summary: [summary],
+    content: [],
+  };
+}
+
+function command(value: string): ThreadItem {
+  return {
+    type: "commandExecution",
+    id: "command-1",
+    pluginId: null,
+    scriptPath: null,
+    command: value,
+    cwd: "/workspace",
+    processId: null,
+    source: "agent",
+    status: "completed",
+    commandActions: [],
+    aggregatedOutput: "ThreadView.tsx",
+    exitCode: 0,
     durationMs: null,
   };
 }


### PR DESCRIPTION
## Summary
- remove the redundant assistant avatar/logo and ZenX identity row from conversation turns
- collapse Worked for / Working metadata directly above assistant content and trace affordances
- document the conversation-only scope and add focused rendering coverage

## Verification
- `npx --yes tsx@4.20.6 --tsconfig apps/zenx/tsconfig.web.json --test apps/zenx/test/thread-view-component.test.ts`
- `npm --workspace apps/zenx run typecheck`
- `npx prettier --check apps/zenx/docs/ui-ux.md apps/zenx/src/renderer/src/ThreadView.tsx apps/zenx/src/renderer/src/styles.css apps/zenx/test/thread-view-component.test.ts`
- `git diff --check origin/codex/zenx-product-integration...HEAD`