### PR TITLE
fix(zenx): keep one browser archive authority

### DIFF
--- a/apps/zenx/resources/providers/README.md
+++ b/apps/zenx/resources/providers/README.md
@@ -19,13 +19,14 @@ again before use; partial, oversized, timed-out, or mismatched responses never
 become cache entries. Provider assembly writes only to the caller's private run
 staging directory.
 
-The browser archive URL, Playwright revision, version, executable path, and
-per-platform SHA-256 are part of the same release lock. Assembly acquires that
-archive through the verified artifact cache, extracts it directly, and never
-invokes Playwright's downloader. The final provider manifest pins both the
-browser executable and a deterministic digest of the complete extracted
-payload; bundled-provider selection and launch verification re-hash them. The
-manifest explicitly excludes only Playwright's root `DEPENDENCIES_VALIDATED`
+The verified browser archive URL and per-platform SHA-256 are the sole archive
+authority in the same release lock as the Playwright revision, version, and
+executable path. Assembly acquires that archive through the verified artifact
+cache, extracts it directly, and never invokes Playwright's downloader. The
+final provider manifest pins both the browser executable and a deterministic
+digest of the complete extracted payload. Bundled-provider selection and
+launch verification re-hash them. The manifest explicitly excludes only
+Playwright's root `DEPENDENCIES_VALIDATED`
 host-validation state file; all archive entries and any other additions remain
 inside the fail-closed digest boundary. The complete directory is re-hashed at
 selection and immediately before each browser launch; later commands against

--- a/apps/zenx/resources/providers/provider-lock.json
+++ b/apps/zenx/resources/providers/provider-lock.json
@@ -33,31 +33,26 @@
     "platformArchives": {
       "win32-x64": {
         "url": "https://storage.googleapis.com/chrome-for-testing-public/152.0.7977.8/win64/chrome-win64.zip",
-        "sourceUrl": "https://cdn.playwright.dev/builds/cft/152.0.7977.8/win64/chrome-win64.zip",
         "sha256": "8bee006dddbee3c428e30cc4b2f9035870b403dc52ffd9bdf2bd3c1bf3822166",
         "executable": "chrome-win64/chrome.exe"
       },
       "darwin-x64": {
         "url": "https://storage.googleapis.com/chrome-for-testing-public/152.0.7977.8/mac-x64/chrome-mac-x64.zip",
-        "sourceUrl": "https://cdn.playwright.dev/builds/cft/152.0.7977.8/mac-x64/chrome-mac-x64.zip",
         "sha256": "d2f6f1b817032dfbc03f80fa304f3a2e91727293ce6e796b248e483ddea32099",
         "executable": "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
       },
       "darwin-arm64": {
         "url": "https://storage.googleapis.com/chrome-for-testing-public/152.0.7977.8/mac-arm64/chrome-mac-arm64.zip",
-        "sourceUrl": "https://cdn.playwright.dev/builds/cft/152.0.7977.8/mac-arm64/chrome-mac-arm64.zip",
         "sha256": "78570bb23c7442f581c2b5f1c86c3e83b68b6cd35424cf390add51a1e305398b",
         "executable": "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
       },
       "linux-x64": {
         "url": "https://storage.googleapis.com/chrome-for-testing-public/152.0.7977.8/linux64/chrome-linux64.zip",
-        "sourceUrl": "https://cdn.playwright.dev/builds/cft/152.0.7977.8/linux64/chrome-linux64.zip",
         "sha256": "931865951a28fccf0491a7f5e0a2fe1a0605765210a4ce4a4758d9d3d97d0b77",
         "executable": "chrome-linux64/chrome"
       },
       "linux-arm64": {
         "url": "https://playwright.download.prss.microsoft.com/dbazure/download/playwright/builds/chromium/1237/chromium-linux-arm64.zip",
-        "sourceUrl": "https://cdn.playwright.dev/dbazure/download/playwright/builds/chromium/1237/chromium-linux-arm64.zip",
         "sha256": "a188a0c13a944da8eb9b327dd473bf0378a10e170b2729d75b7be4520a9cfa1a",
         "executable": "chrome-linux/chrome"
       }

--- a/apps/zenx/test/playwright-browser-assembly.test.mjs
+++ b/apps/zenx/test/playwright-browser-assembly.test.mjs
@@ -49,10 +49,10 @@ test("provider lock is the only Playwright browser archive authority", async () 
       archive.url,
       /^https:\/\/(?:storage\.googleapis\.com|playwright\.download\.prss\.microsoft\.com)\//u,
     );
-    assert.match(archive.sourceUrl, /^https:\/\/cdn\.playwright\.dev\//u);
     assert.match(archive.sha256, /^[a-f0-9]{64}$/u);
     assert.equal(typeof archive.executable, "string");
     assert.ok(archive.executable.length > 0);
+    assert.equal("sourceUrl" in archive, false);
   }
   const assemblySource = await readFile(
     path.join(repositoryRoot, "scripts", "assemble-zenx-providers.mjs"),
@@ -62,7 +62,7 @@ test("provider lock is the only Playwright browser archive authority", async () 
   assert.doesNotMatch(assemblySource, /PLAYWRIGHT_DOWNLOAD_HOST/u);
 });
 
-test("browser assembly fails closed on digest and reuses verified cache offline", async () => {
+test("browser assembly rejects a wrong archive mapping and reuses verified cache offline", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-browser-assembly-test-"),
   );
@@ -134,7 +134,7 @@ test("browser assembly fails closed on digest and reuses verified cache offline"
           platformArchives: {
             [platformKey]: {
               ...pin.platformArchives[platformKey],
-              sha256: "0".repeat(64),
+              url: `${server.url}/wrong-browser.tar`,
             },
           },
         },
@@ -241,8 +241,16 @@ test("browser assembly fails closed on digest and reuses verified cache offline"
 });
 
 async function createArchiveServer(archive, size, onRequest) {
-  const server = createServer((_request, response) => {
+  const server = createServer((request, response) => {
     onRequest();
+    if (request.url === "/wrong-browser.tar") {
+      const wrongArchive = Buffer.from("not the pinned browser archive");
+      response.writeHead(200, {
+        "content-length": String(wrongArchive.byteLength),
+      });
+      response.end(wrongArchive);
+      return;
+    }
     response.writeHead(200, { "content-length": String(size) });
     createReadStream(archive).pipe(response);
   });


### PR DESCRIPTION
Closes #97.

## Current-main audit

| Requirement | Current-main result | Implementation / evidence |
| --- | --- | --- |
| Browser archive identity and verified acquisition | The browser revision, version, platform executable, digest, and archive URL are already pinned and `assemblePlaywrightBrowser` already calls the shared `acquireVerifiedArtifact`. One authority defect remained: each platform also advertised an unused, different `sourceUrl`, while assembly trusted only `url`. | Remove the non-consumed second URL so the verified `url` + SHA-256 pair is the sole archive authority. The regression requires exactly that shape and feeds wrong bytes through the authoritative URL to prove digest rejection and no payload publication. |
| Packaged runtime launches the verified browser | Already solved on current main. The manifest covers the complete browser directory plus executable; selection and pre-launch bind re-hash them; packaged Playwright receives the bundled `PLAYWRIGHT_BROWSERS_PATH` and explicit `--browser chromium`. | Existing provisioning, catalog, provider-launch, and packaged-smoke tests pass. Real Windows packaged smoke selected `playwright-cli` 0.1.18 with `integrity: verified`, launched and inspected the bundled Chromium page successfully. |
| Portable/smoke build snapshot isolation | Already solved on current main. `createBuildSnapshot` sends electron-vite output to a private per-run staging directory before either target packages it; app and smoke retain separate publication locks. | Existing deterministic cross-command test passed 10/10 under `--test-concurrency=1`. Real portable and packaged smoke both completed through private run directories. |

## Red to green

Before the lock edit, the focused authority test failed because all five platform entries exposed `sourceUrl` in addition to the only URL acquisition actually consumes. After the edit, browser lock/acquisition assembly tests pass, including wrong mapping/no browser publication and offline verified-cache reuse.

## Verification at `874dca53dcf9f3f6a4731b551ad90369df90a31e`

- focused acquisition / browser assembly / provisioning / catalog / runtime-launch suite: 42 passed, 1 intentional POSIX skip
- cross-command private snapshot race: 10 repeated runs passed
- ZenX typecheck: passed
- ZenX production build: passed
- root lint, typecheck, Node tests (98 passed, 1 Windows skip), and IMZen tests (38 passed): passed
- full ZenX suite: 486 passed, 11 skips; two unrelated Windows-host baselines failed (`EPERM` for unprivileged symlink creation and a concurrent credential-vault rename)
- real Windows `package:portable`: passed; 619,693,550-byte provider assembly, manifest `d48342242587964979787ed63e4ba233ec30b0467f06d76cb5697b7480ca1289`
- real Windows `smoke:packaged`: passed and actually launched/inspected the verified bundled Chromium payload; bundled WinApp selection was also verified
- touched-file Prettier and `git diff --check`: passed

No provider-lock product contents, acquisition/cache implementation, fallback policy, lifecycle/state machine, or #95 packaging scope changed. The post-#92 audit intentionally retains the transaction module's hidden `.transactions` directory; old draft #115's pre-#92 exact cache-directory assertion is obsolete.