### PR TITLE
fix(zenx): rebuild plugin profile generations on Windows

### DIFF
--- a/apps/zenx/src/main/plugin-profile.ts
+++ b/apps/zenx/src/main/plugin-profile.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import {
   access,
   cp,
+  copyFile,
   mkdir,
   readFile,
   realpath,
@@ -150,17 +151,11 @@ export async function stagePluginPackage(options: {
       );
     } else {
       const current = generationPath(paths, options.currentGeneration);
-      await cp(current, generationDirectory, { recursive: true });
-      const currentPackage = await readProfilePackageJson(generationDirectory);
-      await writeProfilePackageJson(
+      await stageProfileDependencyState(
+        current,
         generationDirectory,
-        currentPackage.dependencies,
-        options.allowBuilds ?? currentPackage.pnpm?.allowBuilds ?? {},
+        options.allowBuilds,
       );
-      await rm(path.join(generationDirectory, "node_modules"), {
-        recursive: true,
-        force: true,
-      });
       await runBundledPnpm({
         cliPath: options.pnpmCliPath,
         cwd: generationDirectory,
@@ -266,12 +261,10 @@ export async function stagePluginRemoval(options: {
   const generationDirectory = path.join(paths.generations, generation);
   await mkdir(paths.generations, { recursive: true, mode: 0o700 });
   try {
-    await cp(
+    const before = await stageProfileDependencyState(
       generationPath(paths, options.currentGeneration),
       generationDirectory,
-      { recursive: true },
     );
-    const before = await readProfilePackageJson(generationDirectory);
     if (before.dependencies[options.packageName] === undefined) {
       throw new Error(
         `Profile dependency ${options.packageName} is not installed`,
@@ -594,6 +587,30 @@ async function writeProfilePackageJson(
     )}\n`,
     { encoding: "utf8", mode: 0o600 },
   );
+}
+
+async function stageProfileDependencyState(
+  currentGenerationDirectory: string,
+  stagedGenerationDirectory: string,
+  allowBuilds?: Readonly<Record<string, boolean>>,
+): Promise<{
+  dependencies: Record<string, string>;
+  pnpm?: { allowBuilds?: Record<string, boolean> };
+}> {
+  const currentPackage = await readProfilePackageJson(
+    currentGenerationDirectory,
+  );
+  await mkdir(stagedGenerationDirectory, { mode: 0o700 });
+  await copyFile(
+    path.join(currentGenerationDirectory, "pnpm-lock.yaml"),
+    path.join(stagedGenerationDirectory, "pnpm-lock.yaml"),
+  );
+  await writeProfilePackageJson(
+    stagedGenerationDirectory,
+    currentPackage.dependencies,
+    allowBuilds ?? currentPackage.pnpm?.allowBuilds ?? {},
+  );
+  return currentPackage;
 }
 
 async function readProfilePackageJson(directory: string): Promise<{

--- a/apps/zenx/src/main/plugin-profile.ts
+++ b/apps/zenx/src/main/plugin-profile.ts
@@ -605,6 +605,15 @@ async function stageProfileDependencyState(
     path.join(currentGenerationDirectory, "pnpm-lock.yaml"),
     path.join(stagedGenerationDirectory, "pnpm-lock.yaml"),
   );
+  try {
+    await cp(
+      path.join(currentGenerationDirectory, ".zenx-sources"),
+      path.join(stagedGenerationDirectory, ".zenx-sources"),
+      { recursive: true },
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
   await writeProfilePackageJson(
     stagedGenerationDirectory,
     currentPackage.dependencies,

--- a/apps/zenx/test/plugin-profile-install.test.ts
+++ b/apps/zenx/test/plugin-profile-install.test.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  realpath,
   readdir,
   rm,
   writeFile,
@@ -194,6 +195,85 @@ test("Settings host installs one tarball through the committed profile and Agent
   } finally {
     await manager.stop();
     await capabilities.close();
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a second profile install rebuilds links inside the new generation", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-profile-generation-links-"),
+  );
+  const userData = path.join(directory, "user-data");
+  const resourcesDirectory = path.join(directory, "resources");
+  const pluginResources = path.join(resourcesDirectory, "plugins");
+  await mkdir(pluginResources, { recursive: true });
+  const firstTarball = await createTarballFixture(pluginResources, {
+    id: "generation-first",
+    packageName: "@zenx-test/generation-first",
+    runtimeType: "bundled",
+    runtimeModule: 'export const identity = "first";\n',
+  });
+  const secondTarball = await createTarballFixture(pluginResources, {
+    id: "generation-second",
+    packageName: "@zenx-test/generation-second",
+    runtimeType: "bundled",
+    runtimeModule: 'export const identity = "second";\n',
+  });
+  const service = profileService(userData, {
+    pnpmCliPath: pnpmCli,
+    resourcesDirectory,
+    trustedProfileLoaders: {
+      "generation-first": () => ({
+        invoke: async () => ({ output: "first", exitCode: 0 }),
+      }),
+      "generation-second": () => ({
+        invoke: async () => ({ output: "second", exitCode: 0 }),
+      }),
+    },
+  });
+  try {
+    await service.initialize();
+    await service.installBundledPluginPackage(firstTarball, {
+      pluginId: "generation-first",
+      packageName: "@zenx-test/generation-first",
+    });
+    const firstCatalog = await readCatalog(userData);
+    await service.installBundledPluginPackage(secondTarball, {
+      pluginId: "generation-second",
+      packageName: "@zenx-test/generation-second",
+    });
+    const secondCatalog = await readCatalog(userData);
+    assert.notEqual(
+      secondCatalog.profileGeneration,
+      firstCatalog.profileGeneration,
+    );
+    assert.deepEqual(
+      service
+        .pluginSnapshot()
+        .plugins.map(({ id }) => id)
+        .sort(),
+      ["generation-first", "generation-second"],
+    );
+    const secondGeneration = path.join(
+      userData,
+      "plugin-profile",
+      "generations",
+      secondCatalog.profileGeneration,
+    );
+    const firstPackage = await realpath(
+      path.join(
+        secondGeneration,
+        "node_modules",
+        "@zenx-test",
+        "generation-first",
+      ),
+    );
+    assert.ok(
+      firstPackage.startsWith(`${secondGeneration}${path.sep}`),
+      `${firstPackage} must stay inside ${secondGeneration}`,
+    );
+  } finally {
+    await service.close();
     await rm(directory, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- stage only the controlled plugin profile manifest and pnpm lockfile when creating a new generation
- rebuild node_modules offline instead of copying Windows junctions
- cover sequential built-in installs and generation-local link targets

## Validation
- focused Windows generation regressions: 2/2
- first-party built-in profile tests: 25/25
- ZenX node/web and plugin SDK typechecks
- ZenX production build
- real packaged upgrade on the existing Rooms-only profile to all five built-ins, followed by restart

## Known baseline
The full Windows profile test file retains four unrelated existing failures in process-pipe fault injection and local git URL handling; the affected lifecycle tests pass.