### PR TITLE
fix(runtime): continue after tool-local failures

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -320,6 +320,12 @@ connection descriptor 发布，并让该 authority 独立于窗口生命周期�
   `skills/list` 不因此获得新的会话语义。
 - 同一模型响应产生的多个工具调用当前仍按顺序执行；同一 Turn 的真正并行执行
   是后续效率优化，不属于本阶段。
+- 每条 canonical `tool_call` 必须恰好结算一条 canonical `tool_result`。prepare、
+  Host admission、provider execution 或 result normalization 的局部失败以简洁错误和
+  非零 exit code 形成该结果，继续执行同一模型响应中后续调用并进入下一次模型采样；
+  不额外写 `failure` 或把 Turn 标记为 failed。
+- 显式用户取消或 Turn abort 仍是中断 Turn 的控制流；模型流、journal append、Runtime
+  不变量等非工具局部失败仍按既有 Turn failure 语义终止，不能伪装成 tool result。
 
 ### 历史、结果与能力变化
 

--- a/LESSONS.md
+++ b/LESSONS.md
@@ -31,6 +31,8 @@
 - 独立 Skills 平台；本阶段插件以 main document 提供首要模型说明
 - 同一 Turn 的并行工具执行，以及借 Plugin Platform 顺带进行 Provider、图片、
   attachment 或 compaction 重构
+- 工具失败后的自动重试、fallback、自愈或 durable recovery 状态机；工具局部失败只
+  结算一次 canonical failed result 并让模型决定下一步
 - 覆盖率门禁、按层重复跑的测试矩阵
 - 与 zen-legacy 的数据、协议、接口兼容
 

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -104,6 +104,9 @@ Host policy、路由和回写，插件或外部服务拥有实际领域执行。
 child process、本地服务或远程服务。模型初始只看到 builtin tools 与 `zenx_plugin`：`discover`
 返回 id/name/short description/status，`read` 返回 main document/tool index，随后采样才披露所选
 插件的普通 namespaced schemas。整个过程只使用既有 tool call/result，不新增 discovery Item。
+工具 prepare、admission、execution 或 result normalization 的局部失败会形成唯一 failed tool result；
+同一模型响应中的后续调用仍按顺序执行，随后模型可读取全部结果继续 Turn。只有显式用户/Turn
+取消会中断这条工具路径；模型、journal 与 Runtime 失败仍保留既有 Turn failure 语义。
 
 目标插件生命周期只有 installed / enabled / uninstalled；bundled plugin 同样可卸载、以后重装，
 卸载默认保留数据，删除数据是独立动作。目标权限只有默认 `full_access` 与可选 `ask_unknown`；后者

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -20,6 +20,7 @@ import type { ModelAdapter, ModelMessage, ModelTool } from "./model.js";
 import type { Thread } from "./thread.js";
 import {
   ToolEnvironment,
+  ToolResultNormalizationError,
   toolProviderFromExecutor,
   type ApprovalHandler,
   type ToolExecutionResult,
@@ -484,11 +485,12 @@ export class AgentRuntime {
         toolCall,
         {
           output: `Tool preparation failed: ${describeError(error)}`,
-          exitCode: options.signal.aborted || isAbortError(error) ? 130 : 1,
+          exitCode: options.signal.aborted ? 130 : 1,
         },
         options,
       );
-      throw error;
+      if (options.signal.aborted) throw error;
+      return;
     }
 
     let decision: ApprovalDecision;
@@ -517,12 +519,13 @@ export class AgentRuntime {
       await this.#completeToolResult(
         toolCall,
         {
-          output: `Tool approval did not complete: ${describeError(error)}`,
-          exitCode: options.signal.aborted || isAbortError(error) ? 130 : 1,
+          output: `Tool admission failed: ${describeError(error)}`,
+          exitCode: options.signal.aborted ? 130 : 1,
         },
         options,
       );
-      throw error;
+      if (options.signal.aborted) throw error;
+      return;
     }
 
     if (decision === "cancel") {
@@ -541,16 +544,21 @@ export class AgentRuntime {
       try {
         result = await this.#tools.execute(prepared);
       } catch (error) {
-        const interrupted = options.signal.aborted || isAbortError(error);
+        const interrupted = options.signal.aborted;
+        const phase =
+          error instanceof ToolResultNormalizationError
+            ? "Tool result normalization failed"
+            : "Tool execution failed";
         await this.#completeToolResult(
           toolCall,
           {
-            output: `Tool execution failed: ${describeError(error)}`,
+            output: `${phase}: ${describeError(error)}`,
             exitCode: interrupted ? 130 : 1,
           },
           options,
         );
-        throw error;
+        if (interrupted) throw error;
+        return;
       }
     }
 

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -388,10 +388,12 @@ export class ToolEnvironment {
     const provider = this.#requirePrepared(prepared).provider;
     try {
       prepared.invocation.signal.throwIfAborted();
-      return normalizeToolExecutionResult(
-        await provider.execute(prepared.invocation),
-        prepared.provider,
-      );
+      const result = await provider.execute(prepared.invocation);
+      try {
+        return normalizeToolExecutionResult(result, prepared.provider);
+      } catch (error) {
+        throw new ToolResultNormalizationError(error);
+      }
     } finally {
       this.#releasePrepared(prepared);
     }
@@ -413,6 +415,13 @@ export class ToolEnvironment {
     registration.released = true;
     this.#preparedProviders.delete(prepared);
     registration.release?.();
+  }
+}
+
+export class ToolResultNormalizationError extends Error {
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+    this.name = "ToolResultNormalizationError";
   }
 }
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1409,7 +1409,7 @@ test("cancelled approval records results for the cancelled and abandoned calls",
   assert.equal(snapshot.turns[0]?.status, "interrupted");
 });
 
-test("approval errors record results for the failed and abandoned calls", async () => {
+test("approval errors settle each call and let the model continue", async () => {
   const server = createServer({
     approvalPolicy: "always",
     model: createTwoCallModel(),
@@ -1429,15 +1429,21 @@ test("approval errors record results for the failed and abandoned calls", async 
     results.map((result) => [result.callId, result.exitCode]),
     [
       ["call_one", 1],
-      ["call_two", 125],
+      ["call_two", 1],
     ],
   );
-  assert.equal(snapshot.turns[0]?.status, "failed");
+  assert(!snapshot.items.some((item) => item.type === "failure"));
+  assert.equal(snapshot.turns[0]?.status, "completed");
 });
 
-test("execution errors record results for the failed and abandoned calls", async () => {
-  const tools = createStubTools(async () => {
-    throw new Error("execution exploded");
+test("execution errors settle one result and do not abandon later calls", async () => {
+  const executed: string[] = [];
+  const tools = createStubTools(async (invocation) => {
+    executed.push(invocation.callId);
+    if (invocation.callId === "call_one") {
+      throw new Error("execution exploded");
+    }
+    return { output: "second completed", exitCode: 0 };
   });
   const server = createServer({ model: createTwoCallModel(), tools });
   const thread = await server.startThread();
@@ -1451,10 +1457,112 @@ test("execution errors record results for the failed and abandoned calls", async
     results.map((result) => [result.callId, result.exitCode]),
     [
       ["call_one", 1],
-      ["call_two", 125],
+      ["call_two", 0],
     ],
   );
-  assert.equal(snapshot.turns[0]?.status, "failed");
+  assert.deepEqual(executed, ["call_one", "call_two"]);
+  assert(!snapshot.items.some((item) => item.type === "failure"));
+  assert.equal(snapshot.turns[0]?.status, "completed");
+});
+
+test("a provider AbortError is tool-local unless the Turn signal is aborted", async () => {
+  const tools = createStubTools(async (invocation) => {
+    if (invocation.callId === "call_one") {
+      throw new DOMException("provider stopped its operation", "AbortError");
+    }
+    return { output: "second completed", exitCode: 0 };
+  });
+  const server = createServer({ model: createTwoCallModel(), tools });
+  const thread = await server.startThread();
+  await (
+    await server.startTurn(thread.id, "provider abort")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assertEveryToolCallHasOneResult(snapshot.items);
+  const results = snapshot.items.filter((item) => item.type === "tool_result");
+  assert.deepEqual(
+    results.map((result) => [result.callId, result.exitCode]),
+    [
+      ["call_one", 1],
+      ["call_two", 0],
+    ],
+  );
+  assert(!snapshot.items.some((item) => item.type === "turn_aborted"));
+  assert.equal(snapshot.turns[0]?.status, "completed");
+});
+
+test("preparation errors settle one result and let later calls run", async () => {
+  const model: ModelAdapter = {
+    provider: "prepare-failure-test",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      if (request.messages.some((message) => message.role === "tool")) {
+        yield { type: "text_delta", delta: "tools complete" };
+        return;
+      }
+      yield {
+        type: "tool_call",
+        callId: "call_missing",
+        name: "missing_tool",
+        arguments: {},
+      };
+      yield {
+        type: "tool_call",
+        callId: "call_shell",
+        name: "shell",
+        arguments: { command: "printf prepared" },
+      };
+    },
+  };
+  const server = createServer({ model });
+  const thread = await server.startThread();
+  await (
+    await server.startTurn(thread.id, "prepare tools")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assertEveryToolCallHasOneResult(snapshot.items);
+  const results = snapshot.items.filter((item) => item.type === "tool_result");
+  assert.deepEqual(
+    results.map((result) => [result.callId, result.exitCode]),
+    [
+      ["call_missing", 1],
+      ["call_shell", 0],
+    ],
+  );
+  assert.match(results[0]?.output ?? "", /Unsupported tool: missing_tool/u);
+  assert(!snapshot.items.some((item) => item.type === "failure"));
+  assert.equal(snapshot.turns[0]?.status, "completed");
+});
+
+test("result normalization errors become failed results and the loop continues", async () => {
+  const tools = createStubTools(async (invocation) =>
+    invocation.callId === "call_one"
+      ? ({ output: 42, exitCode: 0 } as unknown as {
+          output: string;
+          exitCode: number;
+        })
+      : { output: "normalized", exitCode: 0 },
+  );
+  const server = createServer({ model: createTwoCallModel(), tools });
+  const thread = await server.startThread();
+  await (
+    await server.startTurn(thread.id, "normalize tools")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assertEveryToolCallHasOneResult(snapshot.items);
+  const results = snapshot.items.filter((item) => item.type === "tool_result");
+  assert.deepEqual(
+    results.map((result) => [result.callId, result.exitCode]),
+    [
+      ["call_one", 1],
+      ["call_two", 0],
+    ],
+  );
+  assert.match(results[0]?.output ?? "", /invalid output or exit code/u);
+  assert(!snapshot.items.some((item) => item.type === "failure"));
+  assert.equal(snapshot.turns[0]?.status, "completed");
 });
 
 test("interrupting an approval records results even when the handler ignores abort", async () => {

--- a/test/tool-environment.test.ts
+++ b/test/tool-environment.test.ts
@@ -165,7 +165,7 @@ test("structured result admission rejects non-JSON, cyclic, oversized, and forei
   }
 });
 
-test("invalid structured content settles its tool call with existing failure semantics", async () => {
+test("invalid structured content settles its tool call and lets the model continue", async () => {
   const provider: ToolProvider = {
     identity: { kind: "plugin", id: "fixture" },
     definitions: [
@@ -192,7 +192,11 @@ test("invalid structured content settles its tool call with existing failure sem
   assert.equal(results.length, 1);
   assert.equal(results[0]!.exitCode, 1);
   assert.match(results[0]!.output, /does not own/u);
-  assert.equal(snapshot.turns[0]?.status, "failed");
+  assert.equal(snapshot.turns[0]?.status, "completed");
+  assert.equal(
+    snapshot.items.some((item) => item.type === "failure"),
+    false,
+  );
   assert.equal(
     snapshot.items.some(
       (item) =>


### PR DESCRIPTION
## Summary

- settle prepare, admission, execution, and result-normalization failures as one failed canonical tool result
- continue later tool calls from the same model response and resample the model
- keep explicit user or Turn cancellation interrupting while model, journal, and runtime failures remain terminal
- add no automatic retry, fallback, self-repair, or DNS behavior

## Validation

- focused fail-open matrix: 8/8 passed
- exact worker head npm run check: Core 213/213 and IMZen 38/38 passed
- covers provider AbortError, missing tools, admission failures, malformed results, multiple-call continuation, and explicit abort

Split from the previously combined #140 so this runtime behavior can be reviewed independently.