### PR TITLE
Optimize ZenX prepared CI lifecycle

### DIFF
--- a/apps/zenx/package.json
+++ b/apps/zenx/package.json
@@ -11,12 +11,14 @@
     "prepare:first-party-plugins": "node ./scripts/pack-first-party-plugins.mjs ./resources",
     "prebuild": "npm run prepare:first-party-plugins",
     "build": "electron-vite build",
+    "build:prepared": "electron-vite build",
     "brand:generate": "node ./scripts/generate-brand-assets.mjs",
     "brand:check": "node ./scripts/generate-brand-assets.mjs --check",
     "pretypecheck": "npm run prepare:plugin-sdk",
     "typecheck": "tsc -p tsconfig.node.json --noEmit --pretty false && tsc -p tsconfig.web.json --noEmit --pretty false",
     "pretest": "npm run prepare:first-party-plugins",
     "test": "tsx --test test/**/*.test.ts test/**/*.test.mjs",
+    "test:prepared": "tsx --test test/**/*.test.ts test/**/*.test.mjs",
     "test:project-identity": "tsx --test test/project-projection.test.ts test/settings-service.test.ts test/self-control-capability.test.ts",
     "stress:hosted-flakes": "node ./scripts/stress-hosted-flakes.mjs",
     "smoke:capabilities": "npm run smoke:packaged",
@@ -30,7 +32,7 @@
     "smoke:windows-projects": "powershell -NoProfile -ExecutionPolicy Bypass -File ./scripts/windows-project-workspace-smoke.ps1",
     "smoke:windows-user-browser": "tsx src/main/user-browser-smoke.ts",
     "smoke:providers": "npm run build && electron ./out/main/provider-smoke.js",
-    "check": "npm run brand:check && npm run typecheck && npm test && npm run build"
+    "check": "npm run brand:check && npm run typecheck && npm run prepare:first-party-plugins && npm run test:prepared && npm run build:prepared"
   },
   "dependencies": {
     "@zenx/plugin-sdk": "0.1.0",

--- a/apps/zenx/test/first-party-remaining-profile.test.ts
+++ b/apps/zenx/test/first-party-remaining-profile.test.ts
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { packZenXFirstPartyPlugins } from "../scripts/pack-first-party-plugins.mjs";
 import { ZenXCapabilityService } from "../src/main/capability-service.js";
 import { ZenXTriggersCapabilityPackage } from "../src/main/capabilities/automation-control-package.js";
 import type { ZenXAutomationControlPort } from "../src/main/capabilities/automation-control-package.js";
@@ -32,6 +31,17 @@ import {
 const pnpmCli = fileURLToPath(
   new URL("../../../node_modules/pnpm/bin/pnpm.cjs", import.meta.url),
 );
+const preparedPluginsDirectory = fileURLToPath(
+  new URL("../resources/plugins/", import.meta.url),
+);
+
+async function copyPreparedFirstPartyPlugins(
+  outputDirectory: string,
+): Promise<void> {
+  await cp(preparedPluginsDirectory, path.join(outputDirectory, "plugins"), {
+    recursive: true,
+  });
+}
 
 test("remaining first-party tarballs install, invoke, cycle lifecycle, and restart offline", async () => {
   const root = await mkdtemp(
@@ -39,7 +49,7 @@ test("remaining first-party tarballs install, invoke, cycle lifecycle, and resta
   );
   const userData = path.join(root, "user-data");
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   const selfPort = new MutableAppServerRequestPort();
   await selfPort.attach({ request: async () => ({ data: [] }) as never });
   const self = new ZenXSelfControlCapabilityPackage({ appServer: selfPort });
@@ -211,7 +221,7 @@ test("an uninstalled Browser reinstalls the current Host-selected App Resource v
   );
   const resources = path.join(root, "resources");
   const userData = path.join(root, "user-data");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   const environment: NodeJS.ProcessEnv = {
     PATH: "",
     ZENX_BROWSER_MODE: "user-session",
@@ -283,7 +293,7 @@ test("provider variant admission and Catalog failures retain the old backend and
   );
   const userData = path.join(root, "user-data");
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   const oldBackend = trackedBrowserBackend("old");
   const environment: NodeJS.ProcessEnv = {
     PATH: "",
@@ -343,7 +353,7 @@ test("provider variant admission and Catalog failures retain the old backend and
     await assert.rejects(service.resetTransient());
     await assertOldProvider(service, userData, committed, "user-browser-cdp");
 
-    await packZenXFirstPartyPlugins({ outputDirectory: resources });
+    await copyPreparedFirstPartyPlugins(resources);
     store.failNextSave();
     await assert.rejects(
       service.resetTransient(),
@@ -373,7 +383,7 @@ test("restart keeps a committed Browser backend isolated from a different curren
     path.join(os.tmpdir(), "zenx-browser-restart-variant-"),
   );
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   try {
     for (const direction of [
       {
@@ -508,7 +518,7 @@ test("restart keeps a committed Browser backend isolated from a different curren
 test("remaining first-party packages adopt every legacy Catalog lifecycle through the canonical installer", async (t) => {
   const root = await mkdtemp(path.join(os.tmpdir(), "zenx-first-party-adopt-"));
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   try {
     for (const lifecycle of ["enabled", "installed", "uninstalled"] as const) {
       await t.test(lifecycle, async () => {
@@ -568,7 +578,7 @@ test("ordinary tarballs cannot claim any remaining first-party trusted runtime",
     path.join(os.tmpdir(), "zenx-first-party-untrusted-"),
   );
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   const service = new ZenXCapabilityService({
     userDataDirectory: path.join(root, "user-data"),
     pnpmCliPath: pnpmCli,
@@ -596,7 +606,7 @@ test("profile-managed Computer remains absent on Linux and unavailable Windows p
     path.join(os.tmpdir(), "zenx-computer-profile-gates-"),
   );
   const resources = path.join(root, "resources");
-  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  await copyPreparedFirstPartyPlugins(resources);
   try {
     for (const platform of ["linux", "win32"] as const) {
       await t.test(platform, async () => {


### PR DESCRIPTION
## Summary
- prepare first-party plugin tarballs once in the composed ZenX check
- reuse isolated copies of prepared tarballs in first-party lifecycle fixtures
- preserve standalone test/build preparation and real clean packaging coverage

## Evidence
- local test phase: 253.30s -> 49.36s
- repeated lifecycle file: 216.76s -> 22.52s
- exact test selection remains 691 cases (681 pass / 10 skip on hosted baseline)
- independent R1 review PASS

## Validation
- focused packaging/profile: 22/22 pass
- standalone production build with preparation: pass
- ZenX typecheck and prepared build: pass
- root npm test and npm run check: pass
- git diff --check: pass

Hosted CI must confirm the required ZenX critical path completes successfully in <=7 minutes.