### PR TITLE
fix(zenx): preserve trace disclosure while streaming

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -51,7 +51,7 @@
 Thread
 └── Turn
     ├── Agent Message Item
-    ├── Trace Group（连续 Thinking / Tool Call Item 的 UI 聚合）
+    ├── Trace sequence（singleton 直接显示；连续 2+ 为 Trace Group）
     │   ├── Thinking Item
     │   ├── Tool Call Item
     │   └── ...
@@ -61,8 +61,8 @@ Thread
 
 - Turn 是一段按顺序追加的 Items，不是独立时间线数据库。
 - Agent Message 是 Turn 内一级 Item，不能嵌入 Thinking/Tool 容器。
-- Trace Group 是可丢弃的 UI projection，不需要成为 Core 或协议实体。
-- Thinking 与 Tool Call 在组内仍是独立 Item，保留 canonical 顺序和稳定 ID。
+- Trace sequence 是可丢弃的 UI projection：连续序列只有一个 Thinking / Tool Call Item 时直接显示该 Item，达到两个或更多时才显示 Trace Group；它不需要成为 Core 或协议实体。
+- Thinking 与 Tool Call 在 sequence 内仍是独立 Item，保留 canonical 顺序和稳定 ID。
 - Tool details 位于聊天流中对应 Trace Item 的 disclosure；不迁移到第二份执行 transcript 或常驻 Activity rail。
 - 审批是 active Turn 的瞬态交互，显示在 Composer 上方；最终执行或拒绝仍由 canonical tool result 表达。
 
@@ -144,14 +144,16 @@ Thread
 - 如果完成后没有 Final Message，显示明确 fallback，不留下空 Turn。
 - Final Message 是完成结果，不能与中间 Agent Message 重复渲染。
 
-Trace Group projection 按 Item 顺序生成：
+Trace sequence projection 按 Item 顺序生成：
 
-1. 遇到 Thinking 或 Tool Call，开始或继续当前 Trace Group。
-2. 遇到 Agent Message、Final Message、approval 或其他独立 Item，结束当前 Trace Group。
+1. 遇到 Thinking 或 Tool Call，开始或继续当前 trace sequence。
+2. 遇到 Agent Message、Final Message、approval 或其他独立 Item，结束当前 trace sequence。
 3. 不按工具类型、状态或时间重新排序。
 4. 流式追加只更新最后一个仍可合并的组，避免重建整个 Turn。
 
-Trace Group 默认收起，只显示轻量摘要、Item 数量和 disclosure icon。展开后，每个 Thinking / Tool Call row 仍默认收起；row 使用一致的密度、字号、间距和 disclosure 行为，以图标、标签和状态区分。组关闭后可以把组内 Items 恢复为收起，但该行为必须稳定、可预测。
+只有一个 Item 的 trace sequence 直接显示该 Thinking / Tool Call row；连续达到两个或更多 Items 时才显示 Trace Group。sequence identity 取首个 Item 的稳定 identity，因此流式追加只更新现有 sequence，不重挂载 disclosure 或丢失键盘焦点。singleton 升级为 group 时继承用户当前的展开或收起状态；用户在 Turn 运行期间显式展开或收起后，后续 streaming patch 不得覆盖该选择。
+
+Trace Group 默认收起，只显示轻量摘要、Item 数量和 disclosure icon。展开后，每个 Thinking / Tool Call row 仍默认收起；row 使用一致的密度、字号、间距和 disclosure 行为，以图标、标签和状态区分。组关闭后可以把组内 Items 恢复为收起，但该行为必须稳定、可预测。Turn 进入 completed / interrupted / failed 终态时统一折叠其中间 trace；用户随后展开完成态 Turn 时可以再次操作这些 disclosure。
 
 Tool 状态统一投影为 `queued / running / success / failed / cancelled / approval_required`。状态更新同一个稳定 Item，不创建重复 row；长 payload 在摘要截断，在详情内换行或局部滚动。
 

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -567,6 +567,9 @@ function TraceSequence({
   const toggleExpanded = () => {
     setExpanded((current) => {
       if (current) setOpenItems(new Set());
+      else if (singleton !== null && singletonExpandable) {
+        setOpenItems(new Set([singleton.id]));
+      }
       return !current;
     });
   };

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -541,7 +541,7 @@ function DisplayNode({
   return node.kind === "agent" ? (
     <AgentMessage item={node.item} />
   ) : (
-    <TraceGroup
+    <TraceSequence
       node={node}
       pluginSnapshot={pluginSnapshot}
       pluginUiRegistry={pluginUiRegistry}
@@ -549,52 +549,67 @@ function DisplayNode({
   );
 }
 
-function TraceGroup({
+function TraceSequence({
   node,
   pluginSnapshot,
   pluginUiRegistry,
 }: {
-  node: Extract<TurnDisplayNode, { kind: "trace" }>;
+  node: Extract<TurnDisplayNode, { kind: "traceItem" | "traceGroup" }>;
   pluginSnapshot: ZenXPluginSnapshot | null;
   pluginUiRegistry: PluginUiRegistry | null;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [openItems, setOpenItems] = useState<Set<string>>(new Set());
+  const grouped = node.kind === "traceGroup";
+  const singleton = node.kind === "traceItem" ? node.item : null;
+  const singletonExpandable =
+    singleton !== null && traceItemExpandable(singleton);
+  const toggleExpanded = () => {
+    setExpanded((current) => {
+      if (current) setOpenItems(new Set());
+      return !current;
+    });
+  };
   return (
-    <section className="trace-group">
-      <button
-        className="trace-toggle"
-        type="button"
-        aria-expanded={expanded}
-        onClick={() => {
-          setExpanded((value) => !value);
-          if (expanded) setOpenItems(new Set());
-        }}
-      >
-        <Icon name="layers" size={15} />
-        <span>{node.summary}</span>
-        <small>{node.items.length} items</small>
-        <Icon name="chevron-down" size={13} />
-      </button>
-      {expanded ? (
+    <section className={grouped ? "trace-group" : "trace-item trace-singleton"}>
+      {grouped ? (
+        <button
+          className="trace-toggle"
+          type="button"
+          aria-expanded={expanded}
+          onClick={toggleExpanded}
+        >
+          <Icon name="layers" size={15} />
+          <span>{node.summary}</span>
+          <small>{node.items.length} items</small>
+          <Icon name="chevron-down" size={13} />
+        </button>
+      ) : singletonExpandable ? (
+        <button
+          className="trace-item-toggle"
+          type="button"
+          aria-expanded={expanded}
+          onClick={toggleExpanded}
+        >
+          <TraceItemHeader item={singleton} expandable />
+        </button>
+      ) : (
+        <div className="trace-item-static">
+          <TraceItemHeader item={singleton!} expandable={false} />
+        </div>
+      )}
+      {!grouped && expanded && singletonExpandable ? (
+        <TraceDetail
+          item={singleton}
+          pluginSnapshot={pluginSnapshot}
+          pluginUiRegistry={pluginUiRegistry}
+        />
+      ) : null}
+      {grouped && expanded ? (
         <div className="trace-items">
           {node.items.map((item) => {
             const open = openItems.has(item.id);
-            const expandable =
-              item.type !== "reasoning" ||
-              reasoningContentText(item).trim().length > 0;
-            const header = (
-              <>
-                <Icon
-                  name={item.type === "reasoning" ? "reasoning" : "terminal"}
-                  size={14}
-                />
-                <strong>{item.type === "reasoning" ? "Think" : "Tool"}</strong>
-                <span>{traceItemLabel(item)}</span>
-                <StatusMark item={item} />
-                {expandable ? <Icon name="chevron-down" size={13} /> : null}
-              </>
-            );
+            const expandable = traceItemExpandable(item);
             return (
               <div className="trace-item" key={item.id}>
                 {expandable ? (
@@ -611,10 +626,12 @@ function TraceGroup({
                       })
                     }
                   >
-                    {header}
+                    <TraceItemHeader item={item} expandable />
                   </button>
                 ) : (
-                  <div className="trace-item-static">{header}</div>
+                  <div className="trace-item-static">
+                    <TraceItemHeader item={item} expandable={false} />
+                  </div>
                 )}
                 {open && expandable ? (
                   <TraceDetail
@@ -629,6 +646,35 @@ function TraceGroup({
         </div>
       ) : null}
     </section>
+  );
+}
+
+function TraceItemHeader({
+  item,
+  expandable,
+}: {
+  item: Extract<ThreadItem, { type: "reasoning" | "commandExecution" }>;
+  expandable: boolean;
+}) {
+  return (
+    <>
+      <Icon
+        name={item.type === "reasoning" ? "reasoning" : "terminal"}
+        size={14}
+      />
+      <strong>{item.type === "reasoning" ? "Think" : "Tool"}</strong>
+      <span>{traceItemLabel(item)}</span>
+      <StatusMark item={item} />
+      {expandable ? <Icon name="chevron-down" size={13} /> : null}
+    </>
+  );
+}
+
+function traceItemExpandable(
+  item: Extract<ThreadItem, { type: "reasoning" | "commandExecution" }>,
+): boolean {
+  return (
+    item.type !== "reasoning" || reasoningContentText(item).trim().length > 0
   );
 }
 

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1357,6 +1357,10 @@ a:focus-visible {
   max-width: 760px;
   min-width: 0;
 }
+.trace-singleton {
+  max-width: 760px;
+  min-width: 0;
+}
 .trace-toggle {
   width: 100%;
   min-height: 34px;

--- a/apps/zenx/src/renderer/src/turn-projection.ts
+++ b/apps/zenx/src/renderer/src/turn-projection.ts
@@ -3,7 +3,12 @@ import type { ThreadItem, Turn } from "../../protocol-client/index.js";
 export type TurnDisplayNode =
   | { kind: "agent"; item: Extract<ThreadItem, { type: "agentMessage" }> }
   | {
-      kind: "trace";
+      kind: "traceItem";
+      id: string;
+      item: Extract<ThreadItem, { type: "reasoning" | "commandExecution" }>;
+    }
+  | {
+      kind: "traceGroup";
       id: string;
       items: Array<
         Extract<ThreadItem, { type: "reasoning" | "commandExecution" }>
@@ -42,12 +47,17 @@ export function projectTurn(turn: Turn): TurnDisplayProjection {
   > = [];
   const flushTrace = () => {
     if (traceItems.length === 0) return;
-    history.push({
-      kind: "trace",
-      id: traceItems.map((item) => item.id).join(":"),
-      summary: traceSummary(traceItems),
-      items: traceItems,
-    });
+    const id = traceItems[0]!.id;
+    history.push(
+      traceItems.length === 1
+        ? { kind: "traceItem", id, item: traceItems[0]! }
+        : {
+            kind: "traceGroup",
+            id,
+            summary: traceSummary(traceItems),
+            items: traceItems,
+          },
+    );
     traceItems = [];
   };
   for (const item of historySource) {

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -136,6 +136,47 @@ test("singleton promotion preserves its disclosure and focused button", async ()
     assert.equal(groupToggle, singletonToggle);
     assert.equal(document.activeElement, groupToggle);
     assert.equal(groupToggle.getAttribute("aria-expanded"), "true");
+    assert.equal(
+      requiredElement(".trace-group .trace-item .trace-detail").textContent,
+      "Public reasoning",
+    );
+
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        reasoningItem(
+          "reasoning-promote",
+          ["Mapped the rendering path"],
+          ["Updated public reasoning"],
+        ),
+        commandItem("command-promote", "rg ThreadView"),
+      ]),
+    );
+    assert.equal(requiredButton(".trace-group > .trace-toggle"), groupToggle);
+    assert.equal(document.activeElement, groupToggle);
+    assert.equal(
+      requiredElement(".trace-group .trace-item .trace-detail").textContent,
+      "Updated public reasoning",
+    );
+  });
+});
+
+test("tool singleton promotion preserves its open detail", async () => {
+  await withDom(async (root) => {
+    const first = commandItem("command-promote-first", "rg ThreadView");
+    await renderInteractive(root, turnWithItems("inProgress", [first]));
+    await act(async () => requiredButton(".trace-singleton > button").click());
+
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        first,
+        reasoningItem("reasoning-promote-second", ["Mapped"], []),
+      ]),
+    );
+    const detail = requiredElement(".trace-group .trace-item .trace-detail");
+    assert.equal(requiredWithin(detail, "code").textContent, "rg ThreadView");
+    assert.match(detail.textContent ?? "", /ThreadView\.tsx/u);
   });
 });
 

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -94,6 +94,136 @@ test("assistant messages retain running reasoning and tool disclosure affordance
   );
 });
 
+test("renders one trace Item directly and wraps only a sequence of two or more", () => {
+  const singleton = renderTurns([
+    turnWithItems("inProgress", [reasoning("Mapped the rendering path")]),
+  ]);
+  assert.match(singleton, /class="trace-item trace-singleton"/u);
+  assert.doesNotMatch(singleton, /class="trace-group"/u);
+  assert.doesNotMatch(singleton, /[>]1 items[<]/u);
+
+  const grouped = renderTurns([
+    turnWithItems("inProgress", [
+      reasoning("Mapped the rendering path"),
+      command("rg ThreadView"),
+    ]),
+  ]);
+  assert.match(grouped, /class="trace-group"/u);
+  assert.match(grouped, /[>]2 items[<]/u);
+});
+
+test("singleton promotion preserves its disclosure and focused button", async () => {
+  await withDom(async (root) => {
+    const first = reasoningItem(
+      "reasoning-promote",
+      ["Mapped the rendering path"],
+      ["Public reasoning"],
+    );
+    await renderInteractive(root, turnWithItems("inProgress", [first]));
+    const singletonToggle = requiredButton(".trace-singleton > button");
+    singletonToggle.focus();
+    await act(async () => singletonToggle.click());
+    assert.equal(singletonToggle.getAttribute("aria-expanded"), "true");
+
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        first,
+        commandItem("command-promote", "rg ThreadView"),
+      ]),
+    );
+    const groupToggle = requiredButton(".trace-group > .trace-toggle");
+    assert.equal(groupToggle, singletonToggle);
+    assert.equal(document.activeElement, groupToggle);
+    assert.equal(groupToggle.getAttribute("aria-expanded"), "true");
+  });
+});
+
+test("collapsed singleton promotes to a collapsed trace group", async () => {
+  await withDom(async (root) => {
+    const first = reasoningItem(
+      "reasoning-promote-closed",
+      ["Mapped the rendering path"],
+      ["Public reasoning"],
+    );
+    await renderInteractive(root, turnWithItems("inProgress", [first]));
+    assert.equal(
+      requiredButton(".trace-singleton > button").getAttribute("aria-expanded"),
+      "false",
+    );
+
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        first,
+        commandItem("command-promote-closed", "rg ThreadView"),
+      ]),
+    );
+    assert.equal(
+      requiredButton(".trace-group > .trace-toggle").getAttribute(
+        "aria-expanded",
+      ),
+      "false",
+    );
+  });
+});
+
+test("streaming append preserves an explicitly closed trace group", async () => {
+  await withDom(async (root) => {
+    const first = reasoningItem("reasoning-close", ["Mapped"], []);
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        first,
+        commandItem("command-close-a", "rg ThreadView"),
+      ]),
+    );
+    const toggle = requiredButton(".trace-toggle");
+    await act(async () => toggle.click());
+    await act(async () => toggle.click());
+    toggle.focus();
+
+    await renderInteractive(
+      root,
+      turnWithItems("inProgress", [
+        first,
+        commandItem("command-close-a", "rg ThreadView"),
+        commandItem("command-close-b", "npm test"),
+      ]),
+    );
+    const updated = requiredButton(".trace-toggle");
+    assert.equal(updated, toggle);
+    assert.equal(document.activeElement, updated);
+    assert.equal(updated.getAttribute("aria-expanded"), "false");
+  });
+});
+
+test("terminal transition folds intermediate trace before Turn history reopens", async () => {
+  await withDom(async (root) => {
+    const items = [
+      reasoningItem("reasoning-terminal", ["Mapped"], []),
+      commandItem("command-terminal", "npm test"),
+    ];
+    await renderInteractive(root, turnWithItems("inProgress", items));
+    await act(async () => requiredButton(".trace-toggle").click());
+    assert.equal(
+      requiredButton(".trace-toggle").getAttribute("aria-expanded"),
+      "true",
+    );
+
+    await renderInteractive(
+      root,
+      turnWithItems("completed", [...items, agent("Done")]),
+    );
+    assert.equal(document.querySelector(".trace-toggle"), null);
+    await act(async () => requiredButton(".turn-toggle").click());
+    assert.equal(
+      requiredButton(".trace-toggle").getAttribute("aria-expanded"),
+      "false",
+    );
+  });
+});
+
 test("public reasoning with a summary expands from summary to full content", async () => {
   await withDom(async (root) => {
     const row = await openReasoningRow(
@@ -216,7 +346,6 @@ test("streamed public content turns a static row into an expandable completed it
       root,
       turnWithItems("inProgress", [reasoningItem(id, [], [])]),
     );
-    await act(async () => requiredButton(".trace-toggle").click());
     assert.ok(document.querySelector(".trace-item-static"));
     assert.equal(document.querySelector(".trace-item-toggle"), null);
 
@@ -225,10 +354,6 @@ test("streamed public content turns a static row into an expandable completed it
       turnWithItems("inProgress", [
         reasoningItem(id, [], ["Streaming public reasoning"]),
       ]),
-    );
-    assert.equal(
-      requiredButton(".trace-toggle").getAttribute("aria-expanded"),
-      "true",
     );
     assert.equal(
       requiredButton(".trace-item-toggle").getAttribute("aria-expanded"),
@@ -242,7 +367,6 @@ test("streamed public content turns a static row into an expandable completed it
       ]),
     );
     await act(async () => requiredButton(".turn-toggle").click());
-    await act(async () => requiredButton(".trace-toggle").click());
     const toggle = requiredButton(".trace-item-toggle");
     await act(async () => toggle.click());
     assert.equal(
@@ -365,8 +489,7 @@ async function openReasoningRow(
   item: Extract<ThreadItem, { type: "reasoning" }>,
 ): Promise<HTMLElement> {
   await renderInteractive(root, turnWithItems("inProgress", [item]));
-  await act(async () => requiredButton(".trace-toggle").click());
-  return requiredElement<HTMLElement>(".trace-item");
+  return requiredElement<HTMLElement>(".trace-singleton");
 }
 
 async function renderInteractive(root: Root, value: Turn): Promise<void> {
@@ -524,9 +647,13 @@ function reasoningItem(
 }
 
 function command(value: string): ThreadItem {
+  return commandItem("command-1", value);
+}
+
+function commandItem(id: string, value: string): ThreadItem {
   return {
     type: "commandExecution",
-    id: "command-1",
+    id,
     pluginId: null,
     scriptPath: null,
     command: value,

--- a/apps/zenx/test/turn-projection.test.ts
+++ b/apps/zenx/test/turn-projection.test.ts
@@ -18,11 +18,31 @@ test("groups only consecutive reasoning and tool Items", () => {
   assert.equal(projection.userItems.length, 1);
   assert.deepEqual(
     projection.history.map((node) =>
-      node.kind === "trace" ? [node.kind, node.items.length] : [node.kind],
+      node.kind === "traceGroup" ? [node.kind, node.items.length] : [node.kind],
     ),
-    [["agent"], ["trace", 2], ["agent"], ["trace", 1]],
+    [["agent"], ["traceGroup", 2], ["agent"], ["traceItem"]],
   );
   assert.equal(projection.finalItem, null);
+});
+
+test("projects a singleton trace Item directly and promotes it with stable identity", () => {
+  const singleton = projectTurn(
+    turn("inProgress", [reasoning("reason-a", "Mapped Items")]),
+  ).history[0];
+  const grouped = projectTurn(
+    turn("inProgress", [
+      reasoning("reason-a", "Mapped Items"),
+      command("tool-a", "rg files"),
+    ]),
+  ).history[0];
+
+  assert.deepEqual(singleton, {
+    kind: "traceItem",
+    id: "reason-a",
+    item: reasoning("reason-a", "Mapped Items"),
+  });
+  assert.equal(grouped?.kind, "traceGroup");
+  assert.equal(grouped?.id, "reason-a");
 });
 
 test("completed turns reserve the last Agent Message as the final result", () => {


### PR DESCRIPTION
## Summary

- render one thinking or tool item directly without a redundant group wrapper
- group only two or more consecutive trace items using a stable sequence identity
- preserve expanded, collapsed, and focused state while streaming and during singleton promotion
- fold intermediate trace when a Turn becomes terminal while keeping completed Turn disclosure available

## Validation

- red tests reproduced singleton wrapping and disclosure remounts
- projection, component, state, and hosted integration tests: 32/32 passed
- ZenX typecheck, renderer CSP, production build, formatting, and lint passed on the exact worker head

Split from the previously combined #140 so the renderer behavior can be reviewed independently.