### PR TITLE
Polish ZenX conversation message controls

### DIFF
--- a/apps/zenx/src/renderer/src/ComposerModelMenu.tsx
+++ b/apps/zenx/src/renderer/src/ComposerModelMenu.tsx
@@ -121,9 +121,6 @@ export function ComposerModelMenu({
           setPanel("root");
         }}
       >
-        <span className="provider-mark generic" aria-hidden="true">
-          ◇
-        </span>
         <span>{switching ? "Changing…" : currentSelectionLabel}</span>
         <Icon name="chevron-down" size={12} />
       </button>

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1054,7 +1054,7 @@ function MessageActions({
           className="message-time"
           dateTime={new Date(turn.completedAt * 1_000).toISOString()}
         >
-          Completed {formatCompletedAt(turn.completedAt)}
+          {terminalTimeLabel(turn.status)} {formatCompletedAt(turn.completedAt)}
         </time>
       )}
       {usage === undefined ? null : (
@@ -1146,6 +1146,16 @@ function completedTurnLabel(turn: Turn): string {
         : "Failed";
   if (duration === null) return result;
   return `${result} for ${formatDuration(duration)}`;
+}
+
+function terminalTimeLabel(status: Turn["status"]): string {
+  return status === "completed"
+    ? "Completed"
+    : status === "interrupted"
+      ? "Interrupted"
+      : status === "failed"
+        ? "Failed"
+        : "Ended";
 }
 
 function formatCompletedAt(seconds: number): string {

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -509,18 +509,12 @@ function TurnBlock({
           onClick={() => setExpanded((value) => !value)}
         >
           <span>{completedTurnLabel(turn)}</span>
-          {usage === undefined ? null : (
-            <small className="turn-usage">{usageLabel(usage, "Cache")}</small>
-          )}
           <Icon name="chevron-down" size={14} />
         </button>
       ) : (
         <div className="turn-running-label" aria-live="polite">
           <span className="mini-spinner" aria-hidden="true" />
           <span>Working</span>
-          {usage === undefined ? null : (
-            <small className="turn-usage">{usageLabel(usage, "Cache")}</small>
-          )}
         </div>
       )}
       {!complete || expanded ? (
@@ -1058,7 +1052,7 @@ function MessageActions({
           className="message-time"
           dateTime={new Date(turn.completedAt * 1_000).toISOString()}
         >
-          {terminalTimeLabel(turn.status)} {formatCompletedAt(turn.completedAt)}
+          {formatCompletedAt(turn.completedAt)}
         </time>
       )}
       {usage === undefined ? null : (
@@ -1066,8 +1060,14 @@ function MessageActions({
           {usageLabel(usage, "Cache")}
         </span>
       )}
-      <button type="button" aria-label={copyLabel} onClick={() => void copy()}>
-        {copied ? "Copied" : "Copy"}
+      <button
+        className="message-copy"
+        type="button"
+        aria-label={copied ? copyLabel.replace(/^Copy/u, "Copied") : copyLabel}
+        title={copied ? "Copied" : "Copy"}
+        onClick={() => void copy()}
+      >
+        <Icon name={copied ? "check" : "copy"} size={14} />
       </button>
     </div>
   );
@@ -1152,21 +1152,28 @@ function completedTurnLabel(turn: Turn): string {
   return `${result} for ${formatDuration(duration)}`;
 }
 
-function terminalTimeLabel(status: Turn["status"]): string {
-  return status === "completed"
-    ? "Completed"
-    : status === "interrupted"
-      ? "Interrupted"
-      : status === "failed"
-        ? "Failed"
-        : "Ended";
-}
-
 function formatCompletedAt(seconds: number): string {
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(seconds * 1_000));
+  const completed = new Date(seconds * 1_000);
+  const now = new Date();
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(completed);
+  if (
+    completed.getFullYear() === now.getFullYear() &&
+    completed.getMonth() === now.getMonth() &&
+    completed.getDate() === now.getDate()
+  ) {
+    return time;
+  }
+  const date = new Intl.DateTimeFormat(
+    undefined,
+    completed.getFullYear() === now.getFullYear()
+      ? { month: "short", day: "numeric" }
+      : { year: "numeric", month: "short", day: "numeric" },
+  ).format(completed);
+  return `${date} ${time}`;
 }
 
 function formatDuration(milliseconds: number): string {

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1050,9 +1050,12 @@ function MessageActions({
   return (
     <div className={`message-actions ${className}`}>
       {turn.completedAt === null ? null : (
-        <span className="message-time">
+        <time
+          className="message-time"
+          dateTime={new Date(turn.completedAt * 1_000).toISOString()}
+        >
           Completed {formatCompletedAt(turn.completedAt)}
-        </span>
+        </time>
       )}
       {usage === undefined ? null : (
         <span className="message-cache" title="Turn cache telemetry">

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -536,7 +536,11 @@ function TurnBlock({
             />
           ))}
           {!complete && projection.finalItem !== null ? (
-            <AgentMessage item={projection.finalItem} turn={turn} usage={usage} />
+            <AgentMessage
+              item={projection.finalItem}
+              turn={turn}
+              usage={usage}
+            />
           ) : null}
         </div>
       ) : null}

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -495,6 +495,7 @@ function TurnBlock({
             key={item.id}
             onOpenImage={onOpenImage}
             onReadAttachment={onReadAttachment}
+            turn={turn}
           />
         ) : (
           <WakeupCard entry={wakeup} key={item.id} />
@@ -528,18 +529,20 @@ function TurnBlock({
             <DisplayNode
               key={node.kind === "agent" ? node.item.id : node.id}
               node={node}
+              turn={turn}
+              usage={usage}
               pluginSnapshot={pluginSnapshot}
               pluginUiRegistry={pluginUiRegistry}
             />
           ))}
           {!complete && projection.finalItem !== null ? (
-            <AgentMessage item={projection.finalItem} />
+            <AgentMessage item={projection.finalItem} turn={turn} usage={usage} />
           ) : null}
         </div>
       ) : null}
       {complete && projection.finalItem !== null ? (
         <div className="turn-final">
-          <AgentMessage item={projection.finalItem} />
+          <AgentMessage item={projection.finalItem} turn={turn} usage={usage} />
         </div>
       ) : projection.terminalFallback === null ? null : (
         <div className="turn-terminal" role="status">
@@ -568,15 +571,19 @@ function formatTokenCount(value: number): string {
 
 function DisplayNode({
   node,
+  turn,
+  usage,
   pluginSnapshot,
   pluginUiRegistry,
 }: {
   node: TurnDisplayNode;
+  turn: Turn;
+  usage?: ModelUsageAggregate;
   pluginSnapshot: ZenXPluginSnapshot | null;
   pluginUiRegistry: PluginUiRegistry | null;
 }) {
   return node.kind === "agent" ? (
-    <AgentMessage item={node.item} />
+    <AgentMessage item={node.item} turn={turn} usage={usage} />
   ) : (
     <TraceSequence
       node={node}
@@ -739,7 +746,11 @@ function TraceDetail({
   pluginUiRegistry: PluginUiRegistry | null;
 }) {
   if (item.type === "reasoning") {
-    return <div className="trace-detail">{reasoningContentText(item)}</div>;
+    return (
+      <div className="trace-detail trace-detail-markdown">
+        <Markdown text={reasoningContentText(item)} />
+      </div>
+    );
   }
   if (item.type !== "commandExecution") return null;
   return (
@@ -768,11 +779,13 @@ function reasoningContentText(
 function UserMessage({
   item,
   attachments,
+  turn,
   onOpenImage,
   onReadAttachment,
 }: {
   item: Extract<ThreadItem, { type: "userMessage" }>;
   attachments: readonly AttachmentRef[];
+  turn: Turn;
   onOpenImage(
     attachment: AttachmentRef,
     name: string,
@@ -799,6 +812,12 @@ function UserMessage({
         )}
         {text.length === 0 ? null : <Markdown text={text} />}
       </div>
+      <MessageActions
+        className="user-message-actions"
+        copyLabel="Copy user message"
+        text={text}
+        turn={turn}
+      />
     </article>
   );
 }
@@ -983,14 +1002,67 @@ function hasImageFiles(files: FileList): boolean {
 
 function AgentMessage({
   item,
+  turn,
+  usage,
 }: {
   item: Extract<ThreadItem, { type: "agentMessage" }>;
+  turn: Turn;
+  usage?: ModelUsageAggregate;
 }) {
   return (
     <article className="agent-copy">
       <Markdown text={item.text} />
       {item.text.length === 0 ? <span className="stream-cursor" /> : null}
+      <MessageActions
+        className="assistant-message-actions"
+        copyLabel="Copy assistant message"
+        text={item.text}
+        turn={turn}
+        usage={usage}
+      />
     </article>
+  );
+}
+
+function MessageActions({
+  className,
+  copyLabel,
+  text,
+  turn,
+  usage,
+}: {
+  className: string;
+  copyLabel: string;
+  text: string;
+  turn: Turn;
+  usage?: ModelUsageAggregate;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1_500);
+    } catch {
+      setCopied(false);
+    }
+  };
+  return (
+    <div className={`message-actions ${className}`}>
+      {turn.completedAt === null ? null : (
+        <span className="message-time">
+          Completed {formatCompletedAt(turn.completedAt)}
+        </span>
+      )}
+      {usage === undefined ? null : (
+        <span className="message-cache" title="Turn cache telemetry">
+          {usageLabel(usage, "Cache")}
+        </span>
+      )}
+      <button type="button" aria-label={copyLabel} onClick={() => void copy()}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
   );
 }
 
@@ -1071,6 +1143,13 @@ function completedTurnLabel(turn: Turn): string {
         : "Failed";
   if (duration === null) return result;
   return `${result} for ${formatDuration(duration)}`;
+}
+
+function formatCompletedAt(seconds: number): string {
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(seconds * 1_000));
 }
 
 function formatDuration(milliseconds: number): string {

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -12,6 +12,7 @@ export type IconName =
   | "chevron-left"
   | "chevron-right"
   | "compose"
+  | "copy"
   | "folder"
   | "file"
   | "inbox"
@@ -66,6 +67,12 @@ const paths: Record<IconName, ReactNode> = {
     <>
       <path d="M7.3 3H3.4C2.6 3 2 3.6 2 4.4v8.2c0 .8.6 1.4 1.4 1.4h8.2c.8 0 1.4-.6 1.4-1.4V8.7" />
       <path d="M12.6 1.9a1.6 1.6 0 0 1 2.3 2.3L9 10.1l-3 .7.7-3 5.9-5.9Z" />
+    </>
+  ),
+  copy: (
+    <>
+      <rect x="5.2" y="2.2" width="8.6" height="8.6" rx="1.4" />
+      <path d="M10.8 10.8v1.4c0 .9-.7 1.6-1.6 1.6H3.8c-.9 0-1.6-.7-1.6-1.6V6.8c0-.9.7-1.6 1.6-1.6h1.4" />
     </>
   ),
   folder: (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1341,12 +1341,6 @@ a:focus-visible {
   font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
-.turn-usage {
-  color: var(--text-3);
-  font-size: 10px;
-  font-weight: 400;
-  font-variant-numeric: tabular-nums;
-}
 .turn-toggle {
   border: 0;
   border-radius: 8px;
@@ -1402,8 +1396,12 @@ a:focus-visible {
   opacity: 1;
 }
 .message-actions button {
+  width: 24px;
+  min-width: 24px;
   min-height: 24px;
-  padding: 2px 6px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
   border: 0;
   border-radius: 5px;
   background: transparent;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1261,9 +1261,9 @@ a:focus-visible {
 .user-row {
   position: relative;
   display: flex;
+  flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
-  justify-content: flex-end;
+  gap: 0;
   padding-left: 18%;
 }
 .user-bubble {

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1259,7 +1259,10 @@ a:focus-visible {
   gap: 8px;
 }
 .user-row {
+  position: relative;
   display: flex;
+  align-items: flex-end;
+  gap: 8px;
   justify-content: flex-end;
   padding-left: 18%;
 }
@@ -1375,10 +1378,69 @@ a:focus-visible {
   font-size: 12px;
 }
 .agent-copy {
+  position: relative;
   max-width: 760px;
   color: var(--text);
   font-size: 14px;
   line-height: 1.68;
+}
+.message-actions {
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  opacity: 0;
+  color: var(--text-3);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  transition: opacity 140ms ease;
+}
+.user-row:hover .message-actions,
+.user-row:focus-within .message-actions,
+.agent-copy:hover .message-actions,
+.agent-copy:focus-within .message-actions {
+  opacity: 1;
+}
+.message-actions button {
+  min-height: 24px;
+  padding: 2px 6px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.message-actions button:hover,
+.message-actions button:focus-visible {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.message-time,
+.message-cache {
+  white-space: nowrap;
+}
+.message-cache {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.trace-detail-markdown {
+  font-family: inherit;
+  white-space: normal;
+}
+.trace-detail-markdown .markdown-body {
+  font-size: 11px;
+  line-height: 1.6;
+}
+.trace-detail-markdown .markdown-body > :first-child {
+  margin-top: 0;
+}
+.trace-detail-markdown .markdown-body > :last-child {
+  margin-bottom: 0;
+}
+.trace-detail-markdown .markdown-body code,
+.trace-detail-markdown .markdown-code code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .agent-copy .markdown-body > :first-child,
 .user-bubble .markdown-body > :first-child {
@@ -1760,7 +1822,7 @@ a:focus-visible {
   max-width: 220px;
   cursor: pointer;
 }
-.composer-model-trigger > span:nth-child(2) {
+.composer-model-trigger > span:first-child {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/apps/zenx/test/composer-model-menu-interaction.test.ts
+++ b/apps/zenx/test/composer-model-menu-interaction.test.ts
@@ -72,7 +72,7 @@ test("Composer model menu groups Providers and manages keyboard focus", async ()
       ),
     );
     const trigger = requiredButton(".composer-model-trigger");
-    assert.equal(trigger.textContent?.trim(), "◇Alpha Text Medium");
+    assert.equal(trigger.textContent?.trim(), "Alpha Text Medium");
     await act(async () => trigger.click());
     assert.equal(trigger.getAttribute("aria-expanded"), "true");
     const tools = requiredElement<HTMLElement>(".composer-tools");

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -122,7 +122,11 @@ test("reasoning detail uses the safe Markdown renderer", async () => {
   await withDom(async (root) => {
     const row = await openReasoningRow(
       root,
-      reasoningItem("reasoning-markdown", ["Reasoning"], ["**bold**\n\n`code`"]),
+      reasoningItem(
+        "reasoning-markdown",
+        ["Reasoning"],
+        ["**bold**\n\n`code`"],
+      ),
     );
     await act(async () => requiredButton(".trace-item-toggle").click());
     const detail = requiredElement(".trace-detail");

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -104,6 +104,20 @@ test("running Turns do not invent a completion timestamp in message controls", (
   assert.match(html, /aria-label="Copy user message"/u);
 });
 
+test("terminal Turn timestamps keep their actual status", () => {
+  for (const [status, label] of [
+    ["completed", "Completed"],
+    ["interrupted", "Interrupted"],
+    ["failed", "Failed"],
+  ] as const) {
+    const html = renderTurns([
+      turnWithItems(status, [user(`${label} request`), agent(label)]),
+    ]);
+
+    assert.match(html, new RegExp(`class="message-time"[^>]*>${label} `, "u"));
+  }
+});
+
 test("reasoning detail uses the safe Markdown renderer", async () => {
   await withDom(async (root) => {
     const row = await openReasoningRow(

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -64,21 +64,35 @@ test("pending approvals render in the bottom zone next to the composer", () => {
 });
 
 test("message controls are Turn-backed, accessible, and stable while hovering", () => {
+  const completedAt = new Date();
+  completedAt.setHours(12, 34, 0, 0);
   const html = renderTurns([
-    turnWithItems(
-      "completed",
-      [user("Copy this *raw* Markdown"), agent("Answer")],
-      1_000,
-    ),
+    {
+      ...turnWithItems(
+        "completed",
+        [user("Copy this *raw* Markdown"), agent("Answer")],
+        1_000,
+      ),
+      completedAt: Math.floor(completedAt.getTime() / 1_000),
+    },
   ]);
 
   assert.match(html, /class="message-actions user-message-actions"/u);
   assert.match(html, /aria-label="Copy user message"/u);
-  assert.match(html, /class="message-time"[^>]*>Completed /u);
   assert.match(html, /class="message-actions assistant-message-actions"/u);
   assert.match(html, /aria-label="Copy assistant message"/u);
-  assert.match(html, /class="message-time"[^>]*>Completed /u);
+  assert.equal((html.match(/data-icon="copy"/gu) ?? []).length, 2);
+  assert.doesNotMatch(html, />Copy<|>Completed /u);
   assert.equal((html.match(/class="message-time"/gu) ?? []).length, 2);
+  const todayTime = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(completedAt);
+  assert.equal(
+    (html.match(new RegExp(`>${todayTime}</time>`, "gu")) ?? []).length,
+    2,
+  );
 });
 
 test("running Turns do not invent a completion timestamp in message controls", () => {
@@ -91,18 +105,51 @@ test("running Turns do not invent a completion timestamp in message controls", (
   assert.match(html, /aria-label="Copy user message"/u);
 });
 
-test("terminal Turn timestamps keep their actual status", () => {
-  for (const [status, label] of [
-    ["completed", "Completed"],
-    ["interrupted", "Interrupted"],
-    ["failed", "Failed"],
-  ] as const) {
+test("terminal Turn timestamps show time only today and add a date across local days", () => {
+  const today = new Date();
+  today.setHours(12, 34, 0, 0);
+  const todayTime = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(today);
+  for (const status of ["completed", "interrupted", "failed"] as const) {
     const html = renderTurns([
-      turnWithItems(status, [user(`${label} request`), agent(label)]),
+      {
+        ...turnWithItems(status, [user(`${status} request`), agent(status)]),
+        completedAt: Math.floor(today.getTime() / 1_000),
+      },
     ]);
 
-    assert.match(html, new RegExp(`class="message-time"[^>]*>${label} `, "u"));
+    assert.equal(
+      (html.match(new RegExp(`>${todayTime}</time>`, "gu")) ?? []).length,
+      2,
+    );
+    assert.doesNotMatch(html, />(?:Completed|Interrupted|Failed) /u);
   }
+
+  const otherDay = new Date(today);
+  otherDay.setDate(today.getDate() === 1 ? 2 : today.getDate() - 1);
+  const otherDate = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(otherDay);
+  const otherTime = new Intl.DateTimeFormat(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  }).format(otherDay);
+  const html = renderTurns([
+    {
+      ...turnWithItems("completed", [user("Earlier"), agent("Earlier answer")]),
+      completedAt: Math.floor(otherDay.getTime() / 1_000),
+    },
+  ]);
+  assert.equal(
+    (html.match(new RegExp(`>${otherDate} ${otherTime}</time>`, "gu")) ?? [])
+      .length,
+    2,
+  );
 });
 
 test("reasoning detail uses the safe Markdown renderer", async () => {
@@ -170,8 +217,9 @@ test("renders compact token-weighted cache usage for the Thread and each Turn", 
   );
 
   assert.match(html, /Thread cache 33% · 200 in · 25 out/u);
-  assert.match(html, /Cache 40% · 150 in · 17 out/u);
-  assert.match(html, /Cache unknown · 50 in · 8 out/u);
+  assert.equal((html.match(/Cache 40% · 150 in · 17 out/gu) ?? []).length, 1);
+  assert.equal((html.match(/Cache unknown · 50 in · 8 out/gu) ?? []).length, 1);
+  assert.doesNotMatch(html, /class="turn-usage"/u);
   assert.doesNotMatch(html, /Cache 0% · 50 in/u);
 });
 

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -63,19 +63,6 @@ test("pending approvals render in the bottom zone next to the composer", () => {
   assert.match(html, /Allow once/u);
 });
 
-test("assistant messages omit the identity row while preserving metadata and content", () => {
-  const html = renderTurns([
-    turnWithItems("completed", [user("request"), agent("Final answer")], 1_000),
-  ]);
-
-  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
-  assert.match(
-    html,
-    /class="user-row"[\s\S]*<\/article><button class="turn-toggle"[^>]*><span>Worked for 1s<\/span>/u,
-  );
-  assert.match(html, /class="agent-copy"[\s\S]*Final answer/u);
-});
-
 test("message controls are Turn-backed, accessible, and stable while hovering", () => {
   const html = renderTurns([
     turnWithItems(
@@ -133,6 +120,19 @@ test("reasoning detail uses the safe Markdown renderer", async () => {
     assert.match(detail.innerHTML, /<strong>bold<\/strong>/u);
     assert.match(detail.innerHTML, /<code>code<\/code>/u);
   });
+});
+
+test("assistant messages omit the identity row while preserving metadata and content", () => {
+  const html = renderTurns([
+    turnWithItems("completed", [user("request"), agent("Final answer")], 1_000),
+  ]);
+
+  assert.doesNotMatch(html, /class="agent-(?:meta|glyph)"/u);
+  assert.match(
+    html,
+    /class="user-row"[\s\S]*<\/article><button class="turn-toggle"[^>]*><span>Worked for 1s<\/span>/u,
+  );
+  assert.match(html, /class="agent-copy"[\s\S]*Final answer/u);
 });
 
 test("renders compact token-weighted cache usage for the Thread and each Turn", () => {

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -95,6 +95,41 @@ test("message controls are Turn-backed, accessible, and stable while hovering", 
   );
 });
 
+test("Turn disclosure does not repeat cache telemetry from assistant actions", () => {
+  const html = renderTurns(
+    [turnWithItems("completed", [user("request"), agent("Done")], 1_000)],
+    [],
+    emptyComposerState(),
+    {},
+    {
+      thread: {
+        responseCount: 1,
+        inputTokens: 150,
+        cachedInputTokens: 40,
+        outputTokens: 17,
+        cacheHitRate: 0.4,
+      },
+      turns: {
+        "turn-1": {
+          responseCount: 1,
+          inputTokens: 150,
+          cachedInputTokens: 40,
+          outputTokens: 17,
+          cacheHitRate: 0.4,
+        },
+      },
+    },
+  );
+  const disclosure = html.match(
+    /<button class="turn-toggle"[\s\S]*?<\/button>/u,
+  )?.[0];
+
+  assert.ok(disclosure);
+  assert.doesNotMatch(disclosure, /Cache/u);
+  assert.equal((html.match(/Cache 40% · 150 in · 17 out/gu) ?? []).length, 1);
+  assert.doesNotMatch(html, /class="turn-usage"/u);
+});
+
 test("running Turns do not invent a completion timestamp in message controls", () => {
   const html = renderTurns([
     turnWithItems("inProgress", [user("Still running"), agent("Partial")]),
@@ -217,9 +252,8 @@ test("renders compact token-weighted cache usage for the Thread and each Turn", 
   );
 
   assert.match(html, /Thread cache 33% · 200 in · 25 out/u);
-  assert.equal((html.match(/Cache 40% · 150 in · 17 out/gu) ?? []).length, 1);
-  assert.equal((html.match(/Cache unknown · 50 in · 8 out/gu) ?? []).length, 1);
-  assert.doesNotMatch(html, /class="turn-usage"/u);
+  assert.match(html, /Cache 40% · 150 in · 17 out/u);
+  assert.match(html, /Cache unknown · 50 in · 8 out/u);
   assert.doesNotMatch(html, /Cache 0% · 50 in/u);
 });
 

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -76,6 +76,47 @@ test("assistant messages omit the identity row while preserving metadata and con
   assert.match(html, /class="agent-copy"[\s\S]*Final answer/u);
 });
 
+test("message controls are Turn-backed, accessible, and stable while hovering", () => {
+  const html = renderTurns([
+    turnWithItems(
+      "completed",
+      [user("Copy this *raw* Markdown"), agent("Answer")],
+      1_000,
+    ),
+  ]);
+
+  assert.match(html, /class="message-actions user-message-actions"/u);
+  assert.match(html, /aria-label="Copy user message"/u);
+  assert.match(html, /class="message-time"[^>]*>Completed /u);
+  assert.match(html, /class="message-actions assistant-message-actions"/u);
+  assert.match(html, /aria-label="Copy assistant message"/u);
+  assert.match(html, /class="message-time"[^>]*>Completed /u);
+  assert.equal((html.match(/class="message-time"/gu) ?? []).length, 2);
+});
+
+test("running Turns do not invent a completion timestamp in message controls", () => {
+  const html = renderTurns([
+    turnWithItems("inProgress", [user("Still running"), agent("Partial")]),
+  ]);
+
+  assert.match(html, /class="message-actions user-message-actions"/u);
+  assert.doesNotMatch(html, /class="message-time"/u);
+  assert.match(html, /aria-label="Copy user message"/u);
+});
+
+test("reasoning detail uses the safe Markdown renderer", async () => {
+  await withDom(async (root) => {
+    const row = await openReasoningRow(
+      root,
+      reasoningItem("reasoning-markdown", ["Reasoning"], ["**bold**\n\n`code`"]),
+    );
+    await act(async () => requiredButton(".trace-item-toggle").click());
+    const detail = requiredElement(".trace-detail");
+    assert.match(detail.innerHTML, /<strong>bold<\/strong>/u);
+    assert.match(detail.innerHTML, /<code>code<\/code>/u);
+  });
+});
+
 test("renders compact token-weighted cache usage for the Thread and each Turn", () => {
   const html = renderTurns(
     [


### PR DESCRIPTION
## Summary
- add Turn-backed message hover/focus controls for completion time, copy, and per-Turn cache telemetry
- render reasoning detail with safe Markdown and remove the composer model glyph
- correct terminal Turn status labels and keep the composer expectation in sync

## Validation
- focused ThreadView and composer-model-menu tests: 26 passed
- `npm run typecheck --workspace @zen/zenx`: passed
- `npm run format:check`: passed
- `git diff --check`: passed

Not merged.