### PR TITLE
Fix hosted Windows process observation lifecycle

### DIFF
--- a/apps/zenx/src/main/trigger-program-runner.ts
+++ b/apps/zenx/src/main/trigger-program-runner.ts
@@ -63,6 +63,10 @@ export interface TriggerProgramRunner {
 }
 
 export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
+  constructor(
+    private readonly windowsProcessOperations: WindowsProcessOperations = realWindowsProcessOperations,
+  ) {}
+
   async run(
     spec: TriggerProgramSpec,
     input: TriggerProgramRunInput,
@@ -156,7 +160,10 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
           forceTimer = undefined;
         }
         if (capturedTree === undefined && child.exitCode !== null) {
-          const exited = await verifyExitedChild(child);
+          const exited = await verifyExitedChild(
+            child,
+            this.windowsProcessOperations.captureProcessTable,
+          );
           if (settled || requested === null) return;
           if (exited.ok) {
             finish(requested);
@@ -166,7 +173,12 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         containment ??= (
           termination ?? Promise.resolve({ ok: true, error: "" })
         ).then(async (softTermination) => {
-          const forced = await terminateProcessTree(child, true, capturedTree);
+          const forced = await terminateProcessTree(
+            child,
+            true,
+            capturedTree,
+            this.windowsProcessOperations,
+          );
           if (
             !softTermination.ok &&
             softTermination.error.startsWith(
@@ -199,22 +211,17 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         }
         if (settled || requested === null) return;
         if (terminationResult.ok) finish(requested);
-        else
-          finish(
-            result(
-              "failed",
-              null,
-              null,
-              `Program ${requested.status} did not prove process-tree containment: ${terminationResult.error}`,
-            ),
-          );
+        else finish(containmentFailure(requested, terminationResult.error));
       };
       const requestTermination = (value: TriggerProgramRunResult): void => {
         if (settled || requested !== null) return;
         requested = value;
         stopCollection();
         child.stdin.destroy();
-        const treeAtTermination = captureProcessTree(child.pid).then(
+        const treeAtTermination = captureProcessTree(
+          child.pid,
+          this.windowsProcessOperations.captureProcessTable,
+        ).then(
           (tree) => ({ tree, error: null }),
           (error: unknown) => ({
             tree: undefined,
@@ -224,10 +231,23 @@ export class ZenXTriggerProgramRunner implements TriggerProgramRunner {
         termination = treeAtTermination.then(async (snapshot) => {
           if (snapshot.tree !== undefined) {
             capturedTree = snapshot.tree;
-            return await terminateProcessTree(child, false, snapshot.tree);
+            return await terminateProcessTree(
+              child,
+              false,
+              snapshot.tree,
+              this.windowsProcessOperations,
+            );
           }
-          await terminateProcessTree(child, false);
-          const exited = await verifyExitedChild(child);
+          await terminateProcessTree(
+            child,
+            false,
+            undefined,
+            this.windowsProcessOperations,
+          );
+          const exited = await verifyExitedChild(
+            child,
+            this.windowsProcessOperations.captureProcessTable,
+          );
           if (exited.ok) return exited;
           return {
             ok: false as const,
@@ -433,6 +453,7 @@ function terminateProcessTree(
   child: ChildProcessWithoutNullStreams,
   force: boolean,
   tree?: ProcessTreeSnapshot,
+  windowsOperations: WindowsProcessOperations = realWindowsProcessOperations,
 ): Promise<TerminationResult> {
   if (child.pid === undefined)
     return Promise.resolve({
@@ -442,7 +463,7 @@ function terminateProcessTree(
   if (!force && child.exitCode !== null)
     return Promise.resolve({ ok: true, error: "" });
   if (process.platform === "win32")
-    return terminateWindowsProcessTree(child, force, tree);
+    return terminateWindowsProcessTree(child, force, tree, windowsOperations);
   return terminatePosixProcessTree(child, force, tree);
 }
 
@@ -450,6 +471,7 @@ async function terminateWindowsProcessTree(
   child: ChildProcessWithoutNullStreams,
   force: boolean,
   tree?: ProcessTreeSnapshot,
+  operations: WindowsProcessOperations = realWindowsProcessOperations,
 ): Promise<TerminationResult> {
   if (child.pid === undefined)
     return { ok: false, error: "the child process did not expose a PID" };
@@ -467,7 +489,11 @@ async function terminateWindowsProcessTree(
       error:
         "process-tree identity was unavailable; containment was not proven",
     };
-  return await verifyAndTerminateWindowsProcessTree(child.pid, tree);
+  return await verifyAndTerminateWindowsProcessTree(
+    child.pid,
+    tree,
+    operations,
+  );
 }
 
 async function terminatePosixProcessTree(
@@ -489,6 +515,7 @@ async function terminatePosixProcessTree(
 
 async function verifyExitedChild(
   child: ChildProcessWithoutNullStreams,
+  capture: () => Promise<ProcessTableSnapshot> = captureProcessTable,
 ): Promise<TerminationResult> {
   if (child.pid === undefined || child.exitCode === null)
     return {
@@ -496,7 +523,7 @@ async function verifyExitedChild(
       error: "the child process identity was unavailable before termination",
     };
   try {
-    const table = await captureProcessTable();
+    const table = await capture();
     const survivors = table.entries.filter(
       (entry) =>
         entry.parentPid === child.pid || entry.processGroupId === child.pid,
@@ -1002,10 +1029,11 @@ if (!$matched) { exit 3 }
 
 function captureProcessTree(
   pid: number | undefined,
+  capture: () => Promise<ProcessTableSnapshot> = captureProcessTable,
 ): Promise<ProcessTreeSnapshot> {
   if (pid === undefined)
     return Promise.reject(new Error("the child process did not expose a PID"));
-  return captureProcessTable().then((table) => {
+  return capture().then((table) => {
     const root = table.entries.find((entry) => entry.pid === pid);
     if (root === undefined || root.startTime === null)
       throw new Error("root process identity was unavailable");
@@ -1020,71 +1048,166 @@ function captureProcessTree(
 
 async function captureProcessTable(): Promise<ProcessTableSnapshot> {
   const command = process.platform === "win32" ? "powershell.exe" : "ps";
+  const windowsScript = `
+$ErrorActionPreference = 'Stop'
+$searcher = [System.Management.ManagementObjectSearcher]::new('SELECT ProcessId, ParentProcessId, CreationDate FROM Win32_Process')
+try {
+  $processes = $searcher.Get()
+  try {
+    foreach ($process in $processes) {
+      $created = [System.Management.ManagementDateTimeConverter]::ToDateTime([string]$process.CreationDate).ToUniversalTime().Ticks
+      [Console]::Out.WriteLine('{0}|{1}|{2}', $process.ProcessId, $process.ParentProcessId, $created)
+    }
+  } finally {
+    $processes.Dispose()
+  }
+} finally {
+  $searcher.Dispose()
+}
+`;
   const args =
     process.platform === "win32"
       ? [
           "-NoProfile",
           "-NonInteractive",
-          "-Command",
-          [
-            "$ErrorActionPreference = 'Stop'",
-            "Get-CimInstance Win32_Process -Property ProcessId,ParentProcessId,CreationDate | ForEach-Object {",
-            "  '{0}|{1}|{2}' -f $_.ProcessId, $_.ParentProcessId, $_.CreationDate.ToUniversalTime().Ticks",
-            "}",
-          ].join("; "),
+          "-EncodedCommand",
+          Buffer.from(windowsScript, "utf16le").toString("base64"),
         ]
       : process.platform === "linux"
         ? ["-eo", "pid=,ppid=,pgid=,sid=,lstart="]
         : // Darwin ps has no sid= keyword; session identity is not used here.
           ["-axo", "pid=,ppid=,pgid=,lstart="];
-  const output = await new Promise<string>((resolve, reject) => {
+  const output = await captureProcessTableCommandOutput(command, args);
+  return process.platform === "win32"
+    ? parseWindowsProcessTable(output)
+    : parsePosixProcessTable(output, process.platform === "linux");
+}
+
+export async function captureProcessTableCommandOutput(
+  command: string,
+  args: readonly string[],
+  options: {
+    timeoutMs?: number;
+    maxOutputBytes?: number;
+    // Test-only observation hook; it cannot alter helper ownership.
+    onSpawn?: (child: ChildProcess) => void;
+  } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? PROCESS_TABLE_TIMEOUT_MS;
+  const maxOutputBytes = options.maxOutputBytes ?? MAX_PROCESS_TABLE_BYTES;
+  const overflowError = `process-table snapshot exceeded its ${
+    maxOutputBytes === MAX_PROCESS_TABLE_BYTES
+      ? "128 KiB"
+      : `${String(maxOutputBytes)} byte`
+  } bound`;
+  return await new Promise<string>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let bytes = 0;
     let overflowed = false;
     let settled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    let escalationTimer: ReturnType<typeof setTimeout> | undefined;
     let processHandle: ReturnType<typeof spawn> | undefined;
+    let observation: OwnedChildObservation | undefined;
+    let escalationSettlement: Promise<unknown> | undefined;
+    let forcedFailure: Error | undefined;
+    let stderr = "";
     const finish = (error: Error | null): void => {
       if (settled) return;
       settled = true;
       if (timer !== undefined) clearTimeout(timer);
+      if (escalationTimer !== undefined) clearTimeout(escalationTimer);
       if (error !== null) reject(error);
-      else if (overflowed)
-        reject(new Error("process-table snapshot exceeded its 128 KiB bound"));
+      else if (overflowed) reject(new Error(overflowError));
       else resolve(Buffer.concat(chunks).toString("utf8"));
     };
     try {
       processHandle = spawn(command, args, {
         windowsHide: true,
-        stdio: ["ignore", "pipe", "ignore"],
+        stdio: ["ignore", "pipe", "pipe"],
       });
+      observation = observeOwnedChild(processHandle);
+      try {
+        options.onSpawn?.(processHandle);
+      } catch (error) {
+        stderr += `; helper observation hook failed: ${describeError(error)}`;
+      }
       processHandle.stdout?.on("data", (chunk: Buffer | string) => {
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-        if (bytes + buffer.length > MAX_PROCESS_TABLE_BYTES) {
+        if (bytes + buffer.length > maxOutputBytes) {
           overflowed = true;
           return;
         }
         bytes += buffer.length;
         chunks.push(buffer);
       });
-      processHandle.once("error", (error: unknown) =>
-        finish(new Error(describeError(error))),
-      );
-      processHandle.once("close", (code: number | null) => {
-        if (code === 0) finish(null);
-        else finish(new Error(`${command} exited with code ${String(code)}`));
+      processHandle.stderr?.setEncoding("utf8");
+      processHandle.stderr?.on("data", (chunk: string) => {
+        if (stderr.length < MAX_PROGRAM_STDERR_BYTES) stderr += chunk;
       });
+      processHandle.on("error", (error: unknown) => {
+        if (observation?.outcome()?.type !== "spawn_error")
+          stderr += `; helper error: ${describeError(error)}`;
+      });
+      void observation.terminal.then(async (outcome) => {
+        await escalationSettlement;
+        if (forcedFailure !== undefined) {
+          const diagnostic = boundedError(stderr);
+          finish(
+            diagnostic === null
+              ? forcedFailure
+              : new Error(`${forcedFailure.message}; stderr=${diagnostic}`),
+          );
+        } else if (outcome.type === "spawn_error") finish(outcome.error);
+        else if (outcome.code === 0) finish(null);
+        else
+          finish(
+            new Error(
+              `${command} exited with code ${String(outcome.code)} and signal ${String(outcome.signal)}${boundedError(stderr) === null ? "" : `: ${boundedError(stderr)}`}`,
+            ),
+          );
+      });
+      const terminateAndSettle = (error: Error): void => {
+        if (forcedFailure !== undefined) return;
+        forcedFailure = error;
+        if (
+          processHandle?.pid === undefined ||
+          observation?.outcome() !== undefined
+        )
+          return;
+        try {
+          processHandle.kill("SIGKILL");
+        } catch (killError) {
+          stderr += `; exact helper kill failed: ${describeError(killError)}`;
+        }
+        if (process.platform === "win32") {
+          escalationTimer = setTimeout(() => {
+            if (
+              processHandle?.pid === undefined ||
+              observation?.outcome() !== undefined
+            )
+              return;
+            const escalation = spawn(
+              "taskkill.exe",
+              ["/PID", String(processHandle.pid), "/T", "/F"],
+              { stdio: "ignore", windowsHide: true },
+            );
+            escalationSettlement = observeOwnedChild(escalation).terminal;
+          }, PROGRAM_TERM_GRACE_MS);
+        }
+      };
       timer = setTimeout(() => {
-        processHandle?.kill("SIGKILL");
-        finish(new Error(`${command} process-tree snapshot timed out`));
-      }, PROCESS_TABLE_TIMEOUT_MS);
+        terminateAndSettle(
+          new Error(`${command} process-tree snapshot timed out`),
+        );
+      }, timeoutMs);
+      processHandle.stdout?.on("data", () => {
+        if (overflowed) terminateAndSettle(new Error(overflowError));
+      });
     } catch (error) {
       finish(new Error(describeError(error)));
     }
   });
-  return process.platform === "win32"
-    ? parseWindowsProcessTable(output)
-    : parsePosixProcessTable(output, process.platform === "linux");
 }
 
 function parseWindowsProcessTable(output: string): ProcessTableSnapshot {
@@ -1169,6 +1292,19 @@ function result(
   error: string | null,
 ): TriggerProgramRunResult {
   return { status, output: bound(output), exitCode, error: bound(error) };
+}
+
+function containmentFailure(
+  requested: TriggerProgramRunResult,
+  containmentError: string,
+): TriggerProgramRunResult {
+  const detail = `process-tree containment was not proven: ${containmentError}`;
+  return result(
+    requested.status,
+    requested.output,
+    requested.exitCode,
+    requested.error === null ? detail : `${requested.error}; ${detail}`,
+  );
 }
 
 function minimalEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -572,7 +572,7 @@ test("program runner contains descendants when the direct child exits", async ()
 });
 
 test(
-  "program runner rejects an overflowed process-table snapshot instead of proving false quiescence",
+  "program runner preserves cancellation with an overflowed process-table diagnostic",
   { skip: process.platform === "win32" },
   async () => {
     const fixture = await installProcessTableFixture("overflow");
@@ -593,7 +593,8 @@ test(
       pid = Number(await waitForFile(ready));
       controller.abort(new Error("overflow fixture"));
       const result = await running;
-      assert.equal(result.status, "failed");
+      assert.equal(result.status, "cancelled");
+      assert.match(result.error ?? "", /overflow fixture/u);
       assert.match(
         result.error ?? "",
         /process-table snapshot exceeded its 128 KiB bound/u,
@@ -611,7 +612,7 @@ test(
 );
 
 test(
-  "program runner preserves process discovery failure instead of reporting a deadline",
+  "program runner preserves cancellation with a discovery-failure diagnostic",
   { skip: process.platform === "win32" },
   async () => {
     const fixture = await installProcessTableFixture("failure");
@@ -628,7 +629,8 @@ test(
       pid = Number(await waitForFile(ready));
       controller.abort(new Error("discovery failure fixture"));
       const result = await running;
-      assert.equal(result.status, "failed");
+      assert.equal(result.status, "cancelled");
+      assert.match(result.error ?? "", /discovery failure fixture/u);
       assert.match(result.error ?? "", /ps exited with code 7/u);
       assert.doesNotMatch(
         result.error ?? "",

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -13,6 +13,7 @@ import path from "node:path";
 import test from "node:test";
 
 import {
+  captureProcessTableCommandOutput,
   ZenXTriggerProgramRunner,
   realWindowsProcessOperations,
   terminateWindowsProcessIdentity,
@@ -23,6 +24,48 @@ import {
 } from "../src/main/trigger-program-runner.js";
 
 const runner = new ZenXTriggerProgramRunner();
+
+test("timed-out process observation settles its exact helper before rejecting", async () => {
+  let helperClosed = false;
+
+  await assert.rejects(
+    captureProcessTableCommandOutput(
+      process.execPath,
+      ["-e", "setInterval(() => undefined, 1000)"],
+      {
+        timeoutMs: 20,
+        onSpawn: (child) => {
+          child.once("close", () => {
+            helperClosed = true;
+          });
+        },
+      },
+    ),
+    /process-tree snapshot timed out/u,
+  );
+
+  assert.equal(helperClosed, true);
+});
+
+test(
+  "Windows process-table observation stays complete under concurrent cold helpers",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const snapshots = await Promise.all(
+      Array.from({ length: 4 }, async () =>
+        realWindowsProcessOperations.captureProcessTable(),
+      ),
+    );
+
+    for (const snapshot of snapshots) {
+      const current = snapshot.entries.find(
+        (entry) => entry.pid === process.pid,
+      );
+      assert(current !== undefined);
+      assert.match(current.startTime ?? "", /^\d+$/u);
+    }
+  },
+);
 
 test("Windows containment never reuses stale identity evidence for a second tree kill", async () => {
   const root: WindowsProcessIdentity = {
@@ -323,6 +366,68 @@ test("program runner records malformed, nonzero, and oversized outcomes", async 
   );
   assert.equal(oversized.status, "oversized_output");
 });
+
+test(
+  "program runner preserves originating outcomes when process discovery fails",
+  { skip: process.platform !== "win32" },
+  async () => {
+    const discoveryError = "deterministic hosted process observation failure";
+    const constrainedRunner = new ZenXTriggerProgramRunner({
+      captureProcessTable: async () => {
+        throw new Error(discoveryError);
+      },
+      terminateProcessIdentity: async () => ({
+        ok: false,
+        error: "process was not found",
+      }),
+    });
+
+    const run = (
+      args: string[],
+      invocationId: string,
+      signal = new AbortController().signal,
+      timeoutMs?: number,
+    ) =>
+      constrainedRunner.run(
+        {
+          command: process.execPath,
+          args,
+          maxOutputBytes: 256,
+          ...(timeoutMs === undefined ? {} : { timeoutMs }),
+        },
+        { invocationId, stage: "action", event: {} },
+        signal,
+      );
+    const oversized = await run(
+      ["-e", "console.log(JSON.stringify({ok:true, x:'x'.repeat(1000)}))"],
+      "oversized-discovery",
+    );
+    const timedOut = await run(
+      ["-e", "setInterval(() => undefined, 1000)"],
+      "timeout-discovery",
+      undefined,
+      20,
+    );
+    const controller = new AbortController();
+    const cancelledRun = run(
+      ["-e", "setInterval(() => undefined, 1000)"],
+      "cancelled-discovery",
+      controller.signal,
+    );
+    controller.abort(new Error("fixture cancellation"));
+    const cancelled = await cancelledRun;
+
+    for (const [actual, expected] of [
+      [oversized, "oversized_output"],
+      [timedOut, "timed_out"],
+      [cancelled, "cancelled"],
+    ] as const) {
+      assert.equal(actual.status, expected);
+      assert.match(actual.error ?? "", new RegExp(discoveryError, "u"));
+      assert.match(actual.error ?? "", /containment was not proven/u);
+    }
+  },
+);
 
 test("program runner preserves timeout and cancellation outcomes after containment", async () => {
   const timedOut = await runner.run(

--- a/apps/zenx/test/trigger-program-runner.test.ts
+++ b/apps/zenx/test/trigger-program-runner.test.ts
@@ -48,14 +48,12 @@ test("timed-out process observation settles its exact helper before rejecting", 
 });
 
 test(
-  "Windows process-table observation stays complete under concurrent cold helpers",
+  "Windows process-table observation stays complete across repeated cold helpers",
   { skip: process.platform !== "win32" },
   async () => {
-    const snapshots = await Promise.all(
-      Array.from({ length: 4 }, async () =>
-        realWindowsProcessOperations.captureProcessTable(),
-      ),
-    );
+    const snapshots: WindowsProcessTableSnapshot[] = [];
+    for (let attempt = 0; attempt < 4; attempt += 1)
+      snapshots.push(await realWindowsProcessOperations.captureProcessTable());
 
     for (const snapshot of snapshots) {
       const current = snapshot.entries.find(


### PR DESCRIPTION
## Summary

- replace per-snapshot `Get-CimInstance` module startup with a direct, bounded `System.Management` WMI query while preserving PID, parent PID, and creation-time identity
- own the snapshot helper through terminal `close`: timeout and overflow terminate the exact helper, use bounded exact-PID escalation on Windows, and do not return before helper settlement
- retain `oversized_output`, `timed_out`, and `cancelled` as the originating outcome when discovery/containment also fails, while appending the explicit containment failure instead of collapsing the record to generic `failed`
- inject the existing Windows process-operations seam through the runner so discovery-failure/outcome regressions are deterministic

Closes #96

## Root cause

The hosted failures were not evidence that the 4-second bound was inherently too short. Every process-table sample launched a cold Windows PowerShell and autoloaded CimCmdlets for `Get-CimInstance`. When that observation crossed its bound, the collector killed the helper but rejected immediately, before the exact helper emitted `close`; subsequent lifecycle work could overlap the retiring observer. A later observation failure could also replace an already-known program outcome with generic `failed`.

The replacement uses the in-box `System.Management` WMI API directly from the same bounded PowerShell process, avoiding CimCmdlets module startup. The 4-second process-table deadline is unchanged.

## Red to green

A deterministic injected discovery failure initially showed that an originating oversized result returned without its containment/discovery evidence. The regression now covers `oversized_output`, `timed_out`, and `cancelled`, each retaining its classification and explicit `containment was not proven` diagnostic.

A second narrow regression verifies a timed-out observation does not reject until the exact helper has emitted `close`. Existing owned-child tests continue to prove post-spawn `error` is diagnostic-only and a no-PID spawn failure is the only non-close terminal proof.

## Local Windows validation

Exact local head `d53621d6b5e2732652f2d0cd6dd50998bc34c806` (full SHA will be pinned by GitHub after push):

- focused owned-child + trigger runner: 18 passed, 4 platform skips
- repeated hosted regression performs four sequential cold helper snapshots; an additional local stress probe ran five test processes with four concurrent snapshots each (20 complete snapshots) without changing the per-helper 4s deadline
- ZenX typecheck and production build passed
- root lint, typecheck, Node tests (98 passed, 1 platform skip), and IMZen tests (38 passed) passed
- full ZenX test run: 479 passed, 10 skipped; unrelated local Windows filesystem baselines failed with `EPERM` for one atomic rename and the macOS symlink fixture. The atomic-rename case passed in isolated rerun; the symlink restriction is the established local baseline
- changed-file Prettier and `git diff --check` passed
- full-repository Prettier check remains an environmental line-ending baseline in this Windows worktree (214 untouched files reported); changed files pass directly

Fresh exact-head CI run https://github.com/albert-zen/zen/actions/runs/32412204355 passed all 8 jobs. The acceptance-critical Windows WinApp/trigger job passed directly in 48 seconds, ZenX check passed in 1 minute 27 seconds, and the attached-browser smoke passed in 51 seconds. No timeout was increased, no retry was added, and no identity, replacement-process, or quiescence check was weakened.


