### PR TITLE
fix(zenx): preserve project thread context

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,6 +64,7 @@
   realpath 不可用时退回 lexical absolute path，配置刷新按 latest-wins 发布且不长期缓存 filesystem identity，
   每次投影、筛选、创建或 workspace mutation 从一份不可变的 canonicalization snapshot 派生，mutation
   在既有队列内有界重验；最近使用项由同一 host profile 持有且失效时不隐式回退，
+  Project 作用域的新建意图以 typed IPC 进入 main、重新解析已配置 workspace 后才调用 App Server `thread/start`，
   它不拥有 Project、Thread、journal 或 durable coordination 状态。
 - **ZenXDirectoryBrowser** — ZenX main 把 home、documents、Windows drive / POSIX root 与
   canonical 只读目录枚举投影给内部 picker；symlink/junction 只解析为目录目标，不修改文件系统。

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,7 @@
   realpath 不可用时退回 lexical absolute path，配置刷新按 latest-wins 发布且不长期缓存 filesystem identity，
   每次投影、筛选、创建或 workspace mutation 从一份不可变的 canonicalization snapshot 派生，mutation
   在既有队列内有界重验；最近使用项由同一 host profile 持有且失效时不隐式回退，
-  Project 作用域的新建意图以 typed IPC 进入 main、重新解析已配置 workspace 后才调用 App Server `thread/start`，
+  Project 作用域的新建意图以 typed IPC 进入 main、在同一已发布 configuration revision 上重新解析已配置 workspace 后才调用 App Server `thread/start`，
   它不拥有 Project、Thread、journal 或 durable coordination 状态。
 - **ZenXDirectoryBrowser** — ZenX main 把 home、documents、Windows drive / POSIX root 与
   canonical 只读目录枚举投影给内部 picker；symlink/junction 只解析为目录目标，不修改文件系统。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -153,6 +153,7 @@ Add Project 使用只读的内部目录 picker。Windows/Linux 不安装 Electro
 选择 Project，不把 Documents、进程 cwd 或默认 Project 当作隐式替代。
 Project row 的 quick-create 始终以被点击 Project 的 canonical workspace 发起 `thread/start`；
 New thread 因缺少可用 Project 而打开目录 picker 时，确认目录会继续完成 Thread 创建，而不只添加 Project。
+创建成功后 ZenX 在解除 pending 前刷新 Thread summaries 与 Project projection；失败在用户当前页面明确显示并可原位重试。
 
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -151,6 +151,8 @@ Add Project 使用只读的内部目录 picker。Windows/Linux 不安装 Electro
 只保留系统合规的最小 native menu；这些都属于桌面产品外层，不改变 Core 或 wire protocol。
 顶部 New thread 只使用 host profile 中仍有效的最近使用 workspace；没有记录时由用户明确
 选择 Project，不把 Documents、进程 cwd 或默认 Project 当作隐式替代。
+Project row 的 quick-create 始终以被点击 Project 的 canonical workspace 发起 `thread/start`；
+New thread 因缺少可用 Project 而打开目录 picker 时，确认目录会继续完成 Thread 创建，而不只添加 Project。
 
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -104,6 +104,7 @@ Thread
 
 - Projects 标题旁提供 icon-only **Add project**，具备 tooltip、accessible name、focus state 和完整 hit target。
 - Add project 使用 ZenX 只读 directory picker；Thread 创建最终必须解析为明确的 cwd，并消费同一个 canonical Project projection。
+- Project quick-create 一旦呈现，必须把被点击 Project 作为唯一创建作用域；默认或最近 Project 不能覆盖它。New thread 打开 directory picker 时，确认目录必须继续完成原始的 Thread 创建意图，不能退化成只添加 Project。
 - **Experiment / TBD：** Project quick-create 是否保留、全局 New thread 是否复用 last-used Project，以及 last-used 失效时是否直接打开 picker，均属于最终 New thread IA 的待定部分。不得把 Documents、`process.cwd()` 或隐藏默认 Project 当成已经确认的产品 fallback。
 
 ### 3.4 原生应用菜单与按需面板

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -105,6 +105,7 @@ Thread
 - Projects 标题旁提供 icon-only **Add project**，具备 tooltip、accessible name、focus state 和完整 hit target。
 - Add project 使用 ZenX 只读 directory picker；Thread 创建最终必须解析为明确的 cwd，并消费同一个 canonical Project projection。
 - Project quick-create 一旦呈现，必须把被点击 Project 作为唯一创建作用域；默认或最近 Project 不能覆盖它。New thread 打开 directory picker 时，确认目录必须继续完成原始的 Thread 创建意图，不能退化成只添加 Project。
+- New thread 的 pending 状态只由该创建操作拥有；创建成功后再解除 pending 并刷新 summaries / Project projection，失败则在当前页面显示可重试的明确反馈。
 - **Experiment / TBD：** Project quick-create 是否保留、全局 New thread 是否复用 last-used Project，以及 last-used 失效时是否直接打开 picker，均属于最终 New thread IA 的待定部分。不得把 Documents、`process.cwd()` 或隐藏默认 Project 当成已经确认的产品 fallback。
 
 ### 3.4 原生应用菜单与按需面板

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -51,7 +51,10 @@ import {
 } from "./capabilities/self-control-package.js";
 import { installApplicationMenu } from "./application-menu.js";
 import { ZenXDirectoryBrowser } from "./directory-browser.js";
-import { ZenXProjectProjection } from "./project-projection.js";
+import {
+  startConfiguredProjectThread,
+  ZenXProjectProjection,
+} from "./project-projection.js";
 import {
   projectWorkspaceAcceptanceConfigPath,
   runProjectWorkspaceAcceptance,
@@ -580,6 +583,15 @@ function installProtocolIpc(
     );
   });
   ipcMain.handle(
+    ipcChannels.projectThreadStart,
+    async (_event, workspace: unknown) =>
+      await startConfiguredProjectThread(
+        projects,
+        workspace,
+        async (params) => await manager.request("thread/start", params),
+      ),
+  );
+  ipcMain.handle(
     ipcChannels.request,
     async (_event, method: unknown, params: unknown) => {
       if (!isClientRequestMethod(method)) {
@@ -689,6 +701,7 @@ function installFailedProtocolIpc(message: string): void {
     ipcChannels.imageAttachmentsRead,
     ipcChannels.threadAttachmentsRead,
     ipcChannels.threadUsageRead,
+    ipcChannels.projectThreadStart,
   ]) {
     ipcMain.handle(channel, () => {
       throw new Error(`Zen App Server is not ready: ${message}`);

--- a/apps/zenx/src/main/project-projection.ts
+++ b/apps/zenx/src/main/project-projection.ts
@@ -45,6 +45,7 @@ export interface ProjectPathIdentity {
 export type ProjectPathSnapshot = readonly ProjectPathIdentity[];
 
 interface ProjectConfigurationSnapshot {
+  readonly revision: number;
   readonly workspaces: readonly string[];
   readonly defaultWorkspace: string | null;
   readonly lastUsedWorkspace: string | null;
@@ -59,6 +60,7 @@ export class ZenXProjectProjection {
   readonly #platform: NodeJS.Platform;
   readonly #realpath: ProjectRealpath;
   #configuration: ProjectConfigurationSnapshot = Object.freeze({
+    revision: 0,
     workspaces: Object.freeze([]),
     defaultWorkspace: null,
     lastUsedWorkspace: null,
@@ -113,6 +115,7 @@ export class ZenXProjectProjection {
         : (unique.get(lastUsedKey)?.displayPath ?? null);
     if (revision !== this.#configurationRevision) return;
     this.#configuration = Object.freeze({
+      revision,
       workspaces: Object.freeze(nextWorkspaces),
       defaultWorkspace: nextDefaultWorkspace,
       lastUsedWorkspace: nextLastUsedWorkspace,
@@ -212,11 +215,19 @@ export class ZenXProjectProjection {
   }
 
   async configuredWorkspace(value: string): Promise<string | null> {
+    const revision = this.#configurationRevision;
     const configuration = this.#configuration;
+    if (configuration.revision !== revision) return null;
     const identities = await this.#canonicalSnapshot([
       ...configuration.workspaces,
       value,
     ]);
+    if (
+      this.#configurationRevision !== revision ||
+      this.#configuration !== configuration
+    ) {
+      return null;
+    }
     const requested = identities.at(-1);
     if (requested === undefined) return null;
     return (

--- a/apps/zenx/src/main/project-projection.ts
+++ b/apps/zenx/src/main/project-projection.ts
@@ -22,6 +22,21 @@ export interface ZenXProjectProjectionSnapshot {
 
 export type ProjectRealpath = (candidate: string) => Promise<string>;
 
+export async function startConfiguredProjectThread<T>(
+  projection: ZenXProjectProjection,
+  workspace: unknown,
+  start: (params: { cwd: string }) => Promise<T>,
+): Promise<T> {
+  if (typeof workspace !== "string" || workspace.trim().length === 0) {
+    throw new Error("Invalid Project workspace");
+  }
+  const configuredWorkspace = await projection.configuredWorkspace(workspace);
+  if (configuredWorkspace === null) {
+    throw new Error("Project workspace is not configured");
+  }
+  return await start({ cwd: configuredWorkspace });
+}
+
 export interface ProjectPathIdentity {
   readonly displayPath: string;
   readonly key: string;

--- a/apps/zenx/src/main/project-workspace-smoke.ts
+++ b/apps/zenx/src/main/project-workspace-smoke.ts
@@ -147,15 +147,37 @@ async function waitForProjectThread(
   window: BrowserWindow,
   project: string,
 ): Promise<void> {
-  await waitForRenderer(
-    window,
-    `(() => {
-      const action = ${buttonLookup(`New thread in ${project}`)};
-      return action instanceof HTMLButtonElement &&
-        action.closest(".project-group")?.querySelector(".thread-row-shell") instanceof HTMLElement;
-    })()`,
-    `Thread created inside Project ${project}`,
-  );
+  try {
+    await waitForRenderer(
+      window,
+      `(() => {
+        const action = ${buttonLookup(`New thread in ${project}`)};
+        return action instanceof HTMLButtonElement &&
+          action.closest(".project-group")?.querySelector(".thread-row-shell") instanceof HTMLElement;
+      })()`,
+      `Thread created inside Project ${project}`,
+    );
+  } catch (error) {
+    const diagnostics = await window.webContents.executeJavaScript(
+      `Promise.all([
+        window.zenx.threads.list({ archived: false }),
+        window.zenx.projects.get({ archived: false }),
+      ]).then(([threads, projects]) => ({
+        threads,
+        projects,
+        groups: Array.from(document.querySelectorAll(".project-group")).map((group) => ({
+          text: group.textContent?.trim().replace(/\\s+/gu, " "),
+          actions: Array.from(group.querySelectorAll("button")).map((button) => button.getAttribute("aria-label")),
+          rows: group.querySelectorAll(".thread-row-shell").length,
+        })),
+        error: document.querySelector('[role="alert"]')?.textContent?.trim() ?? null,
+      }))`,
+      true,
+    );
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}; diagnostics=${JSON.stringify(diagnostics)}`,
+    );
+  }
 }
 
 async function waitForRenderer(

--- a/apps/zenx/src/main/project-workspace-smoke.ts
+++ b/apps/zenx/src/main/project-workspace-smoke.ts
@@ -60,6 +60,9 @@ export async function runProjectWorkspaceAcceptance(
       await clickButton(options.window, `More actions for ${config.projectB}`);
       await waitForButton(options.window, "Remove from ZenX");
 
+      await clickButton(options.window, `New thread in ${config.projectB}`);
+      await waitForProjectThread(options.window, config.projectB);
+
       await clickButton(options.window, "Set as default");
       await clickButton(options.window, `More actions for ${config.projectA}`);
       await clickButton(options.window, "Remove from ZenX");
@@ -137,6 +140,21 @@ async function waitForProjectState(
     restarted
       ? "persisted Project state after restart"
       : "Project removal to settle",
+  );
+}
+
+async function waitForProjectThread(
+  window: BrowserWindow,
+  project: string,
+): Promise<void> {
+  await waitForRenderer(
+    window,
+    `(() => {
+      const action = ${buttonLookup(`New thread in ${project}`)};
+      return action instanceof HTMLButtonElement &&
+        action.closest(".project-group")?.querySelector(".thread-row-shell") instanceof HTMLElement;
+    })()`,
+    `Thread created inside Project ${project}`,
   );
 }
 

--- a/apps/zenx/src/preload/index.ts
+++ b/apps/zenx/src/preload/index.ts
@@ -148,6 +148,10 @@ contextBridge.exposeInMainWorld("zenx", {
       options: ThreadSummaryListOptions = {},
     ): Promise<ZenXProjectProjectionSnapshot> =>
       await ipcRenderer.invoke(ipcChannels.projectsGet, options),
+    startThread: async (
+      workspace: string,
+    ): Promise<ClientRequestResults["thread/start"]> =>
+      await ipcRenderer.invoke(ipcChannels.projectThreadStart, workspace),
   },
   settings: {
     get: async (): Promise<PublicHostSettings> =>

--- a/apps/zenx/src/preload/ipc.ts
+++ b/apps/zenx/src/preload/ipc.ts
@@ -14,6 +14,7 @@ export const ipcChannels = {
   threadAttachmentsRead: "zenx:thread-attachments:read",
   threadUsageRead: "zenx:thread-usage:read",
   projectsGet: "zenx:projects:get",
+  projectThreadStart: "zenx:projects:thread-start",
   settingsGet: "zenx:settings:get",
   settingsSave: "zenx:settings:save",
   providerAdd: "zenx:settings:provider-add",

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -86,6 +86,7 @@ const MODEL_CATALOG_LOADING = "Models are still loading. Try again.";
 
 export function App() {
   const selectionEpoch = useRef(0);
+  const newThreadPendingRef = useRef(false);
   const threadUsageLoadEpoch = useRef(0);
   const threadSummaryLoadEpoch = useRef(0);
   const projectLoadEpoch = useRef(0);
@@ -99,7 +100,9 @@ export function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
-  const [projectPickerOpen, setProjectPickerOpen] = useState(false);
+  const [projectPickerIntent, setProjectPickerIntent] = useState<
+    "add-project" | "new-thread" | null
+  >(null);
   const [pluginSnapshot, setPluginSnapshot] =
     useState<ZenXPluginSnapshot | null>(null);
   const [titleSnapshot, setTitleSnapshot] = useState<ThreadTitleSnapshot>({});
@@ -510,13 +513,13 @@ export function App() {
   useEffect(() => {
     const close = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      if (projectPickerOpen) setProjectPickerOpen(false);
+      if (projectPickerIntent !== null) setProjectPickerIntent(null);
       else if (workspaceOpen) setWorkspaceOpen(false);
       else if (sidebarOpen) setSidebarOpen(false);
     };
     window.addEventListener("keydown", close);
     return () => window.removeEventListener("keydown", close);
-  }, [projectPickerOpen, sidebarOpen, workspaceOpen]);
+  }, [projectPickerIntent, sidebarOpen, workspaceOpen]);
 
   const activeSummaries = threadSummaries.map((summary) =>
     titleSnapshot[summary.threadId]?.title === undefined
@@ -552,6 +555,8 @@ export function App() {
   const lastUsedWorkspace = lastUsedProjectWorkspace(projects);
 
   const newThread = async (workspace: string) => {
+    if (newThreadPendingRef.current) return;
+    newThreadPendingRef.current = true;
     const epoch = ++selectionEpoch.current;
     setThreadLoading(true);
     setThreadError(null);
@@ -560,8 +565,7 @@ export function App() {
       const result = await startProjectThread(
         workspace,
         async (candidate) => await window.zenx.settings.addWorkspace(candidate),
-        async (params) =>
-          await window.zenx.protocol.request("thread/start", params),
+        async (params) => await window.zenx.projects.startThread(params.cwd),
         (startedWorkspace) => {
           void window.zenx.settings
             .markWorkspaceUsed(startedWorkspace)
@@ -584,6 +588,7 @@ export function App() {
       if (selectionEpoch.current === epoch)
         setThreadError(describeError(error));
     } finally {
+      newThreadPendingRef.current = false;
       if (selectionEpoch.current === epoch) setThreadLoading(false);
     }
   };
@@ -965,9 +970,11 @@ export function App() {
           }
         }}
         onNewThread={(workspace) => {
-          if (workspace !== undefined) void newThread(workspace);
+          if (workspace === undefined) setProjectPickerIntent("new-thread");
+          else void newThread(workspace);
         }}
-        onAddProject={() => setProjectPickerOpen(true)}
+        onAddProject={() => setProjectPickerIntent("add-project")}
+        newThreadDisabled={threadLoading}
         onRemoveProject={(workspace) => {
           void window.zenx.settings
             .removeWorkspace(workspace)
@@ -1083,10 +1090,10 @@ export function App() {
               (project) => project.configured,
             )}
             hasLastUsedProject={lastUsedWorkspace !== null}
-            onAddProject={() => setProjectPickerOpen(true)}
+            onAddProject={() => setProjectPickerIntent("add-project")}
             onNewThread={() => {
               if (lastUsedWorkspace !== null) void newThread(lastUsedWorkspace);
-              else setProjectPickerOpen(true);
+              else setProjectPickerIntent("new-thread");
             }}
             onOpenSidebar={() => setSidebarOpen(true)}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
@@ -1135,15 +1142,20 @@ export function App() {
           thread={threadDetail}
         />
       ) : null}
-      {projectPickerOpen ? (
+      {projectPickerIntent !== null ? (
         <DirectoryPicker
-          onCancel={() => setProjectPickerOpen(false)}
+          onCancel={() => setProjectPickerIntent(null)}
           onSelect={(workspace) => {
+            if (projectPickerIntent === "new-thread") {
+              setProjectPickerIntent(null);
+              void newThread(workspace);
+              return;
+            }
             void window.zenx.settings
               .addWorkspace(workspace)
               .then(async () => {
                 await loadProjects();
-                setProjectPickerOpen(false);
+                setProjectPickerIntent(null);
               })
               .catch((error: unknown) => setRequestError(describeError(error)));
           }}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -135,6 +135,11 @@ export function App() {
   const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
   const [threadLoading, setThreadLoading] = useState(false);
   const [threadError, setThreadError] = useState<string | null>(null);
+  const [newThreadFailure, setNewThreadFailure] = useState<{
+    workspace: string;
+    message: string;
+  } | null>(null);
+  const [newThreadPending, setNewThreadPending] = useState(false);
   const [approvals, setApprovals] = useState<ApprovalCardState[]>([]);
   const [models, setModels] = useState<ModelSummary[]>([]);
   const [providerProfiles, setProviderProfiles] = useState<
@@ -558,7 +563,8 @@ export function App() {
     if (newThreadPendingRef.current) return;
     newThreadPendingRef.current = true;
     const epoch = ++selectionEpoch.current;
-    setThreadLoading(true);
+    setNewThreadPending(true);
+    setNewThreadFailure(null);
     setThreadError(null);
     setModelUpdateError(null);
     try {
@@ -566,11 +572,14 @@ export function App() {
         workspace,
         async (candidate) => await window.zenx.settings.addWorkspace(candidate),
         async (params) => await window.zenx.projects.startThread(params.cwd),
-        (startedWorkspace) => {
-          void window.zenx.settings
-            .markWorkspaceUsed(startedWorkspace)
-            .then(() => loadProjects())
-            .catch((error: unknown) => setRequestError(describeError(error)));
+        async (startedWorkspace) => {
+          try {
+            await window.zenx.settings.markWorkspaceUsed(startedWorkspace);
+          } catch (error) {
+            setRequestError(describeError(error));
+          }
+          await loadThreadSummaries();
+          await loadProjects();
         },
       );
       if (selectionEpoch.current !== epoch) return;
@@ -583,13 +592,11 @@ export function App() {
       setThreadAttachments({});
       setThreadUsage(undefined);
       setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
-      await loadThreadSummaries();
     } catch (error) {
-      if (selectionEpoch.current === epoch)
-        setThreadError(describeError(error));
+      setNewThreadFailure({ workspace, message: describeError(error) });
     } finally {
       newThreadPendingRef.current = false;
-      if (selectionEpoch.current === epoch) setThreadLoading(false);
+      setNewThreadPending(false);
     }
   };
 
@@ -974,7 +981,7 @@ export function App() {
           else void newThread(workspace);
         }}
         onAddProject={() => setProjectPickerIntent("add-project")}
-        newThreadDisabled={threadLoading}
+        newThreadDisabled={newThreadPending}
         onRemoveProject={(workspace) => {
           void window.zenx.settings
             .removeWorkspace(workspace)
@@ -1015,6 +1022,22 @@ export function App() {
       />
 
       <main className="workspace">
+        {newThreadFailure === null ? null : (
+          <div className="new-thread-error-banner" role="alert">
+            <div>
+              <strong>New thread failed</strong>
+              <span>{newThreadFailure.message}</span>
+            </div>
+            <button
+              className="secondary-button"
+              type="button"
+              disabled={newThreadPending}
+              onClick={() => void newThread(newThreadFailure.workspace)}
+            >
+              Try again
+            </button>
+          </div>
+        )}
         {page === "settings" ? (
           <SettingsView
             archivedError={threadListErrors.archived}
@@ -1125,7 +1148,7 @@ export function App() {
             }
             threadDetail={threadDetail}
             threadError={threadError}
-            threadLoading={threadLoading}
+            threadLoading={threadLoading || newThreadPending}
             titleProjection={
               selectedSummary === null
                 ? undefined

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -50,6 +50,7 @@ interface SidebarProps {
   ): Promise<void>;
   onModeChange(mode: SidebarMode): void;
   onNewThread(workspace?: string): void;
+  newThreadDisabled?: boolean;
   onAddProject(): void;
   onRemoveProject(workspace: string): void;
   onSetDefaultProject(workspace: string): void;
@@ -82,6 +83,7 @@ export function Sidebar({
   onReorderThread,
   onModeChange,
   onNewThread,
+  newThreadDisabled = false,
   onAddProject,
   onRemoveProject,
   onSetDefaultProject,
@@ -211,9 +213,10 @@ export function Sidebar({
                   ? projectChooserOpen
                   : undefined
               }
+              disabled={newThreadDisabled}
               onClick={() => {
                 if (configuredProjects.length === 0) {
-                  onAddProject();
+                  onNewThread();
                   return;
                 }
                 if (lastUsedProject !== undefined) {
@@ -242,6 +245,7 @@ export function Sidebar({
                     key={project.key}
                     type="button"
                     title={project.workspace}
+                    disabled={newThreadDisabled}
                     onClick={() => {
                       setProjectChooserOpen(false);
                       onNewThread(project.workspace);
@@ -361,6 +365,7 @@ export function Sidebar({
                   projects={projects}
                   sidebarOrder={sidebarOrder}
                   onNewThread={onNewThread}
+                  newThreadDisabled={newThreadDisabled}
                   onRemoveProject={onRemoveProject}
                   onSetDefaultProject={onSetDefaultProject}
                   onSelectThread={onSelectThread}
@@ -576,6 +581,7 @@ function ProjectsView({
   projects,
   sidebarOrder,
   onNewThread,
+  newThreadDisabled,
   onRemoveProject,
   onSetDefaultProject,
   threads,
@@ -596,6 +602,7 @@ function ProjectsView({
   projects: ZenXProjectProjectionSnapshot;
   sidebarOrder: ZenXSidebarOrder;
   onNewThread(workspace?: string): void;
+  newThreadDisabled: boolean;
   onRemoveProject(workspace: string): void;
   onSetDefaultProject(workspace: string): void;
   threads: readonly NativeThreadSummary[];
@@ -639,6 +646,7 @@ function ProjectsView({
       onChangeThreadPinned={onChangeThreadPinned}
       onRenameThread={onRenameThread}
       onNewThread={onNewThread}
+      newThreadDisabled={newThreadDisabled}
       onRemoveProject={onRemoveProject}
       onSetDefaultProject={onSetDefaultProject}
       onSelectThread={onSelectThread}
@@ -816,6 +824,7 @@ interface ThreadReorderHandlers {
 function ProjectRows({
   group,
   onNewThread,
+  newThreadDisabled,
   onRemoveProject,
   onSetDefaultProject,
   selectedThreadId,
@@ -832,6 +841,7 @@ function ProjectRows({
 }: {
   group: ReturnType<typeof deriveProjectGroups>[number];
   onNewThread(workspace?: string): void;
+  newThreadDisabled: boolean;
   onRemoveProject(workspace: string): void;
   onSetDefaultProject(workspace: string): void;
   selectedThreadId: string | null;
@@ -961,6 +971,7 @@ function ProjectRows({
               type="button"
               aria-label={`New thread in ${group.label}`}
               title="New thread here"
+              disabled={newThreadDisabled}
               onClick={() => onNewThread(group.workspace!)}
             >
               <Icon name="compose" size={13} />

--- a/apps/zenx/src/renderer/src/env.d.ts
+++ b/apps/zenx/src/renderer/src/env.d.ts
@@ -99,6 +99,9 @@ declare global {
         get(
           options?: ThreadSummaryListOptions,
         ): Promise<ZenXProjectProjectionSnapshot>;
+        startThread(
+          workspace: string,
+        ): Promise<ClientRequestResults["thread/start"]>;
       };
       settings: {
         get(): Promise<PublicHostSettings>;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -972,6 +972,7 @@ a:focus-visible {
 }
 
 .workspace {
+  position: relative;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -982,6 +983,39 @@ a:focus-visible {
       transparent 60%
     ),
     var(--main);
+}
+.new-thread-error-banner {
+  position: absolute;
+  z-index: 20;
+  top: 72px;
+  right: 22px;
+  left: 22px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid color-mix(in srgb, var(--danger) 52%, var(--border));
+  border-radius: 10px;
+  background: var(--surface-danger);
+  box-shadow: var(--shadow-medium);
+  color: var(--danger);
+}
+.new-thread-error-banner > div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+.new-thread-error-banner strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  font-weight: 600;
+}
+.new-thread-error-banner span {
+  overflow-wrap: anywhere;
+  font-size: 10px;
 }
 .agent-surface,
 .product-page {
@@ -3927,6 +3961,11 @@ a:focus-visible {
   .product-page {
     width: 100%;
     height: 100%;
+  }
+  .new-thread-error-banner {
+    top: 68px;
+    right: 12px;
+    left: 12px;
   }
   .agent-surface,
   .product-page {

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -81,11 +81,11 @@ export async function startProjectThread<T>(
   workspace: string,
   configure: (workspace: string) => Promise<unknown>,
   start: (params: { cwd: string }) => Promise<T>,
-  onStarted: (workspace: string) => void,
+  onStarted: (workspace: string) => unknown | Promise<unknown>,
 ): Promise<T> {
   await configure(workspace);
   const result = await start(projectThreadStartParams(workspace));
-  onStarted(workspace);
+  await onStarted(workspace);
   return result;
 }
 

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -150,6 +150,180 @@ test("Project quick-create keeps the clicked workspace authoritative and fences 
   }
 });
 
+test("successful Project quick-create commits profile, summaries, and projection before settling", async () => {
+  const workspace = "/work/zen";
+  const profileCommit = deferred<ReturnType<typeof publicSettings>>();
+  let committed = false;
+  let starts = 0;
+  const emptyProjects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: workspace,
+        workspace,
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: workspace,
+  };
+  const populatedProjects: ZenXProjectProjectionSnapshot = {
+    ...emptyProjects,
+    projects: [{ ...emptyProjects.projects[0]!, threadIds: ["thread-1"] }],
+  };
+  const harness = await mountApp(emptyProjects, {
+    markWorkspaceUsed: async () => {
+      const result = await profileCommit.promise;
+      committed = true;
+      return result;
+    },
+    projectsGet: async () => (committed ? populatedProjects : emptyProjects),
+    startProjectThread: async () => {
+      starts += 1;
+      return started(liveThread(), workspace);
+    },
+    threads: async (archived) =>
+      !archived && committed ? [summary(false)] : [],
+  });
+  try {
+    const create = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="New thread in zen"]',
+      ),
+    );
+    await act(async () => create.click());
+    await waitFor(() => starts === 1);
+    assert.equal(
+      document.querySelector(".project-group .thread-row-shell"),
+      null,
+    );
+
+    await act(async () => {
+      profileCommit.resolve(publicSettings([]));
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      document.querySelector(".project-group .thread-row-shell"),
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("New thread failure stays visible on Settings and retries in place", async () => {
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  let starts = 0;
+  const populatedProjects: ZenXProjectProjectionSnapshot = {
+    ...projects,
+    projects: [{ ...projects.projects[0]!, threadIds: ["thread-1"] }],
+  };
+  const harness = await mountApp(projects, {
+    projectsGet: async () => (starts >= 2 ? populatedProjects : projects),
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      if (starts === 1) throw new Error("runtime offline");
+      return started(liveThread(), workspace);
+    },
+    threads: async (archived) =>
+      !archived && starts >= 2 ? [summary(false)] : [],
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
+    );
+    await waitFor(() => /Settings/u.test(document.body.textContent ?? ""));
+    await act(async () =>
+      document
+        .querySelector<HTMLButtonElement>('[aria-label="New thread in zen"]')
+        ?.click(),
+    );
+
+    const retry = await waitFor(() => exactButton("Try again"));
+    assert.match(document.body.textContent ?? "", /New thread failed/u);
+    assert.match(document.body.textContent ?? "", /runtime offline/u);
+    assert.match(document.body.textContent ?? "", /Settings/u);
+
+    await act(async () => retry.click());
+    await waitFor(() => starts === 2);
+    await waitFor(() => /Thread one/u.test(document.body.textContent ?? ""));
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("Project quick-create releases its loading fence after selection epoch changes and failure", async () => {
+  const firstStart = deferred<ReturnType<typeof started>>();
+  let starts = 0;
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: ["thread-1"],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  const harness = await mountApp(projects, {
+    request: async (method) => {
+      if (method === "thread/resume") return resumed(liveThread());
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      if (starts === 1) return await firstStart.promise;
+      return started(liveThread(), workspace);
+    },
+    threads: async (archived) => (archived ? [] : [summary(false)]),
+  });
+  try {
+    const create = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="New thread in zen"]',
+      ),
+    );
+    await act(async () => create.click());
+    await waitFor(() => starts === 1);
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".thread-row")?.click(),
+    );
+    await waitFor(() => /Thread one/u.test(document.body.textContent ?? ""));
+    await act(async () => {
+      firstStart.reject(new Error("first start failed"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const retryCreate = await waitFor(() => {
+      const button = document.querySelector<HTMLButtonElement>(
+        '[aria-label="New thread in zen"]',
+      );
+      return button !== null && !button.disabled ? button : null;
+    });
+    assert.match(document.body.textContent ?? "", /first start failed/u);
+    await act(async () => retryCreate.click());
+    await waitFor(() => starts === 2);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("packaged startup clears a transient Project failure after the App Server becomes ready", async () => {
   const projects: ZenXProjectProjectionSnapshot = {
     projects: [
@@ -960,6 +1134,9 @@ async function mountApp(
     onStatus?(listener: (status: AppServerHostStatus) => void): () => void;
     onPinnedThreadIds?(threadIds: readonly string[]): void;
     models?: ModelSummary[];
+    markWorkspaceUsed?(
+      workspace: string,
+    ): Promise<ReturnType<typeof publicSettings>>;
     projectsGet?(): Promise<ZenXProjectProjectionSnapshot>;
     startProjectThread?(workspace: string): Promise<unknown>;
     setPinnedThreadIds?(
@@ -1046,7 +1223,10 @@ async function mountApp(
         currentSettings = publicSettings([...threadIds]);
         return currentSettings;
       },
-      markWorkspaceUsed: async () => currentSettings,
+      markWorkspaceUsed: async (workspace: string) =>
+        options.markWorkspaceUsed === undefined
+          ? currentSettings
+          : await options.markWorkspaceUsed(workspace),
       onManualCodeRequested: () => () => undefined,
       addWorkspace: async () => ({ profile: { onboardingComplete: true } }),
       getDirectoryBrowser: async () => ({

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -48,11 +48,20 @@ test("desktop Choose project opens the existing directory picker", async () => {
 });
 
 test("zero-Project New thread opens the existing directory picker", async () => {
-  const harness = await mountApp({
-    projects: [],
-    unavailableThreadIds: [],
-    lastUsedWorkspace: null,
-  });
+  const startedWorkspaces: string[] = [];
+  const harness = await mountApp(
+    {
+      projects: [],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: null,
+    },
+    {
+      startProjectThread: async (workspace) => {
+        startedWorkspaces.push(workspace);
+        return started(liveThread(), workspace);
+      },
+    },
+  );
   try {
     const newThread = await waitFor(() =>
       document.querySelector<HTMLButtonElement>(".new-thread-action"),
@@ -64,6 +73,78 @@ test("zero-Project New thread opens the existing directory picker", async () => 
       document.querySelector('[role="dialog"]')?.textContent ?? "",
       /Add a project folder/u,
     );
+    await act(async () => exactButton("Add folder")?.click());
+    await waitFor(() => startedWorkspaces.length === 1);
+    assert.deepEqual(startedWorkspaces, ["/"]);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("Project quick-create keeps the clicked workspace authoritative and fences duplicate starts", async () => {
+  const selectedWorkspace = "/work/documents";
+  const startResponse = deferred<ReturnType<typeof started>>();
+  const scopedStarts: string[] = [];
+  const genericStarts: unknown[] = [];
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/documents",
+        workspace: selectedWorkspace,
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
+      {
+        key: "/work",
+        workspace: "/work",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work",
+  };
+  const harness = await mountApp(projects, {
+    startProjectThread: async (workspace) => {
+      scopedStarts.push(workspace);
+      return await startResponse.promise;
+    },
+    request: async (method, params) => {
+      if (method === "thread/start") {
+        genericStarts.push(params);
+        return await startResponse.promise;
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const createInDocuments = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="New thread in documents"]',
+      ),
+    );
+    await act(async () => {
+      createInDocuments.click();
+      createInDocuments.click();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => scopedStarts.length + genericStarts.length === 1);
+    assert.deepEqual(scopedStarts, [selectedWorkspace]);
+    assert.deepEqual(genericStarts, []);
+    assert.equal(createInDocuments.disabled, true);
+    assert.equal(
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.disabled,
+      true,
+    );
+
+    await act(async () => {
+      startResponse.resolve(started(liveThread(), selectedWorkspace));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
   } finally {
     await unmountApp(harness);
   }
@@ -880,6 +961,7 @@ async function mountApp(
     onPinnedThreadIds?(threadIds: readonly string[]): void;
     models?: ModelSummary[];
     projectsGet?(): Promise<ZenXProjectProjectionSnapshot>;
+    startProjectThread?(workspace: string): Promise<unknown>;
     setPinnedThreadIds?(
       threadIds: readonly string[],
     ): Promise<ReturnType<typeof publicSettings>>;
@@ -948,6 +1030,12 @@ async function mountApp(
         options.projectsGet === undefined
           ? projects
           : await options.projectsGet(),
+      startThread: async (workspace: string) => {
+        if (options.startProjectThread === undefined) {
+          throw new Error(`Unexpected Project Thread start: ${workspace}`);
+        }
+        return await options.startProjectThread(workspace);
+      },
     },
     settings: {
       get: async () => currentSettings,
@@ -1146,6 +1234,19 @@ function runningThread(): Thread {
 
 function resumed(thread: Thread) {
   return { thread, model: "fake", modelProvider: "fake" };
+}
+
+function started(thread: Thread, cwd: string) {
+  return {
+    ...resumed({ ...thread, cwd }),
+    approvalPolicy: "never" as const,
+    approvalsReviewer: "user" as const,
+    cwd,
+    instructionSources: [],
+    reasoningEffort: "medium",
+    sandbox: { type: "dangerFullAccess" as const },
+    serviceTier: null,
+  };
 }
 
 async function mountThreadApp(

--- a/apps/zenx/test/project-projection.test.ts
+++ b/apps/zenx/test/project-projection.test.ts
@@ -7,8 +7,37 @@ import test from "node:test";
 import {
   projectPathKey,
   resolveProjectPath,
+  startConfiguredProjectThread,
   ZenXProjectProjection,
 } from "../src/main/project-projection.js";
+
+test("Project-scoped Thread start resolves the configured workspace and never falls back", async () => {
+  const projection = new ZenXProjectProjection("win32");
+  await projection.updateConfiguration(
+    ["D:\\Work", "C:\\Users\\two-one\\Documents"],
+    "D:\\Work",
+  );
+  const starts: Array<{ cwd: string }> = [];
+
+  const result = await startConfiguredProjectThread(
+    projection,
+    "c:\\users\\two-one\\documents",
+    async (params) => {
+      starts.push(params);
+      return { threadId: "documents-thread" };
+    },
+  );
+
+  assert.deepEqual(result, { threadId: "documents-thread" });
+  assert.deepEqual(starts, [{ cwd: "C:\\Users\\two-one\\Documents" }]);
+  await assert.rejects(
+    startConfiguredProjectThread(projection, "E:\\Unconfigured", async () => {
+      throw new Error("must not start");
+    }),
+    /not configured/u,
+  );
+  assert.deepEqual(starts, [{ cwd: "C:\\Users\\two-one\\Documents" }]);
+});
 
 test("projects share Windows case-insensitive identity and keep empty configured workspaces", async () => {
   const projection = new ZenXProjectProjection("win32");

--- a/apps/zenx/test/project-projection.test.ts
+++ b/apps/zenx/test/project-projection.test.ts
@@ -39,6 +39,41 @@ test("Project-scoped Thread start resolves the configured workspace and never fa
   assert.deepEqual(starts, [{ cwd: "C:\\Users\\two-one\\Documents" }]);
 });
 
+test("Project-scoped Thread start rejects authorization from a removed configuration revision", async () => {
+  const authorizationEntered = deferred<void>();
+  const releaseAuthorization = deferred<void>();
+  let holdAuthorization = false;
+  const projection = new ZenXProjectProjection("linux", async (candidate) => {
+    if (holdAuthorization && candidate === "/work/requested") {
+      authorizationEntered.resolve();
+      await releaseAuthorization.promise;
+      return "/work/authorized";
+    }
+    return candidate;
+  });
+  await projection.updateConfiguration(
+    ["/work/authorized"],
+    "/work/authorized",
+  );
+  holdAuthorization = true;
+  let starts = 0;
+
+  const pending = startConfiguredProjectThread(
+    projection,
+    "/work/requested",
+    async () => {
+      starts += 1;
+      return { threadId: "stale-thread" };
+    },
+  );
+  await authorizationEntered.promise;
+  await projection.updateConfiguration([], null);
+  releaseAuthorization.resolve();
+
+  await assert.rejects(pending, /not configured/u);
+  assert.equal(starts, 0);
+});
+
 test("projects share Windows case-insensitive identity and keep empty configured workspaces", async () => {
   const projection = new ZenXProjectProjection("win32");
   await projection.updateConfiguration(
@@ -463,4 +498,18 @@ async function exerciseAliasRetarget(type: "dir" | "junction"): Promise<void> {
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((onResolve, onReject) => {
+    resolve = onResolve;
+    reject = onReject;
+  });
+  return { promise, resolve, reject };
 }

--- a/apps/zenx/test/project-workspace-smoke.test.ts
+++ b/apps/zenx/test/project-workspace-smoke.test.ts
@@ -130,6 +130,8 @@ test("packaged Project acceptance opens each Project menu before its actions", a
       "Add folder",
       "More actions for project-b",
       "Remove from ZenX",
+      "New thread in project-b",
+      "New thread in project-b",
       "Set as default",
       "More actions for project-a",
       "Remove from ZenX",

--- a/apps/zenx/test/projects-ui.test.ts
+++ b/apps/zenx/test/projects-ui.test.ts
@@ -31,7 +31,7 @@ const baseProps = {
   threads: [],
 };
 
-test("no-project sidebar keeps explicit Add project and non-creating New thread guidance", async () => {
+test("no-project sidebar keeps explicit Add project and New thread guidance", async () => {
   Object.assign(globalThis, { React });
   const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
   const html = renderToStaticMarkup(

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -332,6 +332,30 @@ test("configures a derived Project before starting its Thread", async () => {
   ]);
 });
 
+test("waits for the successful Project Thread post-start commit", async () => {
+  const commitEntered = deferred<void>();
+  const releaseCommit = deferred<void>();
+  let completed = false;
+
+  const pending = startProjectThread(
+    "/work/committed",
+    async () => undefined,
+    async () => ({ id: "thread-committed" }),
+    async () => {
+      commitEntered.resolve();
+      await releaseCommit.promise;
+    },
+  ).then(() => {
+    completed = true;
+  });
+  await commitEntered.promise;
+  assert.equal(completed, false);
+
+  releaseCommit.resolve();
+  await pending;
+  assert.equal(completed, true);
+});
+
 test("presents trigger wakeups without leaking raw system prompts", () => {
   const wakeup = [
     "[ZenX trigger wakeup]",
@@ -431,4 +455,15 @@ function project(key: string, threadIds: string[]) {
     isDefault: false,
     threadIds,
   };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((onResolve) => {
+    resolve = onResolve;
+  });
+  return { promise, resolve };
 }

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -1492,7 +1492,7 @@ export class ZenAppServer {
         .selection;
     }
     if (input.model === undefined && input.reasoningEffort === undefined) {
-      return structuredClone(current);
+      return selectionFrom(current);
     }
     return this.#requireSelection(
       {

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -108,6 +108,21 @@ test("requires one visible default while hidden models remain addressable", () =
   assert.equal(catalog.get("model-hidden")?.hidden, true);
 });
 
+test("startThread preserves an explicit cwd over the host default", async () => {
+  const server = createServer();
+  const requestedCwd = path.join(process.cwd(), "project-thread-cwd-override");
+
+  const thread = await server.startThread({ cwd: requestedCwd });
+
+  assert.equal(thread.cwd, requestedCwd);
+  assert.equal(
+    thread.items.find(
+      (item): item is ThreadMetadataItem => item.type === "thread_metadata",
+    )?.cwd,
+    requestedCwd,
+  );
+});
+
 test("preserves credential-matching model and tool trace strings verbatim", async () => {
   const credentialBytes = "credential-bytes";
   const model: ModelAdapter = {


### PR DESCRIPTION
## Summary
- start Project-row threads through a typed Project-scoped IPC boundary that resolves the configured canonical workspace in main
- preserve New thread intent through the zero-Project directory picker
- fence duplicate thread starts and disable equivalent creation controls while a start is pending
- document the confirmed Project creation contract and extend focused/project smoke coverage

## Verification
- focused Project/sidebar suite: 44 tests, 40 passed, 4 skipped
- ZenX typecheck passed
- production build passed
- full prepared suite: 690 passed, 11 skipped, 7 unrelated Windows/environment failures
- packaged Project smoke completed build then hung without output and was stopped under the agreed timeout; exact-head CI is required for packaged evidence

Review and merge are owned by the integration task.