### PR TITLE
fix(runtime): make tool rounds unlimited by default

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -257,7 +257,7 @@
   admission-failure audit，确保 65th admission-failure 事实不会被同一 mutation 淘汰。
 
 **Project 不存在于 Zen Core**：Runtime 需要的只是某次执行的环境
-（cwd、model、tool policy）。App Server 从协议请求与宿主配置解析这些输入并
+（cwd、model、tool policy，以及可选的 tool-round 上限）。App Server 从协议请求与宿主配置解析这些输入并
 转交 Runtime；credential 只由宿主的外部配置解析，不进入协议或 Thread。
 Thread 记录实际使用的 cwd；"项目列表"是客户端按 workspace 派生的分组视图，
 不是运行时容器。
@@ -303,6 +303,8 @@ connection descriptor 发布，并让该 authority 独立于窗口生命周期�
 
 - AgentRuntime 始终拥有模型采样、provider-neutral tool loop，以及 canonical
   `tool_call` / `tool_result` 的编译和记录；Plugin Runtime 不能拥有自己的 AgentRuntime。
+- tool loop 默认没有轮数上限；Host 可以显式配置正整数 `maxToolRounds`，未配置时
+  Runtime 不得因为累计工具轮数终止健康 Turn。
 - Tool Environment 同时组合 Builtin、Plugin 与 External Tool Providers。Zen 解析
   stable tool name、执行 Host policy、路由与回写；插件或外部服务可以拥有实际领域执行。
 - 模型初始只看到 builtin tools 与一个稳定入口 `zenx_plugin`。`discover` 只返回
@@ -460,9 +462,9 @@ journal append 失败都明确返回且不追加 compaction Item，不隐藏重�
 `contextWindow` 判断自动 compaction；只有 Provider 实际报告的有效 `inputTokens`
 达到窗口的 80% 整数上界才执行，多次采样或 tool round 取观察到的最高 input context。
 Unknown window、缺失或无效 usage、非成功 Turn 与已覆盖边界都不猜测、不追加。
-自动生成、验证或 persistence 必须在成功 Turn handle settle 前完成；失败通过既有
-Turn execution error surface 明确返回且不重试，已完成 Turn 的原始 canonical trace
-保持不变。
+自动生成、验证或 persistence 在成功 Turn handle settle 前尝试一次；失败只记录 Host
+诊断，不得把已经 canonical completed 的 Turn 重新投影为 failed，也不在同一 Turn 内重试。
+下一次达到条件的 completed Turn 可以再次尝试，已完成 Turn 的原始 canonical trace 保持不变。
 
 `context_compaction` canonical Item 记录 `coveredThroughItemId`、原样 summary、
 稳定 canonical 顺序的 `retainedItemIds`、实际 Provider selection、
@@ -630,7 +632,8 @@ Zen 只在 Codex 0.146.0 没有等价原子语义时增加明确命名的协议�
 AbortController，以及可从 active Turn Item 重建的 SoftSteerDeliveryAnchor，
 不把它们当成会话事实。Thread 的 runtime append、steer、interrupt 与终态提交
 经过同一个 mutation boundary 线性化，禁止 canonical 用户消息落到 terminal
-Item 之后。跨 Thread 直接并发运行，没有
+Item 之后。App Server event subscriber 只是瞬时投影观察者；抛异常的 subscriber
+会被隔离并移除，不得反向改变 Turn 或 canonical append。跨 Thread 直接并发运行，没有
 ProjectCoordinator、调度队列或可持久化的 scheduler。进程崩了就崩了：重启后
 从 journal 恢复 Thread 内容，未完成的 Turn 派生为中断，由用户重发。
 

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -110,6 +110,8 @@ child process、本地服务或远程服务。模型初始只看到 builtin tool
 工具 prepare、admission、execution 或 result normalization 的局部失败会形成唯一 failed tool result；
 同一模型响应中的后续调用仍按顺序执行，随后模型可读取全部结果继续 Turn。只有显式用户/Turn
 取消会中断这条工具路径；模型、journal 与 Runtime 失败仍保留既有 Turn failure 语义。
+tool loop 默认不限轮数；ZenX General Settings 可选择一个正整数最大轮数，只有显式配置后
+Runtime 才以该上限终止持续请求工具的 Turn。
 
 目标插件生命周期只有 installed / enabled / uninstalled；bundled plugin 同样可卸载、以后重装，
 卸载默认保留数据，删除数据是独立动作。目标权限只有默认 `full_access` 与可选 `ask_unknown`；后者

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -87,6 +87,8 @@ export interface ZenHostOptions {
   threadSummaryProjection?: ThreadSummaryProjection;
   toolEnvironment?: ToolEnvironment;
   toolDefinitionProjection?: ToolDefinitionProjection;
+  /** Omit to allow the model to use as many tool rounds as the Turn needs. */
+  maxToolRounds?: number;
   /** Compatibility input for callers that still provide one static executor. */
   tools?: ToolExecutor;
   attachments?: AttachmentStore;
@@ -209,6 +211,9 @@ export function createHostedAppServer(
       ...(options.toolDefinitionProjection === undefined
         ? {}
         : { toolDefinitionProjection: options.toolDefinitionProjection }),
+      ...(options.maxToolRounds === undefined
+        ? {}
+        : { maxToolRounds: options.maxToolRounds }),
     }),
     providerRegistry: new ProviderRegistry(profiles),
     threadMetadata:

--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -51,6 +51,8 @@ export interface ZenXHostProfile {
   workspaces: string[];
   lastUsedWorkspace: string | null;
   approvalPolicy: "always" | "never";
+  /** Omitted means tool rounds are unlimited. */
+  maxToolRounds?: number;
   pinnedThreadIds: string[];
   sidebarOrder: ZenXSidebarOrder;
 }
@@ -62,6 +64,7 @@ export type ZenXSettingsUpdate = Pick<
   | "defaultModel"
   | "titleModel"
   | "approvalPolicy"
+  | "maxToolRounds"
 >;
 
 export interface ZenXProviderEditOptions {
@@ -242,6 +245,7 @@ export function validateHostProfile(
   if (value.approvalPolicy !== "always" && value.approvalPolicy !== "never") {
     throw new Error("ZenX approval policy is invalid");
   }
+  const maxToolRounds = optionalMaximumToolRounds(value.maxToolRounds);
   const workspace =
     value.workspace === null
       ? null
@@ -269,6 +273,7 @@ export function validateHostProfile(
     workspaces,
     lastUsedWorkspace,
     approvalPolicy: value.approvalPolicy,
+    ...(maxToolRounds === undefined ? {} : { maxToolRounds }),
     pinnedThreadIds: normalizePinnedThreadIds(value.pinnedThreadIds),
     sidebarOrder: normalizeSidebarOrder(value.sidebarOrder),
   };
@@ -395,6 +400,9 @@ export function hostConfigFromProfile(
     cwd: validated.workspace ?? path.resolve(options.fallbackWorkspace),
     dataDirectory: options.dataDirectory,
     approvalPolicy: validated.approvalPolicy,
+    ...(validated.maxToolRounds === undefined
+      ? {}
+      : { maxToolRounds: validated.maxToolRounds }),
     providers: validated.providerProfiles.map((providerProfile) => ({
       ...providerRuntimeCatalog(providerProfile, validated.defaultModel),
       providerProfileId: providerProfile.providerProfileId,
@@ -831,6 +839,14 @@ export function workspaceKey(
 ): string {
   const resolved = resolveProjectPath(value, projectPlatform);
   return projectPlatform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function optionalMaximumToolRounds(value: unknown): number | undefined {
+  if (value === undefined) return undefined;
+  if (!Number.isSafeInteger(value) || (value as number) < 1) {
+    throw new Error("ZenX maximum tool rounds must be a positive safe integer");
+  }
+  return value as number;
 }
 
 function nonEmpty(value: unknown, label: string): string {

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -454,6 +454,7 @@ export class ZenXSettingsService {
             defaultModel: settings.defaultModel,
             titleModel: settings.titleModel,
             approvalPolicy: settings.approvalPolicy,
+            maxToolRounds: settings.maxToolRounds,
           }),
           [],
         )

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -89,6 +89,7 @@ export function SettingsView({
         defaultModel: draft.defaultModel,
         titleModel: draft.titleModel,
         approvalPolicy: draft.approvalPolicy,
+        maxToolRounds: draft.maxToolRounds,
       });
       setSettings(value);
       setDraft(value.profile);
@@ -1874,6 +1875,13 @@ function GeneralPanel({
   const [appearance, setAppearance] = useState<AppearancePreference>(() =>
     appearanceController.getPreference(),
   );
+  const [maximumInput, setMaximumInput] = useState(
+    draft.maxToolRounds?.toString() ?? "",
+  );
+  const [maximumError, setMaximumError] = useState<string | null>(null);
+  useEffect(() => {
+    setMaximumInput(draft.maxToolRounds?.toString() ?? "");
+  }, [draft.maxToolRounds]);
   return (
     <>
       <header>
@@ -1939,7 +1947,55 @@ function GeneralPanel({
               <option value="never">Full access</option>
             </select>
           </label>
+          <label className="field">
+            <span>Maximum tool rounds</span>
+            <input
+              type="number"
+              min="1"
+              step="1"
+              value={maximumInput}
+              aria-describedby={
+                maximumError === null
+                  ? "max-tool-rounds-help"
+                  : "max-tool-rounds-help max-tool-rounds-error"
+              }
+              aria-invalid={maximumError === null ? undefined : true}
+              onChange={(event) => {
+                const value = event.currentTarget.value;
+                setMaximumInput(value);
+                if (value === "") {
+                  setMaximumError(null);
+                  setDraft({ ...draft, maxToolRounds: undefined });
+                  return;
+                }
+                if (!/^\d+$/u.test(value)) return;
+                const maximum = Number(value);
+                if (!Number.isSafeInteger(maximum) || maximum < 1) return;
+                setMaximumError(null);
+                setDraft({ ...draft, maxToolRounds: maximum });
+              }}
+              onBlur={() => {
+                if (
+                  maximumInput !== "" &&
+                  (!/^\d+$/u.test(maximumInput) ||
+                    !Number.isSafeInteger(Number(maximumInput)) ||
+                    Number(maximumInput) < 1)
+                ) {
+                  setMaximumError("Enter a whole number of 1 or more.");
+                }
+              }}
+            />
+            {maximumError === null ? null : (
+              <small id="max-tool-rounds-error" className="form-error">
+                {maximumError}
+              </small>
+            )}
+          </label>
         </div>
+        <p id="max-tool-rounds-help" className="settings-note">
+          Leave blank for unlimited. A finite maximum stops a Turn that keeps
+          requesting tools after that many model rounds.
+        </p>
         <p className="settings-note">
           Add, remove, and select Projects from the Projects sidebar. Folder
           selection always uses the ZenX directory picker.

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -65,9 +65,29 @@ test("round-trips credential-free v3 profiles and builds all host registry entri
       ["qwen3", "deepseek-r1", "gpt-5.6-luna"],
     );
     assert.deepEqual(config.defaultSelection, profile.defaultModel);
+    assert.equal(config.maxToolRounds, undefined);
     assert.equal(JSON.stringify(read).includes("secret"), false);
   } finally {
     await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("validates and projects an opt-in maximum tool round setting", () => {
+  const configured = validateHostProfile({ ...profile, maxToolRounds: 24 });
+  const config = hostConfigFromProfile(configured, {
+    dataDirectory: path.join(os.tmpdir(), "data"),
+    subscriptionProfilePath: path.join(os.tmpdir(), "auth"),
+    fallbackWorkspace: path.join(os.tmpdir(), "fallback"),
+    apiKeys: { local: "secret" },
+  });
+
+  assert.equal(configured.maxToolRounds, 24);
+  assert.equal(config.maxToolRounds, 24);
+  for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(
+      () => validateHostProfile({ ...profile, maxToolRounds: invalid }),
+      /maximum tool rounds/u,
+    );
   }
 });
 

--- a/apps/zenx/test/settings-interaction.test.ts
+++ b/apps/zenx/test/settings-interaction.test.ts
@@ -931,6 +931,50 @@ test("General switches Appearance immediately without restarting the host", asyn
   }
 });
 
+test("General exposes an optional maximum tool round setting", async () => {
+  const saved: ZenXSettingsUpdate[] = [];
+  const harness = await mountSettings("general", {
+    save: async (profile) => {
+      saved.push(profile);
+      return { ...settings, profile: { ...settings.profile, ...profile } };
+    },
+  });
+  try {
+    const maximum = await waitFor(() => requiredInput("Maximum tool rounds"));
+    assert.equal(maximum.type, "number");
+    assert.equal(maximum.value, "");
+    assert.equal(maximum.min, "1");
+    assert.equal(maximum.step, "1");
+    assert.match(
+      document.getElementById("max-tool-rounds-help")?.textContent ?? "",
+      /blank for unlimited/u,
+    );
+
+    await changeControl(maximum, "0");
+    await act(async () => {
+      maximum.dispatchEvent(new window.Event("focusout", { bubbles: true }));
+      await Promise.resolve();
+    });
+    assert.equal(maximum.getAttribute("aria-invalid"), "true");
+    assert.match(
+      document.getElementById("max-tool-rounds-error")?.textContent ?? "",
+      /whole number of 1 or more/u,
+    );
+    assert.equal(exactButtonRequired("Apply & restart").disabled, true);
+
+    await changeControl(maximum, "12");
+    assert.equal(maximum.hasAttribute("aria-invalid"), false);
+    const apply = exactButtonRequired("Apply & restart");
+    assert.equal(apply.disabled, false);
+    await click(apply);
+
+    assert.equal(saved.length, 1);
+    assert.equal(saved[0]?.maxToolRounds, 12);
+  } finally {
+    await unmount(harness);
+  }
+});
+
 interface Harness {
   dom: JSDOM;
   root: Root;

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -426,6 +426,38 @@ test("merges stale Settings fields without overwriting a newer Project mutation"
   }
 });
 
+test("persists and clears the optional maximum tool round setting", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-tool-round-settings-"),
+  );
+  try {
+    const service = settingsFor(directory, inactiveSubscription());
+    await service.initialize({});
+    const initial = (await service.publicSettings()).profile;
+    assert.equal(initial.maxToolRounds, undefined);
+
+    await service.save({ ...initial, maxToolRounds: 12 });
+    assert.equal((await service.publicSettings()).profile.maxToolRounds, 12);
+    assert.equal((await service.hostConfig()).maxToolRounds, 12);
+
+    const restarted = settingsFor(directory, inactiveSubscription());
+    await restarted.initialize({});
+    const persisted = (await restarted.publicSettings()).profile;
+    assert.equal(persisted.maxToolRounds, 12);
+
+    const unlimited = { ...persisted };
+    delete unlimited.maxToolRounds;
+    await restarted.save(unlimited);
+    assert.equal(
+      (await restarted.publicSettings()).profile.maxToolRounds,
+      undefined,
+    );
+    assert.equal((await restarted.hostConfig()).maxToolRounds, undefined);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("restores the previous credential when profile persistence fails", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-profile-persistence-failure-"),

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -1006,11 +1006,18 @@ export class ZenAppServer {
         status: "completed",
       };
       await this.#commit(thread, completed);
-      await this.#compactCompletedTurnAutomatically({
-        thread,
-        completed,
-        ...automaticCompaction,
-      });
+      try {
+        await this.#compactCompletedTurnAutomatically({
+          thread,
+          completed,
+          ...automaticCompaction,
+        });
+      } catch (error) {
+        console.warn(
+          `Could not automatically compact completed Turn ${turnId}`,
+          error,
+        );
+      }
       return true;
     });
   }
@@ -1525,7 +1532,15 @@ export class ZenAppServer {
 
   #emit(event: AppServerEvent): void {
     for (const subscriber of this.#subscribers) {
-      subscriber(event);
+      try {
+        subscriber(event);
+      } catch (error) {
+        this.#subscribers.delete(subscriber);
+        console.warn(
+          "Removed a failing Zen App Server event subscriber",
+          error,
+        );
+      }
     }
   }
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -112,7 +112,7 @@ export class AgentRuntime {
   readonly #tools: ToolEnvironment;
   readonly #id: () => string;
   readonly #now: () => string;
-  readonly #maxToolRounds: number;
+  readonly #maxToolRounds: number | undefined;
   readonly #toolDefinitionProjection: ToolDefinitionProjection | undefined;
 
   constructor(options: {
@@ -137,7 +137,14 @@ export class AgentRuntime {
     }
     this.#id = options.idFactory ?? randomUUID;
     this.#now = options.now ?? (() => new Date().toISOString());
-    this.#maxToolRounds = options.maxToolRounds ?? 8;
+    if (
+      options.maxToolRounds !== undefined &&
+      (!Number.isSafeInteger(options.maxToolRounds) ||
+        options.maxToolRounds < 1)
+    ) {
+      throw new Error("Maximum tool rounds must be a positive safe integer");
+    }
+    this.#maxToolRounds = options.maxToolRounds;
     this.#toolDefinitionProjection = options.toolDefinitionProjection;
   }
 
@@ -201,7 +208,7 @@ export class AgentRuntime {
           });
           return;
         }
-        if (round >= this.#maxToolRounds) {
+        if (this.#maxToolRounds !== undefined && round >= this.#maxToolRounds) {
           throw new Error(
             `Model exceeded ${String(this.#maxToolRounds)} tool rounds`,
           );

--- a/test/context-compaction.test.ts
+++ b/test/context-compaction.test.ts
@@ -370,7 +370,11 @@ test("automatic compaction freezes admitted selection across a concurrent settin
   assert.equal(compacted.reasoningEffort, "medium");
 });
 
-test("automatic compaction failure rejects the Turn handle once without append or retry", async () => {
+test("automatic compaction failure does not fail a completed Turn", async (t) => {
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (...arguments_: unknown[]) => {
+    warnings.push(String(arguments_[0]));
+  });
   let normalCalls = 0;
   let summaryCalls = 0;
   const journal = new InMemoryThreadJournal();
@@ -396,9 +400,10 @@ test("automatic compaction failure rejects the Turn handle once without append o
   const thread = await server.startThread();
 
   const first = await server.startTurn(thread.id, "one");
-  await expectAppServerCode(first.done, "automatic_compaction_failed");
+  await first.done;
   let snapshot = await server.readThread(thread.id);
   assert.equal(summaryCalls, 1);
+  assert.equal(snapshot.turns[0]?.status, "completed");
   assert.equal(
     snapshot.items.filter((item) => item.type === "turn_completed").length,
     1,
@@ -409,9 +414,10 @@ test("automatic compaction failure rejects the Turn handle once without append o
   );
 
   const second = await server.startTurn(thread.id, "two");
-  await expectAppServerCode(second.done, "automatic_compaction_failed");
+  await second.done;
   snapshot = await server.readThread(thread.id);
   assert.equal(summaryCalls, 2);
+  assert.equal(snapshot.turns[1]?.status, "completed");
   assert.equal(
     snapshot.items.filter((item) => item.type === "turn_completed").length,
     2,
@@ -457,16 +463,23 @@ test("automatic compaction failure rejects the Turn handle once without append o
     persistenceThread.id,
     "persist",
   );
-  await expectAppServerCode(
-    persistenceHandle.done,
-    "automatic_compaction_failed",
-  );
+  await persistenceHandle.done;
   assert.equal(persistenceSummaryCalls, 1);
+  assert.equal(
+    (await persistence.readThread(persistenceThread.id)).turns[0]?.status,
+    "completed",
+  );
   assert.equal(
     (await persistenceBacking.read(persistenceThread.id)).some(
       (item) => item.type === "context_compaction",
     ),
     false,
+  );
+  assert.equal(warnings.length, 3);
+  assert(
+    warnings.every((warning) =>
+      warning.startsWith("Could not automatically compact completed Turn"),
+    ),
   );
 });
 

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -925,6 +925,132 @@ test("runs a deterministic in-memory turn from append-only items", async () => {
   assert.equal(events.at(-1)?.type, "turn_completed");
 });
 
+test("allows more than eight tool rounds when no maximum is configured", async () => {
+  let samples = 0;
+  const model: ModelAdapter = {
+    provider: "many-tools",
+    async *stream(): AsyncIterable<ModelEvent> {
+      samples += 1;
+      if (samples <= 10) {
+        yield {
+          type: "tool_call",
+          callId: `call-${String(samples)}`,
+          name: "continue",
+          arguments: {},
+        };
+        return;
+      }
+      yield { type: "text_delta", delta: "finished" };
+    },
+  };
+  const tools: ToolExecutor = {
+    definitions: [
+      {
+        name: "continue",
+        description: "Continue the deterministic fixture.",
+        inputSchema: { type: "object" },
+      },
+    ],
+    execute: async () => ({ output: "continue", exitCode: 0 }),
+  };
+  const server = createServer({ model, tools });
+  const thread = await server.startThread();
+
+  await (
+    await server.startTurn(thread.id, "keep working")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assert.equal(samples, 11);
+  assert.equal(snapshot.turns[0]?.status, "completed");
+  assert.equal(
+    snapshot.items.filter((item) => item.type === "tool_result").length,
+    10,
+  );
+  assert.equal(
+    snapshot.items.find((item) => item.type === "agent_message")?.text,
+    "finished",
+  );
+});
+
+test("honors an explicitly configured maximum tool round count", async () => {
+  let samples = 0;
+  const model: ModelAdapter = {
+    provider: "bounded-tools",
+    async *stream(): AsyncIterable<ModelEvent> {
+      samples += 1;
+      yield {
+        type: "tool_call",
+        callId: `call-${String(samples)}`,
+        name: "continue",
+        arguments: {},
+      };
+    },
+  };
+  const tools: ToolExecutor = {
+    definitions: [
+      {
+        name: "continue",
+        description: "Continue the deterministic fixture.",
+        inputSchema: { type: "object" },
+      },
+    ],
+    execute: async () => ({ output: "continue", exitCode: 0 }),
+  };
+  const runtime = new AgentRuntime({ tools, maxToolRounds: 2 });
+  const server = createServer({ model, runtime });
+  const thread = await server.startThread();
+
+  await (
+    await server.startTurn(thread.id, "stop after two")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assert.equal(samples, 3);
+  assert.equal(snapshot.turns[0]?.status, "failed");
+  assert.equal(
+    snapshot.items.filter((item) => item.type === "tool_result").length,
+    2,
+  );
+  assert.match(
+    snapshot.items.find((item) => item.type === "failure")?.message ?? "",
+    /exceeded 2 tool rounds/u,
+  );
+  for (const invalid of [0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1]) {
+    assert.throws(
+      () => new AgentRuntime({ tools, maxToolRounds: invalid }),
+      /Maximum tool rounds/u,
+    );
+  }
+});
+
+test("event observers cannot fail or strand a Turn", async (t) => {
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (...arguments_: unknown[]) => {
+    warnings.push(String(arguments_[0]));
+  });
+  const server = createServer();
+  let observed = 0;
+  server.subscribe(() => {
+    throw new Error("observer failed");
+  });
+  server.subscribe(() => {
+    observed += 1;
+  });
+  const thread = await server.startThread();
+
+  await (
+    await server.startTurn(thread.id, "hello")
+  ).done;
+
+  const snapshot = await server.readThread(thread.id);
+  assert.equal(snapshot.turns[0]?.status, "completed");
+  assert(observed > 0);
+  assert.deepEqual(warnings, [
+    "Removed a failing Zen App Server event subscriber",
+  ]);
+});
+
 test("journal stores only complete canonical items, never deltas", async () => {
   const temporaryDirectory = await mkdtemp(
     path.join(os.tmpdir(), "zen-journal-test-"),


### PR DESCRIPTION
## Summary
- make Runtime tool rounds unlimited unless a host explicitly configures a positive maximum
- persist and expose the optional maximum in ZenX General Settings
- degrade automatic compaction and App Server subscriber failures without re-failing completed model work
- document the runtime policy and add focused regression coverage

## Verification
- targeted Runtime fail-close tests: 3 passed
- automatic compaction degradation: 1 passed
- ZenX host profile/settings/service/interaction: 55 passed, 2 platform skips
- direct Core and ZenX TypeScript checks passed
- changed-file Prettier and git diff checks passed

Review and merge are owned by the integration task.