### PR TITLE
feat(zenx): promote reviewed UI follow-ups to main

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,9 @@
 - **ZenXThreadPinProjection** — ZenXHostProfile 按本机 threadId 顺序持久化 Sidebar Pin，
   renderer 只把仍存在的 active Thread 投影到独立 Pinned section；Pin 不同步、不进入
   canonical ItemList，也不改变 Runtime、调度或 Inbox 优先级。
+- **ZenXSidebarOrderPreference** — ZenXHostProfile 按 canonical Project key 与 owning
+  Project 分区的 threadId preference list 持久化本机 Sidebar 顺序；未知项按稳定投影追加、
+  移除项忽略，且排序不改变 cwd、Project identity、Thread state 或 canonical ItemList。
 - **ZenXCredentialVault** — ZenX 通过操作系统安全存储保护的 Provider credential
   存放点；解密后的 secret 只在主进程内存中交给 host，绝不进入 renderer、进程环境、
   App Server 协议或 canonical ItemList。

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -28,7 +28,9 @@
 - Thread 列表产品数据来自 ZAS native `ThreadSummary` / `CurrentMetadata` read model，经 Electron main/preload typed IPC 投影。
 - Thread 的名称与归档由 ZAS 产品元数据负责；当前选择、disclosure、草稿、打开的菜单和面板属于 renderer-local UI 状态。
 - Archive 是当前已定义的可逆生命周期操作。本阶段 ZenX 不直接删除 journal，也不伪造 App Server 尚未定义的 Delete；永久 Delete 的 ownership、恢复、附件与历史语义仍为 **TBD**，这里不是永久产品禁令。
-- Pin 是 profile-local ZenX 产品状态。Pinned Thread IDs 不进入 canonical Items、不跨设备同步，也不改变 runtime priority、scheduling priority 或 Inbox ordering；Pin 只允许改变本地 Sidebar prominence。是否使用独立 Pinned section、放置位置与排序规则仍为 **TBD**。
+- Pin 是 profile-local ZenX 产品状态。Pinned Thread IDs 不进入 canonical Items、不跨设备同步，也不改变 runtime priority、scheduling priority 或 Inbox ordering；Pin 只允许改变本地 Sidebar prominence。Pin 不改变 Thread 的 owning Project，也不清除其 Project 内排序偏好。是否使用独立 Pinned section、放置位置与该 section 自身的排序规则仍为 **TBD**。
+- Project 与 Thread 的 Sidebar 顺序是 Settings-owned host-profile local preference，不是 canonical Item/journal fact，也不跨设备同步。Project 使用 canonical Project key 排序；Thread 顺序按 owning Project 分区保存，排序操作不能改变 cwd、Project identity 或把 Thread 移到另一 Project。
+- 持久化顺序是 preference list：仍存在的已知 ID 按记录顺序出现；未知或新出现的 Project/Thread 按当前稳定投影顺序追加；已移除的 ID 被忽略，并可在后续用户排序写入时自然修剪。Settings mutation 按用户操作调用顺序串行化，最后一次操作获胜。
 
 ### 2.2 Project 身份与 cwd
 
@@ -122,6 +124,9 @@ Thread
 - Escape 只在菜单或弹层确实打开时关闭并归还焦点，不得在无菜单时抢走当前焦点。
 - Thread title、ellipsis 与状态在紧凑宽度下不得重叠。异步 summary/read 结果必须有 freshness fence，旧结果不能覆盖较新的 Thread 选择。
 - 当前菜单不暴露未定义的永久 Delete；未来是否提供以及它的产品合同仍为 **TBD**。
+- Projects mode 中每个 Project header 与 owning Project 内的非 Pinned Thread row 提供轻量 reorder handle。handle 默认隐藏，只在 row/header hover、focus-within 或自身 focus 时出现，不占据默认视觉注意力；窄 Sidebar 仍保留完整可点击区域且不得造成 title/action overlap。
+- Pointer drag 可以全局重排 Project；Thread drag 只接受同一 owning Project 内的 drop。跨 Project drop 不产生 mutation，也不改变 cwd、selection、Pin、active Turn、menu、disclosure 或 archive semantics。
+- 每个 reorder handle 都是可聚焦 button，并以 Arrow Up / Arrow Down 执行等价移动；移动完成或保存失败后，焦点确定性返回同一个被移动对象的 handle。键盘路径与 pointer 路径使用同一 Settings mutation 与 reconciliation 规则。
 
 ### 4.2 Turn 状态与 disclosure
 
@@ -272,6 +277,10 @@ ThreadView
 - [ ] Add project 可发现、可聚焦，并遵守 canonical Project cwd 规则；New thread 最终 IA 不作为本轮验收合同。
 - [ ] canonical cwd aliases 归一为一个 Project，同时保留稳定 display path。
 - [ ] Pin 只改变 profile-local Sidebar prominence，不改变 Inbox/runtime/scheduling；不假定独立 Pinned section 或排序。
+- [ ] Project 可在 Sidebar 全局拖动排序；Thread 只可在 owning Project 内排序，跨 Project drop 不产生 mutation，也不改变 cwd/Project identity。
+- [ ] Sidebar 排序在 host profile 中本地持久化并按 preference list reconcile；新/未知项稳定追加、已移除项忽略，重复并发操作最后一次获胜。
+- [ ] Reorder handle 仅在 hover/focus 时出现；Arrow Up/Down 提供等价键盘操作并把焦点恢复到被移动对象，窄宽度下仍可操作。
+- [ ] Project/Thread 排序不改变 selection、Pin、active Turn、menus、focus recovery 或 archived semantics。
 - [ ] Thread row 只显示 local Provider logo + model name；unknown provider 使用 generic fallback。
 - [ ] Horizontal ellipsis 只在 hover、focus-within 或 menu open 时显示；selection 不让它常驻。
 - [ ] Thread menu 提供 Rename、Archive/Unarchive、Pin/Unpin；本阶段不伪造未定义的 Delete，但不把未来 Delete 写成永久禁令。

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -153,6 +153,7 @@ Tool 状态统一投影为 `queued / running / success / failed / cancelled / ap
 以下是 visual guidance，不是协议或状态要求：
 
 - 用户消息使用右对齐气泡；Agent Message 左侧自然排版，不使用气泡或重复头像轨道。
+- Conversation stream 中的 Agent Message 不显示重复的 assistant logo/avatar + “ZenX” identity row；Completed Turn 的 **Worked for** disclosure 或 Running Turn 的 **Working** 状态直接成为首条 metadata，正文与 inline Trace / Tool affordance 紧随其后。此规则不影响产品壳/Sidebar 的 ZenX 品牌，也不影响 Thread row 的 Provider logo + model identity。
 - Agent Message 与 Trace Group 位于 Turn 的同一一级流中，不制造错误缩进。
 - 正文优先可读宽度、行高和段落节奏；Trace 比正文更小、更弱。
 - Trace Group 保持轻量，不使用厚边框或每一步一个大卡片。

--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -14,6 +14,11 @@ export type ZenXProviderProfile =
       baseUrl: string;
     };
 
+export interface ZenXSidebarOrder {
+  projectKeys: string[];
+  threadIdsByProject: Record<string, string[]>;
+}
+
 export interface ZenXHostProfile {
   version: 1;
   onboardingComplete: boolean;
@@ -26,6 +31,7 @@ export interface ZenXHostProfile {
   lastUsedWorkspace: string | null;
   approvalPolicy: "always" | "never";
   pinnedThreadIds: string[];
+  sidebarOrder: ZenXSidebarOrder;
 }
 
 export type ZenXSettingsUpdate = Pick<
@@ -133,6 +139,7 @@ export function validateHostProfile(value: unknown): ZenXHostProfile {
     workspaces,
   );
   const pinnedThreadIds = normalizePinnedThreadIds(value.pinnedThreadIds);
+  const sidebarOrder = normalizeSidebarOrder(value.sidebarOrder);
   return {
     version: 1,
     onboardingComplete: value.onboardingComplete === true,
@@ -145,7 +152,77 @@ export function validateHostProfile(value: unknown): ZenXHostProfile {
     lastUsedWorkspace,
     approvalPolicy: value.approvalPolicy,
     pinnedThreadIds,
+    sidebarOrder,
   };
+}
+
+function normalizeSidebarOrder(value: unknown): ZenXSidebarOrder {
+  if (value === undefined) {
+    return { projectKeys: [], threadIdsByProject: {} };
+  }
+  if (!isRecord(value) || !isRecord(value.threadIdsByProject)) {
+    throw new Error("ZenX Sidebar order is invalid");
+  }
+  const projectKeys = normalizeOrderIdentifiers(
+    value.projectKeys,
+    "Project key",
+    32_768,
+  );
+  const entries = Object.entries(value.threadIdsByProject);
+  if (entries.length > 4_096) {
+    throw new Error("ZenX Sidebar Thread order is invalid");
+  }
+  let totalThreadIds = 0;
+  const threadIdsByProject = Object.fromEntries(
+    entries.map(([projectKey, threadIds]) => {
+      const normalizedProjectKey = normalizeOrderIdentifier(
+        projectKey,
+        "Project key",
+        32_768,
+      );
+      const normalizedThreadIds = normalizeOrderIdentifiers(
+        threadIds,
+        "Thread id",
+        512,
+      );
+      totalThreadIds += normalizedThreadIds.length;
+      if (totalThreadIds > 4_096) {
+        throw new Error("ZenX Sidebar Thread order is invalid");
+      }
+      return [normalizedProjectKey, normalizedThreadIds] as const;
+    }),
+  );
+  return { projectKeys, threadIdsByProject };
+}
+
+function normalizeOrderIdentifiers(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): string[] {
+  if (!Array.isArray(value) || value.length > 4_096) {
+    throw new Error(`ZenX Sidebar ${label} list is invalid`);
+  }
+  return [
+    ...new Set(
+      value.map((entry) => normalizeOrderIdentifier(entry, label, maxLength)),
+    ),
+  ];
+}
+
+function normalizeOrderIdentifier(
+  value: unknown,
+  label: string,
+  maxLength: number,
+): string {
+  if (typeof value !== "string") {
+    throw new Error(`ZenX Sidebar ${label} is invalid`);
+  }
+  const identifier = value.trim();
+  if (identifier.length === 0 || identifier.length > maxLength) {
+    throw new Error(`ZenX Sidebar ${label} is invalid`);
+  }
+  return identifier;
 }
 
 function normalizePinnedThreadIds(value: unknown): string[] {

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -18,7 +18,7 @@ import { ipcChannels } from "../preload/ipc.js";
 import { AppServerManager } from "./app-server-manager.js";
 import type { ApprovalDecision } from "./app-server-manager.js";
 import { ZenXCredentialVault } from "./credential-vault.js";
-import type { ZenXSettingsUpdate } from "./host-profile.js";
+import type { ZenXSettingsUpdate, ZenXSidebarOrder } from "./host-profile.js";
 import { ZenXSettingsService } from "./settings-service.js";
 import { zenXProviderTransport } from "./system-proxy.js";
 import { ZenXTriggerService } from "./trigger-service.js";
@@ -514,6 +514,13 @@ function installSettingsIpc(
       if (!Array.isArray(threadIds))
         throw new Error("Invalid pinned Thread list");
       await settings.setPinnedThreadIds(threadIds);
+      return await settings.publicSettings();
+    },
+  );
+  ipcMain.handle(
+    ipcChannels.sidebarOrderSet,
+    async (_event, order: unknown) => {
+      await settings.setSidebarOrder(order as ZenXSidebarOrder);
       return await settings.publicSettings();
     },
   );

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -10,6 +10,7 @@ import {
   type PublicHostSettings,
   type ZenXHostProfile,
   ZenXHostProfileStore,
+  type ZenXSidebarOrder,
   type ZenXSettingsUpdate,
   validateHostProfile,
 } from "./host-profile.js";
@@ -320,6 +321,23 @@ export class ZenXSettingsService {
     });
   }
 
+  async setSidebarOrder(order: ZenXSidebarOrder): Promise<void> {
+    await this.#queueProfileOperation(async () => {
+      const current = this.#requireProfile();
+      const next = validateHostProfile({
+        ...current,
+        sidebarOrder: order,
+      });
+      if (
+        JSON.stringify(next.sidebarOrder) ===
+        JSON.stringify(current.sidebarOrder)
+      )
+        return;
+      await this.#profileStore.write(next);
+      this.#profile = next;
+    });
+  }
+
   async login(
     openBrowser: (url: string) => void,
     manualCodeRequested: () => void,
@@ -546,5 +564,6 @@ function profileFromLegacy(
     lastUsedWorkspace: null,
     approvalPolicy: config.approvalPolicy,
     pinnedThreadIds: [],
+    sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
   };
 }

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -16,6 +16,7 @@ import type {
 import { ipcChannels } from "./ipc.js";
 import type {
   PublicHostSettings,
+  ZenXSidebarOrder,
   ZenXSettingsUpdate,
 } from "../main/host-profile.js";
 import type {
@@ -141,6 +142,10 @@ contextBridge.exposeInMainWorld("zenx", {
       threadIds: readonly string[],
     ): Promise<PublicHostSettings> =>
       await ipcRenderer.invoke(ipcChannels.pinnedThreadsSet, threadIds),
+    setSidebarOrder: async (
+      order: ZenXSidebarOrder,
+    ): Promise<PublicHostSettings> =>
+      await ipcRenderer.invoke(ipcChannels.sidebarOrderSet, order),
     getDirectoryBrowser: async (): Promise<DirectoryBrowserSnapshot> =>
       await ipcRenderer.invoke(ipcChannels.directorySnapshot),
     listDirectory: async (directory: string): Promise<DirectoryListing> =>

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -16,6 +16,7 @@ export const ipcChannels = {
   workspaceDefault: "zenx:settings:workspace-default",
   workspaceUse: "zenx:settings:workspace-use",
   pinnedThreadsSet: "zenx:settings:pinned-threads-set",
+  sidebarOrderSet: "zenx:settings:sidebar-order-set",
   directorySnapshot: "zenx:directory:snapshot",
   directoryList: "zenx:directory:list",
   subscriptionLogin: "zenx:settings:subscription-login",

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import type {
 } from "../../main/capabilities/types.js";
 import type { TriggerSnapshot } from "../../main/trigger-types.js";
 import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
+import type { ZenXSidebarOrder } from "../../main/host-profile.js";
 import type {
   ThreadTitleProjection,
   ThreadTitleSnapshot,
@@ -53,9 +54,12 @@ import { SettingsView, type SettingsTab } from "./SettingsView.js";
 import { Sidebar } from "./Sidebar.js";
 import {
   derivePinnedThreads,
+  EMPTY_SIDEBAR_ORDER,
   readSidebarMode,
   threadHasActiveTurn,
   lastUsedProjectWorkspace,
+  moveSidebarProject,
+  moveSidebarThread,
   startProjectThread,
   threadTitle,
   writeSidebarMode,
@@ -75,7 +79,8 @@ export function App() {
   const archivingThreadIdsRef = useRef<ReadonlySet<string>>(new Set());
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
   const pinnedThreadIdsRef = useRef<string[]>([]);
-  const pinMutationQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const sidebarOrderRef = useRef<ZenXSidebarOrder>(EMPTY_SIDEBAR_ORDER);
+  const profilePreferenceQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
@@ -99,6 +104,8 @@ export function App() {
     [],
   );
   const [pinnedThreadIds, setPinnedThreadIds] = useState<string[]>([]);
+  const [sidebarOrder, setSidebarOrder] =
+    useState<ZenXSidebarOrder>(EMPTY_SIDEBAR_ORDER);
   const [archivedThreadSummaries, setArchivedThreadSummaries] = useState<
     NativeThreadSummary[]
   >([]);
@@ -153,18 +160,56 @@ export function App() {
     setPinnedThreadIds(confirmed);
   };
 
+  const confirmSidebarOrder = (order: ZenXSidebarOrder) => {
+    const confirmed = {
+      projectKeys: [...order.projectKeys],
+      threadIdsByProject: Object.fromEntries(
+        Object.entries(order.threadIdsByProject).map(
+          ([projectKey, threadIds]) => [projectKey, [...threadIds]],
+        ),
+      ),
+    };
+    sidebarOrderRef.current = confirmed;
+    setSidebarOrder(confirmed);
+  };
+
+  const confirmProfilePreferences = (profile: {
+    pinnedThreadIds: readonly string[];
+    sidebarOrder: ZenXSidebarOrder;
+  }) => {
+    confirmPinnedThreadIds(profile.pinnedThreadIds);
+    confirmSidebarOrder(profile.sidebarOrder);
+  };
+
   const queuePinMutation = (
     update: (current: readonly string[]) => readonly string[],
   ): Promise<void> => {
-    const result = pinMutationQueueRef.current.then(async () => {
+    const result = profilePreferenceQueueRef.current.then(async () => {
       const current = pinnedThreadIdsRef.current;
       const next = update(current);
       if (next === current) return;
       const value = await window.zenx.settings.setPinnedThreadIds(next);
-      confirmPinnedThreadIds(value.profile.pinnedThreadIds);
+      confirmProfilePreferences(value.profile);
     });
-    pinMutationQueueRef.current = result.catch(() => undefined);
+    profilePreferenceQueueRef.current = result.catch(() => undefined);
     return result;
+  };
+
+  const queueSidebarOrderMutation = (
+    update: (current: ZenXSidebarOrder) => ZenXSidebarOrder,
+  ): Promise<void> => {
+    const result = profilePreferenceQueueRef.current.then(async () => {
+      const current = sidebarOrderRef.current;
+      const next = update(current);
+      if (next === current) return;
+      const value = await window.zenx.settings.setSidebarOrder(next);
+      confirmProfilePreferences(value.profile);
+    });
+    profilePreferenceQueueRef.current = result.catch(() => undefined);
+    return result.catch((error: unknown) => {
+      setRequestError(`Could not save Sidebar order: ${describeError(error)}`);
+      throw error;
+    });
   };
 
   const loadThreadSummaries = async (showLoading = false) => {
@@ -363,12 +408,12 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    const result = pinMutationQueueRef.current.then(async () => {
+    const result = profilePreferenceQueueRef.current.then(async () => {
       const value = await window.zenx.settings.get();
-      confirmPinnedThreadIds(value.profile.pinnedThreadIds);
+      confirmProfilePreferences(value.profile);
       if (!value.profile.onboardingComplete) setPage("settings");
     });
-    pinMutationQueueRef.current = result.catch(() => undefined);
+    profilePreferenceQueueRef.current = result.catch(() => undefined);
   }, []);
 
   useEffect(() => {
@@ -704,6 +749,37 @@ export function App() {
           performThreadLifecycle(summary, true)
         }
         onChangeThreadPinned={changeThreadPinned}
+        onReorderProject={(sourceKey, targetKey, placement) =>
+          queueSidebarOrderMutation((current) =>
+            moveSidebarProject(
+              current,
+              projects,
+              sourceKey,
+              targetKey,
+              placement,
+            ),
+          )
+        }
+        onReorderThread={(
+          sourceProjectKey,
+          sourceThreadId,
+          targetProjectKey,
+          targetThreadId,
+          placement,
+        ) =>
+          queueSidebarOrderMutation((current) =>
+            moveSidebarThread(
+              current,
+              activeSummaries,
+              projects,
+              sourceProjectKey,
+              sourceThreadId,
+              targetProjectKey,
+              targetThreadId,
+              placement,
+            ),
+          )
+        }
         onModeChange={(mode) => {
           setSidebarMode(mode);
           try {
@@ -739,6 +815,7 @@ export function App() {
         selectedThreadId={selectedThreadId}
         serverReady={serverStatus.type === "ready"}
         projects={projects}
+        sidebarOrder={sidebarOrder}
         pinnedThreads={pinnedSummaries}
         threadError={threadListErrors.active}
         threadLoading={!threadListLoaded.active}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -207,10 +207,7 @@ export function App() {
       confirmProfilePreferences(value.profile);
     });
     profilePreferenceQueueRef.current = result.catch(() => undefined);
-    return result.catch((error: unknown) => {
-      setRequestError(`Could not save Sidebar order: ${describeError(error)}`);
-      throw error;
-    });
+    return result;
   };
 
   const loadThreadSummaries = async (showLoading = false) => {

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -475,11 +475,19 @@ export function App() {
     )
       return;
     const threadId = threadDetail.id;
-    const started = updateComposer(threadId, (state) =>
-      beginComposerSubmission(state, intent, expectedTurnId, () =>
-        crypto.randomUUID(),
-      ),
+    const current = composerStatesRef.current[threadId] ?? emptyComposerState();
+    const started = beginComposerSubmission(
+      current,
+      intent,
+      expectedTurnId,
+      () => crypto.randomUUID(),
     );
+    if (started === current) return;
+    composerStatesRef.current = {
+      ...composerStatesRef.current,
+      [threadId]: started,
+    };
+    setComposerStates(composerStatesRef.current);
     const submission = started.submission;
     if (submission === null || submission.status !== "pending") return;
     try {

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -107,6 +107,12 @@ export function Sidebar({
   threads,
   triggerSnapshot,
 }: SidebarProps) {
+  const [sidebarOrderError, setSidebarOrderError] = useState<string | null>(
+    null,
+  );
+  const [sidebarOrderRetry, setSidebarOrderRetry] = useState<
+    (() => Promise<void>) | null
+  >(null);
   const [projectsOpen, setProjectsOpen] = useState(true);
   const [projectChooserOpen, setProjectChooserOpen] = useState(false);
   const lastUsedProject =
@@ -139,6 +145,19 @@ export function Sidebar({
     const willPin = !pinnedThreadIds.has(thread.threadId);
     await onChangeThreadPinned(thread);
     setPendingPinFocus(willPin && mode === "projects" ? "pinned" : "list");
+  };
+  const reportSidebarOrderError = (
+    error: unknown,
+    retry: () => Promise<void>,
+  ) => {
+    setSidebarOrderError(
+      `Could not save Sidebar order: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    setSidebarOrderRetry(() => retry);
+  };
+  const clearSidebarOrderError = () => {
+    setSidebarOrderError(null);
+    setSidebarOrderRetry(null);
   };
   useLayoutEffect(() => {
     if (pendingPinFocus === null) return;
@@ -315,6 +334,21 @@ export function Sidebar({
           className="sidebar-scroll"
           aria-labelledby="sidebar-thread-list-heading"
         >
+          {sidebarOrderError !== null ? (
+            <div className="sidebar-empty sidebar-error" role="alert">
+              <p>{sidebarOrderError}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  const retry = sidebarOrderRetry;
+                  clearSidebarOrderError();
+                  if (retry !== null) void retry();
+                }}
+              >
+                Try again
+              </button>
+            </div>
+          ) : null}
           {!serverReady ? (
             <p className="sidebar-empty">Waiting for the local App Server.</p>
           ) : threadLoading ? (
@@ -373,6 +407,8 @@ export function Sidebar({
                   onRenameThread={onRenameThread}
                   onReorderProject={onReorderProject}
                   onReorderThread={onReorderThread}
+                  onSidebarOrderError={reportSidebarOrderError}
+                  onSidebarOrderAttempt={clearSidebarOrderError}
                   pendingApprovalThreadIds={pendingApprovalThreadIds}
                   selectedThreadId={selectedThreadId}
                   threads={threads.filter(
@@ -533,6 +569,8 @@ function ProjectsView({
   onRenameThread,
   onReorderProject,
   onReorderThread,
+  onSidebarOrderError,
+  onSidebarOrderAttempt,
   pendingApprovalThreadIds,
   liveThread,
   watchingThreadIds,
@@ -551,6 +589,8 @@ function ProjectsView({
   onRenameThread(threadId: string, title: string): Promise<void>;
   onReorderProject?: SidebarProps["onReorderProject"];
   onReorderThread?: SidebarProps["onReorderThread"];
+  onSidebarOrderError?: (error: unknown, retry: () => Promise<void>) => void;
+  onSidebarOrderAttempt?: () => void;
   pendingApprovalThreadIds: ReadonlySet<string>;
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
@@ -624,6 +664,8 @@ function ProjectsView({
                       group.key,
                       dropPlacement(event),
                     ),
+                  onSidebarOrderAttempt,
+                  onSidebarOrderError,
                 );
               },
               onKeyDown: (event) => {
@@ -644,6 +686,8 @@ function ProjectsView({
                       target.key,
                       event.key === "ArrowUp" ? "before" : "after",
                     ),
+                  onSidebarOrderAttempt,
+                  onSidebarOrderError,
                 );
               },
             }
@@ -691,6 +735,8 @@ function ProjectsView({
                       targetThreadId,
                       dropPlacement(event),
                     ),
+                  onSidebarOrderAttempt,
+                  onSidebarOrderError,
                 );
               },
               onKeyDown: (threadIndex, threadId, event) => {
@@ -712,6 +758,8 @@ function ProjectsView({
                       target.threadId,
                       event.key === "ArrowUp" ? "before" : "after",
                     ),
+                  onSidebarOrderAttempt,
+                  onSidebarOrderError,
                 );
               },
             }
@@ -1348,11 +1396,16 @@ function dropPlacement<T extends HTMLElement>(
 async function reorderAndRestoreFocus(
   handleId: string,
   operation: () => Promise<void>,
+  onAttempt?: () => void,
+  onError?: (error: unknown, retry: () => Promise<void>) => void,
 ): Promise<void> {
+  onAttempt?.();
   try {
     await operation();
-  } catch {
-    // App reports persistence failures in its existing request-error surface.
+  } catch (error) {
+    onError?.(error, () =>
+      reorderAndRestoreFocus(handleId, operation, onAttempt, onError),
+    );
   } finally {
     const restore = () => document.getElementById(handleId)?.focus();
     if (typeof requestAnimationFrame === "function") {

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -4,6 +4,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type DragEvent as ReactDragEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type RefObject,
 } from "react";
 
@@ -11,6 +13,7 @@ import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { TriggerSnapshot } from "../../main/trigger-types.js";
 import type { Thread } from "../../protocol-client/index.js";
 import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
+import type { ZenXSidebarOrder } from "../../main/host-profile.js";
 import { Icon } from "./icons.js";
 import type { LoadedPluginContribution } from "./plugin-contributions.js";
 import { ProviderLogo } from "./ProviderLogo.js";
@@ -18,11 +21,13 @@ import { ZenXBrand } from "./ZenXBrand.js";
 import {
   deriveInboxSections,
   deriveProjectGroups,
+  EMPTY_SIDEBAR_ORDER,
   threadModelIdentity,
   threadHasActiveTurn,
   threadProject,
   threadTitle,
   type SidebarMode,
+  type SidebarOrderPlacement,
 } from "./thread-list.js";
 
 interface SidebarProps {
@@ -31,6 +36,18 @@ interface SidebarProps {
   onClose(): void;
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
   onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
+  onReorderProject?(
+    sourceKey: string,
+    targetKey: string,
+    placement: SidebarOrderPlacement,
+  ): Promise<void>;
+  onReorderThread?(
+    sourceProjectKey: string,
+    sourceThreadId: string,
+    targetProjectKey: string,
+    targetThreadId: string,
+    placement: SidebarOrderPlacement,
+  ): Promise<void>;
   onModeChange(mode: SidebarMode): void;
   onNewThread(workspace?: string): void;
   onAddProject(): void;
@@ -50,6 +67,7 @@ interface SidebarProps {
   threadError: string | null;
   threadLoading: boolean;
   projects: ZenXProjectProjectionSnapshot;
+  sidebarOrder?: ZenXSidebarOrder;
   pinnedThreads: readonly NativeThreadSummary[];
   threads: readonly NativeThreadSummary[];
   triggerSnapshot: TriggerSnapshot;
@@ -61,6 +79,8 @@ export function Sidebar({
   onClose,
   onChangeThreadLifecycle,
   onChangeThreadPinned,
+  onReorderProject,
+  onReorderThread,
   onModeChange,
   onNewThread,
   onAddProject,
@@ -80,6 +100,7 @@ export function Sidebar({
   threadError,
   threadLoading,
   projects,
+  sidebarOrder = EMPTY_SIDEBAR_ORDER,
   pinnedThreads,
   threads,
   triggerSnapshot,
@@ -94,9 +115,17 @@ export function Sidebar({
             project.configured &&
             project.workspace === projects.lastUsedWorkspace,
         );
-  const configuredProjects = projects.projects.filter(
-    (project) => project.configured,
+  const projectsByKey = new Map(
+    projects.projects.map((project) => [project.key, project] as const),
   );
+  const configuredProjects = deriveProjectGroups(
+    [],
+    projects,
+    sidebarOrder,
+  ).flatMap((group) => {
+    const project = projectsByKey.get(group.key);
+    return project?.configured === true ? [project] : [];
+  });
   const pinnedThreadIds = useMemo(
     () => new Set(pinnedThreads.map((thread) => thread.threadId)),
     [pinnedThreads],
@@ -332,6 +361,7 @@ export function Sidebar({
               {!projectsOpen ? null : (
                 <ProjectsView
                   projects={projects}
+                  sidebarOrder={sidebarOrder}
                   onNewThread={onNewThread}
                   onRemoveProject={onRemoveProject}
                   onSetDefaultProject={onSetDefaultProject}
@@ -339,6 +369,8 @@ export function Sidebar({
                   onChangeThreadLifecycle={onChangeThreadLifecycle}
                   onChangeThreadPinned={changeThreadPinned}
                   onRenameThread={onRenameThread}
+                  onReorderProject={onReorderProject}
+                  onReorderThread={onReorderThread}
                   pendingApprovalThreadIds={pendingApprovalThreadIds}
                   selectedThreadId={selectedThreadId}
                   threads={threads.filter(
@@ -481,6 +513,7 @@ function PinnedThreadsView({
 
 function ProjectsView({
   projects,
+  sidebarOrder,
   onNewThread,
   onRemoveProject,
   onSetDefaultProject,
@@ -490,12 +523,15 @@ function ProjectsView({
   onChangeThreadLifecycle,
   onChangeThreadPinned,
   onRenameThread,
+  onReorderProject,
+  onReorderThread,
   pendingApprovalThreadIds,
   liveThread,
   watchingThreadIds,
   pinnedThreadIds,
 }: {
   projects: ZenXProjectProjectionSnapshot;
+  sidebarOrder: ZenXSidebarOrder;
   onNewThread(workspace?: string): void;
   onRemoveProject(workspace: string): void;
   onSetDefaultProject(workspace: string): void;
@@ -505,11 +541,17 @@ function ProjectsView({
   onChangeThreadLifecycle(thread: NativeThreadSummary): Promise<void>;
   onChangeThreadPinned(thread: NativeThreadSummary): Promise<void>;
   onRenameThread(threadId: string, title: string): Promise<void>;
+  onReorderProject?: SidebarProps["onReorderProject"];
+  onReorderThread?: SidebarProps["onReorderThread"];
   pendingApprovalThreadIds: ReadonlySet<string>;
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
   pinnedThreadIds: ReadonlySet<string>;
 }) {
+  const projectDrag = useRef<string | null>(null);
+  const threadDrag = useRef<{ projectKey: string; threadId: string } | null>(
+    null,
+  );
   if (
     projects.projects.length === 0 &&
     projects.unavailableThreadIds.length === 0
@@ -522,7 +564,8 @@ function ProjectsView({
       </div>
     );
   }
-  return deriveProjectGroups(threads, projects).map((group) => (
+  const groups = deriveProjectGroups(threads, projects, sidebarOrder);
+  return groups.map((group, projectIndex) => (
     <ProjectRows
       group={group}
       key={group.key}
@@ -538,6 +581,133 @@ function ProjectsView({
       selectedThreadId={selectedThreadId}
       pinnedThreadIds={pinnedThreadIds}
       watchingThreadIds={watchingThreadIds}
+      projectReorder={
+        onReorderProject === undefined || group.key === "__unavailable__"
+          ? undefined
+          : {
+              handleId: sidebarOrderHandleId("project", group.key),
+              onDragStart: (event) => {
+                projectDrag.current = group.key;
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", group.key);
+              },
+              onDragEnd: () => {
+                projectDrag.current = null;
+              },
+              onDragOver: (event) => {
+                if (
+                  projectDrag.current === null ||
+                  projectDrag.current === group.key
+                )
+                  return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+              },
+              onDrop: (event) => {
+                const sourceKey = projectDrag.current;
+                projectDrag.current = null;
+                if (sourceKey === null || sourceKey === group.key) return;
+                event.preventDefault();
+                void reorderAndRestoreFocus(
+                  sidebarOrderHandleId("project", sourceKey),
+                  () =>
+                    onReorderProject(
+                      sourceKey,
+                      group.key,
+                      dropPlacement(event),
+                    ),
+                );
+              },
+              onKeyDown: (event) => {
+                const target =
+                  event.key === "ArrowUp"
+                    ? groups[projectIndex - 1]
+                    : event.key === "ArrowDown"
+                      ? groups[projectIndex + 1]
+                      : undefined;
+                if (target === undefined || target.key === "__unavailable__")
+                  return;
+                event.preventDefault();
+                void reorderAndRestoreFocus(
+                  sidebarOrderHandleId("project", group.key),
+                  () =>
+                    onReorderProject(
+                      group.key,
+                      target.key,
+                      event.key === "ArrowUp" ? "before" : "after",
+                    ),
+                );
+              },
+            }
+      }
+      threadReorder={
+        onReorderThread === undefined || group.key === "__unavailable__"
+          ? undefined
+          : {
+              onDragStart: (threadId, event) => {
+                threadDrag.current = { projectKey: group.key, threadId };
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", threadId);
+              },
+              onDragEnd: () => {
+                threadDrag.current = null;
+              },
+              onDragOver: (targetThreadId, event) => {
+                const source = threadDrag.current;
+                if (
+                  source === null ||
+                  source.projectKey !== group.key ||
+                  source.threadId === targetThreadId
+                )
+                  return;
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+              },
+              onDrop: (targetThreadId, event) => {
+                const source = threadDrag.current;
+                threadDrag.current = null;
+                if (
+                  source === null ||
+                  source.projectKey !== group.key ||
+                  source.threadId === targetThreadId
+                )
+                  return;
+                event.preventDefault();
+                void reorderAndRestoreFocus(
+                  sidebarOrderHandleId("thread", source.threadId),
+                  () =>
+                    onReorderThread(
+                      source.projectKey,
+                      source.threadId,
+                      group.key,
+                      targetThreadId,
+                      dropPlacement(event),
+                    ),
+                );
+              },
+              onKeyDown: (threadIndex, threadId, event) => {
+                const target =
+                  event.key === "ArrowUp"
+                    ? group.threads[threadIndex - 1]
+                    : event.key === "ArrowDown"
+                      ? group.threads[threadIndex + 1]
+                      : undefined;
+                if (target === undefined) return;
+                event.preventDefault();
+                void reorderAndRestoreFocus(
+                  sidebarOrderHandleId("thread", threadId),
+                  () =>
+                    onReorderThread(
+                      group.key,
+                      threadId,
+                      group.key,
+                      target.threadId,
+                      event.key === "ArrowUp" ? "before" : "after",
+                    ),
+                );
+              },
+            }
+      }
     />
   ));
 }
@@ -545,6 +715,27 @@ function ProjectsView({
 function projectLabelForSidebar(workspace: string): string {
   const normalized = workspace.replace(/[\\/]+$/u, "");
   return normalized.split(/[\\/]/u).filter(Boolean).at(-1) ?? workspace;
+}
+
+interface ProjectReorderHandlers {
+  handleId: string;
+  onDragStart(event: ReactDragEvent<HTMLButtonElement>): void;
+  onDragEnd(): void;
+  onDragOver(event: ReactDragEvent<HTMLElement>): void;
+  onDrop(event: ReactDragEvent<HTMLElement>): void;
+  onKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>): void;
+}
+
+interface ThreadReorderHandlers {
+  onDragStart(threadId: string, event: ReactDragEvent<HTMLButtonElement>): void;
+  onDragEnd(): void;
+  onDragOver(threadId: string, event: ReactDragEvent<HTMLDivElement>): void;
+  onDrop(threadId: string, event: ReactDragEvent<HTMLDivElement>): void;
+  onKeyDown(
+    threadIndex: number,
+    threadId: string,
+    event: ReactKeyboardEvent<HTMLButtonElement>,
+  ): void;
 }
 
 function ProjectRows({
@@ -561,6 +752,8 @@ function ProjectRows({
   liveThread,
   watchingThreadIds,
   pinnedThreadIds,
+  projectReorder,
+  threadReorder,
 }: {
   group: ReturnType<typeof deriveProjectGroups>[number];
   onNewThread(workspace?: string): void;
@@ -575,11 +768,34 @@ function ProjectRows({
   liveThread: Thread | null;
   watchingThreadIds: ReadonlySet<string>;
   pinnedThreadIds: ReadonlySet<string>;
+  projectReorder?: ProjectReorderHandlers;
+  threadReorder?: ThreadReorderHandlers;
 }) {
   const [open, setOpen] = useState(true);
   return (
-    <section className="project-group">
+    <section
+      className="project-group"
+      data-project-key={group.key}
+      onDragOver={projectReorder?.onDragOver}
+      onDrop={projectReorder?.onDrop}
+    >
       <div className="project-header">
+        {projectReorder === undefined ? null : (
+          <button
+            className="reorder-handle project-reorder-handle"
+            type="button"
+            id={projectReorder.handleId}
+            aria-keyshortcuts="ArrowUp ArrowDown"
+            aria-label={`Reorder project ${group.label}. Use Up and Down arrow keys.`}
+            title="Drag to reorder; use Up and Down arrow keys"
+            draggable
+            onDragStart={projectReorder.onDragStart}
+            onDragEnd={projectReorder.onDragEnd}
+            onKeyDown={projectReorder.onKeyDown}
+          >
+            <Icon name="grip" size={14} />
+          </button>
+        )}
         <button
           className="project-toggle"
           type="button"
@@ -630,7 +846,7 @@ function ProjectRows({
       {open && group.threads.length === 0 ? (
         <p className="project-empty">No threads yet.</p>
       ) : open ? (
-        group.threads.map((thread) => (
+        group.threads.map((thread, threadIndex) => (
           <ThreadRow
             hasActiveTurn={threadHasActiveTurn(thread, liveThread)}
             key={thread.threadId}
@@ -643,11 +859,40 @@ function ProjectRows({
             selected={thread.threadId === selectedThreadId}
             thread={thread}
             watching={watchingThreadIds.has(thread.threadId)}
+            reorder={
+              threadReorder === undefined
+                ? undefined
+                : {
+                    handleId: sidebarOrderHandleId("thread", thread.threadId),
+                    onDragStart: (event) =>
+                      threadReorder.onDragStart(thread.threadId, event),
+                    onDragEnd: threadReorder.onDragEnd,
+                    onDragOver: (event) =>
+                      threadReorder.onDragOver(thread.threadId, event),
+                    onDrop: (event) =>
+                      threadReorder.onDrop(thread.threadId, event),
+                    onKeyDown: (event) =>
+                      threadReorder.onKeyDown(
+                        threadIndex,
+                        thread.threadId,
+                        event,
+                      ),
+                  }
+            }
           />
         ))
       ) : null}
     </section>
   );
+}
+
+interface ThreadRowReorderHandlers {
+  handleId: string;
+  onDragStart(event: ReactDragEvent<HTMLButtonElement>): void;
+  onDragEnd(): void;
+  onDragOver(event: ReactDragEvent<HTMLDivElement>): void;
+  onDrop(event: ReactDragEvent<HTMLDivElement>): void;
+  onKeyDown(event: ReactKeyboardEvent<HTMLButtonElement>): void;
 }
 
 function ThreadRow({
@@ -662,6 +907,7 @@ function ThreadRow({
   pinned,
   watching,
   inbox = false,
+  reorder,
 }: {
   thread: NativeThreadSummary;
   selected: boolean;
@@ -674,6 +920,7 @@ function ThreadRow({
   pinned: boolean;
   watching: boolean;
   inbox?: boolean;
+  reorder?: ThreadRowReorderHandlers;
 }) {
   const rowRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -777,7 +1024,10 @@ function ThreadRow({
   return (
     <div
       ref={rowRef}
-      className="thread-row-shell"
+      className={`thread-row-shell${reorder === undefined ? "" : " reorderable"}`}
+      data-thread-id={thread.threadId}
+      onDragOver={reorder?.onDragOver}
+      onDrop={reorder?.onDrop}
       onKeyDown={(event) => {
         if (menuOpen && event.key === "Escape") {
           event.preventDefault();
@@ -785,6 +1035,22 @@ function ThreadRow({
         }
       }}
     >
+      {reorder === undefined ? null : (
+        <button
+          className="reorder-handle thread-reorder-handle"
+          type="button"
+          id={reorder.handleId}
+          aria-keyshortcuts="ArrowUp ArrowDown"
+          aria-label={`Reorder ${threadTitle(thread)} within ${threadProject(thread)}. Use Up and Down arrow keys.`}
+          title="Drag to reorder; use Up and Down arrow keys"
+          draggable
+          onDragStart={reorder.onDragStart}
+          onDragEnd={reorder.onDragEnd}
+          onKeyDown={reorder.onKeyDown}
+        >
+          <Icon name="grip" size={14} />
+        </button>
+      )}
       {thread.status === "systemError" ? (
         <div className={`thread-row system-error${inbox ? " inbox" : ""}`}>
           {contents}
@@ -1053,4 +1319,38 @@ function enabledMenuItems(container: HTMLElement | null): HTMLButtonElement[] {
       'button[role="menuitem"]:not(:disabled)',
     ),
   );
+}
+
+function sidebarOrderHandleId(
+  kind: "project" | "thread",
+  identifier: string,
+): string {
+  return `sidebar-${kind}-order-${encodeURIComponent(identifier)}`;
+}
+
+function dropPlacement<T extends HTMLElement>(
+  event: ReactDragEvent<T>,
+): SidebarOrderPlacement {
+  const bounds = event.currentTarget.getBoundingClientRect();
+  return bounds.height > 0 && event.clientY >= bounds.top + bounds.height / 2
+    ? "after"
+    : "before";
+}
+
+async function reorderAndRestoreFocus(
+  handleId: string,
+  operation: () => Promise<void>,
+): Promise<void> {
+  try {
+    await operation();
+  } catch {
+    // App reports persistence failures in its existing request-error surface.
+  } finally {
+    const restore = () => document.getElementById(handleId)?.focus();
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(restore);
+    } else {
+      queueMicrotask(restore);
+    }
+  }
 }

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -324,12 +324,6 @@ function TurnBlock({
           <WakeupCard entry={wakeup} key={item.id} />
         );
       })}
-      <div className="agent-meta">
-        <span className="agent-glyph" aria-hidden="true">
-          Z
-        </span>
-        <strong>ZenX</strong>
-      </div>
       {complete ? (
         <button
           className="turn-toggle"

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -182,7 +182,13 @@ export function ThreadView({
             onRespond={onRespondToApproval}
           />
         ))}
-        <div className="composer">
+        <form
+          className="composer"
+          onSubmit={(event) => {
+            event.preventDefault();
+            primary();
+          }}
+        >
           <label className="sr-only" htmlFor="thread-composer">
             Message ZenX
           </label>
@@ -193,7 +199,9 @@ export function ThreadView({
             onChange={(event) => onDraftChange(event.target.value)}
             onKeyDown={(event) => {
               if (event.key !== "Enter" || event.shiftKey) return;
+              if (event.nativeEvent.isComposing) return;
               event.preventDefault();
+              if (event.repeat) return;
               submit(runningTurn === null ? "start" : "steer");
             }}
             placeholder={
@@ -294,7 +302,7 @@ export function ThreadView({
               {interruptError ?? composer.submission?.error ?? modelError}
             </p>
           ) : null}
-        </div>
+        </form>
       </div>
     </div>
   );

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -14,6 +14,7 @@ import type {
 import type {
   PublicHostSettings,
   ZenXHostProfile,
+  ZenXSidebarOrder,
   ZenXSettingsUpdate,
 } from "../../main/host-profile.js";
 import type {
@@ -92,6 +93,7 @@ declare global {
         setPinnedThreadIds(
           threadIds: readonly string[],
         ): Promise<PublicHostSettings>;
+        setSidebarOrder(order: ZenXSidebarOrder): Promise<PublicHostSettings>;
         getDirectoryBrowser(): Promise<DirectoryBrowserSnapshot>;
         listDirectory(directory: string): Promise<DirectoryListing>;
         loginSubscription(): Promise<PublicHostSettings>;

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -12,6 +12,7 @@ type IconName =
   | "file"
   | "inbox"
   | "folder-plus"
+  | "grip"
   | "layers"
   | "lock"
   | "moon"
@@ -64,6 +65,16 @@ const paths: Record<IconName, ReactNode> = {
     <>
       <path d="M1.8 4.2C1.8 3.5 2.3 3 3 3h3l1.4 1.6H13c.7 0 1.2.5 1.2 1.2v6c0 .7-.5 1.2-1.2 1.2H3c-.7 0-1.2-.5-1.2-1.2V4.2Z" />
       <path d="M8 7v4M6 9h4" />
+    </>
+  ),
+  grip: (
+    <>
+      <circle cx="5.5" cy="4" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="10.5" cy="4" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="5.5" cy="8" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="10.5" cy="8" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="5.5" cy="12" r="0.6" fill="currentColor" stroke="none" />
+      <circle cx="10.5" cy="12" r="0.6" fill="currentColor" stroke="none" />
     </>
   ),
   file: (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -432,6 +432,43 @@ a:focus-visible {
   color: var(--text-2);
   background: rgb(255 255 255 / 2.5%);
 }
+.reorder-handle {
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-3);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  cursor: grab;
+  transition:
+    opacity 140ms ease,
+    color 140ms ease,
+    background 140ms ease;
+}
+.reorder-handle:active {
+  cursor: grabbing;
+}
+.project-reorder-handle {
+  width: 26px;
+  height: 30px;
+  flex: 0 0 26px;
+}
+.project-header:hover > .project-reorder-handle,
+.project-header:focus-within > .project-reorder-handle,
+.project-reorder-handle:focus-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+.reorder-handle:hover,
+.reorder-handle:focus-visible {
+  color: var(--text);
+  background: var(--surface-3);
+}
 .project-toggle {
   min-width: 0;
   min-height: 34px;
@@ -524,6 +561,24 @@ a:focus-visible {
 .thread-row-shell {
   position: relative;
   min-width: 0;
+}
+.thread-row-shell.reorderable .thread-row {
+  padding-left: 44px;
+}
+.thread-reorder-handle {
+  position: absolute;
+  z-index: 2;
+  top: 14px;
+  left: 4px;
+  width: 34px;
+  height: 36px;
+}
+.thread-row-shell:hover .thread-reorder-handle,
+.thread-row-shell:focus-within .thread-reorder-handle,
+.thread-reorder-handle:focus-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 .thread-menu-trigger {
   position: absolute;
@@ -2775,6 +2830,8 @@ a:focus-visible {
     min-height: 44px;
   }
   .thread-menu-trigger,
+  .thread-reorder-handle,
+  .project-reorder-handle,
   .thread-item-menu > button {
     min-width: 44px;
     min-height: 44px;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1045,28 +1045,6 @@ a:focus-visible {
   line-height: 1.55;
   box-shadow: inset 0 1px rgb(255 255 255 / 2.5%);
 }
-.agent-meta {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-3);
-  font-size: 11px;
-}
-.agent-glyph {
-  width: 20px;
-  height: 20px;
-  display: grid;
-  place-items: center;
-  border: 1px solid #343743;
-  border-radius: 7px;
-  background: #191b20;
-  color: #b3bfff;
-  font-size: 9px;
-}
-.agent-meta strong {
-  color: var(--text-2);
-  font-weight: 500;
-}
 .turn-running-label,
 .turn-toggle {
   width: fit-content;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -441,7 +441,6 @@ a:focus-visible {
   background: transparent;
   color: var(--text-3);
   opacity: 0;
-  visibility: hidden;
   pointer-events: none;
   cursor: grab;
   transition:
@@ -461,7 +460,6 @@ a:focus-visible {
 .project-header:focus-within > .project-reorder-handle,
 .project-reorder-handle:focus-visible {
   opacity: 1;
-  visibility: visible;
   pointer-events: auto;
 }
 .reorder-handle:hover,
@@ -577,7 +575,6 @@ a:focus-visible {
 .thread-row-shell:focus-within .thread-reorder-handle,
 .thread-reorder-handle:focus-visible {
   opacity: 1;
-  visibility: visible;
   pointer-events: auto;
 }
 .thread-menu-trigger {

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -1,6 +1,7 @@
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { Thread } from "../../protocol-client/index.js";
 import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
+import type { ZenXSidebarOrder } from "../../main/host-profile.js";
 
 export type SidebarMode = "inbox" | "projects";
 
@@ -28,6 +29,13 @@ export interface ThreadModelIdentity {
   label: string;
   providerKind: "openai" | "deepseek" | "qwen" | "local" | "generic";
 }
+
+export type SidebarOrderPlacement = "before" | "after";
+
+export const EMPTY_SIDEBAR_ORDER: ZenXSidebarOrder = {
+  projectKeys: [],
+  threadIdsByProject: {},
+};
 
 export function derivePinnedThreads(
   threads: readonly NativeThreadSummary[],
@@ -153,32 +161,46 @@ export function deriveInboxSections(
 export function deriveProjectGroups(
   threads: readonly NativeThreadSummary[],
   projection: ZenXProjectProjectionSnapshot,
+  preference: ZenXSidebarOrder = EMPTY_SIDEBAR_ORDER,
 ): ProjectGroup[] {
   const byId = new Map(threads.map((thread) => [thread.threadId, thread]));
-  const groups: ProjectGroup[] = projection.projects.map((project) => ({
-    key: project.key,
-    label: projectLabel(project.workspace),
-    workspace: project.workspace,
-    configured: project.configured,
-    isDefault: project.isDefault,
-    threads: sortByRecency(
-      project.threadIds.flatMap((threadId) => {
-        const thread = byId.get(threadId);
-        return thread === undefined ? [] : [thread];
-      }),
-    ),
-  }));
-  groups.sort(
-    (left, right) =>
-      left.label.localeCompare(right.label) ||
-      left.key.localeCompare(right.key),
+  const groups: ProjectGroup[] = projection.projects
+    .map((project) => {
+      const stableThreads = sortByRecency(
+        project.threadIds.flatMap((threadId) => {
+          const thread = byId.get(threadId);
+          return thread === undefined ? [] : [thread];
+        }),
+      );
+      return {
+        key: project.key,
+        label: projectLabel(project.workspace),
+        workspace: project.workspace,
+        configured: project.configured,
+        isDefault: project.isDefault,
+        threads: orderByPreference(
+          stableThreads,
+          preference.threadIdsByProject[project.key] ?? [],
+          (thread) => thread.threadId,
+        ),
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.label.localeCompare(right.label) ||
+        left.key.localeCompare(right.key),
+    );
+  const orderedGroups = orderByPreference(
+    groups,
+    preference.projectKeys,
+    (group) => group.key,
   );
   const unavailable = projection.unavailableThreadIds.flatMap((threadId) => {
     const thread = byId.get(threadId);
     return thread === undefined ? [] : [thread];
   });
   if (unavailable.length > 0)
-    groups.push({
+    orderedGroups.push({
       key: "__unavailable__",
       label: "Unavailable journals",
       workspace: null,
@@ -186,7 +208,86 @@ export function deriveProjectGroups(
       isDefault: false,
       threads: unavailable,
     });
-  return groups;
+  return orderedGroups;
+}
+
+export function moveSidebarProject(
+  preference: ZenXSidebarOrder,
+  projection: ZenXProjectProjectionSnapshot,
+  sourceKey: string,
+  targetKey: string,
+  placement: SidebarOrderPlacement,
+): ZenXSidebarOrder {
+  const stableProjects = projection.projects
+    .map((project) => ({
+      key: project.key,
+      label: projectLabel(project.workspace),
+    }))
+    .sort(
+      (left, right) =>
+        left.label.localeCompare(right.label) ||
+        left.key.localeCompare(right.key),
+    );
+  const order = orderByPreference(
+    stableProjects,
+    preference.projectKeys,
+    (project) => project.key,
+  ).map((project) => project.key);
+  const moved = moveIdentifier(order, sourceKey, targetKey, placement);
+  if (moved === null) return preference;
+  return {
+    projectKeys: moved,
+    threadIdsByProject: preference.threadIdsByProject,
+  };
+}
+
+export function moveSidebarThread(
+  preference: ZenXSidebarOrder,
+  threads: readonly NativeThreadSummary[],
+  projection: ZenXProjectProjectionSnapshot,
+  sourceProjectKey: string,
+  sourceThreadId: string,
+  targetProjectKey: string,
+  targetThreadId: string,
+  placement: SidebarOrderPlacement,
+): ZenXSidebarOrder {
+  if (sourceProjectKey !== targetProjectKey) return preference;
+  const project = projection.projects.find(
+    (candidate) => candidate.key === sourceProjectKey,
+  );
+  if (
+    project === undefined ||
+    !project.threadIds.includes(sourceThreadId) ||
+    !project.threadIds.includes(targetThreadId)
+  ) {
+    return preference;
+  }
+  const byId = new Map(threads.map((thread) => [thread.threadId, thread]));
+  const stableThreads = sortByRecency(
+    project.threadIds.flatMap((threadId) => {
+      const thread = byId.get(threadId);
+      return thread === undefined ? [] : [thread];
+    }),
+  );
+  const order = orderByPreference(
+    stableThreads,
+    preference.threadIdsByProject[sourceProjectKey] ?? [],
+    (thread) => thread.threadId,
+  ).map((thread) => thread.threadId);
+  const moved = moveIdentifier(
+    order,
+    sourceThreadId,
+    targetThreadId,
+    placement,
+  );
+  if (moved === null) return preference;
+  return {
+    projectKeys: preference.projectKeys,
+    threadIdsByProject: {
+      ...preference.threadIdsByProject,
+      [sourceProjectKey]: moved,
+    },
+  };
 }
 
 export function threadTitle(thread: NativeThreadSummary): string {
@@ -259,6 +360,50 @@ function sortByRecency(
       right.updatedAt === null ? 0 : Date.parse(right.updatedAt);
     return rightTime - leftTime || left.threadId.localeCompare(right.threadId);
   });
+}
+
+function orderByPreference<T>(
+  stableItems: readonly T[],
+  preferredIds: readonly string[],
+  identify: (item: T) => string,
+): T[] {
+  const byId = new Map(stableItems.map((item) => [identify(item), item]));
+  const ordered: T[] = [];
+  const included = new Set<string>();
+  for (const id of preferredIds) {
+    const item = byId.get(id);
+    if (item === undefined || included.has(id)) continue;
+    included.add(id);
+    ordered.push(item);
+  }
+  for (const item of stableItems) {
+    const id = identify(item);
+    if (included.has(id)) continue;
+    included.add(id);
+    ordered.push(item);
+  }
+  return ordered;
+}
+
+function moveIdentifier(
+  current: readonly string[],
+  sourceId: string,
+  targetId: string,
+  placement: SidebarOrderPlacement,
+): string[] | null {
+  if (sourceId === targetId) return null;
+  const sourceIndex = current.indexOf(sourceId);
+  const targetIndex = current.indexOf(targetId);
+  if (sourceIndex === -1 || targetIndex === -1) return null;
+  const moved = [...current];
+  moved.splice(sourceIndex, 1);
+  const remainingTargetIndex = moved.indexOf(targetId);
+  moved.splice(
+    placement === "after" ? remainingTargetIndex + 1 : remainingTargetIndex,
+    0,
+    sourceId,
+  );
+  return moved.every((id, index) => id === current[index]) ? null : moved;
 }
 
 function projectLabel(cwd: string): string {

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -595,6 +595,7 @@ function publicSettings(pinnedThreadIds: string[]) {
       lastUsedWorkspace: "/work/zen",
       approvalPolicy: "never" as const,
       pinnedThreadIds,
+      sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
     },
     hasApiKey: false,
     subscription: { authenticated: false, expired: false },

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -142,6 +142,179 @@ test("packaged startup clears a transient Project failure after the App Server b
   }
 });
 
+test("same-event-loop duplicate Send owns one title stage and turn request", async () => {
+  const titleResponse = deferred<undefined>();
+  let titleCalls = 0;
+  const turnStartRequests: unknown[] = [];
+  const harness = await mountThreadApp({
+    observeTitle: async () => {
+      titleCalls += 1;
+      return await titleResponse.promise;
+    },
+    request: async (method, params) => {
+      if (method === "thread/resume") return resumed(liveThread());
+      if (method === "turn/start") {
+        turnStartRequests.push(params);
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Only once");
+    const send = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+    );
+    await invokePrimarySubmit(send, 2, async () => {
+      titleResponse.resolve(undefined);
+    });
+
+    assert.equal(titleCalls, 1);
+    assert.equal(turnStartRequests.length, 1);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("Composer keyboard and form routes do not duplicate one submit event", async () => {
+  const turnStartRequests: unknown[] = [];
+  const harness = await mountThreadApp({
+    request: async (method, params) => {
+      if (method === "thread/resume") return resumed(liveThread());
+      if (method === "turn/start") {
+        turnStartRequests.push(params);
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Keyboard message");
+    await dispatchComposerKey(composer, { isComposing: true, key: "Enter" });
+    await dispatchComposerKey(composer, { key: "Enter", repeat: true });
+    assert.equal(turnStartRequests.length, 0);
+    assert.equal(composer.value, "Keyboard message");
+
+    await dispatchComposerKey(composer, { key: "Enter" });
+    await waitFor(() => turnStartRequests.length === 1);
+    await waitFor(() => composer.value === "");
+
+    await setTextareaValue(composer, "Command Enter message");
+    await dispatchComposerKey(composer, { key: "Enter", metaKey: true });
+    await waitFor(() => turnStartRequests.length === 2);
+    await waitFor(() => composer.value === "");
+
+    await setTextareaValue(composer, "Form message");
+    const form = document.querySelector<HTMLFormElement>("form.composer");
+    assert.ok(form);
+    await invokeFormSubmit(form);
+    assert.equal(turnStartRequests.length, 3);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("running Steer and Interrupt and send each own one pending admission", async () => {
+  const steerResponse = deferred<unknown>();
+  const replaceResponse = deferred<unknown>();
+  let steerCalls = 0;
+  let replaceCalls = 0;
+  const harness = await mountThreadApp({
+    request: async (method) => {
+      if (method === "thread/resume") return resumed(runningThread());
+      if (method === "turn/steer") {
+        steerCalls += 1;
+        return await steerResponse.promise;
+      }
+      if (method === "turn/replace") {
+        replaceCalls += 1;
+        return await replaceResponse.promise;
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Guide this turn");
+    const steer = await waitFor(() => exactButton("Steer"));
+    await invokeButtonClick(steer, 2);
+    assert.equal(steerCalls, 1);
+    await act(async () => {
+      steerResponse.resolve({ turnId: "turn-1" });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => composer.value === "");
+
+    await setTextareaValue(composer, "Replace this turn");
+    const replace = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Interrupt and send"]',
+      ),
+    );
+    await invokePrimarySubmit(replace, 2);
+    assert.equal(replaceCalls, 1);
+    await act(async () => {
+      replaceResponse.resolve({
+        interruptedTurnId: "turn-1",
+        turnId: "turn-2",
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("failed Send preserves its draft and stable id for a deliberate retry", async () => {
+  const turnStartRequests: Array<{
+    clientUserMessageId?: string;
+  }> = [];
+  const harness = await mountThreadApp({
+    request: async (method, params) => {
+      if (method === "thread/resume") return resumed(liveThread());
+      if (method === "turn/start") {
+        turnStartRequests.push(
+          (params ?? {}) as { clientUserMessageId?: string },
+        );
+        if (turnStartRequests.length === 1) throw new Error("offline");
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Retry this message");
+    const send = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+    );
+    await act(async () => {
+      send.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => (document.body.textContent ?? "").includes("offline"));
+    assert.equal(composer.value, "Retry this message");
+
+    await act(async () => {
+      send.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => turnStartRequests.length === 2);
+    assert.equal(
+      turnStartRequests[1]?.clientUserMessageId,
+      turnStartRequests[0]?.clientUserMessageId,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("Sidebar archive clears the selected Chat and opens its Settings restore entry", async () => {
   let archived = false;
   let persistedPins = ["thread-1"];
@@ -570,7 +743,7 @@ async function mountApp(
     setPinnedThreadIds?(
       threadIds: readonly string[],
     ): Promise<ReturnType<typeof publicSettings>>;
-    request?(method: string): Promise<unknown>;
+    request?(method: string, params?: unknown): Promise<unknown>;
     observeTitle?(): Promise<undefined>;
     threads?(archived: boolean): Promise<NativeThreadSummary[]>;
   } = {},
@@ -597,9 +770,10 @@ async function mountApp(
           ? { type: "ready", reconnected: false }
           : await options.getStatus(),
       getPendingApprovals: async () => [],
-      request: async (method: string) => {
+      request: async (method: string, params?: unknown) => {
         if (method === "model/list") return { data: [] };
-        if (options.request !== undefined) return await options.request(method);
+        if (options.request !== undefined)
+          return await options.request(method, params);
         throw new Error(`Unexpected protocol request: ${method}`);
       },
       respondToApproval: async () => undefined,
@@ -746,6 +920,143 @@ function liveThread(): Thread {
   };
 }
 
+function runningThread(): Thread {
+  return {
+    ...liveThread(),
+    status: { type: "active", activeFlags: [] },
+    turns: [
+      {
+        id: "turn-1",
+        items: [],
+        itemsView: "full",
+        status: "inProgress",
+        error: null,
+        startedAt: 10,
+        completedAt: null,
+        durationMs: null,
+      },
+    ],
+  };
+}
+
+function resumed(thread: Thread) {
+  return { thread, model: "fake", modelProvider: "fake" };
+}
+
+async function mountThreadApp(
+  options: Parameters<typeof mountApp>[1],
+): Promise<AppHarness> {
+  return await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: ["thread-1"],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      threads: async (archived) => (archived ? [] : [summary(false)]),
+      ...options,
+    },
+  );
+}
+
+async function selectedComposer(): Promise<HTMLTextAreaElement> {
+  const row = await waitFor(() =>
+    document.querySelector<HTMLButtonElement>(".thread-row"),
+  );
+  await act(async () => row.click());
+  return await waitFor(() =>
+    document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+  );
+}
+
+async function dispatchComposerKey(
+  composer: HTMLTextAreaElement,
+  init: KeyboardEventInit,
+): Promise<void> {
+  const onKeyDown = reactProps<{
+    onKeyDown?(event: {
+      key: string;
+      metaKey: boolean;
+      nativeEvent: { isComposing: boolean };
+      preventDefault(): void;
+      repeat: boolean;
+      shiftKey: boolean;
+    }): void;
+  }>(composer).onKeyDown;
+  assert.ok(onKeyDown);
+  await act(async () => {
+    onKeyDown({
+      key: init.key ?? "",
+      metaKey: init.metaKey ?? false,
+      nativeEvent: { isComposing: init.isComposing ?? false },
+      preventDefault: () => undefined,
+      repeat: init.repeat ?? false,
+      shiftKey: init.shiftKey ?? false,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function invokeButtonClick(
+  button: HTMLButtonElement,
+  times = 1,
+): Promise<void> {
+  const onClick = reactProps<{ onClick?(): void }>(button).onClick;
+  assert.ok(onClick);
+  await act(async () => {
+    for (let index = 0; index < times; index += 1) onClick();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function invokePrimarySubmit(
+  button: HTMLButtonElement,
+  times = 1,
+  beforeSettle?: () => Promise<void>,
+): Promise<void> {
+  const onClick = reactProps<{ onClick?(): void }>(button).onClick;
+  const form = button.closest<HTMLFormElement>("form");
+  await act(async () => {
+    for (let index = 0; index < times; index += 1) {
+      if (onClick !== undefined) onClick();
+      else {
+        assert.ok(form);
+        invokeFormSubmitNow(form);
+      }
+    }
+    await Promise.resolve();
+    await beforeSettle?.();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function invokeFormSubmit(form: HTMLFormElement): Promise<void> {
+  await act(async () => {
+    invokeFormSubmitNow(form);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function invokeFormSubmitNow(form: HTMLFormElement): void {
+  const onSubmit = reactProps<{
+    onSubmit?(event: { preventDefault(): void }): void;
+  }>(form).onSubmit;
+  assert.ok(onSubmit);
+  onSubmit({ preventDefault: () => undefined });
+}
+
 async function unmountApp(harness: AppHarness): Promise<void> {
   await act(async () => harness.root.unmount());
   Object.assign(globalThis, {
@@ -758,22 +1069,23 @@ async function setTextareaValue(
   textarea: HTMLTextAreaElement,
   value: string,
 ): Promise<void> {
-  const reactPropsKey = Object.getOwnPropertyNames(textarea).find((key) =>
-    key.startsWith("__reactProps$"),
-  );
-  assert.ok(reactPropsKey);
-  const props = (
-    textarea as unknown as Record<
-      string,
-      { onChange?(event: { target: { value: string } }): void }
-    >
-  )[reactPropsKey];
+  const props = reactProps<{
+    onChange?(event: { target: { value: string } }): void;
+  }>(textarea);
   const onChange = props?.onChange;
   assert.ok(onChange);
   await act(async () => {
     onChange({ target: { value } });
     await Promise.resolve();
   });
+}
+
+function reactProps<T>(element: Element): T {
+  const reactPropsKey = Object.getOwnPropertyNames(element).find((key) =>
+    key.startsWith("__reactProps$"),
+  );
+  assert.ok(reactPropsKey);
+  return (element as unknown as Record<string, T>)[reactPropsKey] as T;
 }
 
 function exactButton(label: string): HTMLButtonElement | undefined {

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -27,6 +27,7 @@ const profile = {
   lastUsedWorkspace: null,
   approvalPolicy: "always" as const,
   pinnedThreadIds: [],
+  sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
 };
 
 test("round-trips credential-free host settings and builds the ModelCatalog config", async () => {
@@ -81,6 +82,7 @@ test("defaults legacy profiles to the independent Luna title model", () => {
     workspaces: _workspaces,
     lastUsedWorkspace: _lastUsedWorkspace,
     pinnedThreadIds: _pinnedThreadIds,
+    sidebarOrder: _sidebarOrder,
     ...legacy
   } = profile;
   const validated = validateHostProfile(legacy);
@@ -88,6 +90,10 @@ test("defaults legacy profiles to the independent Luna title model", () => {
   assert.deepEqual(validated.workspaces, [path.resolve(profile.workspace)]);
   assert.equal(validated.lastUsedWorkspace, null);
   assert.deepEqual(validated.pinnedThreadIds, []);
+  assert.deepEqual(validated.sidebarOrder, {
+    projectKeys: [],
+    threadIdsByProject: {},
+  });
 });
 
 test("reports a corrupt persisted host profile instead of silently replacing it", async () => {

--- a/apps/zenx/test/settings-interaction.test.ts
+++ b/apps/zenx/test/settings-interaction.test.ts
@@ -30,6 +30,7 @@ const settings: PublicHostSettings = {
     lastUsedWorkspace: "/work/zen",
     approvalPolicy: "never",
     pinnedThreadIds: [],
+    sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
   },
   hasApiKey: false,
   subscription: { authenticated: false, expired: false },

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -181,6 +181,87 @@ test("serializes concurrent workspace mutations without losing either update", a
   }
 });
 
+test("persists Sidebar Project and per-Project Thread order across reload", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-sidebar-order-"),
+  );
+  try {
+    const first = settingsFor(directory, inactiveSubscription());
+    await first.initialize({});
+    await first.setSidebarOrder({
+      projectKeys: ["/work/b", "/work/a"],
+      threadIdsByProject: {
+        "/work/a": ["thread-2", "thread-1"],
+      },
+    });
+
+    const reloaded = settingsFor(directory, inactiveSubscription());
+    await reloaded.initialize({});
+    assert.deepEqual((await reloaded.publicSettings()).profile.sidebarOrder, {
+      projectKeys: ["/work/b", "/work/a"],
+      threadIdsByProject: {
+        "/work/a": ["thread-2", "thread-1"],
+      },
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("serializes repeated Sidebar reorders so the latest invocation wins", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-sidebar-order-latest-"),
+  );
+  const initial = settingsFor(directory, inactiveSubscription());
+  await initial.initialize({});
+  const store = new InverseCompletionProfileStore(
+    path.join(directory, "host-profile.json"),
+  );
+  const service = new ZenXSettingsService({
+    userDataDirectory: directory,
+    zenDataDirectory: path.join(directory, "zen"),
+    profileStore: store,
+    vault: new ZenXCredentialVault(
+      path.join(directory, "credentials.vault"),
+      encryption,
+    ),
+  });
+  try {
+    await service.initialize({});
+    const first = service.setSidebarOrder({
+      projectKeys: ["first", "second"],
+      threadIdsByProject: {},
+    });
+    await store.firstWriteStarted;
+    const second = service.setSidebarOrder({
+      projectKeys: ["second", "first"],
+      threadIdsByProject: { first: ["thread-b", "thread-a"] },
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(store.writeCalls, 1);
+    store.releaseFirstWrite();
+    await Promise.all([first, second]);
+
+    const expected = {
+      projectKeys: ["second", "first"],
+      threadIdsByProject: { first: ["thread-b", "thread-a"] },
+    };
+    assert.deepEqual(
+      (await service.publicSettings()).profile.sidebarOrder,
+      expected,
+    );
+    assert.deepEqual(
+      JSON.parse(
+        await readFile(path.join(directory, "host-profile.json"), "utf8"),
+      ).sidebarOrder,
+      expected,
+    );
+  } finally {
+    store.releaseFirstWrite();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("keeps inverse-completing initialize and save writes in invocation order", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-inverse-profile-writes-"),
@@ -310,6 +391,10 @@ test("merges stale Settings fields without overwriting a newer Project mutation"
     await service.initialize({});
     const stale = (await service.publicSettings()).profile;
     await service.addWorkspace(workspace);
+    await service.setSidebarOrder({
+      projectKeys: ["newest-project", "older-project"],
+      threadIdsByProject: { "newest-project": ["thread-2", "thread-1"] },
+    });
 
     await service.save({
       ...stale,
@@ -321,6 +406,10 @@ test("merges stale Settings fields without overwriting a newer Project mutation"
     assert.equal(profile.defaultModel, "saved-model");
     assert.equal(profile.workspace, path.resolve(workspace));
     assert.deepEqual(profile.workspaces, [path.resolve(workspace)]);
+    assert.deepEqual(profile.sidebarOrder, {
+      projectKeys: ["newest-project", "older-project"],
+      threadIdsByProject: { "newest-project": ["thread-2", "thread-1"] },
+    });
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
@@ -841,6 +930,7 @@ function fakeProfile(model: string): ZenXHostProfile {
     workspaces: [],
     lastUsedWorkspace: null,
     pinnedThreadIds: [],
+    sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
     approvalPolicy: "always",
   };
 }

--- a/apps/zenx/test/sidebar-ordering-interaction.test.ts
+++ b/apps/zenx/test/sidebar-ordering-interaction.test.ts
@@ -1,0 +1,375 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { JSDOM } from "jsdom";
+import * as React from "react";
+import { createRoot } from "react-dom/client";
+
+import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import type { ZenXSidebarOrder } from "../src/main/host-profile.js";
+import type { ZenXProjectProjectionSnapshot } from "../src/main/project-projection.js";
+import {
+  moveSidebarProject,
+  moveSidebarThread,
+  type SidebarOrderPlacement,
+} from "../src/renderer/src/thread-list.js";
+
+const { act, createElement, useState } = React;
+Object.assign(globalThis, { React });
+const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
+const noop = () => undefined;
+
+const projection: ZenXProjectProjectionSnapshot = {
+  projects: [
+    {
+      key: "/work/a",
+      workspace: "/work/a",
+      configured: true,
+      isDefault: true,
+      threadIds: ["pinned", "active", "idle"],
+    },
+    {
+      key: "/work/b",
+      workspace: "/work/b",
+      configured: true,
+      isDefault: false,
+      threadIds: ["other"],
+    },
+  ],
+  unavailableThreadIds: [],
+  lastUsedWorkspace: "/work/a",
+};
+
+const threads = [
+  summary("pinned", "idle", 40, "/work/a"),
+  summary("active", "active", 30, "/work/a"),
+  summary("idle", "idle", 20, "/work/a"),
+  summary("other", "idle", 10, "/work/b"),
+];
+
+test("keyboard reorder restores focus while preserving selection, Pin, and active Turn state", async () => {
+  await withDom(async (root) => {
+    await act(async () => root.render(createElement(OrderingSidebar)));
+
+    const projectA = requiredButton('[aria-label^="Reorder project a."]');
+    projectA.focus();
+    await act(async () => {
+      projectA.dispatchEvent(
+        new window.KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.deepEqual(projectKeys(), ["/work/b", "/work/a"]);
+    assert.equal(document.activeElement, projectA);
+
+    await act(async () =>
+      requiredButton('[data-thread-id="idle"] .thread-menu-trigger').click(),
+    );
+    assert.ok(
+      document.querySelector('[data-thread-id="idle"] .thread-item-menu'),
+    );
+    const idleHandle = requiredButton('[aria-label^="Reorder idle within"]');
+    idleHandle.focus();
+    await act(async () => {
+      idleHandle.dispatchEvent(
+        new window.KeyboardEvent("keydown", {
+          key: "ArrowUp",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const projectAThreads = [
+      ...document.querySelectorAll<HTMLElement>(
+        '[data-project-key="/work/a"] .thread-row-shell',
+      ),
+    ].map((row) => row.dataset.threadId);
+    assert.deepEqual(projectAThreads, ["idle", "active"]);
+    assert.equal(document.activeElement, idleHandle);
+    assert.ok(
+      document.querySelector('[data-thread-id="idle"] .thread-item-menu'),
+    );
+    assert.equal(
+      document
+        .querySelector('[data-thread-id="active"] .thread-row')
+        ?.getAttribute("aria-current"),
+      "page",
+    );
+    assert.ok(
+      document.querySelector(
+        '[data-thread-id="active"] [aria-label="Running"]',
+      ),
+    );
+    assert.deepEqual(
+      [
+        ...document.querySelectorAll<HTMLElement>(
+          ".pinned-thread-group .thread-row-shell",
+        ),
+      ].map((row) => row.dataset.threadId),
+      ["pinned"],
+    );
+  });
+});
+
+test("native Thread drag refuses a drop in a different Project", async () => {
+  let reorderCalls = 0;
+  await withDom(async (root) => {
+    await act(async () =>
+      root.render(
+        createElement(StaticSidebar, {
+          onReorderThread: async () => {
+            reorderCalls += 1;
+          },
+        }),
+      ),
+    );
+    const source = requiredButton('[aria-label^="Reorder active within"]');
+    const target = document.querySelector<HTMLElement>(
+      '[data-thread-id="other"]',
+    );
+    assert.ok(target);
+    const dataTransfer = dragData();
+    await act(async () => {
+      source.dispatchEvent(dragEvent("dragstart", dataTransfer));
+      target.dispatchEvent(dragEvent("dragover", dataTransfer));
+      target.dispatchEvent(dragEvent("drop", dataTransfer));
+      await Promise.resolve();
+    });
+    assert.equal(reorderCalls, 0);
+    assert.deepEqual(projectKeys(), ["/work/a", "/work/b"]);
+  });
+});
+
+test("native drag reorders Projects globally and Threads inside one Project", async () => {
+  await withDom(async (root) => {
+    await act(async () => root.render(createElement(OrderingSidebar)));
+    const projectSource = requiredButton('[aria-label^="Reorder project b."]');
+    const projectTarget = document.querySelector<HTMLElement>(
+      '[data-project-key="/work/a"]',
+    );
+    assert.ok(projectTarget);
+    const projectTransfer = dragData();
+    await act(async () => {
+      projectSource.dispatchEvent(dragEvent("dragstart", projectTransfer));
+      projectTarget.dispatchEvent(dragEvent("dragover", projectTransfer));
+      projectTarget.dispatchEvent(dragEvent("drop", projectTransfer));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.deepEqual(projectKeys(), ["/work/b", "/work/a"]);
+
+    const threadSource = requiredButton('[aria-label^="Reorder idle within"]');
+    const threadTarget = document.querySelector<HTMLElement>(
+      '[data-thread-id="active"]',
+    );
+    assert.ok(threadTarget);
+    const threadTransfer = dragData();
+    await act(async () => {
+      threadSource.dispatchEvent(dragEvent("dragstart", threadTransfer));
+      threadTarget.dispatchEvent(dragEvent("dragover", threadTransfer));
+      threadTarget.dispatchEvent(dragEvent("drop", threadTransfer));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.deepEqual(
+      [
+        ...document.querySelectorAll<HTMLElement>(
+          '[data-project-key="/work/a"] .thread-row-shell',
+        ),
+      ].map((row) => row.dataset.threadId),
+      ["idle", "active"],
+    );
+  });
+});
+
+function OrderingSidebar() {
+  const [order, setOrder] = useState<ZenXSidebarOrder>({
+    projectKeys: [],
+    threadIdsByProject: {},
+  });
+  return createElement(StaticSidebar, {
+    sidebarOrder: order,
+    onReorderProject: async (
+      sourceKey: string,
+      targetKey: string,
+      placement: SidebarOrderPlacement,
+    ) =>
+      setOrder((current) =>
+        moveSidebarProject(
+          current,
+          projection,
+          sourceKey,
+          targetKey,
+          placement,
+        ),
+      ),
+    onReorderThread: async (
+      sourceProjectKey: string,
+      sourceThreadId: string,
+      targetProjectKey: string,
+      targetThreadId: string,
+      placement: SidebarOrderPlacement,
+    ) =>
+      setOrder((current) =>
+        moveSidebarThread(
+          current,
+          threads,
+          projection,
+          sourceProjectKey,
+          sourceThreadId,
+          targetProjectKey,
+          targetThreadId,
+          placement,
+        ),
+      ),
+  });
+}
+
+function StaticSidebar({
+  sidebarOrder = { projectKeys: [], threadIdsByProject: {} },
+  onReorderProject = async () => undefined,
+  onReorderThread = async () => undefined,
+}: {
+  sidebarOrder?: ZenXSidebarOrder;
+  onReorderProject?: (
+    sourceKey: string,
+    targetKey: string,
+    placement: SidebarOrderPlacement,
+  ) => Promise<void>;
+  onReorderThread?: (
+    sourceProjectKey: string,
+    sourceThreadId: string,
+    targetProjectKey: string,
+    targetThreadId: string,
+    placement: SidebarOrderPlacement,
+  ) => Promise<void>;
+}) {
+  return createElement(Sidebar, {
+    liveThread: null,
+    mode: "projects",
+    open: true,
+    onClose: noop,
+    onModeChange: noop,
+    onNewThread: noop,
+    onAddProject: noop,
+    onRemoveProject: noop,
+    onSetDefaultProject: noop,
+    onOpenContribution: noop,
+    onOpenSettings: noop,
+    onChangeThreadLifecycle: async () => undefined,
+    onChangeThreadPinned: async () => undefined,
+    onReorderProject,
+    onReorderThread,
+    onRenameThread: async () => undefined,
+    onRetryThreads: noop,
+    onSelectThread: noop,
+    pendingApprovalThreadIds: new Set<string>(),
+    pinnedThreads: [threads[0]!],
+    pluginContributions: [],
+    projects: projection,
+    sidebarOrder,
+    selectedPage: "agent",
+    selectedThreadId: "active",
+    serverReady: true,
+    threadError: null,
+    threadLoading: false,
+    threads,
+    triggerSnapshot: { triggers: [], history: [], rooms: [] },
+  });
+}
+
+async function withDom(
+  operation: (root: ReturnType<typeof createRoot>) => Promise<void>,
+): Promise<void> {
+  const dom = new JSDOM(
+    "<!doctype html><html><body><div id=root></div></body></html>",
+    { url: "http://localhost" },
+  );
+  const previous = {
+    document: globalThis.document,
+    HTMLElement: globalThis.HTMLElement,
+    Node: globalThis.Node,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+    window: globalThis.window,
+  };
+  Object.assign(globalThis, {
+    document: dom.window.document,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    requestAnimationFrame: undefined,
+    window: dom.window,
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const container = document.getElementById("root");
+  assert.ok(container);
+  const root = createRoot(container);
+  try {
+    await operation(root);
+  } finally {
+    await act(async () => root.unmount());
+    Object.assign(globalThis, previous, {
+      IS_REACT_ACT_ENVIRONMENT: undefined,
+    });
+    dom.window.close();
+  }
+}
+
+function requiredButton(selector: string): HTMLButtonElement {
+  const button = document.querySelector<HTMLButtonElement>(selector);
+  assert.ok(button, `Expected ${selector}`);
+  return button;
+}
+
+function projectKeys(): (string | undefined)[] {
+  return [...document.querySelectorAll<HTMLElement>(".project-group")].map(
+    (group) => group.dataset.projectKey,
+  );
+}
+
+function dragData() {
+  return {
+    dropEffect: "none",
+    effectAllowed: "all",
+    setData: () => undefined,
+  };
+}
+
+function dragEvent(type: string, dataTransfer: ReturnType<typeof dragData>) {
+  const event = new window.Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    clientY: { value: 0 },
+    dataTransfer: { value: dataTransfer },
+  });
+  return event;
+}
+
+function summary(
+  threadId: string,
+  status: "idle" | "active",
+  updated: number,
+  cwd: string,
+): NativeThreadSummary {
+  return {
+    threadId,
+    currentMetadata: {
+      model: "gpt-5.6-terra",
+      provider: "openai",
+      cwd,
+      sandbox: "danger-full-access",
+      approvalPolicy: "never",
+    },
+    archived: false,
+    createdAt: new Date((updated - 1) * 1_000).toISOString(),
+    updatedAt: new Date(updated * 1_000).toISOString(),
+    name: threadId,
+    preview: "",
+    status,
+  };
+}

--- a/apps/zenx/test/sidebar-ordering-interaction.test.ts
+++ b/apps/zenx/test/sidebar-ordering-interaction.test.ts
@@ -13,7 +13,7 @@ import {
   type SidebarOrderPlacement,
 } from "../src/renderer/src/thread-list.js";
 
-const { act, createElement, useState } = React;
+const { act, createElement, useRef, useState } = React;
 Object.assign(globalThis, { React });
 const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
 const noop = () => undefined;
@@ -118,6 +118,27 @@ test("keyboard reorder restores focus while preserving selection, Pin, and activ
   });
 });
 
+test("reorder handles remain in sequential Tab order while visually quiet", async () => {
+  await withDom(async (root) => {
+    await act(async () => root.render(createElement(StaticSidebar)));
+    const handles = [
+      ...document.querySelectorAll<HTMLButtonElement>(".reorder-handle"),
+    ];
+    assert.ok(handles.length > 0);
+    assert.ok(handles.every((handle) => handle.tabIndex === 0));
+    assert.deepEqual(
+      handles.map((handle) => handle.id),
+      [
+        "sidebar-project-order-%2Fwork%2Fa",
+        "sidebar-thread-order-active",
+        "sidebar-thread-order-idle",
+        "sidebar-project-order-%2Fwork%2Fb",
+        "sidebar-thread-order-other",
+      ],
+    );
+  });
+});
+
 test("native Thread drag refuses a drop in a different Project", async () => {
   let reorderCalls = 0;
   await withDom(async (root) => {
@@ -144,6 +165,54 @@ test("native Thread drag refuses a drop in a different Project", async () => {
     });
     assert.equal(reorderCalls, 0);
     assert.deepEqual(projectKeys(), ["/work/a", "/work/b"]);
+  });
+});
+
+test("Sidebar order failure is recoverable without replacing the Thread view", async () => {
+  await withDom(async (root) => {
+    await act(async () => root.render(createElement(FailingSidebar)));
+    const projectA = requiredButton('[aria-label^="Reorder project a."]');
+    projectA.focus();
+    await act(async () => {
+      projectA.dispatchEvent(
+        new window.KeyboardEvent("keydown", {
+          key: "ArrowDown",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(
+      document.body.textContent ?? "",
+      /Could not save Sidebar order/u,
+    );
+    assert.equal(
+      document
+        .querySelector('[data-thread-id="active"] .thread-row')
+        ?.getAttribute("aria-current"),
+      "page",
+    );
+    assert.equal(document.activeElement, projectA);
+
+    await act(async () => {
+      requiredButton(".sidebar-error button").click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.doesNotMatch(
+      document.body.textContent ?? "",
+      /Could not save Sidebar order/u,
+    );
+    assert.deepEqual(projectKeys(), ["/work/b", "/work/a"]);
+    assert.equal(document.activeElement, projectA);
+    assert.equal(
+      document
+        .querySelector('[data-thread-id="active"] .thread-row')
+        ?.getAttribute("aria-current"),
+      "page",
+    );
   });
 });
 
@@ -229,6 +298,34 @@ function OrderingSidebar() {
           placement,
         ),
       ),
+  });
+}
+
+function FailingSidebar() {
+  const [order, setOrder] = useState<ZenXSidebarOrder>({
+    projectKeys: [],
+    threadIdsByProject: {},
+  });
+  const attempts = useRef(0);
+  return createElement(StaticSidebar, {
+    sidebarOrder: order,
+    onReorderProject: async (
+      sourceKey: string,
+      targetKey: string,
+      placement: SidebarOrderPlacement,
+    ) => {
+      attempts.current += 1;
+      if (attempts.current === 1) throw new Error("temporary profile failure");
+      setOrder((current) =>
+        moveSidebarProject(
+          current,
+          projection,
+          sourceKey,
+          targetKey,
+          placement,
+        ),
+      );
+    },
   });
 }
 

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -44,3 +44,27 @@ test("Thread overflow stays inert until hover, focus, or an open menu", async ()
     /\.thread-row\.selected[^}]*\.thread-menu-trigger/su,
   );
 });
+
+test("reorder handles stay visually quiet with keyboard and narrow-width access", async () => {
+  const styles = await readFile(
+    new URL("../src/renderer/src/styles.css", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    styles,
+    /\.reorder-handle\s*\{[^}]*opacity: 0;[^}]*visibility: hidden;[^}]*pointer-events: none;/su,
+  );
+  assert.match(
+    styles,
+    /\.project-header:focus-within > \.project-reorder-handle/u,
+  );
+  assert.match(
+    styles,
+    /\.thread-row-shell:focus-within \.thread-reorder-handle/u,
+  );
+  const mobile = styles.slice(styles.indexOf("@media (max-width: 640px)"));
+  assert.match(
+    mobile,
+    /\.thread-reorder-handle,\s*\.project-reorder-handle,\s*\.thread-item-menu > button\s*\{\s*min-width: 44px;\s*min-height: 44px;/su,
+  );
+});

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -52,8 +52,9 @@ test("reorder handles stay visually quiet with keyboard and narrow-width access"
   );
   assert.match(
     styles,
-    /\.reorder-handle\s*\{[^}]*opacity: 0;[^}]*visibility: hidden;[^}]*pointer-events: none;/su,
+    /\.reorder-handle\s*\{[^}]*opacity: 0;[^}]*pointer-events: none;/su,
   );
+  assert.doesNotMatch(styles, /\.reorder-handle\s*\{[^}]*visibility: hidden/su);
   assert.match(
     styles,
     /\.project-header:focus-within > \.project-reorder-handle/u,

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -6,6 +6,8 @@ import {
   deriveInboxSections,
   derivePinnedThreads,
   deriveProjectGroups,
+  moveSidebarProject,
+  moveSidebarThread,
   projectThreadStartParams,
   readSidebarMode,
   startProjectThread,
@@ -15,6 +17,7 @@ import {
   threadTitle,
   writeSidebarMode,
 } from "../src/renderer/src/thread-list.js";
+import type { ZenXSidebarOrder } from "../src/main/host-profile.js";
 
 test("persists the selected sidebar mode and defaults invalid values to projects", () => {
   const values = new Map<string, string>();
@@ -113,6 +116,111 @@ test("groups native summaries only by current cwd", () => {
       ["zen", ["zen-a"]],
       ["Unavailable journals", ["broken"]],
     ],
+  );
+});
+
+test("reconciles persisted Project and per-Project Thread preferences with current stable order", () => {
+  const preference: ZenXSidebarOrder = {
+    projectKeys: ["/removed", "/work/b"],
+    threadIdsByProject: {
+      "/work/b": ["removed-thread", "b-old"],
+    },
+  };
+  const projection = {
+    projects: [
+      project("/work/a", ["a-new"]),
+      project("/work/b", ["b-new", "b-old"]),
+      project("/work/c", ["c-new"]),
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  };
+
+  const groups = deriveProjectGroups(
+    [
+      summary("a-new", "idle", 40, "/work/a"),
+      summary("b-new", "idle", 30, "/work/b"),
+      summary("b-old", "idle", 20, "/work/b"),
+      summary("c-new", "idle", 10, "/work/c"),
+    ],
+    projection,
+    preference,
+  );
+
+  assert.deepEqual(
+    groups.map((group) => [
+      group.key,
+      group.threads.map((thread) => thread.threadId),
+    ]),
+    [
+      ["/work/b", ["b-old", "b-new"]],
+      ["/work/a", ["a-new"]],
+      ["/work/c", ["c-new"]],
+    ],
+  );
+});
+
+test("moves Threads only inside their owning Project without changing membership", () => {
+  const projection = {
+    projects: [project("/work/a", ["a-1", "a-2"]), project("/work/b", ["b-1"])],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  };
+  const threads = [
+    summary("a-1", "active", 30, "/work/a"),
+    summary("a-2", "idle", 20, "/work/a"),
+    summary("b-1", "idle", 10, "/work/b"),
+  ];
+  const initial: ZenXSidebarOrder = {
+    projectKeys: [],
+    threadIdsByProject: {},
+  };
+
+  const rejected = moveSidebarThread(
+    initial,
+    threads,
+    projection,
+    "/work/a",
+    "a-1",
+    "/work/b",
+    "b-1",
+    "before",
+  );
+  assert.equal(rejected, initial);
+
+  const moved = moveSidebarThread(
+    initial,
+    threads,
+    projection,
+    "/work/a",
+    "a-2",
+    "/work/a",
+    "a-1",
+    "before",
+  );
+  assert.deepEqual(moved.threadIdsByProject, {
+    "/work/a": ["a-2", "a-1"],
+  });
+  assert.equal(threads[0]!.status, "active");
+  assert.equal(threads[0]!.currentMetadata.cwd, "/work/a");
+});
+
+test("moves Projects globally while retaining per-Project Thread preferences", () => {
+  const projection = {
+    projects: [project("/work/a", []), project("/work/b", [])],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  };
+  const initial: ZenXSidebarOrder = {
+    projectKeys: [],
+    threadIdsByProject: { "/work/a": ["a-2", "a-1"] },
+  };
+  assert.deepEqual(
+    moveSidebarProject(initial, projection, "/work/b", "/work/a", "before"),
+    {
+      projectKeys: ["/work/b", "/work/a"],
+      threadIdsByProject: initial.threadIdsByProject,
+    },
   );
 });
 
@@ -277,5 +385,15 @@ function broken(threadId: string): NativeThreadSummary {
     preview: "",
     status: "systemError",
     error: "journal failed",
+  };
+}
+
+function project(key: string, threadIds: string[]) {
+  return {
+    key,
+    workspace: key,
+    configured: true,
+    isDefault: false,
+    threadIds,
   };
 }

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -3,7 +3,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import test from "node:test";
 
-import type { Thread, Turn } from "../src/protocol-client/index.js";
+import type { Thread, ThreadItem, Turn } from "../src/protocol-client/index.js";
 import type { ApprovalCardState } from "../src/renderer/src/approval-state.js";
 import {
   editComposer,
@@ -55,16 +55,56 @@ test("pending approvals render in the bottom zone next to the composer", () => {
   assert.match(html, /Allow once/u);
 });
 
+test("assistant messages omit the identity row while preserving metadata and content", () => {
+  const html = renderTurns([
+    turnWithItems("completed", [user("request"), agent("Final answer")], 1_000),
+  ]);
+
+  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
+  assert.match(
+    html,
+    /class="user-row"[\s\S]*<\/article><button class="turn-toggle"[^>]*><span>Worked for 1s<\/span>/u,
+  );
+  assert.match(html, /class="agent-copy"[\s\S]*Final answer/u);
+});
+
+test("assistant messages retain running reasoning and tool disclosure affordances", () => {
+  const html = renderTurns([
+    turnWithItems("inProgress", [
+      user("Inspect the project"),
+      agent("Checking the relevant files."),
+      reasoning("Mapped the rendering path"),
+      command("rg ThreadView"),
+    ]),
+  ]);
+
+  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
+  assert.match(html, /class="turn-running-label"[\s\S]*Working/u);
+  assert.match(html, /Checking the relevant files\./u);
+  assert.match(
+    html,
+    /class="trace-toggle"[^>]*aria-expanded="false"[\s\S]*Reasoned and used rg[\s\S]*2 items/u,
+  );
+});
+
 function render(
   active: boolean,
   approvals: readonly ApprovalCardState[],
+  composer: ComposerState = emptyComposerState(),
+) {
+  return renderTurns(active ? [turn()] : [], approvals, composer);
+}
+
+function renderTurns(
+  turns: Turn[],
+  approvals: readonly ApprovalCardState[] = [],
   composer: ComposerState = emptyComposerState(),
 ) {
   return renderToStaticMarkup(
     createElement(ThreadView, {
       approvals,
       composer,
-      thread: thread(active ? [turn()] : []),
+      thread: thread(turns),
       onDraftChange: () => undefined,
       onInterrupt: noop,
       onRespondToApproval: noop,
@@ -104,14 +144,68 @@ function thread(turns: Turn[]): Thread {
 }
 
 function turn(): Turn {
+  return turnWithItems("inProgress", []);
+}
+
+function turnWithItems(
+  status: Turn["status"],
+  items: ThreadItem[],
+  durationMs: number | null = null,
+): Turn {
   return {
     id: "turn-1",
-    items: [],
+    items,
     itemsView: "full",
-    status: "inProgress",
+    status,
     error: null,
     startedAt: 10,
-    completedAt: null,
+    completedAt: status === "inProgress" ? null : 11,
+    durationMs,
+  };
+}
+
+function user(text: string): ThreadItem {
+  return {
+    type: "userMessage",
+    id: "user-1",
+    clientId: null,
+    content: [{ type: "text", text, text_elements: [] }],
+  };
+}
+
+function agent(text: string): ThreadItem {
+  return {
+    type: "agentMessage",
+    id: `agent-${text}`,
+    text,
+    phase: "final_answer",
+    memoryCitation: null,
+  };
+}
+
+function reasoning(summary: string): ThreadItem {
+  return {
+    type: "reasoning",
+    id: "reasoning-1",
+    summary: [summary],
+    content: [],
+  };
+}
+
+function command(value: string): ThreadItem {
+  return {
+    type: "commandExecution",
+    id: "command-1",
+    pluginId: null,
+    scriptPath: null,
+    command: value,
+    cwd: "/workspace",
+    processId: null,
+    source: "agent",
+    status: "completed",
+    commandActions: [],
+    aggregatedOutput: "ThreadView.tsx",
+    exitCode: 0,
     durationMs: null,
   };
 }


### PR DESCRIPTION
Promotes the reviewed post-mainline ZenX UI follow-ups:\n\n- PR #118: remove the assistant identity row (Review PASS R1)\n- PR #119: prevent duplicate first Composer submission (Review PASS R1 retry)\n- PR #120: add local Project/Thread drag ordering with recoverable save errors and keyboard access (Review PASS R2)\n\nEach exact feature head completed its required Review Loop and exact-head CI. This PR advances the already-formal ZenX mainline; it does not include ZAS crash supervision or macOS signing follow-ups tracked separately.