### PR TITLE
Isolate bundled plugin startup failures

### DIFF
--- a/apps/zenx/src/main/bundled-plugin-startup.ts
+++ b/apps/zenx/src/main/bundled-plugin-startup.ts
@@ -1,0 +1,102 @@
+import path from "node:path";
+
+import type { ZenXCapabilityService } from "./capability-service.js";
+import { ZENX_ROOMS_CAPABILITY_ID } from "./capabilities/automation-control-package.js";
+import {
+  FIRST_PARTY_PLUGIN_PACKAGES,
+  firstPartyProviderTarball,
+} from "./first-party-profile-loader.js";
+import {
+  ZENX_ROOMS_PACKAGE_NAME,
+  ZENX_ROOMS_TARBALL,
+} from "./rooms-profile-loader.js";
+
+export async function installZenXBundledPluginsAtStartup(
+  capabilities: ZenXCapabilityService,
+  resourcesDirectory: string,
+): Promise<void> {
+  await isolateBundledPluginInstall(
+    capabilities,
+    ZENX_ROOMS_CAPABILITY_ID,
+    async () => {
+      const installedRooms = capabilities
+        .pluginSnapshot()
+        .plugins.find((plugin) => plugin.id === ZENX_ROOMS_CAPABILITY_ID);
+      if (installedRooms?.profileSource !== undefined) return;
+      await capabilities.installBundledPluginPackage(
+        path.join(resourcesDirectory, "plugins", ZENX_ROOMS_TARBALL),
+        {
+          pluginId: ZENX_ROOMS_CAPABILITY_ID,
+          packageName: ZENX_ROOMS_PACKAGE_NAME,
+        },
+      );
+    },
+  );
+  for (const definition of [
+    FIRST_PARTY_PLUGIN_PACKAGES.browser,
+    FIRST_PARTY_PLUGIN_PACKAGES.computer,
+    FIRST_PARTY_PLUGIN_PACKAGES.selfControl,
+    FIRST_PARTY_PLUGIN_PACKAGES.triggers,
+  ]) {
+    await isolateBundledPluginInstall(
+      capabilities,
+      definition.pluginId,
+      async () => {
+        if (
+          definition.pluginId === "computer" &&
+          providerUnavailable(() => capabilities.computerProfilePackage())
+        )
+          return;
+        if (
+          definition.pluginId === "browser" &&
+          providerUnavailable(() => capabilities.browserProfilePackage())
+        )
+          return;
+        const installed = capabilities
+          .pluginSnapshot()
+          .plugins.find((plugin) => plugin.id === definition.pluginId);
+        if (installed?.profileSource !== undefined) return;
+        const tarball =
+          definition.pluginId === "browser"
+            ? firstPartyProviderTarball(
+                "browser",
+                capabilities.browserProfilePackage().manifest.provider.id,
+              )
+            : definition.pluginId === "computer"
+              ? firstPartyProviderTarball(
+                  "computer",
+                  capabilities.computerProfilePackage().manifest.provider.id,
+                )
+              : definition.tarball;
+        await capabilities.installBundledPluginPackage(
+          path.join(resourcesDirectory, "plugins", tarball),
+          {
+            pluginId: definition.pluginId,
+            packageName: definition.packageName,
+          },
+        );
+      },
+    );
+  }
+}
+
+async function isolateBundledPluginInstall(
+  capabilities: ZenXCapabilityService,
+  pluginId: string,
+  install: () => Promise<void>,
+): Promise<void> {
+  try {
+    await install();
+  } catch (error) {
+    capabilities.recordBundledPluginStartupError(pluginId, error);
+  }
+}
+
+function providerUnavailable(resolve: () => unknown): boolean {
+  try {
+    resolve();
+    return false;
+  } catch {
+    return true;
+  }
+}

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -470,6 +470,10 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     return this.#registry.diagnostics();
   }
 
+  recordBundledPluginStartupError(pluginId: string, error: unknown): void {
+    this.#registry.recordDiscoveryError(`${pluginId}: ${describeError(error)}`);
+  }
+
   marketplaceBuiltIns(): MarketplaceBuiltInEntry[] {
     const diagnostics = this.#registry.diagnostics().providerDiagnostics;
     return FIRST_PARTY_MARKETPLACE_ENTRIES.map((entry) => {

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -73,21 +73,14 @@ import {
 import { secondInstanceDisposition } from "./desktop-lifecycle.js";
 import { validatePluginHostSdkRequest } from "./plugin-host-sdk.js";
 import type { ZenXPluginPackageSource } from "./capabilities/types.js";
-import {
-  createZenXRoomsProfileLoader,
-  ZENX_ROOMS_PACKAGE_NAME,
-  ZENX_ROOMS_TARBALL,
-} from "./rooms-profile-loader.js";
+import { createZenXRoomsProfileLoader } from "./rooms-profile-loader.js";
 import {
   JsonFileMarketplaceCatalogTransport,
   MarketplaceCatalogService,
 } from "./marketplace-catalog.js";
 import { ZenXPluginDevControlServer } from "./plugin-dev-control.js";
-import {
-  createDelegatingFirstPartyProfileLoader,
-  FIRST_PARTY_PLUGIN_PACKAGES,
-  firstPartyProviderTarball,
-} from "./first-party-profile-loader.js";
+import { createDelegatingFirstPartyProfileLoader } from "./first-party-profile-loader.js";
+import { installZenXBundledPluginsAtStartup } from "./bundled-plugin-startup.js";
 
 let appServerManager: AppServerManager | undefined;
 let settingsService: ZenXSettingsService | undefined;
@@ -290,74 +283,10 @@ app.whenReady().then(async () => {
     triggersPackage = new ZenXTriggersCapabilityPackage(automationService);
     await capabilityService.initialize();
     await capabilityService.syncProfileManagedProviderVariants();
-    const installedRooms = capabilityService
-      .pluginSnapshot()
-      .plugins.find((plugin) => plugin.id === ZENX_ROOMS_CAPABILITY_ID);
-    if (installedRooms?.profileSource === undefined) {
-      await capabilityService.installBundledPluginPackage(
-        join(resourcesDirectory, "plugins", ZENX_ROOMS_TARBALL),
-        {
-          pluginId: ZENX_ROOMS_CAPABILITY_ID,
-          packageName: ZENX_ROOMS_PACKAGE_NAME,
-        },
-      );
-    }
-    for (const definition of [
-      FIRST_PARTY_PLUGIN_PACKAGES.browser,
-      FIRST_PARTY_PLUGIN_PACKAGES.computer,
-      FIRST_PARTY_PLUGIN_PACKAGES.selfControl,
-      FIRST_PARTY_PLUGIN_PACKAGES.triggers,
-    ]) {
-      if (
-        definition.pluginId === "computer" &&
-        (() => {
-          try {
-            capabilityService!.computerProfilePackage();
-            return false;
-          } catch {
-            return true;
-          }
-        })()
-      )
-        continue;
-      if (
-        definition.pluginId === "browser" &&
-        (() => {
-          try {
-            capabilityService!.browserProfilePackage();
-            return false;
-          } catch {
-            return true;
-          }
-        })()
-      )
-        continue;
-      const installed = capabilityService
-        .pluginSnapshot()
-        .plugins.find((plugin) => plugin.id === definition.pluginId);
-      if (installed?.profileSource === undefined) {
-        const tarball =
-          definition.pluginId === "browser"
-            ? firstPartyProviderTarball(
-                "browser",
-                capabilityService.browserProfilePackage().manifest.provider.id,
-              )
-            : definition.pluginId === "computer"
-              ? firstPartyProviderTarball(
-                  "computer",
-                  capabilityService.computerProfilePackage().manifest.provider
-                    .id,
-                )
-              : definition.tarball;
-        await capabilityService.installBundledPluginPackage(
-          join(resourcesDirectory, "plugins", tarball),
-          {
-            pluginId: definition.pluginId,
-            packageName: definition.packageName,
-          },
-        );
-      }
-    }
+    await installZenXBundledPluginsAtStartup(
+      capabilityService,
+      resourcesDirectory,
+    );
     installCapabilityIpc(capabilityService, appServerManager, marketplace);
     if (startupError === undefined) {
       await appServerManager.start();

--- a/apps/zenx/test/first-party-rooms-profile.test.ts
+++ b/apps/zenx/test/first-party-rooms-profile.test.ts
@@ -6,11 +6,22 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 
 import type { CanonicalItem } from "../../../src/item.js";
-import { packZenXRoomsPlugin } from "../scripts/pack-first-party-plugins.mjs";
+import {
+  packZenXFirstPartyPlugins,
+  packZenXRoomsPlugin,
+} from "../scripts/pack-first-party-plugins.mjs";
 import { AppServerManager } from "../src/main/app-server-manager.js";
 import { createBundledAutomationPluginService } from "../src/main/automation-plugin-service.js";
+import { installZenXBundledPluginsAtStartup } from "../src/main/bundled-plugin-startup.js";
 import { ZenXCapabilityService } from "../src/main/capability-service.js";
-import { ZENX_ROOMS_CAPABILITY_ID } from "../src/main/capabilities/automation-control-package.js";
+import {
+  ZenXTriggersCapabilityPackage,
+  ZENX_ROOMS_CAPABILITY_ID,
+} from "../src/main/capabilities/automation-control-package.js";
+import {
+  MutableAppServerRequestPort,
+  ZenXSelfControlCapabilityPackage,
+} from "../src/main/capabilities/self-control-package.js";
 import { JsonZenXPluginCatalogStore } from "../src/main/capabilities/plugin-catalog-store.js";
 import type { ZenXPluginManifestV2 } from "../src/main/capabilities/types.js";
 import {
@@ -19,6 +30,7 @@ import {
 } from "../src/main/rooms-profile-loader.js";
 import type { ZenXTriggerAppServerPort } from "../src/main/trigger-service.js";
 import { ZenXTriggerStore } from "../src/main/trigger-store.js";
+import { createDelegatingFirstPartyProfileLoader } from "../src/main/first-party-profile-loader.js";
 
 const pnpmCli = fileURLToPath(
   new URL("../../../node_modules/pnpm/bin/pnpm.cjs", import.meta.url),
@@ -447,6 +459,88 @@ test("packaged Rooms refuses bundled adoption across a legacy Catalog identity m
       undefined,
     );
   } finally {
+    await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("packaged startup isolates a Rooms identity mismatch and starts with a later first-party plugin", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bundled-startup-isolation-"),
+  );
+  const userData = path.join(directory, "user-data");
+  const resources = path.join(directory, "resources");
+  await packZenXFirstPartyPlugins({ outputDirectory: resources });
+  const appServer = {
+    request: async () => {
+      throw new Error("Startup fixture must not start an automation Turn");
+    },
+    onNotification: () => () => {},
+  } as ZenXTriggerAppServerPort;
+  const domain = await createBundledAutomationPluginService({
+    userDataDirectory: userData,
+    appServer,
+  });
+  const selfControlPort = new MutableAppServerRequestPort();
+  const selfControlPackage = new ZenXSelfControlCapabilityPackage({
+    appServer: selfControlPort,
+  });
+  await seedLegacyRoomsCatalog(userData, domain);
+  const catalogFile = path.join(userData, "capability-grants.json");
+  const catalog = JSON.parse(await readFile(catalogFile, "utf8")) as {
+    packages: Record<
+      string,
+      { manifest: ZenXPluginManifestV2 & { resources?: unknown[] } }
+    >;
+  };
+  catalog.packages[ZENX_ROOMS_CAPABILITY_ID]!.manifest.resources = [];
+  await writeFile(catalogFile, `${JSON.stringify(catalog, null, 2)}\n`);
+  const triggersPackage = new ZenXTriggersCapabilityPackage(domain);
+  const capabilities = new ZenXCapabilityService({
+    userDataDirectory: userData,
+    resourcesDirectory: resources,
+    pnpmCliPath: pnpmCli,
+    trustedProfileLoaders: {
+      [ZENX_ROOMS_CAPABILITY_ID]: createZenXRoomsProfileLoader(() => domain),
+      "zenx-triggers": createDelegatingFirstPartyProfileLoader(
+        () => triggersPackage,
+      ),
+      "zenx-self-control": createDelegatingFirstPartyProfileLoader(
+        () => selfControlPackage,
+      ),
+    },
+    bundledProvidersOnly: true,
+  });
+  const manager = appServerManager(directory, userData, capabilities);
+  try {
+    await selfControlPort.attach(manager);
+    await capabilities.initialize();
+    await installZenXBundledPluginsAtStartup(capabilities, resources);
+
+    const plugins = capabilities.pluginSnapshot().plugins;
+    assert.equal(
+      plugins.find((plugin) => plugin.id === ZENX_ROOMS_CAPABILITY_ID)
+        ?.profileSource,
+      undefined,
+    );
+    assert.equal(
+      plugins.find((plugin) => plugin.id === "zenx-triggers")?.profileSource
+        ?.mode,
+      "bundled",
+    );
+    assert.match(
+      capabilities.diagnostics().discoveryErrors.join("\n"),
+      /zenx-rooms: .*does not match its Catalog identity/u,
+    );
+
+    await manager.start();
+    assert.equal(manager.status.type, "ready");
+    assert.equal(
+      typeof (await manager.request("thread/start", {})).thread.id,
+      "string",
+    );
+  } finally {
+    await manager.stop();
     await capabilities.close();
     await rm(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- isolate each bundled plugin installation during ZenX startup
- keep a rejected plugin unavailable while preserving its exact discovery diagnostic
- continue installing later bundled plugins and start the App Server normally
- keep host initialization, provider synchronization, IPC, and App Server failures fatal

## Product boundary
- no legacy manifest compatibility, normalization, or migration
- no validation weakening or durable self-repair state

## Verification
- focused Rooms/startup suite: 7/7
- remaining first-party profile suite: 18/18
- ZenX typecheck and production build
- root `npm test`: 210 Node + 38 Python
- root `npm run check`
- independent R1 review: PASS