### PR TITLE
fix(zenx): recover hosted App Server exits

### DIFF
--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -130,7 +130,8 @@ export class AppServerManager {
     const lifecycle = ++this.#lifecycle;
     this.#setStatus({ type: "starting" });
     try {
-      await this.#startHost(lifecycle, false);
+      await this.#startHost(lifecycle);
+      this.#setStatus({ type: "ready", reconnected: false });
     } catch (error) {
       const message = asError(error).message;
       if (lifecycle === this.#lifecycle && !this.#stopping) {
@@ -140,7 +141,7 @@ export class AppServerManager {
     }
   }
 
-  async #startHost(lifecycle: number, reconnected: boolean): Promise<void> {
+  async #startHost(lifecycle: number): Promise<void> {
     this.#acceptingCapabilityInvocations = false;
     const bearerToken = await createPrivateTokenFile(this.#options.tokenFile);
     if (lifecycle !== this.#lifecycle || this.#stopping) {
@@ -194,7 +195,6 @@ export class AppServerManager {
       this.#forwardNotifications(client);
       this.#acceptingCapabilityInvocations = true;
       this.#recoverUnexpectedExits = true;
-      this.#setStatus({ type: "ready", reconnected });
     } catch (error) {
       this.#acceptingCapabilityInvocations = false;
       if (this.#child === child) this.#child = undefined;
@@ -460,7 +460,9 @@ export class AppServerManager {
         await delay(delayMs);
         if (lifecycle !== this.#lifecycle || this.#stopping) return;
         try {
-          await this.#startHost(lifecycle, true);
+          await this.#startHost(lifecycle);
+          this.#recoveryPromise = undefined;
+          this.#setStatus({ type: "ready", reconnected: true });
           return;
         } catch (error) {
           lastError = asError(error);

--- a/apps/zenx/src/main/app-server-manager.ts
+++ b/apps/zenx/src/main/app-server-manager.ts
@@ -39,6 +39,7 @@ export interface AppServerManagerOptions {
   execArgv?: string[];
   environment?: NodeJS.ProcessEnv;
   startupTimeoutMs?: number;
+  recoveryDelaysMs?: readonly number[];
   capabilityHost?: ZenXCapabilityHost;
 }
 
@@ -94,7 +95,10 @@ export class AppServerManager {
   #client: ZenXProtocolClient | undefined;
   #acceptingCapabilityInvocations = false;
   #stopping = false;
+  #recoverUnexpectedExits = false;
   #stopPromise: Promise<void> | undefined;
+  #recoveryPromise: Promise<void> | undefined;
+  #lifecycle = 0;
   #nextThreadSummaryRequest = 1;
   #capabilityRestartTail: Promise<void> = Promise.resolve();
 
@@ -118,13 +122,31 @@ export class AppServerManager {
   }
 
   async start(): Promise<void> {
-    if (this.#child !== undefined) {
+    if (this.#child !== undefined || this.#recoveryPromise !== undefined) {
       throw new Error("ZenX App Server host is already running");
     }
-    this.#acceptingCapabilityInvocations = false;
     this.#stopping = false;
+    this.#recoverUnexpectedExits = false;
+    const lifecycle = ++this.#lifecycle;
     this.#setStatus({ type: "starting" });
+    try {
+      await this.#startHost(lifecycle, false);
+    } catch (error) {
+      const message = asError(error).message;
+      if (lifecycle === this.#lifecycle && !this.#stopping) {
+        this.#setStatus({ type: "error", message });
+      }
+      throw new Error(message);
+    }
+  }
+
+  async #startHost(lifecycle: number, reconnected: boolean): Promise<void> {
+    this.#acceptingCapabilityInvocations = false;
     const bearerToken = await createPrivateTokenFile(this.#options.tokenFile);
+    if (lifecycle !== this.#lifecycle || this.#stopping) {
+      await removeTokenFile(this.#options.tokenFile);
+      throw new Error("Zen App Server startup was cancelled");
+    }
     const child = fork(this.#options.entryPath, [], {
       cwd: process.cwd(),
       env: {
@@ -159,20 +181,30 @@ export class AppServerManager {
         },
       );
       this.#installCapabilityBridge(child);
-      this.#client = await ZenXProtocolClient.connect({
+      const client = await ZenXProtocolClient.connect({
         url,
         clientInfo: { name: "zenx", title: "ZenX", version: "0.1.0" },
         bearerTokenFile: this.#options.tokenFile,
       });
-      this.#forwardNotifications(this.#client);
+      if (lifecycle !== this.#lifecycle || this.#stopping) {
+        client.close();
+        throw new Error("Zen App Server startup was cancelled");
+      }
+      this.#client = client;
+      this.#forwardNotifications(client);
       this.#acceptingCapabilityInvocations = true;
-      this.#setStatus({ type: "ready", reconnected: false });
+      this.#recoverUnexpectedExits = true;
+      this.#setStatus({ type: "ready", reconnected });
     } catch (error) {
       this.#acceptingCapabilityInvocations = false;
-      const message = asError(error).message;
-      this.#setStatus({ type: "error", message });
-      child.kill("SIGTERM");
-      throw new Error(message);
+      if (this.#child === child) this.#child = undefined;
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGTERM");
+      }
+      if (lifecycle === this.#lifecycle) {
+        await removeTokenFile(this.#options.tokenFile);
+      }
+      throw error;
     }
   }
 
@@ -281,6 +313,8 @@ export class AppServerManager {
       return;
     }
     this.#stopping = true;
+    this.#recoverUnexpectedExits = false;
+    ++this.#lifecycle;
     this.#acceptingCapabilityInvocations = false;
     const stopping = this.#performStop();
     this.#stopPromise = stopping;
@@ -306,6 +340,7 @@ export class AppServerManager {
       if (child.exitCode === null) child.kill("SIGTERM");
     }
     this.#child = undefined;
+    await this.#recoveryPromise;
     await removeTokenFile(this.#options.tokenFile);
     this.#setStatus({ type: "stopped" });
   }
@@ -404,14 +439,47 @@ export class AppServerManager {
     );
     this.#client?.close();
     this.#client = undefined;
-    if (!this.#stopping) {
+    if (!this.#stopping && this.#recoverUnexpectedExits) {
       const reason =
         signal === null ? `exit code ${String(code)}` : `signal ${signal}`;
-      this.#setStatus({
-        type: "error",
-        message: `Zen App Server stopped unexpectedly (${reason})`,
-      });
+      this.#beginRecovery(reason);
     }
+  }
+
+  #beginRecovery(reason: string): void {
+    if (this.#recoveryPromise !== undefined || this.#stopping) return;
+    const lifecycle = this.#lifecycle;
+    const delays = this.#options.recoveryDelaysMs ?? [100, 500, 1_000];
+    const recovery = (async () => {
+      let lastError = new Error(
+        `Zen App Server stopped unexpectedly (${reason})`,
+      );
+      for (const [index, delayMs] of delays.entries()) {
+        const attempt = index + 1;
+        this.#setStatus({ type: "reconnecting", attempt, delayMs });
+        await delay(delayMs);
+        if (lifecycle !== this.#lifecycle || this.#stopping) return;
+        try {
+          await this.#startHost(lifecycle, true);
+          return;
+        } catch (error) {
+          lastError = asError(error);
+        }
+      }
+      if (lifecycle === this.#lifecycle && !this.#stopping) {
+        this.#recoverUnexpectedExits = false;
+        this.#setStatus({
+          type: "error",
+          message: `Zen App Server recovery failed after ${String(delays.length)} attempts: ${lastError.message}`,
+        });
+      }
+    })();
+    this.#recoveryPromise = recovery;
+    void recovery.finally(() => {
+      if (this.#recoveryPromise === recovery) {
+        this.#recoveryPromise = undefined;
+      }
+    });
   }
 
   #setStatus(status: AppServerHostStatus): void {
@@ -577,6 +645,10 @@ async function removeTokenFile(filePath: string): Promise<void> {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 async function waitForReady(

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -253,12 +253,14 @@ export function App() {
     }
   };
 
-  const resumeThread = async (threadId: string) => {
+  const resumeThread = async (threadId: string, preserveNavigation = false) => {
     const epoch = ++selectionEpoch.current;
     selectedThreadIdRef.current = threadId;
-    setPage("agent");
-    setSidebarOpen(false);
-    setWorkspaceOpen(false);
+    if (!preserveNavigation) {
+      setPage("agent");
+      setSidebarOpen(false);
+      setWorkspaceOpen(false);
+    }
     setSelectedThreadId(threadId);
     setThreadDetail(null);
     setSelectedSettings(null);
@@ -307,7 +309,7 @@ export function App() {
         void loadProjects();
         void loadModels();
         if (status.reconnected && selectedThreadIdRef.current !== null) {
-          void resumeThread(selectedThreadIdRef.current);
+          void resumeThread(selectedThreadIdRef.current, true);
         }
       }
     });

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -315,6 +315,61 @@ test("failed Send preserves its draft and stable id for a deliberate retry", asy
   }
 });
 
+test("host recovery refreshes the selected Thread without clearing draft or local navigation", async () => {
+  let statusListener: ((status: AppServerHostStatus) => void) | undefined;
+  let resumeCalls = 0;
+  const harness = await mountThreadApp({
+    onStatus: (listener) => {
+      statusListener = listener;
+      return () => {
+        statusListener = undefined;
+      };
+    },
+    request: async (method) => {
+      if (method === "thread/resume") {
+        resumeCalls += 1;
+        return resumed(liveThread());
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Keep this local draft");
+    const openWorkspace = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Open workspace panel"]',
+      ),
+    );
+    await act(async () => openWorkspace.click());
+    await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Close workspace"]',
+      ),
+    );
+    assert.ok(statusListener);
+
+    await act(async () => {
+      statusListener?.({ type: "reconnecting", attempt: 1, delayMs: 10 });
+      statusListener?.({ type: "ready", reconnected: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => resumeCalls === 2);
+    assert.ok(
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Close workspace"]',
+      ),
+    );
+    assert.equal(
+      document.querySelector<HTMLTextAreaElement>("#thread-composer")?.value,
+      "Keep this local draft",
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("Sidebar archive clears the selected Chat and opens its Settings restore entry", async () => {
   let archived = false;
   let persistedPins = ["thread-1"];

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -223,6 +223,56 @@ test("recovers a killed hosted App Server and admits one subsequent Turn", async
   }
 });
 
+test("recovers again when the replacement child exits as readiness is published", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-recovery-generation-"),
+  );
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+    recoveryDelaysMs: [10, 20, 40],
+  });
+  const recoveredTwice = deferred<void>();
+  let recoveredCount = 0;
+  let firstReplacementProcessId: number | undefined;
+  manager.onStatus((status) => {
+    if (status.type !== "ready" || !status.reconnected) return;
+    recoveredCount += 1;
+    if (recoveredCount === 1) {
+      firstReplacementProcessId = manager.processId;
+      process.kill(firstReplacementProcessId!, "SIGKILL");
+    } else if (recoveredCount === 2) {
+      recoveredTwice.resolve();
+    }
+  });
+  try {
+    await manager.start();
+    process.kill(manager.processId!, "SIGKILL");
+
+    await within(recoveredTwice.promise);
+    assert.equal(recoveredCount, 2);
+    assert.notEqual(manager.processId, firstReplacementProcessId);
+    assert.deepEqual(await manager.request("thread/list", {}), {
+      data: [],
+      nextCursor: null,
+      backwardsCursor: null,
+    });
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("intentional stop does not enter automatic recovery", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-stop-"));
   const manager = managerFor(directory);

--- a/apps/zenx/test/app-server-manager.test.ts
+++ b/apps/zenx/test/app-server-manager.test.ts
@@ -121,32 +121,173 @@ test("serializes concurrent capability restarts", async () => {
   }
 });
 
-test("reports a killed App Server as a terminal error without restarting", async () => {
+test("recovers a killed hosted App Server and admits one subsequent Turn", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-crash-"));
-  const manager = managerFor(directory);
+  const invocations: string[] = [];
+  const capabilityHost: ZenXCapabilityHost = {
+    hostSnapshot: () => ({
+      definitions: [
+        {
+          name: "demo_recovered",
+          description: "Prove the recovered capability bridge",
+          inputSchema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+            additionalProperties: false,
+          },
+        },
+      ],
+    }),
+    execute: async (invocation) => {
+      invocations.push(String(invocation.arguments.value));
+      return { output: '{"recovered":true}', exitCode: 0 };
+    },
+  };
+  const manager = new AppServerManager({
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never",
+      provider: { type: "fake" },
+    },
+    capabilityHost,
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+    recoveryDelaysMs: [10, 20, 40],
+  });
   try {
     await manager.start();
+    const thread = (await manager.request("thread/start", {})).thread;
     const statuses: AppServerHostStatus[] = [];
-    const failed = deferred<AppServerHostStatus & { type: "error" }>();
+    const recovered = deferred<void>();
+    const completed = deferred<void>();
     manager.onStatus((status) => {
       statuses.push(status);
-      if (status.type === "error") failed.resolve(status);
+      if (status.type === "ready" && status.reconnected) recovered.resolve();
     });
-    const processId = manager.processId;
-    assert.notEqual(processId, undefined);
-    process.kill(processId!, "SIGKILL");
+    manager.onNotification((method) => {
+      if (method === "turn/completed") completed.resolve();
+    });
+    const originalProcessId = manager.processId;
+    assert.notEqual(originalProcessId, undefined);
+    process.kill(originalProcessId!, "SIGKILL");
 
-    const status = await within(failed.promise);
-    assert.match(status.message, /stopped unexpectedly/u);
-    await assert.rejects(
-      manager.request("thread/list", {}),
-      /Zen App Server is not ready/u,
+    await within(recovered.promise);
+    assert.notEqual(manager.processId, originalProcessId);
+    assert.equal(
+      statuses.some((status) => status.type === "reconnecting"),
+      true,
     );
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(
+      (await manager.request("thread/resume", { threadId: thread.id })).thread
+        .id,
+      thread.id,
+    );
+    assert.equal((await manager.listThreadSummaries())[0]?.threadId, thread.id);
+    assert.equal((await manager.request("model/list", {})).data[0]?.id, "fake");
+
+    await manager.request("turn/start", {
+      threadId: thread.id,
+      input: [
+        {
+          type: "text",
+          text: '!tool demo_recovered {"value":"once"}',
+        },
+      ],
+      clientUserMessageId: "after-recovery-once",
+    });
+    await within(completed.promise);
+    assert.deepEqual(invocations, ["once"]);
+    const resumed = await manager.request("thread/read", {
+      threadId: thread.id,
+      includeTurns: true,
+    });
+    assert.equal(
+      resumed.thread.turns.filter((turn) =>
+        turn.items.some(
+          (item) =>
+            item.type === "userMessage" &&
+            item.clientId === "after-recovery-once",
+        ),
+      ).length,
+      1,
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("intentional stop does not enter automatic recovery", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-stop-"));
+  const manager = managerFor(directory);
+  const statuses: AppServerHostStatus[] = [];
+  manager.onStatus((status) => statuses.push(status));
+  try {
+    await manager.start();
+    await manager.stop();
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    assert.deepEqual(manager.status, { type: "stopped" });
     assert.equal(manager.processId, undefined);
     assert.equal(
-      statuses.some((entry) => entry.type === "starting"),
+      statuses.some((status) => status.type === "reconnecting"),
       false,
+    );
+  } finally {
+    await manager.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("bounds recovery attempts after a fatal hosted startup failure", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-fatal-"));
+  const options = {
+    entryPath: path.resolve("src/main/app-server-host.ts"),
+    tokenFile: path.join(directory, "runtime", "app-server.token"),
+    hostConfig: {
+      cwd: process.cwd(),
+      dataDirectory: path.join(directory, "data"),
+      model: "fake",
+      models: ["fake"],
+      approvalPolicy: "never" as const,
+      provider: { type: "fake" as const },
+    },
+    execArgv: ["--import", "tsx"],
+    startupTimeoutMs: 10_000,
+    recoveryDelaysMs: [0, 0],
+  };
+  const manager = new AppServerManager(options);
+  const statuses: AppServerHostStatus[] = [];
+  const failed = deferred<AppServerHostStatus & { type: "error" }>();
+  manager.onStatus((status) => {
+    statuses.push(status);
+    if (status.type === "error") failed.resolve(status);
+  });
+  try {
+    await manager.start();
+    options.entryPath = path.join(directory, "missing-host.cjs");
+    process.kill(manager.processId!, "SIGKILL");
+
+    const status = await within(failed.promise);
+    assert.match(status.message, /recovery failed after 2 attempts/u);
+    assert.equal(
+      statuses.filter(
+        (entry) => entry.type === "reconnecting" && entry.delayMs === 0,
+      ).length,
+      2,
+    );
+    assert.equal(manager.processId, undefined);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    assert.equal(
+      statuses.filter(
+        (entry) => entry.type === "reconnecting" && entry.delayMs === 0,
+      ).length,
+      2,
     );
   } finally {
     await manager.stop();


### PR DESCRIPTION
## Summary
- restart the hosted Zen App Server child after unexpected exits with three bounded backoff attempts
- reinstall capability and protocol bridges, then signal renderer rehydration without replaying in-flight requests
- preserve renderer draft and local navigation while refreshing Projects, Threads, ModelCatalog, and the selected Thread

## Verification
- `npm --workspace @zen/zenx exec -- tsx --test test/app-server-manager.test.ts test/app-project-picker-interaction.test.ts` (23 passed)
- `npm --workspace @zen/zenx run typecheck`
- `npm --workspace @zen/zenx run build`
- `npm run typecheck`
- `npm test` (Node: 96 passed, 1 skipped; IMZen: 38 passed)
- `npm --workspace @zen/zenx test` reached 461 passed / 8 skipped with 3 unrelated Windows baseline failures: concurrent credential rename EPERM, symlink privilege EPERM, and renderer CSP Windows path resolution
- `npm --workspace @zen/zenx run check` is additionally blocked by existing stale generated brand assets; root `npm run check` is blocked by existing Windows CRLF formatting drift across the checkout

Closes #122