### PR TITLE
fix: persist streaming usage for known compatible providers

### DIFF
--- a/src/model/openai-compatible.ts
+++ b/src/model/openai-compatible.ts
@@ -130,6 +130,10 @@ export class OpenAiCompatibleModel implements ModelAdapter {
       messages,
       n: 1,
       stream: true,
+      ...(reasoningPolicy.supportsUsageInStreaming &&
+      !Object.hasOwn(this.#defaultParams, "stream_options")
+        ? { stream_options: { include_usage: true } }
+        : {}),
       reasoning_effort: compatibleReasoningEffort({
         policy: reasoningPolicy,
         requestEffort: request.reasoningEffort,
@@ -200,6 +204,7 @@ interface CompatibleReasoningPolicy {
   replay: ReasoningReplay;
   forwardReasoningEffort: boolean;
   enableToolStream: boolean;
+  supportsUsageInStreaming: boolean;
 }
 
 function compatibleReasoningPolicy(options: {
@@ -225,6 +230,7 @@ function compatibleReasoningPolicy(options: {
           : "all-assistant",
       forwardReasoningEffort: true,
       enableToolStream: false,
+      supportsUsageInStreaming: isDashScope,
     };
   }
 
@@ -239,6 +245,7 @@ function compatibleReasoningPolicy(options: {
           : "tool-calls",
       forwardReasoningEffort: isDashScope || isZhipu,
       enableToolStream: true,
+      supportsUsageInStreaming: isDashScope,
     };
   }
 
@@ -247,6 +254,7 @@ function compatibleReasoningPolicy(options: {
       replay: "tool-calls",
       forwardReasoningEffort: false,
       enableToolStream: false,
+      supportsUsageInStreaming: true,
     };
   }
 
@@ -254,6 +262,7 @@ function compatibleReasoningPolicy(options: {
     replay: "all-assistant",
     forwardReasoningEffort: true,
     enableToolStream: false,
+    supportsUsageInStreaming: false,
   };
 }
 

--- a/src/model/openai-compatible.ts
+++ b/src/model/openai-compatible.ts
@@ -219,6 +219,10 @@ function compatibleReasoningPolicy(options: {
   const familyModel = model.split("/").at(-1) ?? model;
   const isDashScope =
     provider.includes("dashscope") || isDashScopeHostname(endpointHostname);
+  const supportsUsageInStreaming =
+    isDashScope ||
+    provider === "deepseek" ||
+    isDeepSeekHostname(endpointHostname);
   const isZhipu =
     provider.includes("zhipu") || endpointHostname.endsWith(".bigmodel.cn");
 
@@ -230,7 +234,7 @@ function compatibleReasoningPolicy(options: {
           : "all-assistant",
       forwardReasoningEffort: true,
       enableToolStream: false,
-      supportsUsageInStreaming: isDashScope,
+      supportsUsageInStreaming,
     };
   }
 
@@ -245,7 +249,7 @@ function compatibleReasoningPolicy(options: {
           : "tool-calls",
       forwardReasoningEffort: isDashScope || isZhipu,
       enableToolStream: true,
-      supportsUsageInStreaming: isDashScope,
+      supportsUsageInStreaming,
     };
   }
 
@@ -254,7 +258,7 @@ function compatibleReasoningPolicy(options: {
       replay: "tool-calls",
       forwardReasoningEffort: false,
       enableToolStream: false,
-      supportsUsageInStreaming: true,
+      supportsUsageInStreaming,
     };
   }
 
@@ -262,7 +266,7 @@ function compatibleReasoningPolicy(options: {
     replay: "all-assistant",
     forwardReasoningEffort: true,
     enableToolStream: false,
-    supportsUsageInStreaming: false,
+    supportsUsageInStreaming,
   };
 }
 
@@ -298,6 +302,10 @@ function isDashScopeHostname(hostname: string): boolean {
     labels[3] === "aliyuncs" &&
     labels[4] === "com"
   );
+}
+
+function isDeepSeekHostname(hostname: string): boolean {
+  return hostname === "api.deepseek.com";
 }
 
 function zhipuPreservedThinking(

--- a/test/openai-compatible.test.ts
+++ b/test/openai-compatible.test.ts
@@ -464,6 +464,17 @@ test("requests streaming usage for known DeepSeek and DashScope endpoints", asyn
   }
 });
 
+test("does not infer streaming usage support from a DeepSeek-looking model name", async () => {
+  const body = await captureRequestBody({
+    provider: "custom-provider",
+    baseUrl: "https://unknown-proxy.test/v1",
+    model: "deepseek-chat",
+    messages: [],
+  });
+
+  assert.equal("stream_options" in body, false);
+});
+
 test("parses DashScope terminal usage chunk with empty choices", async () => {
   const adapter = new OpenAiCompatibleModel({
     baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",

--- a/test/openai-compatible.test.ts
+++ b/test/openai-compatible.test.ts
@@ -441,6 +441,58 @@ test("encodes provider-specific reasoning replay contracts", async (t) => {
   );
 });
 
+test("requests streaming usage for known DeepSeek and DashScope endpoints", async (t) => {
+  for (const scenario of [
+    {
+      name: "direct DeepSeek provider",
+      provider: "deepseek",
+      baseUrl: "https://api.deepseek.com",
+      model: "deepseek-chat",
+    },
+    {
+      name: "DashScope hostname",
+      provider: "custom-provider",
+      baseUrl:
+        "https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+      model: "deepseek-v3",
+    },
+  ]) {
+    await t.test(scenario.name, async () => {
+      const body = await captureRequestBody({ ...scenario, messages: [] });
+      assert.deepEqual(body.stream_options, { include_usage: true });
+    });
+  }
+});
+
+test("parses DashScope terminal usage chunk with empty choices", async () => {
+  const adapter = new OpenAiCompatibleModel({
+    baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+    apiKey: fakeKey,
+    provider: "dashscope",
+    fetch: (async () =>
+      streamResponse([
+        chunk({
+          choices: [],
+          usage: {
+            prompt_tokens: 13,
+            completion_tokens: 5,
+            prompt_tokens_details: { cached_tokens: 8 },
+          },
+        }),
+        "[DONE]",
+      ])) as typeof fetch,
+  });
+
+  assert.deepEqual(await collect(adapter.stream(request())), [
+    {
+      type: "usage",
+      inputTokens: 13,
+      cachedInputTokens: 8,
+      outputTokens: 5,
+    },
+  ]);
+});
+
 test("removes configured tools when a request exposes no tools", async () => {
   let capturedBody: Readonly<Record<string, unknown>> = {};
   const adapter = new OpenAiCompatibleModel({


### PR DESCRIPTION
## Summary

OpenAI-compatible streaming responses already parsed provider usage, but the adapter did not request usage from providers that require an explicit opt-in. DashScope therefore omitted the terminal usage chunk and ZenX could not persist model_usage token/cache statistics.

Known DeepSeek providers and DashScope provider profiles/hostnames now send `stream_options: { include_usage: true }`. Existing `defaultParams.stream_options` remains an explicit override, and unknown compatible endpoints keep their previous request behavior. DashScope terminal chunks with `choices: []` are covered; existing usage parsing carries cached token fields into the canonical usage event and Runtime persistence path.

## TDD evidence

- Red: new request-body contract tests failed before the policy field/request serialization change.
- Green: targeted OpenAI-compatible tests pass, including known DeepSeek, DashScope hostname, empty-choices terminal usage, cached usage parsing, and unknown endpoint behavior.
- `npm run check` passes with bundled Node 24 PATH: format, lint, typecheck, 238 Node tests, and 38 IMZen tests.

No historical model_usage Items are backfilled or rewritten; only future provider-reported usage is persisted.