### PR TITLE
fix(subscription): renew rejected access leases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -353,7 +353,9 @@ Zen 只在 Codex 0.146.0 没有等价原子语义时增加一项明确命名的�
   Item 改变 Thread。
 - **SubscriptionAuthProfile** — 宿主持有的 OAuth credential store 与
   request-time token resolver；它位于 Core 外，不进入 ItemList，ModelAdapter
-  只拿一次请求所需的 access lease。provider 的 sessionId 只允许作为可丢弃的
+  只拿一次请求所需的 access lease；服务端提前拒绝仍未到期的 lease 时，adapter
+  只允许按被拒 access token 作为跨进程比较条件刷新并重试一次，避免并发刷新覆盖
+  已轮换 credential。provider 的 sessionId 只允许作为可丢弃的
   transport cache / affinity hint，不得映射或持久化第二套 Thread。
 - **工具** — shell 等工具的实际执行。
 - **审批** — 审批请求的呈现与应答（各接入端自行实现 UI）。

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -146,6 +146,8 @@ function createModel(
     return new OpenAiSubscriptionModel({
       acquireAccessLease: async (signal) =>
         await profile.acquireAccessLease(signal),
+      renewAccessLease: async (rejectedAccessToken, signal) =>
+        await profile.renewAccessLease(rejectedAccessToken, signal),
       fetch,
     });
   }

--- a/apps/cli/src/subscription-auth.ts
+++ b/apps/cli/src/subscription-auth.ts
@@ -202,6 +202,37 @@ export class OpenAiSubscriptionAuthProfile {
     }
     return { accessToken: credential.access };
   }
+
+  async renewAccessLease(
+    rejectedAccessToken: string,
+    signal: AbortSignal,
+  ): Promise<OpenAiSubscriptionAccessLease> {
+    signal.throwIfAborted();
+    const credential = await this.#store.modify(async (current) => {
+      if (current === undefined) {
+        throw new Error(
+          "OpenAI subscription is not authenticated; run `zen auth login`",
+        );
+      }
+      if (current.access !== rejectedAccessToken) {
+        return undefined;
+      }
+      return await refreshCredential(
+        current.refresh,
+        this.#fetch,
+        this.#tokenEndpoint,
+        signal,
+        this.#now,
+      );
+    }, signal);
+    signal.throwIfAborted();
+    if (credential === undefined) {
+      throw new Error(
+        "OpenAI subscription is not authenticated; run `zen auth login`",
+      );
+    }
+    return { accessToken: credential.access };
+  }
 }
 
 export class SubscriptionCredentialStore {

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -42,7 +42,12 @@ export class ZenXSettingsService {
     OpenAiSubscriptionAuthProfile,
     "login" | "logout" | "status"
   > &
-    Partial<Pick<OpenAiSubscriptionAuthProfile, "acquireAccessLease">>;
+    Partial<
+      Pick<
+        OpenAiSubscriptionAuthProfile,
+        "acquireAccessLease" | "renewAccessLease"
+      >
+    >;
   readonly #vault: ZenXCredentialVault;
   readonly #projectPlatform: NodeJS.Platform;
   readonly #projectRealpath: ProjectRealpath | undefined;
@@ -66,7 +71,13 @@ export class ZenXSettingsService {
     subscription?: Pick<
       OpenAiSubscriptionAuthProfile,
       "login" | "logout" | "status"
-    >;
+    > &
+      Partial<
+        Pick<
+          OpenAiSubscriptionAuthProfile,
+          "acquireAccessLease" | "renewAccessLease"
+        >
+      >;
     projectPlatform?: NodeJS.Platform;
     projectRealpath?: ProjectRealpath;
   }) {
@@ -149,10 +160,21 @@ export class ZenXSettingsService {
       if (acquireAccessLease === undefined) {
         throw new Error("Title model subscription is unavailable");
       }
+      const renewAccessLease = this.#subscription.renewAccessLease;
       return {
         adapter: new OpenAiSubscriptionModel({
           acquireAccessLease: async (signal) =>
             await acquireAccessLease.call(this.#subscription, signal),
+          ...(renewAccessLease === undefined
+            ? {}
+            : {
+                renewAccessLease: async (rejectedAccessToken, signal) =>
+                  await renewAccessLease.call(
+                    this.#subscription,
+                    rejectedAccessToken,
+                    signal,
+                  ),
+              }),
           instructions:
             "Return only a concise display title of at most 64 characters. Do not include quotes, IDs, labels, or punctuation boilerplate.",
         }),

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -652,6 +652,90 @@ test("clears the OAuth concurrency guard after failure so login can retry", asyn
   }
 });
 
+test("title inference renews a subscription lease rejected after acquisition", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-title-auth-"));
+  const profileStore = new ZenXHostProfileStore(
+    path.join(directory, "host-profile.json"),
+  );
+  await profileStore.write({
+    version: 1,
+    onboardingComplete: true,
+    provider: {
+      type: "openai-subscription",
+      displayName: "OpenAI subscription",
+    },
+    defaultModel: "gpt-5.6-terra",
+    titleModel: "gpt-5.6-luna",
+    models: ["gpt-5.6-terra"],
+    workspace: directory,
+    workspaces: [directory],
+    lastUsedWorkspace: directory,
+    pinnedThreadIds: [],
+    sidebarOrder: { projectKeys: [], threadIdsByProject: {} },
+    approvalPolicy: "never",
+  });
+  const rejected = subscriptionJwt("rejected");
+  const renewed = subscriptionJwt("renewed");
+  let renewals = 0;
+  const subscription = {
+    login: async () => undefined,
+    logout: async () => undefined,
+    status: async () => ({ authenticated: true, expired: false }),
+    acquireAccessLease: async () => ({ accessToken: rejected }),
+    renewAccessLease: async (rejectedAccessToken: string) => {
+      assert.equal(rejectedAccessToken, rejected);
+      renewals += 1;
+      return { accessToken: renewed };
+    },
+  };
+  const authorizations: string[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) => {
+    const authorization = new Headers(init?.headers).get("authorization")!;
+    authorizations.push(authorization);
+    return authorization === `Bearer ${rejected}`
+      ? new Response(null, { status: 401 })
+      : new Response(
+          'data: {"type":"response.completed","response":{"status":"completed","output":[]}}\r\n\r\ndata: [DONE]\r\n\r\n',
+          { status: 200 },
+        );
+  };
+  try {
+    const service = new ZenXSettingsService({
+      userDataDirectory: directory,
+      zenDataDirectory: path.join(directory, "zen"),
+      vault: new ZenXCredentialVault(
+        path.join(directory, "credentials.vault"),
+        encryption,
+      ),
+      profileStore,
+      subscription,
+    });
+    await service.initialize({});
+    const configured = await service.titleModel();
+    assert.equal(configured.model, "gpt-5.6-luna");
+    const adapter = configured.adapter;
+    assert.notEqual(adapter, null);
+    if (adapter === null) throw new Error("expected a title model adapter");
+    for await (const _event of adapter.stream({
+      model: configured.model,
+      messages: [{ role: "user", text: "Name this Thread" }],
+      tools: [],
+      signal: new AbortController().signal,
+    })) {
+      // Completion without content is sufficient to prove the retry boundary.
+    }
+    assert.equal(renewals, 1);
+    assert.deepEqual(authorizations, [
+      `Bearer ${rejected}`,
+      `Bearer ${renewed}`,
+    ]);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 async function exerciseAliasWorkspaceMutations(
   type: "dir" | "junction",
 ): Promise<void> {
@@ -957,6 +1041,16 @@ function compatibleEnvironment(name: string): NodeJS.ProcessEnv {
     ZENX_MODEL: `${name}-model`,
     ZENX_MODELS: `${name}-model`,
   };
+}
+
+function subscriptionJwt(marker: string): string {
+  const encode = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none", marker })}.${encode({
+    "https://api.openai.com/auth": {
+      chatgpt_account_id: "acct_zenx_settings_test",
+    },
+  })}.signature`;
 }
 
 function deferred(): { promise: Promise<void>; resolve(): void } {

--- a/src/model/openai-subscription.ts
+++ b/src/model/openai-subscription.ts
@@ -21,6 +21,10 @@ export interface OpenAiSubscriptionModelOptions {
   acquireAccessLease: (
     signal: AbortSignal,
   ) => Promise<OpenAiSubscriptionAccessLease>;
+  renewAccessLease?: (
+    rejectedAccessToken: string,
+    signal: AbortSignal,
+  ) => Promise<OpenAiSubscriptionAccessLease>;
   endpoint?: string;
   fetch?: typeof globalThis.fetch;
   instructions?: string;
@@ -35,12 +39,15 @@ export class OpenAiSubscriptionModel implements ModelAdapter {
   readonly provider = "openai-codex";
 
   readonly #acquireAccessLease: OpenAiSubscriptionModelOptions["acquireAccessLease"];
+  readonly #renewAccessLease:
+    OpenAiSubscriptionModelOptions["renewAccessLease"] | undefined;
   readonly #endpoint: string;
   readonly #fetch: typeof globalThis.fetch;
   readonly #instructions: string;
 
   constructor(options: OpenAiSubscriptionModelOptions) {
     this.#acquireAccessLease = options.acquireAccessLease;
+    this.#renewAccessLease = options.renewAccessLease;
     this.#endpoint = subscriptionEndpoint(options.endpoint ?? defaultEndpoint);
     this.#fetch = options.fetch ?? globalThis.fetch;
     this.#instructions =
@@ -49,15 +56,6 @@ export class OpenAiSubscriptionModel implements ModelAdapter {
 
   async *stream(request: ModelRequest): AsyncIterable<ModelEvent> {
     request.signal.throwIfAborted();
-    const lease = await this.#acquireAccessLease(request.signal);
-    const accessToken = requiredSecret(lease.accessToken);
-    const accountId = extractChatGptAccountId(accessToken);
-    const signal =
-      lease.signal === undefined
-        ? request.signal
-        : AbortSignal.any([request.signal, lease.signal]);
-    signal.throwIfAborted();
-
     const tools = request.tools.map(toResponsesTool);
     const allowedToolNames = new Set(tools.map((tool) => tool.name));
     const sessionHint = promptCacheHint(request.sessionId);
@@ -74,33 +72,18 @@ export class OpenAiSubscriptionModel implements ModelAdapter {
       ...(sessionHint === undefined ? {} : { prompt_cache_key: sessionHint }),
     });
 
-    const headers = new Headers({
-      accept: "text/event-stream",
-      authorization: `Bearer ${accessToken}`,
-      "chatgpt-account-id": accountId,
-      "content-type": "application/json",
-      "openai-beta": "responses=experimental",
-      originator: "zen",
-      "user-agent": "zen/0.1.0",
-    });
-    if (sessionHint !== undefined) {
-      headers.set("session-id", sessionHint);
-      headers.set("x-client-request-id", sessionHint);
-    }
+    let lease = await this.#acquireAccessLease(request.signal);
+    let accessToken = requiredSecret(lease.accessToken);
+    let signal = accessLeaseSignal(request.signal, lease.signal);
+    let response = await this.#request(body, sessionHint, accessToken, signal);
 
-    let response: Response;
-    try {
-      response = await this.#fetch(this.#endpoint, {
-        method: "POST",
-        body,
-        headers,
-        signal,
-      });
-    } catch {
-      signal.throwIfAborted();
-      throw new Error(
-        "OpenAI subscription model request failed before receiving a response",
-      );
+    if (response.status === 401 && this.#renewAccessLease !== undefined) {
+      await response.body?.cancel().catch(() => undefined);
+      request.signal.throwIfAborted();
+      lease = await this.#renewAccessLease(accessToken, request.signal);
+      accessToken = requiredSecret(lease.accessToken);
+      signal = accessLeaseSignal(request.signal, lease.signal);
+      response = await this.#request(body, sessionHint, accessToken, signal);
     }
 
     if (!response.ok) {
@@ -120,6 +103,53 @@ export class OpenAiSubscriptionModel implements ModelAdapter {
       accessToken,
     );
   }
+
+  async #request(
+    body: string,
+    sessionHint: string | undefined,
+    accessToken: string,
+    signal: AbortSignal,
+  ): Promise<Response> {
+    signal.throwIfAborted();
+    const headers = new Headers({
+      accept: "text/event-stream",
+      authorization: `Bearer ${accessToken}`,
+      "chatgpt-account-id": extractChatGptAccountId(accessToken),
+      "content-type": "application/json",
+      "openai-beta": "responses=experimental",
+      originator: "zen",
+      "user-agent": "zen/0.1.0",
+    });
+    if (sessionHint !== undefined) {
+      headers.set("session-id", sessionHint);
+      headers.set("x-client-request-id", sessionHint);
+    }
+    try {
+      return await this.#fetch(this.#endpoint, {
+        method: "POST",
+        body,
+        headers,
+        signal,
+      });
+    } catch {
+      signal.throwIfAborted();
+      throw new Error(
+        "OpenAI subscription model request failed before receiving a response",
+      );
+    }
+  }
+}
+
+function accessLeaseSignal(
+  requestSignal: AbortSignal,
+  leaseSignal: AbortSignal | undefined,
+): AbortSignal {
+  const signal =
+    leaseSignal === undefined
+      ? requestSignal
+      : AbortSignal.any([requestSignal, leaseSignal]);
+  signal.throwIfAborted();
+  return signal;
 }
 
 interface ResponsesTool {

--- a/test/openai-subscription.test.ts
+++ b/test/openai-subscription.test.ts
@@ -9,8 +9,11 @@ import {
   SubscriptionCredentialStore,
   type OAuthCredential,
 } from "../apps/cli/src/subscription-auth.js";
+import { createHostedAppServer } from "../apps/cli/src/host.js";
+import { InMemoryThreadJournal } from "../src/journal.js";
 import type { ModelEvent, ModelRequest, ModelTool } from "../src/model.js";
 import { OpenAiSubscriptionModel } from "../src/model/openai-subscription.js";
+import { InMemoryThreadMetadataStore } from "../src/thread-metadata.js";
 
 const accountId = "acct_zen_test";
 const secretAccessToken = jwt(accountId);
@@ -371,6 +374,194 @@ test("a fresh adapter rebuilds a tool round only from canonical messages", async
   ]);
 });
 
+test("renews a rejected access lease once before exposing HTTP 401", async () => {
+  const refreshedAccessToken = jwt(accountId, "refreshed");
+  const authorizations: string[] = [];
+  let renewals = 0;
+  const adapter = new OpenAiSubscriptionModel({
+    acquireAccessLease: async () => ({ accessToken: secretAccessToken }),
+    renewAccessLease: async (rejectedAccessToken) => {
+      renewals += 1;
+      assert.equal(rejectedAccessToken, secretAccessToken);
+      return { accessToken: refreshedAccessToken };
+    },
+    fetch: async (_input, init) => {
+      authorizations.push(new Headers(init?.headers).get("authorization")!);
+      return new Response(null, { status: 401 });
+    },
+  });
+
+  await assert.rejects(
+    async () => await collect(adapter.stream(request())),
+    /request failed with HTTP 401/u,
+  );
+  assert.equal(renewals, 1);
+  assert.deepEqual(authorizations, [
+    `Bearer ${secretAccessToken}`,
+    `Bearer ${refreshedAccessToken}`,
+  ]);
+});
+
+test("independent title and Agent profiles converge after a rejected access token", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zen-auth-divergence-"));
+  const profilePath = path.join(root, "openai-subscription-auth.json");
+  const rejectedAccessToken = jwt(accountId, "rejected");
+  const refreshedAccessToken = jwt(accountId, "renewed");
+  const store = new SubscriptionCredentialStore(profilePath);
+  await store.modify(async () => ({
+    type: "oauth",
+    access: rejectedAccessToken,
+    refresh: "rotating-refresh",
+    expires: Date.now() + 3_600_000,
+    accountId,
+  }));
+  let refreshes = 0;
+  const tokenFetch: typeof globalThis.fetch = async (_input, init) => {
+    const body = new URLSearchParams(String(init?.body));
+    assert.equal(body.get("grant_type"), "refresh_token");
+    assert.equal(body.get("refresh_token"), "rotating-refresh");
+    refreshes += 1;
+    return Response.json({
+      access_token: refreshedAccessToken,
+      refresh_token: "renewed-refresh",
+      expires_in: 3600,
+    });
+  };
+  const titleProfile = new OpenAiSubscriptionAuthProfile(profilePath, {
+    fetch: tokenFetch,
+    tokenEndpoint: "https://example.test/oauth/token",
+  });
+  const agentProfile = new OpenAiSubscriptionAuthProfile(profilePath, {
+    fetch: tokenFetch,
+    tokenEndpoint: "https://example.test/oauth/token",
+  });
+  const completed = (): Response =>
+    sseResponse([
+      {
+        type: "response.completed",
+        response: { status: "completed", output: [] },
+      },
+    ]);
+  const title = new OpenAiSubscriptionModel({
+    acquireAccessLease: async (signal) =>
+      await titleProfile.acquireAccessLease(signal),
+    renewAccessLease: async (rejected, signal) =>
+      await titleProfile.renewAccessLease(rejected, signal),
+    fetch: async () => completed(),
+  });
+  const agentAuthorizations: string[] = [];
+  const agent = new OpenAiSubscriptionModel({
+    acquireAccessLease: async (signal) =>
+      await agentProfile.acquireAccessLease(signal),
+    renewAccessLease: async (rejected, signal) =>
+      await agentProfile.renewAccessLease(rejected, signal),
+    fetch: async (_input, init) => {
+      const authorization = new Headers(init?.headers).get("authorization")!;
+      agentAuthorizations.push(authorization);
+      return authorization === `Bearer ${rejectedAccessToken}`
+        ? new Response(null, { status: 401 })
+        : completed();
+    },
+  });
+
+  try {
+    await collect(title.stream(request({ model: "gpt-5.6-luna" })));
+    await collect(agent.stream(request({ model: "gpt-5.6-terra" })));
+
+    assert.equal(refreshes, 1);
+    assert.deepEqual(agentAuthorizations, [
+      `Bearer ${rejectedAccessToken}`,
+      `Bearer ${refreshedAccessToken}`,
+    ]);
+    assert.equal(
+      (await new SubscriptionCredentialStore(profilePath).read())?.access,
+      refreshedAccessToken,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("the hosted App Server renews a rejected subscription lease", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zen-host-auth-renewal-"));
+  const profilePath = path.join(root, "openai-subscription-auth.json");
+  const rejectedAccessToken = jwt(accountId, "host-rejected");
+  const refreshedAccessToken = jwt(accountId, "host-renewed");
+  await new SubscriptionCredentialStore(profilePath).modify(async () => ({
+    type: "oauth",
+    access: rejectedAccessToken,
+    refresh: "host-refresh",
+    expires: Date.now() + 3_600_000,
+    accountId,
+  }));
+  const authorizations: string[] = [];
+  let refreshes = 0;
+  const providerFetch: typeof globalThis.fetch = async (input, init) => {
+    if (String(input).includes("/oauth/token")) {
+      refreshes += 1;
+      return Response.json({
+        access_token: refreshedAccessToken,
+        refresh_token: "host-renewed-refresh",
+        expires_in: 3600,
+      });
+    }
+    const authorization = new Headers(init?.headers).get("authorization")!;
+    authorizations.push(authorization);
+    return authorization === `Bearer ${rejectedAccessToken}`
+      ? new Response(null, { status: 401 })
+      : sseResponse([
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { type: "message", id: "msg_host", content: [] },
+          },
+          {
+            type: "response.output_text.delta",
+            output_index: 0,
+            delta: "renewed",
+          },
+          {
+            type: "response.completed",
+            response: { status: "completed", output: [] },
+          },
+        ]);
+  };
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = providerFetch;
+  let host: ReturnType<typeof createHostedAppServer>;
+  try {
+    host = createHostedAppServer({
+      cwd: root,
+      dataDirectory: root,
+      model: "gpt-5.6-terra",
+      approvalPolicy: "never",
+      provider: { type: "openai-subscription", profilePath },
+      journal: new InMemoryThreadJournal(),
+      threadMetadata: new InMemoryThreadMetadataStore(),
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  try {
+    const thread = await host.startThread();
+    const turn = await host.startTurn(thread.id, "hello");
+    await turn.done;
+    assert.equal(
+      (await host.readThread(thread.id)).turns[0]?.status,
+      "completed",
+    );
+    assert.equal(refreshes, 1);
+    assert.deepEqual(authorizations, [
+      `Bearer ${rejectedAccessToken}`,
+      `Bearer ${refreshedAccessToken}`,
+    ]);
+  } finally {
+    await host.closeProviderTransport();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("redacts an access token if a provider error echoes it", async () => {
   const adapter = new OpenAiSubscriptionModel({
     acquireAccessLease: async () => ({ accessToken: secretAccessToken }),
@@ -554,6 +745,54 @@ test("serializes rotating refresh across independent profile instances", async (
   assert.equal(stored.includes("single-use-refresh"), false);
 });
 
+test("serializes rejected-token renewal across independent profile instances", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "zen-rejected-refresh-"));
+  const profilePath = path.join(root, "openai-subscription-auth.json");
+  const rejectedAccessToken = jwt(accountId, "rejected-concurrent");
+  const refreshedAccessToken = jwt(accountId, "refreshed-concurrent");
+  const store = new SubscriptionCredentialStore(profilePath);
+  await store.modify(async () => ({
+    type: "oauth",
+    access: rejectedAccessToken,
+    refresh: "single-use-rejected-refresh",
+    expires: Date.now() + 3_600_000,
+    accountId,
+  }));
+  let refreshes = 0;
+  const fetch: typeof globalThis.fetch = async (_input, init) => {
+    const body = new URLSearchParams(String(init?.body));
+    assert.equal(body.get("refresh_token"), "single-use-rejected-refresh");
+    refreshes += 1;
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    return Response.json({
+      access_token: refreshedAccessToken,
+      refresh_token: "rotated-rejected-refresh",
+      expires_in: 3600,
+    });
+  };
+  const first = new OpenAiSubscriptionAuthProfile(profilePath, {
+    fetch,
+    tokenEndpoint: "https://example.test/oauth/token",
+  });
+  const second = new OpenAiSubscriptionAuthProfile(profilePath, {
+    fetch,
+    tokenEndpoint: "https://example.test/oauth/token",
+  });
+  const signal = new AbortController().signal;
+
+  try {
+    const [left, right] = await Promise.all([
+      first.renewAccessLease(rejectedAccessToken, signal),
+      second.renewAccessLease(rejectedAccessToken, signal),
+    ]);
+    assert.equal(refreshes, 1);
+    assert.equal(left.accessToken, refreshedAccessToken);
+    assert.equal(right.accessToken, refreshedAccessToken);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("aborts promptly while another process owns the profile lock", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "zen-lock-abort-"));
   const profilePath = path.join(root, "openai-subscription-auth.json");
@@ -627,10 +866,10 @@ function sseResponse(events: readonly Record<string, unknown>[]): Response {
   );
 }
 
-function jwt(id: string): string {
+function jwt(id: string, marker = "default"): string {
   const encode = (value: unknown): string =>
     Buffer.from(JSON.stringify(value)).toString("base64url");
-  return `${encode({ alg: "none" })}.${encode({
+  return `${encode({ alg: "none", marker })}.${encode({
     "https://api.openai.com/auth": { chatgpt_account_id: id },
   })}.signature`;
 }


### PR DESCRIPTION
## Summary
- renew an OpenAI subscription lease when the server rejects it with HTTP 401 before its stored expiry
- coordinate title and hosted Agent profiles through the existing cross-process credential lock
- retry the exact request once and preserve the existing terminal 401 after that bound

## Verification
- focused subscription + ZenX Settings tests: 32 passed, 2 platform skips
- root test suite: 102 passed, 1 skip
- full ZenX suite: 488 passed, 11 skips; 1 unrelated Windows symlink EPERM fixture failure
- root and ZenX typechecks
- ZenX production build
- changed-file Prettier and git diff --check

Closes #133