### PR TITLE
ZenX: add macOS title bar sidebar controls

### DIFF
--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -130,6 +130,9 @@ function createWindow(): BrowserWindow {
     minHeight: 560,
     show: false,
     backgroundColor: "#0b0d10",
+    ...(process.platform === "darwin"
+      ? { titleBarStyle: "hiddenInset" as const }
+      : {}),
     webPreferences: {
       preload: join(__dirname, "../preload/index.cjs"),
       contextIsolation: true,

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -85,6 +85,7 @@ import { ThreadView } from "./ThreadView.js";
 
 type ProductPage = string;
 const MODEL_CATALOG_LOADING = "Models are still loading. Try again.";
+const COMPACT_LAYOUT_MAX_WIDTH = 640;
 
 export function App() {
   const isMacPlatform = window.zenx.platform === "darwin";
@@ -101,6 +102,9 @@ export function App() {
   const profilePreferenceQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [compactLayout, setCompactLayout] = useState(
+    () => window.innerWidth <= COMPACT_LAYOUT_MAX_WIDTH,
+  );
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     if (!isMacPlatform) return false;
     try {
@@ -124,6 +128,7 @@ export function App() {
     [],
   );
   const [pinnedThreadIds, setPinnedThreadIds] = useState<string[]>([]);
+
   const [sidebarOrder, setSidebarOrder] =
     useState<ZenXSidebarOrder>(EMPTY_SIDEBAR_ORDER);
   const [archivedThreadSummaries, setArchivedThreadSummaries] = useState<
@@ -187,6 +192,13 @@ export function App() {
   const [threadUsage, setThreadUsage] = useState<
     ModelUsageProjection | undefined
   >();
+
+  useEffect(() => {
+    const updateCompactLayout = () =>
+      setCompactLayout(window.innerWidth <= COMPACT_LAYOUT_MAX_WIDTH);
+    window.addEventListener("resize", updateCompactLayout);
+    return () => window.removeEventListener("resize", updateCompactLayout);
+  }, []);
 
   const confirmPinnedThreadIds = (threadIds: readonly string[]) => {
     const confirmed = [...threadIds];
@@ -937,6 +949,8 @@ export function App() {
     }
   };
 
+  const sidebarHidden = compactLayout ? !sidebarOpen : sidebarCollapsed;
+
   return (
     <div
       className={`app-shell${isMacPlatform ? " mac-titlebar" : ""}${isMacPlatform && sidebarCollapsed ? " sidebar-collapsed" : ""}`}
@@ -946,12 +960,14 @@ export function App() {
           <button
             className="window-sidebar-toggle"
             type="button"
-            aria-label={
-              sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
-            }
+            aria-label={sidebarHidden ? "Expand sidebar" : "Collapse sidebar"}
             aria-controls="zenx-sidebar"
-            aria-pressed={sidebarCollapsed}
+            aria-pressed={sidebarHidden}
             onClick={() => {
+              if (compactLayout) {
+                setSidebarOpen((open) => !open);
+                return;
+              }
               setSidebarCollapsed((collapsed) => {
                 const next = !collapsed;
                 try {

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -208,6 +208,11 @@ export function App() {
     opener?.focus();
   }, []);
 
+  const sidebarVisible = compactLayout
+    ? sidebarOpen
+    : !isMacPlatform || !sidebarCollapsed;
+  const sidebarHidden = !sidebarVisible;
+
   useEffect(() => {
     const updateCompactLayout = () =>
       setCompactLayout(window.innerWidth <= COMPACT_LAYOUT_MAX_WIDTH);
@@ -972,11 +977,6 @@ export function App() {
       setThreadLifecycleBusy(false);
     }
   };
-
-  const sidebarVisible = compactLayout
-    ? sidebarOpen
-    : !isMacPlatform || !sidebarCollapsed;
-  const sidebarHidden = !sidebarVisible;
 
   return (
     <div

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -956,7 +956,7 @@ export function App() {
             });
           }}
         >
-          <Icon name="tree" size={15} />
+          <Icon name="panel-left" size={15} />
         </button>
       </div>
       <Sidebar

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -87,6 +87,7 @@ type ProductPage = string;
 const MODEL_CATALOG_LOADING = "Models are still loading. Try again.";
 
 export function App() {
+  const isMacPlatform = window.zenx.platform === "darwin";
   const selectionEpoch = useRef(0);
   const newThreadPendingRef = useRef(false);
   const threadUsageLoadEpoch = useRef(0);
@@ -101,6 +102,7 @@ export function App() {
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (!isMacPlatform) return false;
     try {
       return readSidebarCollapsed(window.localStorage);
     } catch {
@@ -936,29 +938,35 @@ export function App() {
   };
 
   return (
-    <div className={`app-shell${sidebarCollapsed ? " sidebar-collapsed" : ""}`}>
-      <div className="window-titlebar">
-        <button
-          className="window-sidebar-toggle"
-          type="button"
-          aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-          aria-controls="zenx-sidebar"
-          aria-pressed={sidebarCollapsed}
-          onClick={() => {
-            setSidebarCollapsed((collapsed) => {
-              const next = !collapsed;
-              try {
-                writeSidebarCollapsed(window.localStorage, next);
-              } catch {
-                // The preference remains valid for this window.
-              }
-              return next;
-            });
-          }}
-        >
-          <Icon name="panel-left" size={15} />
-        </button>
-      </div>
+    <div
+      className={`app-shell${isMacPlatform && sidebarCollapsed ? " sidebar-collapsed" : ""}`}
+    >
+      {isMacPlatform ? (
+        <div className="window-titlebar">
+          <button
+            className="window-sidebar-toggle"
+            type="button"
+            aria-label={
+              sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
+            }
+            aria-controls="zenx-sidebar"
+            aria-pressed={sidebarCollapsed}
+            onClick={() => {
+              setSidebarCollapsed((collapsed) => {
+                const next = !collapsed;
+                try {
+                  writeSidebarCollapsed(window.localStorage, next);
+                } catch {
+                  // The preference remains valid for this window.
+                }
+                return next;
+              });
+            }}
+          >
+            <Icon name="panel-left" size={15} />
+          </button>
+        </div>
+      ) : null}
       <Sidebar
         liveThread={threadDetail}
         mode={sidebarMode}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -68,6 +68,7 @@ import {
   derivePinnedThreads,
   EMPTY_SIDEBAR_ORDER,
   readSidebarMode,
+  readSidebarCollapsed,
   threadHasActiveTurn,
   lastUsedProjectWorkspace,
   moveSidebarProject,
@@ -75,6 +76,7 @@ import {
   startProjectThread,
   threadTitle,
   writeSidebarMode,
+  writeSidebarCollapsed,
   type SidebarMode,
 } from "./thread-list.js";
 import { applyThreadViewNotification } from "./thread-view-state.js";
@@ -98,6 +100,13 @@ export function App() {
   const profilePreferenceQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    try {
+      return readSidebarCollapsed(window.localStorage);
+    } catch {
+      return false;
+    }
+  });
   const [settingsTab, setSettingsTab] = useState<SettingsTab>("account");
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [projectPickerIntent, setProjectPickerIntent] = useState<
@@ -927,7 +936,29 @@ export function App() {
   };
 
   return (
-    <div className="app-shell">
+    <div className={`app-shell${sidebarCollapsed ? " sidebar-collapsed" : ""}`}>
+      <div className="window-titlebar">
+        <button
+          className="window-sidebar-toggle"
+          type="button"
+          aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          aria-controls="zenx-sidebar"
+          aria-pressed={sidebarCollapsed}
+          onClick={() => {
+            setSidebarCollapsed((collapsed) => {
+              const next = !collapsed;
+              try {
+                writeSidebarCollapsed(window.localStorage, next);
+              } catch {
+                // The preference remains valid for this window.
+              }
+              return next;
+            });
+          }}
+        >
+          <Icon name="tree" size={15} />
+        </button>
+      </div>
       <Sidebar
         liveThread={threadDetail}
         mode={sidebarMode}

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { ModelUsageProjection } from "../../../../../src/model-usage.js";
@@ -99,6 +99,7 @@ export function App() {
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
   const pinnedThreadIdsRef = useRef<string[]>([]);
   const sidebarOrderRef = useRef<ZenXSidebarOrder>(EMPTY_SIDEBAR_ORDER);
+  const sidebarOpenerRef = useRef<HTMLElement | null>(null);
   const profilePreferenceQueueRef = useRef<Promise<void>>(Promise.resolve());
   const [page, setPage] = useState<ProductPage>("agent");
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -193,12 +194,35 @@ export function App() {
     ModelUsageProjection | undefined
   >();
 
+  const openSidebar = useCallback(() => {
+    const activeElement = document.activeElement;
+    sidebarOpenerRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null;
+    setSidebarOpen(true);
+  }, []);
+
+  const closeSidebar = useCallback(() => {
+    setSidebarOpen(false);
+    const opener = sidebarOpenerRef.current;
+    sidebarOpenerRef.current = null;
+    opener?.focus();
+  }, []);
+
   useEffect(() => {
     const updateCompactLayout = () =>
       setCompactLayout(window.innerWidth <= COMPACT_LAYOUT_MAX_WIDTH);
     window.addEventListener("resize", updateCompactLayout);
     return () => window.removeEventListener("resize", updateCompactLayout);
   }, []);
+
+  useEffect(() => {
+    if (!compactLayout && sidebarOpen) closeSidebar();
+  }, [closeSidebar, compactLayout, sidebarOpen]);
+
+  useEffect(() => {
+    if (!compactLayout || !sidebarOpen) return;
+    document.getElementById("zenx-sidebar")?.focus();
+  }, [compactLayout, sidebarOpen]);
 
   const confirmPinnedThreadIds = (threadIds: readonly string[]) => {
     const confirmed = [...threadIds];
@@ -326,7 +350,7 @@ export function App() {
     selectedThreadIdRef.current = threadId;
     if (!preserveNavigation) {
       setPage("agent");
-      setSidebarOpen(false);
+      closeSidebar();
       setWorkspaceOpen(false);
     }
     setSelectedThreadId(threadId);
@@ -543,11 +567,11 @@ export function App() {
       if (event.key !== "Escape") return;
       if (projectPickerIntent !== null) setProjectPickerIntent(null);
       else if (workspaceOpen) setWorkspaceOpen(false);
-      else if (sidebarOpen) setSidebarOpen(false);
+      else if (sidebarOpen) closeSidebar();
     };
     window.addEventListener("keydown", close);
     return () => window.removeEventListener("keydown", close);
-  }, [projectPickerIntent, sidebarOpen, workspaceOpen]);
+  }, [closeSidebar, projectPickerIntent, sidebarOpen, workspaceOpen]);
 
   const activeSummaries = threadSummaries.map((summary) =>
     titleSnapshot[summary.threadId]?.title === undefined
@@ -609,7 +633,7 @@ export function App() {
       selectedThreadIdRef.current = result.thread.id;
       threadUsageLoadEpoch.current += 1;
       setPage("agent");
-      setSidebarOpen(false);
+      closeSidebar();
       setSelectedThreadId(result.thread.id);
       setThreadDetail(result.thread);
       setThreadAttachments({});
@@ -832,7 +856,7 @@ export function App() {
 
   const openPage = (next: ProductPage) => {
     setPage(next);
-    setSidebarOpen(false);
+    closeSidebar();
     setWorkspaceOpen(false);
   };
 
@@ -949,7 +973,10 @@ export function App() {
     }
   };
 
-  const sidebarHidden = compactLayout ? !sidebarOpen : sidebarCollapsed;
+  const sidebarVisible = compactLayout
+    ? sidebarOpen
+    : !isMacPlatform || !sidebarCollapsed;
+  const sidebarHidden = !sidebarVisible;
 
   return (
     <div
@@ -962,10 +989,11 @@ export function App() {
             type="button"
             aria-label={sidebarHidden ? "Expand sidebar" : "Collapse sidebar"}
             aria-controls="zenx-sidebar"
-            aria-pressed={sidebarHidden}
+            aria-expanded={sidebarVisible}
             onClick={() => {
               if (compactLayout) {
-                setSidebarOpen((open) => !open);
+                if (sidebarOpen) closeSidebar();
+                else openSidebar();
                 return;
               }
               setSidebarCollapsed((collapsed) => {
@@ -986,8 +1014,8 @@ export function App() {
       <Sidebar
         liveThread={threadDetail}
         mode={sidebarMode}
-        open={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
+        open={sidebarVisible}
+        onClose={closeSidebar}
         onChangeThreadLifecycle={(summary) =>
           performThreadLifecycle(summary, true)
         }
@@ -1101,7 +1129,7 @@ export function App() {
             onRetryArchived={() => void loadThreadSummaries(true)}
             onTabChange={setSettingsTab}
             onUnarchive={performThreadLifecycle}
-            onOpenSidebar={() => setSidebarOpen(true)}
+            onOpenSidebar={openSidebar}
             tab={settingsTab}
             pluginSnapshot={pluginSnapshot}
           />
@@ -1110,7 +1138,7 @@ export function App() {
             snapshot={pluginSnapshot}
             route={page}
             navigate={openPage}
-            onOpenSidebar={() => setSidebarOpen(true)}
+            onOpenSidebar={openSidebar}
           />
         ) : (
           <AgentSurface
@@ -1173,7 +1201,7 @@ export function App() {
               if (lastUsedWorkspace !== null) void newThread(lastUsedWorkspace);
               else setProjectPickerIntent("new-thread");
             }}
-            onOpenSidebar={() => setSidebarOpen(true)}
+            onOpenSidebar={openSidebar}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
             onRename={async (title) => {
               if (selectedSummary === null) return;

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -939,7 +939,7 @@ export function App() {
 
   return (
     <div
-      className={`app-shell${isMacPlatform && sidebarCollapsed ? " sidebar-collapsed" : ""}`}
+      className={`app-shell${isMacPlatform ? " mac-titlebar" : ""}${isMacPlatform && sidebarCollapsed ? " sidebar-collapsed" : ""}`}
     >
       {isMacPlatform ? (
         <div className="window-titlebar">

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -172,6 +172,7 @@ export function Sidebar({
   return (
     <>
       <aside
+        id="zenx-sidebar"
         className={`sidebar${open ? " open" : ""}`}
         aria-label="Projects and threads"
       >

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -175,6 +175,9 @@ export function Sidebar({
         id="zenx-sidebar"
         className={`sidebar${open ? " open" : ""}`}
         aria-label="Projects and threads"
+        aria-hidden={open ? undefined : true}
+        inert={!open}
+        tabIndex={-1}
       >
         <header className="sidebar-header">
           <div className="brand-row">
@@ -410,6 +413,8 @@ export function Sidebar({
         className={`sidebar-scrim${open ? " open" : ""}`}
         type="button"
         aria-label="Close sidebar"
+        aria-hidden={open ? undefined : true}
+        disabled={!open}
         onClick={onClose}
       />
     </>

--- a/apps/zenx/src/renderer/src/icons.tsx
+++ b/apps/zenx/src/renderer/src/icons.tsx
@@ -23,6 +23,7 @@ export type IconName =
   | "more"
   | "paperclip"
   | "panel-right"
+  | "panel-left"
   | "pin"
   | "pin-off"
   | "reasoning"
@@ -120,6 +121,12 @@ const paths: Record<IconName, ReactNode> = {
     <>
       <rect x="1.8" y="2.2" width="12.4" height="11.6" rx="1.5" />
       <path d="M10.2 2.2v11.6" />
+    </>
+  ),
+  "panel-left": (
+    <>
+      <rect x="1.8" y="2.2" width="12.4" height="11.6" rx="1.5" />
+      <path d="M5.8 2.2v11.6" />
     </>
   ),
   pin: (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -252,7 +252,7 @@ a:focus-visible {
   .sidebar-collapsed .page-header {
     padding-left: 122px;
   }
-  .app-shell .sidebar-header {
+  .app-shell.mac-titlebar .sidebar-header {
     padding-top: 44px;
   }
 }

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -209,41 +209,41 @@ a:focus-visible {
   background: var(--main);
   isolation: isolate;
 }
+.window-titlebar {
+  position: absolute;
+  z-index: 40;
+  inset: 0 0 auto;
+  height: 38px;
+  pointer-events: none;
+  -webkit-app-region: drag;
+}
+.window-sidebar-toggle {
+  position: absolute;
+  top: 7px;
+  left: 76px;
+  width: 26px;
+  height: 26px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  color: var(--text-3);
+  background: transparent;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  transition:
+    color 160ms ease,
+    background 160ms ease;
+}
+.window-sidebar-toggle:hover,
+.window-sidebar-toggle[aria-pressed="true"] {
+  color: var(--text);
+  background: var(--surface-2);
+}
 @media (min-width: 641px) {
   .app-shell.sidebar-collapsed {
     grid-template-columns: 0 minmax(0, 1fr);
-  }
-  .window-titlebar {
-    position: absolute;
-    z-index: 40;
-    inset: 0 0 auto;
-    height: 38px;
-    pointer-events: none;
-    -webkit-app-region: drag;
-  }
-  .window-sidebar-toggle {
-    position: absolute;
-    top: 7px;
-    left: 76px;
-    width: 26px;
-    height: 26px;
-    display: grid;
-    place-items: center;
-    padding: 0;
-    border: 0;
-    border-radius: 7px;
-    color: var(--text-3);
-    background: transparent;
-    pointer-events: auto;
-    -webkit-app-region: no-drag;
-    transition:
-      color 160ms ease,
-      background 160ms ease;
-  }
-  .window-sidebar-toggle:hover,
-  .window-sidebar-toggle[aria-pressed="true"] {
-    color: var(--text);
-    background: var(--surface-2);
   }
   .sidebar-collapsed .sidebar {
     display: none;
@@ -3985,9 +3985,6 @@ a:focus-visible {
   .app-shell {
     display: block;
   }
-  .window-titlebar {
-    display: none;
-  }
   .sidebar {
     position: absolute;
     inset: 0 auto 0 0;
@@ -4030,8 +4027,18 @@ a:focus-visible {
     gap: 8px;
     padding: 0 8px;
   }
+  .app-shell.mac-titlebar .workspace-header,
+  .app-shell.mac-titlebar .page-header {
+    padding-left: 122px;
+  }
+  .app-shell.mac-titlebar .sidebar-header {
+    padding-top: 44px;
+  }
   .mobile-menu {
     display: inline-grid;
+  }
+  .app-shell.mac-titlebar .mobile-menu {
+    display: none;
   }
   .icon-button {
     width: 44px;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -209,6 +209,61 @@ a:focus-visible {
   background: var(--main);
   isolation: isolate;
 }
+@media (min-width: 641px) {
+  .app-shell.sidebar-collapsed {
+    grid-template-columns: 68px minmax(0, 1fr);
+  }
+  .window-titlebar {
+    position: absolute;
+    z-index: 40;
+    inset: 0 0 auto;
+    height: 38px;
+    pointer-events: none;
+    -webkit-app-region: drag;
+  }
+  .window-sidebar-toggle {
+    position: absolute;
+    top: 7px;
+    left: 76px;
+    width: 26px;
+    height: 26px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 7px;
+    color: var(--text-3);
+    background: transparent;
+    pointer-events: auto;
+    -webkit-app-region: no-drag;
+    transition:
+      color 160ms ease,
+      background 160ms ease;
+  }
+  .window-sidebar-toggle:hover,
+  .window-sidebar-toggle[aria-pressed="true"] {
+    color: var(--text);
+    background: var(--surface-2);
+  }
+  .sidebar-collapsed .sidebar-header {
+    padding-inline: 14px;
+  }
+  .sidebar-collapsed .brand-row {
+    justify-content: center;
+  }
+  .sidebar-collapsed .brand-wordmark,
+  .sidebar-collapsed .brand-actions,
+  .sidebar-collapsed .plugin-spaces,
+  .sidebar-collapsed .new-thread-control,
+  .sidebar-collapsed .sidebar-view,
+  .sidebar-collapsed .sidebar-scroll,
+  .sidebar-collapsed .sidebar-footer {
+    display: none;
+  }
+  .sidebar-collapsed .brand-mark {
+    margin-top: 2px;
+  }
+}
 .sidebar {
   position: relative;
   z-index: 20;
@@ -3936,6 +3991,9 @@ a:focus-visible {
 @media (max-width: 640px) {
   .app-shell {
     display: block;
+  }
+  .window-titlebar {
+    display: none;
   }
   .sidebar {
     position: absolute;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1020,6 +1020,7 @@ a:focus-visible {
 
 .workspace {
   position: relative;
+  grid-column: 2;
   min-width: 0;
   min-height: 0;
   overflow: hidden;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -211,7 +211,7 @@ a:focus-visible {
 }
 @media (min-width: 641px) {
   .app-shell.sidebar-collapsed {
-    grid-template-columns: 68px minmax(0, 1fr);
+    grid-template-columns: 0 minmax(0, 1fr);
   }
   .window-titlebar {
     position: absolute;
@@ -245,23 +245,15 @@ a:focus-visible {
     color: var(--text);
     background: var(--surface-2);
   }
-  .sidebar-collapsed .sidebar-header {
-    padding-inline: 14px;
-  }
-  .sidebar-collapsed .brand-row {
-    justify-content: center;
-  }
-  .sidebar-collapsed .brand-wordmark,
-  .sidebar-collapsed .brand-actions,
-  .sidebar-collapsed .plugin-spaces,
-  .sidebar-collapsed .new-thread-control,
-  .sidebar-collapsed .sidebar-view,
-  .sidebar-collapsed .sidebar-scroll,
-  .sidebar-collapsed .sidebar-footer {
+  .sidebar-collapsed .sidebar {
     display: none;
   }
-  .sidebar-collapsed .brand-mark {
-    margin-top: 2px;
+  .sidebar-collapsed .workspace-header,
+  .sidebar-collapsed .page-header {
+    padding-left: 122px;
+  }
+  .app-shell .sidebar-header {
+    padding-top: 44px;
   }
 }
 .sidebar {

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -253,7 +253,7 @@ a:focus-visible {
     padding-left: 122px;
   }
   .app-shell.mac-titlebar .sidebar-header {
-    padding-top: 44px;
+    padding-top: 38px;
   }
 }
 .sidebar {
@@ -4032,7 +4032,7 @@ a:focus-visible {
     padding-left: 122px;
   }
   .app-shell.mac-titlebar .sidebar-header {
-    padding-top: 44px;
+    padding-top: 38px;
   }
   .mobile-menu {
     display: inline-grid;

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -104,6 +104,19 @@ export function writeSidebarMode(
   storage.setItem("zenx-sidebar-mode", mode);
 }
 
+export function readSidebarCollapsed(
+  storage: Pick<SidebarStorage, "getItem">,
+): boolean {
+  return storage.getItem("zenx-sidebar-collapsed") === "true";
+}
+
+export function writeSidebarCollapsed(
+  storage: Pick<SidebarStorage, "setItem">,
+  collapsed: boolean,
+): void {
+  storage.setItem("zenx-sidebar-collapsed", String(collapsed));
+}
+
 export function threadHasActiveTurn(
   thread: NativeThreadSummary,
   liveThread: Thread | null,

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -654,61 +654,6 @@ test("failed Send preserves its draft and stable id for a deliberate retry", asy
   }
 });
 
-test("host recovery refreshes the selected Thread without clearing draft or local navigation", async () => {
-  let statusListener: ((status: AppServerHostStatus) => void) | undefined;
-  let resumeCalls = 0;
-  const harness = await mountThreadApp({
-    onStatus: (listener) => {
-      statusListener = listener;
-      return () => {
-        statusListener = undefined;
-      };
-    },
-    request: async (method) => {
-      if (method === "thread/resume") {
-        resumeCalls += 1;
-        return resumed(liveThread());
-      }
-      throw new Error(`Unexpected protocol request: ${method}`);
-    },
-  });
-  try {
-    const composer = await selectedComposer();
-    await setTextareaValue(composer, "Keep this local draft");
-    const openWorkspace = await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="Open workspace panel"]',
-      ),
-    );
-    await act(async () => openWorkspace.click());
-    await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="Close workspace"]',
-      ),
-    );
-    assert.ok(statusListener);
-
-    await act(async () => {
-      statusListener?.({ type: "reconnecting", attempt: 1, delayMs: 10 });
-      statusListener?.({ type: "ready", reconnected: true });
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    await waitFor(() => resumeCalls === 2);
-    assert.ok(
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="Close workspace"]',
-      ),
-    );
-    assert.equal(
-      document.querySelector<HTMLTextAreaElement>("#thread-composer")?.value,
-      "Keep this local draft",
-    );
-  } finally {
-    await unmountApp(harness);
-  }
-});
-
 test("macOS title-bar toggle controls the compact sidebar without changing desktop collapse preference", async () => {
   const harness = await mountApp(
     {
@@ -803,6 +748,61 @@ test("macOS title-bar toggle controls the compact sidebar without changing deskt
     assert.equal(
       harness.dom.window.localStorage.getItem("zenx-sidebar-collapsed"),
       "true",
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("host recovery refreshes the selected Thread without clearing draft or local navigation", async () => {
+  let statusListener: ((status: AppServerHostStatus) => void) | undefined;
+  let resumeCalls = 0;
+  const harness = await mountThreadApp({
+    onStatus: (listener) => {
+      statusListener = listener;
+      return () => {
+        statusListener = undefined;
+      };
+    },
+    request: async (method) => {
+      if (method === "thread/resume") {
+        resumeCalls += 1;
+        return resumed(liveThread());
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    const composer = await selectedComposer();
+    await setTextareaValue(composer, "Keep this local draft");
+    const openWorkspace = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Open workspace panel"]',
+      ),
+    );
+    await act(async () => openWorkspace.click());
+    await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Close workspace"]',
+      ),
+    );
+    assert.ok(statusListener);
+
+    await act(async () => {
+      statusListener?.({ type: "reconnecting", attempt: 1, delayMs: 10 });
+      statusListener?.({ type: "ready", reconnected: true });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => resumeCalls === 2);
+    assert.ok(
+      document.querySelector<HTMLButtonElement>(
+        '[aria-label="Close workspace"]',
+      ),
+    );
+    assert.equal(
+      document.querySelector<HTMLTextAreaElement>("#thread-composer")?.value,
+      "Keep this local draft",
     );
   } finally {
     await unmountApp(harness);

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -709,6 +709,48 @@ test("host recovery refreshes the selected Thread without clearing draft or loca
   }
 });
 
+test("macOS title-bar toggle controls the compact sidebar without changing desktop collapse preference", async () => {
+  const harness = await mountApp({
+    projects: [],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  });
+  try {
+    Object.defineProperty(harness.dom.window, "innerWidth", {
+      configurable: true,
+      value: 480,
+    });
+    await act(async () =>
+      harness.dom.window.dispatchEvent(new harness.dom.window.Event("resize")),
+    );
+
+    const toggle = document.querySelector<HTMLButtonElement>(
+      ".window-sidebar-toggle",
+    );
+    assert.ok(toggle);
+    assert.equal(toggle.getAttribute("aria-label"), "Expand sidebar");
+    assert.equal(document.querySelector(".sidebar.open"), null);
+
+    await act(async () => toggle.click());
+    assert.ok(document.querySelector(".sidebar.open"));
+    assert.equal(toggle.getAttribute("aria-label"), "Collapse sidebar");
+
+    await act(async () => toggle.click());
+    assert.equal(document.querySelector(".sidebar.open"), null);
+
+    Object.defineProperty(harness.dom.window, "innerWidth", {
+      configurable: true,
+      value: 800,
+    });
+    await act(async () =>
+      harness.dom.window.dispatchEvent(new harness.dom.window.Event("resize")),
+    );
+    assert.equal(toggle.getAttribute("aria-label"), "Collapse sidebar");
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("Sidebar archive clears the selected Chat and opens its Settings restore entry", async () => {
   let archived = false;
   let persistedPins = ["thread-1"];

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -710,11 +710,14 @@ test("host recovery refreshes the selected Thread without clearing draft or loca
 });
 
 test("macOS title-bar toggle controls the compact sidebar without changing desktop collapse preference", async () => {
-  const harness = await mountApp({
-    projects: [],
-    unavailableThreadIds: [],
-    lastUsedWorkspace: null,
-  });
+  const harness = await mountApp(
+    {
+      projects: [],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: null,
+    },
+    { initialSidebarCollapsed: true },
+  );
   try {
     Object.defineProperty(harness.dom.window, "innerWidth", {
       configurable: true,
@@ -728,15 +731,53 @@ test("macOS title-bar toggle controls the compact sidebar without changing deskt
       ".window-sidebar-toggle",
     );
     assert.ok(toggle);
+    const sidebar = document.querySelector<HTMLElement>("#zenx-sidebar");
+    assert.ok(sidebar);
     assert.equal(toggle.getAttribute("aria-label"), "Expand sidebar");
+    assert.equal(toggle.getAttribute("aria-expanded"), "false");
     assert.equal(document.querySelector(".sidebar.open"), null);
+    assert.equal(sidebar.getAttribute("aria-hidden"), "true");
+    assert.equal(sidebar.hasAttribute("inert"), true);
+    const scrim = document.querySelector<HTMLButtonElement>(".sidebar-scrim");
+    assert.ok(scrim);
+    assert.equal(scrim.disabled, true);
+    assert.equal(scrim.getAttribute("aria-hidden"), "true");
 
+    toggle.focus();
     await act(async () => toggle.click());
     assert.ok(document.querySelector(".sidebar.open"));
     assert.equal(toggle.getAttribute("aria-label"), "Collapse sidebar");
+    assert.equal(toggle.getAttribute("aria-expanded"), "true");
+    assert.equal(sidebar.getAttribute("aria-hidden"), null);
+    assert.equal(sidebar.hasAttribute("inert"), false);
+    assert.equal(scrim.disabled, false);
+    assert.equal(scrim.getAttribute("aria-hidden"), null);
+    assert.equal(document.activeElement, sidebar);
+
+    await act(async () => {
+      harness.dom.window.dispatchEvent(
+        new harness.dom.window.KeyboardEvent("keydown", {
+          key: "Escape",
+          bubbles: true,
+        }),
+      );
+    });
+    assert.equal(document.querySelector(".sidebar.open"), null);
+    assert.equal(sidebar.getAttribute("aria-hidden"), "true");
+    assert.equal(sidebar.hasAttribute("inert"), true);
+    assert.equal(document.activeElement, toggle);
 
     await act(async () => toggle.click());
+    await act(async () => scrim.click());
     assert.equal(document.querySelector(".sidebar.open"), null);
+    assert.equal(document.activeElement, toggle);
+
+    await act(async () => toggle.click());
+    assert.ok(document.querySelector(".sidebar.open"));
+    assert.equal(
+      harness.dom.window.localStorage.getItem("zenx-sidebar-collapsed"),
+      "true",
+    );
 
     Object.defineProperty(harness.dom.window, "innerWidth", {
       configurable: true,
@@ -745,7 +786,24 @@ test("macOS title-bar toggle controls the compact sidebar without changing deskt
     await act(async () =>
       harness.dom.window.dispatchEvent(new harness.dom.window.Event("resize")),
     );
-    assert.equal(toggle.getAttribute("aria-label"), "Collapse sidebar");
+    assert.equal(toggle.getAttribute("aria-label"), "Expand sidebar");
+    assert.equal(toggle.getAttribute("aria-expanded"), "false");
+    assert.equal(document.querySelector(".sidebar.open"), null);
+
+    Object.defineProperty(harness.dom.window, "innerWidth", {
+      configurable: true,
+      value: 480,
+    });
+    await act(async () =>
+      harness.dom.window.dispatchEvent(new harness.dom.window.Event("resize")),
+    );
+    assert.equal(toggle.getAttribute("aria-label"), "Expand sidebar");
+    assert.equal(toggle.getAttribute("aria-expanded"), "false");
+    assert.equal(document.querySelector(".sidebar.open"), null);
+    assert.equal(
+      harness.dom.window.localStorage.getItem("zenx-sidebar-collapsed"),
+      "true",
+    );
   } finally {
     await unmountApp(harness);
   }
@@ -1173,6 +1231,7 @@ async function mountApp(
   options: {
     getStatus?(): Promise<AppServerHostStatus>;
     initialPinnedThreadIds?: string[];
+    initialSidebarCollapsed?: boolean;
     onStatus?(listener: (status: AppServerHostStatus) => void): () => void;
     onPinnedThreadIds?(threadIds: readonly string[]): void;
     models?: ModelSummary[];
@@ -1202,6 +1261,12 @@ async function mountApp(
     window: dom.window,
     IS_REACT_ACT_ENVIRONMENT: true,
   });
+  if (options.initialSidebarCollapsed !== undefined) {
+    dom.window.localStorage.setItem(
+      "zenx-sidebar-collapsed",
+      String(options.initialSidebarCollapsed),
+    );
+  }
   let currentSettings = publicSettings(options.initialPinnedThreadIds ?? []);
   const zenx = {
     platform: "darwin",

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -94,6 +94,7 @@ test("desktop sidebar collapse hides the panel and reserves the native title bar
     desktop,
     /\.sidebar-collapsed \.sidebar\s*\{[^}]*display: none;/su,
   );
+  assert.match(styles, /\.workspace\s*\{[^}]*grid-column:\s*2;/su);
   assert.match(
     desktop,
     /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -109,6 +109,32 @@ test("desktop sidebar collapse hides the panel and reserves the native title bar
   );
 });
 
+test("compact macOS chrome clears the traffic lights without changing other platforms", async () => {
+  const styles = await readFile(
+    new URL("../src/renderer/src/styles.css", import.meta.url),
+    "utf8",
+  );
+  const mobile = styles.slice(styles.indexOf("@media (max-width: 640px)"));
+  assert.match(
+    mobile,
+    /\.workspace-header,\s*\.page-header\s*\{[^}]*padding:\s*0 8px;/su,
+  );
+  assert.match(
+    mobile,
+    /\.app-shell\.mac-titlebar \.workspace-header,\s*\.app-shell\.mac-titlebar \.page-header\s*\{[^}]*padding-left:\s*122px;/su,
+  );
+  assert.match(
+    mobile,
+    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top:\s*44px;/su,
+  );
+  assert.match(mobile, /\.mobile-menu\s*\{[^}]*display:\s*inline-grid;/su);
+  assert.match(
+    mobile,
+    /\.app-shell\.mac-titlebar \.mobile-menu\s*\{[^}]*display:\s*none;/su,
+  );
+  assert.doesNotMatch(mobile, /\.window-titlebar\s*\{[^}]*display:\s*none;/su);
+});
+
 test("title-bar DOM and collapsed classes are gated to macOS", async () => {
   const app = await readFile(
     new URL("../src/renderer/src/App.tsx", import.meta.url),

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -97,11 +97,11 @@ test("desktop sidebar collapse hides the panel and reserves the native title bar
   assert.match(styles, /\.workspace\s*\{[^}]*grid-column:\s*2;/su);
   assert.match(
     desktop,
-    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
+    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top: 38px;/su,
   );
   assert.doesNotMatch(
     desktop,
-    /(?<!mac-titlebar)\.app-shell \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
+    /(?<!mac-titlebar)\.app-shell \.sidebar-header\s*\{[^}]*padding-top: 38px;/su,
   );
   assert.match(
     desktop,
@@ -125,7 +125,7 @@ test("compact macOS chrome clears the traffic lights without changing other plat
   );
   assert.match(
     mobile,
-    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top:\s*44px;/su,
+    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top:\s*38px;/su,
   );
   assert.match(mobile, /\.mobile-menu\s*\{[^}]*display:\s*inline-grid;/su);
   assert.match(

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -103,3 +103,20 @@ test("desktop sidebar collapse hides the panel and reserves the native title bar
     /\.sidebar-collapsed \.workspace-header,[\s\S]*padding-left: 122px;/u,
   );
 });
+
+test("title-bar DOM and collapsed classes are gated to macOS", async () => {
+  const app = await readFile(
+    new URL("../src/renderer/src/App.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(
+    app,
+    /const isMacPlatform = window\.zenx\.platform === "darwin";/u,
+  );
+  assert.match(app, /\{isMacPlatform \? \(/u);
+  assert.match(
+    app,
+    /isMacPlatform && sidebarCollapsed \? " sidebar-collapsed" : ""/u,
+  );
+  assert.match(app, /if \(!isMacPlatform\) return false;/u);
+});

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -96,7 +96,11 @@ test("desktop sidebar collapse hides the panel and reserves the native title bar
   );
   assert.match(
     desktop,
-    /\.app-shell \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
+    /\.app-shell\.mac-titlebar \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
+  );
+  assert.doesNotMatch(
+    desktop,
+    /(?<!mac-titlebar)\.app-shell \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
   );
   assert.match(
     desktop,
@@ -118,5 +122,6 @@ test("title-bar DOM and collapsed classes are gated to macOS", async () => {
     app,
     /isMacPlatform && sidebarCollapsed \? " sidebar-collapsed" : ""/u,
   );
+  assert.match(app, /isMacPlatform \? " mac-titlebar" : ""/u);
   assert.match(app, /if \(!isMacPlatform\) return false;/u);
 });

--- a/apps/zenx/test/sidebar-responsive-style.test.ts
+++ b/apps/zenx/test/sidebar-responsive-style.test.ts
@@ -79,3 +79,27 @@ test("plugin page and panel collapse to one usable narrow desktop column", async
     /\.plugin-page-scroll\s*\{\s*grid-template-columns: minmax\(0, 1fr\);\s*padding: 14px;/su,
   );
 });
+
+test("desktop sidebar collapse hides the panel and reserves the native title bar", async () => {
+  const styles = await readFile(
+    new URL("../src/renderer/src/styles.css", import.meta.url),
+    "utf8",
+  );
+  const desktop = styles.slice(0, styles.indexOf("@media (max-width: 640px)"));
+  assert.match(
+    desktop,
+    /\.app-shell\.sidebar-collapsed\s*\{[^}]*grid-template-columns:\s*0\s+minmax\(0, 1fr\);/su,
+  );
+  assert.match(
+    desktop,
+    /\.sidebar-collapsed \.sidebar\s*\{[^}]*display: none;/su,
+  );
+  assert.match(
+    desktop,
+    /\.app-shell \.sidebar-header\s*\{[^}]*padding-top: 44px;/su,
+  );
+  assert.match(
+    desktop,
+    /\.sidebar-collapsed \.workspace-header,[\s\S]*padding-left: 122px;/u,
+  );
+});

--- a/apps/zenx/test/sidebar-state-transitions.test.ts
+++ b/apps/zenx/test/sidebar-state-transitions.test.ts
@@ -5,11 +5,33 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
+import {
+  readSidebarCollapsed,
+  writeSidebarCollapsed,
+} from "../src/renderer/src/thread-list.js";
 const { act, createElement } = React;
 Object.assign(globalThis, { React });
 const { Sidebar } = await import("../src/renderer/src/Sidebar.js");
 
 const noop = () => undefined;
+
+test("sidebar collapsed preference round-trips through storage", () => {
+  let value: string | null = null;
+  const storage = {
+    getItem: () => value,
+    setItem: (_key: string, next: string) => {
+      value = next;
+    },
+  };
+
+  assert.equal(readSidebarCollapsed(storage), false);
+  writeSidebarCollapsed(storage, true);
+  assert.equal(value, "true");
+  assert.equal(readSidebarCollapsed(storage), true);
+  writeSidebarCollapsed(storage, false);
+  assert.equal(value, "false");
+  assert.equal(readSidebarCollapsed(storage), false);
+});
 
 test("collapsed Projects remain recoverable without an Archived scope", async () => {
   const dom = new JSDOM(


### PR DESCRIPTION
## Summary
- add macOS integrated title-bar sidebar toggle with persistent desktop collapse
- preserve compact drawer behavior with accessible disclosure and focus return
- keep Windows/Linux native layout unchanged

## Validation
- 29 focused app/sidebar tests passed
- `npm run typecheck --workspace apps/zenx` passed
- `npm run format:check` passed
- `git diff --check` passed

UI-1 only; no header-cache or message-content changes included.