### PR TITLE
ZenX: defer Thread creation until first message

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 
 五个概念，各一句话。新抽象必须先在这里获得自己的一句话。
 
+`NewThreadDraft` 是 Renderer 中非持久的临时编辑 UI，在通过 App Server 正常创建前不拥有任何 Thread 或 session 权威。
+
 - **Item** — agent 运行的最小事实单元：Turn 生命周期、用户消息、模型输出、推理、
   工具调用、工具结果与失败，都是 Item。
 - **Thread** — 一个 agent 上下文，权威状态是一条 append-only 的 Item list。

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -3,6 +3,8 @@
 所有接入端平级，都只通过 App Server 协议工作。任何接入端都不得拥有
 自己的 Agent、Thread、Turn 或调度语义。
 
+ZenX 的全局 New thread 采用最近使用的 Project，Project 内入口采用该精确 Project；两者只打开本地 draft，选择目录不会创建 Thread，第一条有效 Send 才配置 Project、创建真实 Thread，并且不等待辅助投影就立即启动 Turn。失败必须明确、可恢复且不遮盖可用会话。
+
 ## 第一客户端
 
 **自建薄 Zen CLI** 是首个稳定接入端，只覆盖启动 / 恢复 Thread、发送消息、
@@ -151,9 +153,7 @@ Add Project 使用只读的内部目录 picker。Windows/Linux 不安装 Electro
 只保留系统合规的最小 native menu；这些都属于桌面产品外层，不改变 Core 或 wire protocol。
 顶部 New thread 只使用 host profile 中仍有效的最近使用 workspace；没有记录时由用户明确
 选择 Project，不把 Documents、进程 cwd 或默认 Project 当作隐式替代。
-Project row 的 quick-create 始终以被点击 Project 的 canonical workspace 发起 `thread/start`；
-New thread 因缺少可用 Project 而打开目录 picker 时，确认目录会继续完成 Thread 创建，而不只添加 Project。
-创建成功后 ZenX 在解除 pending 前刷新 Thread summaries 与 Project projection；失败在用户当前页面明确显示并可原位重试。
+Project row 的 New thread 始终选择被点击 Project 的 canonical workspace；全局入口使用仍有效的最近 workspace，否则要求用户明确选择。点击入口、切换 Project 或确认目录都只维护 Renderer 本地 draft，不创建 Thread；第一条有效 Send 才配置 Project、创建真实 Thread，并立即启动 Turn，不等待 summaries 或 Project projection。失败以不遮盖当前页面的明确通知呈现，并可恢复原 draft 重试。
 
 固定版本 T3 Code 仍是机会型兼容目标：它可以通过协议直接把 Zen 当 provider
 驱动，但不会替代 ZenX 的外层产品能力，也不会反向扩大 Zen Core。

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -1,6 +1,8 @@
 # ZenX UI/UX decisions
 
-更新日期：2026-08-23
+更新日期：2026-08-28
+
+New thread 打开临时本地编辑页；选择或添加 Project 不创建 Thread，第一条有效 Send 才配置所选 Project、创建真实 Thread，并在 Sidebar、usage 等辅助元数据独立刷新时立即启动 Turn。全局入口使用最近 Project，Project 内入口使用该精确 Project；失败以明确、可恢复且不遮盖会话的通知呈现。
 
 ## 1. 文档权威与规则等级
 
@@ -98,15 +100,14 @@ Thread
 - **Settings** 是左下常规导航 row，不是浮动齿轮 tile。
 - 插件只能使用受控 Plugin spaces contribution slot；它们不能重排、隐藏或覆写 Inbox、New thread、Projects/Threads 或 Settings。
 
-**Experiment / TBD — New thread IA：** 是否使用独立全宽文字 row、它相对 Plugin spaces / Projects 的准确顺序，以及全局入口与 Project quick-create 的关系都尚未决定。现有原型与 issue 中的排布只能作为实验，不能据此锁定最终导航。
+New thread 可保留独立 row；它相对 Plugin spaces / Projects 的精确视觉顺序仍可继续迭代，但全局入口与 Project 内入口的选择和创建语义已经确定。
 
 ### 3.3 Project 与 Thread 创建
 
 - Projects 标题旁提供 icon-only **Add project**，具备 tooltip、accessible name、focus state 和完整 hit target。
 - Add project 使用 ZenX 只读 directory picker；Thread 创建最终必须解析为明确的 cwd，并消费同一个 canonical Project projection。
-- Project quick-create 一旦呈现，必须把被点击 Project 作为唯一创建作用域；默认或最近 Project 不能覆盖它。New thread 打开 directory picker 时，确认目录必须继续完成原始的 Thread 创建意图，不能退化成只添加 Project。
-- New thread 的 pending 状态只由该创建操作拥有；创建成功后再解除 pending 并刷新 summaries / Project projection，失败则在当前页面显示可重试的明确反馈。
-- **Experiment / TBD：** Project quick-create 是否保留、全局 New thread 是否复用 last-used Project，以及 last-used 失效时是否直接打开 picker，均属于最终 New thread IA 的待定部分。不得把 Documents、`process.cwd()` 或隐藏默认 Project 当成已经确认的产品 fallback。
+- Project 内入口把被点击 Project 作为唯一作用域；全局入口使用仍有效的 last-used Project，否则要求用户明确选择。不得用默认 Project、Documents 或 `process.cwd()` 隐式替代。
+- 点击入口、切换 Project 或目录确认只更新非持久本地 draft；第一条有效 Send 才配置 Project、创建 Thread，并立即启动 Turn，不等待 summaries / Project projection。失败必须不遮盖当前页面，并提供恢复 draft 的直接重试路径。
 
 ### 3.4 原生应用菜单与按需面板
 
@@ -329,7 +330,7 @@ ThreadView
 - [ ] 默认是 active Thread Sidebar + Chat 两栏；Inbox 只由品牌区 icon 切换。
 - [ ] Sidebar 无 Active/Archived segmented control；Archived Threads 只在 Settings 管理并可 Unarchive。
 - [ ] 产品壳保留正式 ZenX logo/wordmark 位置；Thread Provider logo 不替代产品标识。
-- [ ] Add project 可发现、可聚焦，并遵守 canonical Project cwd 规则；New thread 最终 IA 不作为本轮验收合同。
+- [ ] Add project 可发现、可聚焦并遵守 canonical cwd；New thread 在首次有效 Send 前不创建 Thread，且全局/Project 内入口遵守各自已确认的选择语义。
 - [ ] canonical cwd aliases 归一为一个 Project，同时保留稳定 display path。
 - [ ] Pin 只改变 profile-local Sidebar prominence，不改变 Inbox/runtime/scheduling；不假定独立 Pinned section 或排序。
 - [ ] Project 可在 Sidebar 全局拖动排序；Thread 只可在 owning Project 内排序，跨 Project drop 不产生 mutation，也不改变 cwd/Project identity。

--- a/apps/zenx/src/main/project-workspace-smoke.ts
+++ b/apps/zenx/src/main/project-workspace-smoke.ts
@@ -61,6 +61,8 @@ export async function runProjectWorkspaceAcceptance(
       await waitForButton(options.window, "Remove from ZenX");
 
       await clickButton(options.window, `New thread in ${config.projectB}`);
+      await enterFirstMessage(options.window);
+      await clickButton(options.window, "Send");
       await waitForProjectThread(options.window, config.projectB);
 
       await clickButton(options.window, "Set as default");
@@ -140,6 +142,23 @@ async function waitForProjectState(
     restarted
       ? "persisted Project state after restart"
       : "Project removal to settle",
+  );
+}
+
+async function enterFirstMessage(window: BrowserWindow): Promise<void> {
+  const message = "Packaged Project workspace acceptance";
+  await waitForRenderer(
+    window,
+    `(() => {
+      const composer = document.querySelector("#thread-composer");
+      if (!(composer instanceof HTMLTextAreaElement) || composer.disabled) return false;
+      const setValue = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      if (setValue === undefined) return false;
+      setValue.call(composer, ${JSON.stringify(message)});
+      composer.dispatchEvent(new Event("input", { bubbles: true }));
+      return true;
+    })()`,
+    "editable New thread draft",
   );
 }
 

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { ModelUsageProjection } from "../../../../../src/model-usage.js";
@@ -25,6 +25,7 @@ import type {
   ServerNotificationParams,
   Thread,
 } from "../../protocol-client/index.js";
+import { decodeModelKey } from "../../../../../src/protocol/codex/model-key.js";
 import {
   addApprovalRequest,
   markApprovalResponding,
@@ -87,6 +88,7 @@ type ProductPage = string;
 const MODEL_CATALOG_LOADING = "Models are still loading. Try again.";
 
 interface NewThreadDraft {
+  id: string;
   workspace: string | null;
   composer: ComposerState;
 }
@@ -95,6 +97,12 @@ export function App() {
   const selectionEpoch = useRef(0);
   const newThreadPendingRef = useRef(false);
   const newThreadDraftRef = useRef<NewThreadDraft | null>(null);
+  const newThreadPromotionsRef = useRef(new Map<string, string>());
+  const projectPickerOperationEpoch = useRef(0);
+  const projectPickerPendingRef = useRef(false);
+  const projectPickerIntentRef = useRef<"add-project" | "new-thread" | null>(
+    null,
+  );
   const threadUsageLoadEpoch = useRef(0);
   const threadSummaryLoadEpoch = useRef(0);
   const projectLoadEpoch = useRef(0);
@@ -221,6 +229,20 @@ export function App() {
     setNewThreadDraft(draft);
   };
 
+  const openProjectPicker = (intent: "add-project" | "new-thread") => {
+    projectPickerOperationEpoch.current += 1;
+    projectPickerPendingRef.current = false;
+    projectPickerIntentRef.current = intent;
+    setProjectPickerIntent(intent);
+  };
+
+  const closeProjectPicker = () => {
+    projectPickerOperationEpoch.current += 1;
+    projectPickerPendingRef.current = false;
+    projectPickerIntentRef.current = null;
+    setProjectPickerIntent(null);
+  };
+
   const abandonNewThreadDraft = () => {
     if (newThreadDraftRef.current === null) return;
     selectionEpoch.current += 1;
@@ -296,6 +318,27 @@ export function App() {
     } catch (error) {
       if (projectLoadEpoch.current === epoch)
         setProjectError(describeError(error));
+    }
+  };
+
+  const selectProjectDirectory = async (workspace: string) => {
+    const intent = projectPickerIntentRef.current;
+    if (intent === null || projectPickerPendingRef.current) return;
+    projectPickerPendingRef.current = true;
+    const epoch = projectPickerOperationEpoch.current;
+    try {
+      await window.zenx.settings.addWorkspace(workspace);
+      if (projectPickerOperationEpoch.current !== epoch) return;
+      await loadProjects();
+      if (projectPickerOperationEpoch.current !== epoch) return;
+      closeProjectPicker();
+      if (intent === "new-thread") openNewThreadDraft(workspace);
+    } catch (error) {
+      if (projectPickerOperationEpoch.current === epoch)
+        setRequestError(describeError(error));
+    } finally {
+      if (projectPickerOperationEpoch.current === epoch)
+        projectPickerPendingRef.current = false;
     }
   };
 
@@ -543,7 +586,7 @@ export function App() {
   useEffect(() => {
     const close = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      if (projectPickerIntent !== null) setProjectPickerIntent(null);
+      if (projectPickerIntent !== null) closeProjectPicker();
       else if (workspaceOpen) setWorkspaceOpen(false);
       else if (sidebarOpen) setSidebarOpen(false);
     };
@@ -590,7 +633,7 @@ export function App() {
 
   const openNewThreadDraft = (workspace?: string) => {
     if (workspace === undefined && configuredProjects.length === 0) {
-      setProjectPickerIntent("new-thread");
+      openProjectPicker("new-thread");
       return;
     }
     const selectedWorkspace = workspace ?? lastUsedWorkspace;
@@ -609,6 +652,7 @@ export function App() {
     setThreadError(null);
     setModelUpdateError(null);
     confirmNewThreadDraft({
+      id: crypto.randomUUID(),
       workspace: selectedWorkspace,
       composer: emptyComposerState(),
     });
@@ -639,6 +683,21 @@ export function App() {
       setComposerStates(composerStatesRef.current);
     }
     return next;
+  };
+
+  const updateNewThreadComposer = (
+    draftId: string,
+    update: (state: ComposerState) => ComposerState,
+  ) => {
+    if (newThreadDraftRef.current?.id === draftId) {
+      updateNewThreadDraft((draft) => ({
+        ...draft,
+        composer: update(draft.composer),
+      }));
+      return;
+    }
+    const threadId = newThreadPromotionsRef.current.get(draftId);
+    if (threadId !== undefined) updateComposer(threadId, update);
   };
 
   const deliverComposerSubmission = async (
@@ -756,26 +815,30 @@ export function App() {
     newThreadPendingRef.current = true;
     setNewThreadPending(true);
     const epoch = selectionEpoch.current;
+    const draftId = current.id;
     let createdThreadId: string | null = null;
     try {
+      await window.zenx.settings.addWorkspace(workspace);
       const result = await window.zenx.projects.startThread(workspace);
       createdThreadId = result.thread.id;
+      newThreadPromotionsRef.current.set(draftId, createdThreadId);
+      const activeDraft = newThreadDraftRef.current;
+      const promotedComposer =
+        activeDraft?.id === draftId &&
+        activeDraft.composer.submission?.clientUserMessageId ===
+          submission.clientUserMessageId
+          ? activeDraft.composer
+          : startedComposer;
       const promotedStates = {
         ...composerStatesRef.current,
-        [createdThreadId]: startedComposer,
+        [createdThreadId]: promotedComposer,
       };
       composerStatesRef.current = promotedStates;
       setComposerStates(promotedStates);
-      try {
-        await window.zenx.settings.markWorkspaceUsed(workspace);
-      } catch (error) {
-        setRequestError(describeError(error));
-      }
-      await loadThreadSummaries();
-      await loadProjects();
       const stillCurrent =
         selectionEpoch.current === epoch &&
-        newThreadDraftRef.current?.composer.submission?.clientUserMessageId ===
+        activeDraft?.id === draftId &&
+        activeDraft.composer.submission?.clientUserMessageId ===
           submission.clientUserMessageId;
       if (stillCurrent) {
         selectedThreadIdRef.current = createdThreadId;
@@ -787,6 +850,14 @@ export function App() {
         setSelectedSettings(settingsFromSnapshot(createdThreadId, result));
         confirmNewThreadDraft(null);
       }
+      void window.zenx.settings
+        .markWorkspaceUsed(workspace)
+        .then(async () => await loadProjects())
+        .catch((error: unknown) => {
+          if (selectedThreadIdRef.current === createdThreadId)
+            setRequestError(describeError(error));
+        });
+      void loadThreadSummaries();
       await deliverComposerSubmission(createdThreadId, submission);
       updateComposer(createdThreadId, (state) =>
         acceptComposerSubmission(state, submission.clientUserMessageId),
@@ -821,8 +892,6 @@ export function App() {
               message,
             ),
           }));
-        } else {
-          setRequestError(`New thread failed: ${message}`);
         }
       } else {
         updateComposer(createdThreadId, (state) =>
@@ -979,6 +1048,7 @@ export function App() {
   };
 
   const openPage = (next: ProductPage) => {
+    if (projectPickerIntentRef.current !== null) closeProjectPicker();
     if (next !== "agent") abandonNewThreadDraft();
     setPage(next);
     setSidebarOpen(false);
@@ -1151,7 +1221,7 @@ export function App() {
         onNewThread={(workspace) => {
           openNewThreadDraft(workspace);
         }}
-        onAddProject={() => setProjectPickerIntent("add-project")}
+        onAddProject={() => openProjectPicker("add-project")}
         newThreadDisabled={newThreadPending}
         onRemoveProject={(workspace) => {
           void window.zenx.settings
@@ -1237,6 +1307,7 @@ export function App() {
             onNewThreadProjectChange={(workspace) => {
               setModelUpdateError(null);
               updateNewThreadDraft((current) => ({
+                ...current,
                 workspace,
                 composer: {
                   ...current.composer,
@@ -1261,6 +1332,8 @@ export function App() {
               );
             }}
             onImportNewThreadImages={async (files) => {
+              const draftId = newThreadDraftRef.current?.id;
+              if (draftId === undefined) return;
               const imports = await Promise.all(
                 files.map(async (file) => ({
                   name: file.name,
@@ -1269,10 +1342,9 @@ export function App() {
                 })),
               );
               const images = await window.zenx.imageAttachments.import(imports);
-              updateNewThreadDraft((current) => ({
-                ...current,
-                composer: addComposerImages(current.composer, images),
-              }));
+              updateNewThreadComposer(draftId, (state) =>
+                addComposerImages(state, images),
+              );
             }}
             onPickImages={async (threadId) => {
               const images = await window.zenx.imageAttachments.pick();
@@ -1281,11 +1353,12 @@ export function App() {
               );
             }}
             onPickNewThreadImages={async () => {
+              const draftId = newThreadDraftRef.current?.id;
+              if (draftId === undefined) return;
               const images = await window.zenx.imageAttachments.pick();
-              updateNewThreadDraft((current) => ({
-                ...current,
-                composer: addComposerImages(current.composer, images),
-              }));
+              updateNewThreadComposer(draftId, (state) =>
+                addComposerImages(state, images),
+              );
             }}
             onRemoveImage={(threadId, imageId) =>
               updateComposer(threadId, (state) =>
@@ -1316,7 +1389,7 @@ export function App() {
               (project) => project.configured,
             )}
             hasLastUsedProject={lastUsedWorkspace !== null}
-            onAddProject={() => setProjectPickerIntent("add-project")}
+            onAddProject={() => openProjectPicker("add-project")}
             onNewThread={() => {
               openNewThreadDraft();
             }}
@@ -1370,29 +1443,8 @@ export function App() {
       ) : null}
       {projectPickerIntent !== null ? (
         <DirectoryPicker
-          onCancel={() => setProjectPickerIntent(null)}
-          onSelect={(workspace) => {
-            if (projectPickerIntent === "new-thread") {
-              void window.zenx.settings
-                .addWorkspace(workspace)
-                .then(async () => {
-                  await loadProjects();
-                  setProjectPickerIntent(null);
-                  openNewThreadDraft(workspace);
-                })
-                .catch((error: unknown) =>
-                  setRequestError(describeError(error)),
-                );
-              return;
-            }
-            void window.zenx.settings
-              .addWorkspace(workspace)
-              .then(async () => {
-                await loadProjects();
-                setProjectPickerIntent(null);
-              })
-              .catch((error: unknown) => setRequestError(describeError(error)));
-          }}
+          onCancel={closeProjectPicker}
+          onSelect={(workspace) => void selectProjectDirectory(workspace)}
         />
       ) : null}
     </div>
@@ -1519,7 +1571,9 @@ function AgentSurface({
   const draftProjectLabel =
     newThreadDraft?.workspace === null || newThreadDraft === null
       ? null
-      : projectLabel(newThreadDraft.workspace);
+      : draftProject === undefined
+        ? projectLabel(newThreadDraft.workspace)
+        : projectDisplayLabel(draftProject.workspace, configuredProjects);
   const draftProjectError =
     newThreadDraft?.workspace !== null &&
     newThreadDraft !== null &&
@@ -1800,6 +1854,7 @@ function NewThreadProjectSelector({
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const restoreFocusRef = useRef(false);
   const selectedProject = projects.find(
     (project) => project.workspace === selectedWorkspace,
   );
@@ -1808,15 +1863,21 @@ function NewThreadProjectSelector({
       ? "Choose a Project"
       : selectedProject === undefined
         ? `${projectLabel(selectedWorkspace)} unavailable`
-        : projectLabel(selectedProject.workspace);
+        : projectDisplayLabel(selectedProject.workspace, projects);
 
-  const closeAndRestoreFocus = () => {
+  const closeMenu = (restoreFocus: boolean) => {
+    restoreFocusRef.current = restoreFocus;
     setOpen(false);
-    queueMicrotask(() => triggerRef.current?.focus());
   };
 
+  useLayoutEffect(() => {
+    if (open || !restoreFocusRef.current) return;
+    restoreFocusRef.current = false;
+    triggerRef.current?.focus();
+  }, [open]);
+
   useEffect(() => {
-    if (disabled && open) setOpen(false);
+    if (disabled && open) closeMenu(false);
   }, [disabled, open]);
 
   useEffect(() => {
@@ -1835,12 +1896,13 @@ function NewThreadProjectSelector({
     queueMicrotask(focusSelected);
     const onPointerDown = (event: PointerEvent) => {
       if (rootRef.current?.contains(event.target as Node)) return;
-      setOpen(false);
+      const focusWasInMenu = menuRef.current?.contains(document.activeElement);
+      closeMenu(Boolean(focusWasInMenu && !isFocusableTarget(event.target)));
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
       event.preventDefault();
-      closeAndRestoreFocus();
+      closeMenu(true);
     };
     document.addEventListener("pointerdown", onPointerDown);
     document.addEventListener("keydown", onKeyDown);
@@ -1854,6 +1916,11 @@ function NewThreadProjectSelector({
     <div className="new-thread-project-context" ref={rootRef}>
       <div
         className="new-thread-project-current"
+        aria-label={
+          selectedWorkspace === null
+            ? "No Project selected"
+            : `Selected Project: ${selectedWorkspace}`
+        }
         title={selectedWorkspace ?? undefined}
       >
         <Icon name="folder" size={13} />
@@ -1866,8 +1933,13 @@ function NewThreadProjectSelector({
         aria-controls={open ? "new-thread-project-menu" : undefined}
         aria-expanded={open}
         aria-haspopup="menu"
+        aria-label={
+          selectedWorkspace === null
+            ? "Choose a Project"
+            : `Change Project. Current Project: ${selectedWorkspace}`
+        }
         disabled={disabled}
-        onClick={() => setOpen((value) => !value)}
+        onClick={() => (open ? closeMenu(false) : setOpen(true))}
       >
         Change Project
         <Icon name="chevron-down" size={12} />
@@ -1880,6 +1952,10 @@ function NewThreadProjectSelector({
           role="menu"
           aria-label="Choose a Project"
           onKeyDown={(event) => {
+            if (event.key === "Tab") {
+              closeMenu(false);
+              return;
+            }
             if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key))
               return;
             const options = Array.from(
@@ -1915,14 +1991,15 @@ function NewThreadProjectSelector({
                 type="button"
                 role="menuitemradio"
                 aria-checked={selected}
+                aria-label={`${selected ? "Selected Project" : "Select Project"}: ${project.workspace}`}
                 title={project.workspace}
                 onClick={() => {
                   onChange(project.workspace);
-                  closeAndRestoreFocus();
+                  closeMenu(true);
                 }}
               >
                 <Icon name="folder" size={13} />
-                <span>{projectLabel(project.workspace)}</span>
+                <span>{projectDisplayLabel(project.workspace, projects)}</span>
                 {selected ? <Icon name="check" size={13} /> : null}
               </button>
             );
@@ -2204,19 +2281,50 @@ function defaultDraftSettings(
   const model = models.find(
     (candidate) => candidate.isDefault && !candidate.hidden,
   );
-  return model === undefined
-    ? null
-    : {
-        threadId: "",
-        model: model.id,
-        modelProvider: model.model,
-        reasoningEffort: model.defaultReasoningEffort,
-      };
+  if (model === undefined) return null;
+  let modelProvider = model.model;
+  try {
+    modelProvider = decodeModelKey(model.id).providerProfileId;
+  } catch {
+    // Preserve compatibility with legacy model catalogs that used unencoded ids.
+  }
+  return {
+    threadId: "",
+    model: model.id,
+    modelProvider,
+    reasoningEffort: model.defaultReasoningEffort,
+  };
 }
 
 function projectLabel(workspace: string): string {
   const normalized = workspace.replace(/[\\/]+$/u, "");
   return normalized.split(/[\\/]/u).filter(Boolean).at(-1) ?? workspace;
+}
+
+function projectDisplayLabel(
+  workspace: string,
+  projects: readonly ZenXProjectProjectionEntry[],
+): string {
+  const leaf = projectLabel(workspace);
+  const ambiguous = projects.some(
+    (project) =>
+      project.workspace !== workspace &&
+      projectLabel(project.workspace) === leaf,
+  );
+  if (!ambiguous) return leaf;
+  const normalized = workspace.replace(/[\\/]+$/u, "");
+  const parent = normalized.replace(/[\\/][^\\/]+$/u, "") || workspace;
+  return `${leaf} — ${parent}`;
+}
+
+function isFocusableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Node) || target.nodeType !== Node.ELEMENT_NODE)
+    return false;
+  return (
+    (target as Element).closest(
+      'a[href], button:not(:disabled), input:not(:disabled), select:not(:disabled), textarea:not(:disabled), [tabindex]:not([tabindex="-1"])',
+    ) !== null
+  );
 }
 
 async function composerSubmissionInput(

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -97,7 +97,9 @@ export function App() {
   const selectionEpoch = useRef(0);
   const newThreadPendingRef = useRef(false);
   const newThreadDraftRef = useRef<NewThreadDraft | null>(null);
+  const newThreadPendingDraftRef = useRef<NewThreadDraft | null>(null);
   const newThreadPromotionsRef = useRef(new Map<string, string>());
+  const newThreadImageLeasesRef = useRef(new Map<string, number>());
   const projectPickerOperationEpoch = useRef(0);
   const projectPickerPendingRef = useRef(false);
   const projectPickerIntentRef = useRef<"add-project" | "new-thread" | null>(
@@ -180,6 +182,10 @@ export function App() {
     }
   });
   const [requestError, setRequestError] = useState<string | null>(null);
+  const [optimisticSummary, setOptimisticSummary] =
+    useState<NativeThreadSummary | null>(null);
+  const [recoverableDraft, setRecoverableDraft] =
+    useState<NewThreadDraft | null>(null);
   const [projectError, setProjectError] = useState<string | null>(null);
   const [threadLifecycleBusy, setThreadLifecycleBusy] = useState(false);
   const [threadLifecycleError, setThreadLifecycleError] = useState<
@@ -608,7 +614,10 @@ export function App() {
   const selectedSummary =
     [...activeSummaries, ...archivedSummaries].find(
       (summary) => summary.threadId === selectedThreadId,
-    ) ?? null;
+    ) ??
+    (optimisticSummary?.threadId === selectedThreadId
+      ? optimisticSummary
+      : null);
   const pendingThreadIds = pendingApprovalThreadIds(approvals);
   const pluginContributions = loadedPluginContributions(pluginSnapshot);
   const genericPluginTarget =
@@ -689,6 +698,11 @@ export function App() {
     draftId: string,
     update: (state: ComposerState) => ComposerState,
   ) => {
+    if (newThreadPendingDraftRef.current?.id === draftId)
+      newThreadPendingDraftRef.current = {
+        ...newThreadPendingDraftRef.current,
+        composer: update(newThreadPendingDraftRef.current.composer),
+      };
     if (newThreadDraftRef.current?.id === draftId) {
       updateNewThreadDraft((draft) => ({
         ...draft,
@@ -698,6 +712,23 @@ export function App() {
     }
     const threadId = newThreadPromotionsRef.current.get(draftId);
     if (threadId !== undefined) updateComposer(threadId, update);
+  };
+
+  const acquireNewThreadImageLease = (draftId: string) => {
+    newThreadImageLeasesRef.current.set(
+      draftId,
+      (newThreadImageLeasesRef.current.get(draftId) ?? 0) + 1,
+    );
+  };
+
+  const releaseNewThreadImageLease = (draftId: string) => {
+    const remaining = (newThreadImageLeasesRef.current.get(draftId) ?? 1) - 1;
+    if (remaining > 0) {
+      newThreadImageLeasesRef.current.set(draftId, remaining);
+      return;
+    }
+    newThreadImageLeasesRef.current.delete(draftId);
+    newThreadPromotionsRef.current.delete(draftId);
   };
 
   const deliverComposerSubmission = async (
@@ -808,6 +839,7 @@ export function App() {
     );
     if (startedComposer === current.composer) return;
     const startedDraft = { ...current, composer: startedComposer };
+    newThreadPendingDraftRef.current = startedDraft;
     confirmNewThreadDraft(startedDraft);
     const submission = startedComposer.submission;
     if (submission === null || submission.status !== "pending") return;
@@ -821,7 +853,28 @@ export function App() {
       await window.zenx.settings.addWorkspace(workspace);
       const result = await window.zenx.projects.startThread(workspace);
       createdThreadId = result.thread.id;
+      setOptimisticSummary({
+        threadId: createdThreadId,
+        currentMetadata: {
+          model: result.model,
+          provider: result.modelProvider,
+          cwd: result.cwd,
+          sandbox: "danger-full-access",
+          approvalPolicy:
+            result.approvalPolicy === "on-request"
+              ? "always"
+              : result.approvalPolicy,
+        },
+        archived: false,
+        createdAt: new Date(result.thread.createdAt * 1_000).toISOString(),
+        updatedAt: new Date(result.thread.updatedAt * 1_000).toISOString(),
+        name: result.thread.name ?? "New thread",
+        preview: submission.text,
+        status: "idle",
+      });
       newThreadPromotionsRef.current.set(draftId, createdThreadId);
+      if (!newThreadImageLeasesRef.current.has(draftId))
+        newThreadPromotionsRef.current.delete(draftId);
       const activeDraft = newThreadDraftRef.current;
       const promotedComposer =
         activeDraft?.id === draftId &&
@@ -892,6 +945,20 @@ export function App() {
               message,
             ),
           }));
+        } else {
+          const latestDraft =
+            newThreadPendingDraftRef.current?.id === draftId
+              ? newThreadPendingDraftRef.current
+              : startedDraft;
+          setRecoverableDraft({
+            ...latestDraft,
+            composer: failComposerSubmission(
+              latestDraft.composer,
+              submission.clientUserMessageId,
+              message,
+            ),
+          });
+          setRequestError(`New Thread could not be created: ${message}`);
         }
       } else {
         updateComposer(createdThreadId, (state) =>
@@ -903,6 +970,7 @@ export function App() {
         );
       }
     } finally {
+      newThreadPendingDraftRef.current = null;
       newThreadPendingRef.current = false;
       setNewThreadPending(false);
     }
@@ -1262,6 +1330,44 @@ export function App() {
         threads={activeSummaries}
       />
 
+      {projectError !== null || requestError !== null ? (
+        <div className="app-notice" role="alert">
+          <span>{projectError ?? requestError}</span>
+          {recoverableDraft !== null ? (
+            <button
+              type="button"
+              onClick={() => {
+                selectionEpoch.current += 1;
+                setPage("agent");
+                selectedThreadIdRef.current = null;
+                setSelectedThreadId(null);
+                setThreadDetail(null);
+                setThreadAttachments({});
+                setThreadUsage(undefined);
+                setSelectedSettings(null);
+                setThreadError(null);
+                setWorkspaceOpen(false);
+                confirmNewThreadDraft(recoverableDraft);
+                setRecoverableDraft(null);
+                setRequestError(null);
+              }}
+            >
+              Restore draft
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => {
+              setProjectError(null);
+              setRequestError(null);
+              setRecoverableDraft(null);
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+
       <main className="workspace">
         {page === "settings" ? (
           <SettingsView
@@ -1334,17 +1440,23 @@ export function App() {
             onImportNewThreadImages={async (files) => {
               const draftId = newThreadDraftRef.current?.id;
               if (draftId === undefined) return;
-              const imports = await Promise.all(
-                files.map(async (file) => ({
-                  name: file.name,
-                  mediaType: file.type,
-                  bytes: new Uint8Array(await file.arrayBuffer()),
-                })),
-              );
-              const images = await window.zenx.imageAttachments.import(imports);
-              updateNewThreadComposer(draftId, (state) =>
-                addComposerImages(state, images),
-              );
+              acquireNewThreadImageLease(draftId);
+              try {
+                const imports = await Promise.all(
+                  files.map(async (file) => ({
+                    name: file.name,
+                    mediaType: file.type,
+                    bytes: new Uint8Array(await file.arrayBuffer()),
+                  })),
+                );
+                const images =
+                  await window.zenx.imageAttachments.import(imports);
+                updateNewThreadComposer(draftId, (state) =>
+                  addComposerImages(state, images),
+                );
+              } finally {
+                releaseNewThreadImageLease(draftId);
+              }
             }}
             onPickImages={async (threadId) => {
               const images = await window.zenx.imageAttachments.pick();
@@ -1355,10 +1467,15 @@ export function App() {
             onPickNewThreadImages={async () => {
               const draftId = newThreadDraftRef.current?.id;
               if (draftId === undefined) return;
-              const images = await window.zenx.imageAttachments.pick();
-              updateNewThreadComposer(draftId, (state) =>
-                addComposerImages(state, images),
-              );
+              acquireNewThreadImageLease(draftId);
+              try {
+                const images = await window.zenx.imageAttachments.pick();
+                updateNewThreadComposer(draftId, (state) =>
+                  addComposerImages(state, images),
+                );
+              } finally {
+                releaseNewThreadImageLease(draftId);
+              }
             }}
             onRemoveImage={(threadId, imageId) =>
               updateComposer(threadId, (state) =>
@@ -1412,7 +1529,6 @@ export function App() {
             }}
             onSubmit={submitComposer}
             onSubmitNewThread={submitNewThreadDraft}
-            requestError={projectError ?? requestError}
             selectedSettings={selectedSettings}
             selectedSummary={selectedSummary}
             serverStatus={serverStatus}
@@ -1488,7 +1604,6 @@ function AgentSurface({
   onRetryTitle,
   onSubmit,
   onSubmitNewThread,
-  requestError,
   selectedSettings,
   selectedSummary,
   serverStatus,
@@ -1548,7 +1663,6 @@ function AgentSurface({
     intent: ComposerIntent,
     expectedTurnId: string | null,
   ): Promise<void>;
-  requestError: string | null;
   selectedSettings: SelectedThreadSettings | null;
   selectedSummary: NativeThreadSummary | null;
   serverStatus: AppServerHostStatus;
@@ -1662,17 +1776,11 @@ function AgentSurface({
         </header>
       )}
 
-      {serverStatus.type === "error" || requestError !== null ? (
+      {serverStatus.type === "error" ? (
         <EmptyState
           error
-          title={
-            serverStatus.type === "error"
-              ? "Zen App Server stopped"
-              : "ZenX could not load data"
-          }
-          detail={
-            serverStatus.type === "error" ? serverStatus.message : requestError!
-          }
+          title="Zen App Server stopped"
+          detail={serverStatus.message}
         />
       ) : serverStatus.type !== "ready" ? (
         <EmptyState

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -231,6 +231,12 @@ export function App() {
   };
 
   const confirmNewThreadDraft = (draft: NewThreadDraft | null) => {
+    if (
+      draft === null &&
+      newThreadDraftRef.current !== null &&
+      newThreadPendingDraftRef.current?.id === newThreadDraftRef.current.id
+    )
+      newThreadPendingDraftRef.current = newThreadDraftRef.current;
     newThreadDraftRef.current = draft;
     setNewThreadDraft(draft);
   };
@@ -715,20 +721,15 @@ export function App() {
   };
 
   const acquireNewThreadImageLease = (draftId: string) => {
-    newThreadImageLeasesRef.current.set(
-      draftId,
-      (newThreadImageLeasesRef.current.get(draftId) ?? 0) + 1,
-    );
+    acquireDraftPromotionLease(newThreadImageLeasesRef.current, draftId);
   };
 
   const releaseNewThreadImageLease = (draftId: string) => {
-    const remaining = (newThreadImageLeasesRef.current.get(draftId) ?? 1) - 1;
-    if (remaining > 0) {
-      newThreadImageLeasesRef.current.set(draftId, remaining);
-      return;
-    }
-    newThreadImageLeasesRef.current.delete(draftId);
-    newThreadPromotionsRef.current.delete(draftId);
+    releaseDraftPromotionLease(
+      newThreadImageLeasesRef.current,
+      newThreadPromotionsRef.current,
+      draftId,
+    );
   };
 
   const deliverComposerSubmission = async (
@@ -853,25 +854,7 @@ export function App() {
       await window.zenx.settings.addWorkspace(workspace);
       const result = await window.zenx.projects.startThread(workspace);
       createdThreadId = result.thread.id;
-      setOptimisticSummary({
-        threadId: createdThreadId,
-        currentMetadata: {
-          model: result.model,
-          provider: result.modelProvider,
-          cwd: result.cwd,
-          sandbox: "danger-full-access",
-          approvalPolicy:
-            result.approvalPolicy === "on-request"
-              ? "always"
-              : result.approvalPolicy,
-        },
-        archived: false,
-        createdAt: new Date(result.thread.createdAt * 1_000).toISOString(),
-        updatedAt: new Date(result.thread.updatedAt * 1_000).toISOString(),
-        name: result.thread.name ?? "New thread",
-        preview: submission.text,
-        status: "idle",
-      });
+      setOptimisticSummary(optimisticThreadSummary(result, submission.text));
       newThreadPromotionsRef.current.set(draftId, createdThreadId);
       if (!newThreadImageLeasesRef.current.has(draftId))
         newThreadPromotionsRef.current.delete(draftId);
@@ -2407,6 +2390,56 @@ function defaultDraftSettings(
 function projectLabel(workspace: string): string {
   const normalized = workspace.replace(/[\\/]+$/u, "");
   return normalized.split(/[\\/]/u).filter(Boolean).at(-1) ?? workspace;
+}
+
+export function optimisticThreadSummary(
+  result: {
+    thread: Thread;
+    model: string;
+    modelProvider: string;
+    cwd: string;
+    approvalPolicy: "never" | "on-request";
+  },
+  preview: string,
+): NativeThreadSummary {
+  return {
+    threadId: result.thread.id,
+    currentMetadata: {
+      model: result.model,
+      provider: result.modelProvider,
+      cwd: result.cwd,
+      sandbox: "danger-full-access",
+      approvalPolicy:
+        result.approvalPolicy === "on-request" ? "always" : "never",
+    },
+    archived: false,
+    createdAt: new Date(result.thread.createdAt * 1_000).toISOString(),
+    updatedAt: new Date(result.thread.updatedAt * 1_000).toISOString(),
+    name: result.thread.name ?? "New thread",
+    preview,
+    status: "idle",
+  };
+}
+
+export function acquireDraftPromotionLease(
+  leases: Map<string, number>,
+  draftId: string,
+): void {
+  leases.set(draftId, (leases.get(draftId) ?? 0) + 1);
+}
+
+export function releaseDraftPromotionLease(
+  leases: Map<string, number>,
+  promotions: Map<string, string>,
+  draftId: string,
+): void {
+  const remaining = (leases.get(draftId) ?? 1) - 1;
+  if (remaining > 0) {
+    leases.set(draftId, remaining);
+    return;
+  }
+  leases.delete(draftId);
+  promotions.delete(draftId);
 }
 
 function projectDisplayLabel(

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -184,8 +184,10 @@ export function App() {
   const [requestError, setRequestError] = useState<string | null>(null);
   const [optimisticSummary, setOptimisticSummary] =
     useState<NativeThreadSummary | null>(null);
-  const [recoverableDraft, setRecoverableDraft] =
-    useState<NewThreadDraft | null>(null);
+  const [draftRecoveryNotice, setDraftRecoveryNotice] = useState<{
+    draft: NewThreadDraft;
+    message: string;
+  } | null>(null);
   const [projectError, setProjectError] = useState<string | null>(null);
   const [threadLifecycleBusy, setThreadLifecycleBusy] = useState(false);
   const [threadLifecycleError, setThreadLifecycleError] = useState<
@@ -229,6 +231,8 @@ export function App() {
     confirmPinnedThreadIds(profile.pinnedThreadIds);
     confirmSidebarOrder(profile.sidebarOrder);
   };
+
+  const discardRecoverableDraft = () => setDraftRecoveryNotice(null);
 
   const confirmNewThreadDraft = (draft: NewThreadDraft | null) => {
     if (
@@ -377,6 +381,7 @@ export function App() {
   };
 
   const resumeThread = async (threadId: string, preserveNavigation = false) => {
+    discardRecoverableDraft();
     const epoch = ++selectionEpoch.current;
     confirmNewThreadDraft(null);
     const usageEpoch = ++threadUsageLoadEpoch.current;
@@ -647,6 +652,7 @@ export function App() {
   );
 
   const openNewThreadDraft = (workspace?: string) => {
+    discardRecoverableDraft();
     if (workspace === undefined && configuredProjects.length === 0) {
       openProjectPicker("new-thread");
       return;
@@ -933,15 +939,17 @@ export function App() {
             newThreadPendingDraftRef.current?.id === draftId
               ? newThreadPendingDraftRef.current
               : startedDraft;
-          setRecoverableDraft({
-            ...latestDraft,
-            composer: failComposerSubmission(
-              latestDraft.composer,
-              submission.clientUserMessageId,
-              message,
-            ),
+          setDraftRecoveryNotice({
+            draft: {
+              ...latestDraft,
+              composer: failComposerSubmission(
+                latestDraft.composer,
+                submission.clientUserMessageId,
+                message,
+              ),
+            },
+            message: `New Thread could not be created: ${message}`,
           });
-          setRequestError(`New Thread could not be created: ${message}`);
         }
       } else {
         updateComposer(createdThreadId, (state) =>
@@ -1099,6 +1107,7 @@ export function App() {
   };
 
   const openPage = (next: ProductPage) => {
+    discardRecoverableDraft();
     if (projectPickerIntentRef.current !== null) closeProjectPicker();
     if (next !== "agent") abandonNewThreadDraft();
     setPage(next);
@@ -1313,10 +1322,14 @@ export function App() {
         threads={activeSummaries}
       />
 
-      {projectError !== null || requestError !== null ? (
+      {projectError !== null ||
+      requestError !== null ||
+      draftRecoveryNotice !== null ? (
         <div className="app-notice" role="alert">
-          <span>{projectError ?? requestError}</span>
-          {recoverableDraft !== null ? (
+          <span>
+            {projectError ?? requestError ?? draftRecoveryNotice?.message}
+          </span>
+          {draftRecoveryNotice !== null ? (
             <button
               type="button"
               onClick={() => {
@@ -1330,9 +1343,8 @@ export function App() {
                 setSelectedSettings(null);
                 setThreadError(null);
                 setWorkspaceOpen(false);
-                confirmNewThreadDraft(recoverableDraft);
-                setRecoverableDraft(null);
-                setRequestError(null);
+                confirmNewThreadDraft(draftRecoveryNotice.draft);
+                discardRecoverableDraft();
               }}
             >
               Restore draft
@@ -1343,7 +1355,7 @@ export function App() {
             onClick={() => {
               setProjectError(null);
               setRequestError(null);
-              setRecoverableDraft(null);
+              discardRecoverableDraft();
             }}
           >
             Dismiss

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -8,7 +8,10 @@ import type {
 } from "../../main/app-server-manager.js";
 import type { ZenXThreadAttachmentProjection } from "../../main/image-attachments.js";
 import type { ZenXPluginSnapshot } from "../../main/capabilities/types.js";
-import type { ZenXProjectProjectionSnapshot } from "../../main/project-projection.js";
+import type {
+  ZenXProjectProjectionEntry,
+  ZenXProjectProjectionSnapshot,
+} from "../../main/project-projection.js";
 import type {
   ZenXProviderProfile,
   ZenXSidebarOrder,
@@ -72,7 +75,6 @@ import {
   lastUsedProjectWorkspace,
   moveSidebarProject,
   moveSidebarThread,
-  startProjectThread,
   threadTitle,
   writeSidebarMode,
   type SidebarMode,
@@ -84,12 +86,23 @@ import { ThreadView } from "./ThreadView.js";
 type ProductPage = string;
 const MODEL_CATALOG_LOADING = "Models are still loading. Try again.";
 
+interface NewThreadDraft {
+  workspace: string | null;
+  composer: ComposerState;
+}
+
 export function App() {
   const selectionEpoch = useRef(0);
   const newThreadPendingRef = useRef(false);
+  const newThreadDraftRef = useRef<NewThreadDraft | null>(null);
   const threadUsageLoadEpoch = useRef(0);
   const threadSummaryLoadEpoch = useRef(0);
   const projectLoadEpoch = useRef(0);
+  const projectsRef = useRef<ZenXProjectProjectionSnapshot>({
+    projects: [],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  });
   const selectedThreadIdRef = useRef<string | null>(null);
   const archivingThreadIdsRef = useRef<ReadonlySet<string>>(new Set());
   const composerStatesRef = useRef<Record<string, ComposerState>>({});
@@ -135,11 +148,10 @@ export function App() {
   const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
   const [threadLoading, setThreadLoading] = useState(false);
   const [threadError, setThreadError] = useState<string | null>(null);
-  const [newThreadFailure, setNewThreadFailure] = useState<{
-    workspace: string;
-    message: string;
-  } | null>(null);
   const [newThreadPending, setNewThreadPending] = useState(false);
+  const [newThreadDraft, setNewThreadDraft] = useState<NewThreadDraft | null>(
+    null,
+  );
   const [approvals, setApprovals] = useState<ApprovalCardState[]>([]);
   const [models, setModels] = useState<ModelSummary[]>([]);
   const [providerProfiles, setProviderProfiles] = useState<
@@ -204,6 +216,17 @@ export function App() {
     confirmSidebarOrder(profile.sidebarOrder);
   };
 
+  const confirmNewThreadDraft = (draft: NewThreadDraft | null) => {
+    newThreadDraftRef.current = draft;
+    setNewThreadDraft(draft);
+  };
+
+  const abandonNewThreadDraft = () => {
+    if (newThreadDraftRef.current === null) return;
+    selectionEpoch.current += 1;
+    confirmNewThreadDraft(null);
+  };
+
   const queuePinMutation = (
     update: (current: readonly string[]) => readonly string[],
   ): Promise<void> => {
@@ -266,6 +289,7 @@ export function App() {
     try {
       const snapshot = await window.zenx.projects.get({ archived: false });
       if (projectLoadEpoch.current === epoch) {
+        projectsRef.current = snapshot;
         setProjects(snapshot);
         setProjectError(null);
       }
@@ -299,6 +323,7 @@ export function App() {
 
   const resumeThread = async (threadId: string, preserveNavigation = false) => {
     const epoch = ++selectionEpoch.current;
+    confirmNewThreadDraft(null);
     const usageEpoch = ++threadUsageLoadEpoch.current;
     selectedThreadIdRef.current = threadId;
     if (!preserveNavigation) {
@@ -559,45 +584,45 @@ export function App() {
     page;
   const lastUsedWorkspace = lastUsedProjectWorkspace(projects);
 
-  const newThread = async (workspace: string) => {
-    if (newThreadPendingRef.current) return;
-    newThreadPendingRef.current = true;
-    const epoch = ++selectionEpoch.current;
-    setNewThreadPending(true);
-    setNewThreadFailure(null);
+  const configuredProjects = projects.projects.filter(
+    (project) => project.configured,
+  );
+
+  const openNewThreadDraft = (workspace?: string) => {
+    if (workspace === undefined && configuredProjects.length === 0) {
+      setProjectPickerIntent("new-thread");
+      return;
+    }
+    const selectedWorkspace = workspace ?? lastUsedWorkspace;
+    selectionEpoch.current += 1;
+    threadUsageLoadEpoch.current += 1;
+    selectedThreadIdRef.current = null;
+    setPage("agent");
+    setSidebarOpen(false);
+    setWorkspaceOpen(false);
+    setSelectedThreadId(null);
+    setThreadDetail(null);
+    setThreadLoading(false);
+    setThreadAttachments({});
+    setThreadUsage(undefined);
+    setSelectedSettings(null);
     setThreadError(null);
     setModelUpdateError(null);
-    try {
-      const result = await startProjectThread(
-        workspace,
-        async (candidate) => await window.zenx.settings.addWorkspace(candidate),
-        async (params) => await window.zenx.projects.startThread(params.cwd),
-        async (startedWorkspace) => {
-          try {
-            await window.zenx.settings.markWorkspaceUsed(startedWorkspace);
-          } catch (error) {
-            setRequestError(describeError(error));
-          }
-          await loadThreadSummaries();
-          await loadProjects();
-        },
-      );
-      if (selectionEpoch.current !== epoch) return;
-      selectedThreadIdRef.current = result.thread.id;
-      threadUsageLoadEpoch.current += 1;
-      setPage("agent");
-      setSidebarOpen(false);
-      setSelectedThreadId(result.thread.id);
-      setThreadDetail(result.thread);
-      setThreadAttachments({});
-      setThreadUsage(undefined);
-      setSelectedSettings(settingsFromSnapshot(result.thread.id, result));
-    } catch (error) {
-      setNewThreadFailure({ workspace, message: describeError(error) });
-    } finally {
-      newThreadPendingRef.current = false;
-      setNewThreadPending(false);
-    }
+    confirmNewThreadDraft({
+      workspace: selectedWorkspace,
+      composer: emptyComposerState(),
+    });
+    void loadComposerCatalog();
+  };
+
+  const updateNewThreadDraft = (
+    update: (draft: NewThreadDraft) => NewThreadDraft,
+  ): NewThreadDraft | null => {
+    const current = newThreadDraftRef.current;
+    if (current === null) return null;
+    const next = update(current);
+    if (next !== current) confirmNewThreadDraft(next);
+    return next;
   };
 
   const updateComposer = (
@@ -614,6 +639,204 @@ export function App() {
       setComposerStates(composerStatesRef.current);
     }
     return next;
+  };
+
+  const deliverComposerSubmission = async (
+    threadId: string,
+    submission: ComposerSubmission,
+  ) => {
+    if (submission.text.length > 0)
+      await window.zenx.titles
+        .observe(threadId, submission.text)
+        .then((projection) => {
+          if (projection !== undefined)
+            setTitleSnapshot((current) => ({
+              ...current,
+              [threadId]: projection,
+            }));
+        })
+        .catch((error: unknown) =>
+          setRequestError(
+            `Thread title could not be staged: ${describeError(error)}`,
+          ),
+        );
+    const input = await composerSubmissionInput(submission);
+    if (submission.intent === "start") {
+      if (archivingThreadIdsRef.current.has(threadId))
+        throw new Error(
+          "This Thread is being archived. Try again if archiving fails.",
+        );
+      await window.zenx.protocol.request("turn/start", {
+        threadId,
+        input,
+        clientUserMessageId: submission.clientUserMessageId,
+      });
+    } else if (submission.intent === "steer") {
+      if (submission.expectedTurnId === null)
+        throw new Error("The active turn changed before steering");
+      if (archivingThreadIdsRef.current.has(threadId))
+        throw new Error(
+          "This Thread is being archived. Try again if archiving fails.",
+        );
+      await window.zenx.protocol.request("turn/steer", {
+        threadId,
+        expectedTurnId: submission.expectedTurnId,
+        input,
+        clientUserMessageId: submission.clientUserMessageId,
+      });
+    } else {
+      if (submission.expectedTurnId === null)
+        throw new Error("The active turn changed before replacement");
+      if (archivingThreadIdsRef.current.has(threadId))
+        throw new Error(
+          "This Thread is being archived. Try again if archiving fails.",
+        );
+      await window.zenx.protocol.request("turn/replace", {
+        threadId,
+        expectedTurnId: submission.expectedTurnId,
+        input,
+        clientUserMessageId: submission.clientUserMessageId,
+      });
+    }
+  };
+
+  const submitNewThreadDraft = async (
+    intent: ComposerIntent,
+    expectedTurnId: string | null,
+  ) => {
+    if (intent !== "start" || expectedTurnId !== null) return;
+    const current = newThreadDraftRef.current;
+    if (current === null) return;
+    if (current.workspace === null) {
+      setModelUpdateError("Choose a Project before sending.");
+      return;
+    }
+    const project = projectsRef.current.projects.find(
+      (candidate) =>
+        candidate.configured && candidate.workspace === current.workspace,
+    );
+    if (project === undefined) {
+      setModelUpdateError(
+        "This Project is no longer available. Choose another Project.",
+      );
+      return;
+    }
+    const workspace = project.workspace;
+    const draftSettings = defaultDraftSettings(models);
+    if (current.composer.draft.images.length > 0) {
+      const capabilityError = imageCapabilityMessage(
+        providerProfiles,
+        draftSettings,
+      );
+      if (capabilityError !== null) {
+        setModelUpdateError(capabilityError);
+        return;
+      }
+    }
+    if (draftSettings === null) {
+      setModelUpdateError(modelCatalogError ?? MODEL_CATALOG_LOADING);
+      return;
+    }
+    if (!canSendWithModel(models, draftSettings.model)) {
+      setModelUpdateError("Choose an available model before sending.");
+      return;
+    }
+    const startedComposer = beginComposerSubmission(
+      current.composer,
+      intent,
+      expectedTurnId,
+      () => crypto.randomUUID(),
+    );
+    if (startedComposer === current.composer) return;
+    const startedDraft = { ...current, composer: startedComposer };
+    confirmNewThreadDraft(startedDraft);
+    const submission = startedComposer.submission;
+    if (submission === null || submission.status !== "pending") return;
+    if (newThreadPendingRef.current) return;
+    newThreadPendingRef.current = true;
+    setNewThreadPending(true);
+    const epoch = selectionEpoch.current;
+    let createdThreadId: string | null = null;
+    try {
+      const result = await window.zenx.projects.startThread(workspace);
+      createdThreadId = result.thread.id;
+      const promotedStates = {
+        ...composerStatesRef.current,
+        [createdThreadId]: startedComposer,
+      };
+      composerStatesRef.current = promotedStates;
+      setComposerStates(promotedStates);
+      try {
+        await window.zenx.settings.markWorkspaceUsed(workspace);
+      } catch (error) {
+        setRequestError(describeError(error));
+      }
+      await loadThreadSummaries();
+      await loadProjects();
+      const stillCurrent =
+        selectionEpoch.current === epoch &&
+        newThreadDraftRef.current?.composer.submission?.clientUserMessageId ===
+          submission.clientUserMessageId;
+      if (stillCurrent) {
+        selectedThreadIdRef.current = createdThreadId;
+        threadUsageLoadEpoch.current += 1;
+        setSelectedThreadId(createdThreadId);
+        setThreadDetail(result.thread);
+        setThreadAttachments({});
+        setThreadUsage(undefined);
+        setSelectedSettings(settingsFromSnapshot(createdThreadId, result));
+        confirmNewThreadDraft(null);
+      }
+      await deliverComposerSubmission(createdThreadId, submission);
+      updateComposer(createdThreadId, (state) =>
+        acceptComposerSubmission(state, submission.clientUserMessageId),
+      );
+      if (selectedThreadIdRef.current === createdThreadId) {
+        void window.zenx.imageAttachments
+          .forThread(createdThreadId)
+          .then((attachments) => {
+            if (selectedThreadIdRef.current === createdThreadId)
+              setThreadAttachments(attachments);
+          })
+          .catch((error: unknown) =>
+            setRequestError(
+              `Thread images could not be loaded: ${describeError(error)}`,
+            ),
+          );
+      }
+    } catch (error) {
+      const message = describeError(error);
+      if (createdThreadId === null) {
+        const activeDraft = newThreadDraftRef.current;
+        if (
+          selectionEpoch.current === epoch &&
+          activeDraft?.composer.submission?.clientUserMessageId ===
+            submission.clientUserMessageId
+        ) {
+          updateNewThreadDraft((draft) => ({
+            ...draft,
+            composer: failComposerSubmission(
+              draft.composer,
+              submission.clientUserMessageId,
+              message,
+            ),
+          }));
+        } else {
+          setRequestError(`New thread failed: ${message}`);
+        }
+      } else {
+        updateComposer(createdThreadId, (state) =>
+          failComposerSubmission(
+            state,
+            submission.clientUserMessageId,
+            message,
+          ),
+        );
+      }
+    } finally {
+      newThreadPendingRef.current = false;
+      setNewThreadPending(false);
+    }
   };
 
   const submitComposer = async (
@@ -670,59 +893,7 @@ export function App() {
     const submission = started.submission;
     if (submission === null || submission.status !== "pending") return;
     try {
-      if (submission.text.length > 0)
-        await window.zenx.titles
-          .observe(threadId, submission.text)
-          .then((projection) => {
-            if (projection !== undefined)
-              setTitleSnapshot((current) => ({
-                ...current,
-                [threadId]: projection,
-              }));
-          })
-          .catch((error: unknown) =>
-            setRequestError(
-              `Thread title could not be staged: ${describeError(error)}`,
-            ),
-          );
-      const input = await composerSubmissionInput(submission);
-      if (submission.intent === "start") {
-        if (archivingThreadIdsRef.current.has(threadId))
-          throw new Error(
-            "This Thread is being archived. Try again if archiving fails.",
-          );
-        await window.zenx.protocol.request("turn/start", {
-          threadId,
-          input,
-          clientUserMessageId: submission.clientUserMessageId,
-        });
-      } else if (submission.intent === "steer") {
-        if (submission.expectedTurnId === null)
-          throw new Error("The active turn changed before steering");
-        if (archivingThreadIdsRef.current.has(threadId))
-          throw new Error(
-            "This Thread is being archived. Try again if archiving fails.",
-          );
-        await window.zenx.protocol.request("turn/steer", {
-          threadId,
-          expectedTurnId: submission.expectedTurnId,
-          input,
-          clientUserMessageId: submission.clientUserMessageId,
-        });
-      } else {
-        if (submission.expectedTurnId === null)
-          throw new Error("The active turn changed before replacement");
-        if (archivingThreadIdsRef.current.has(threadId))
-          throw new Error(
-            "This Thread is being archived. Try again if archiving fails.",
-          );
-        await window.zenx.protocol.request("turn/replace", {
-          threadId,
-          expectedTurnId: submission.expectedTurnId,
-          input,
-          clientUserMessageId: submission.clientUserMessageId,
-        });
-      }
+      await deliverComposerSubmission(threadId, submission);
       updateComposer(threadId, (state) =>
         acceptComposerSubmission(state, submission.clientUserMessageId),
       );
@@ -808,6 +979,7 @@ export function App() {
   };
 
   const openPage = (next: ProductPage) => {
+    if (next !== "agent") abandonNewThreadDraft();
     setPage(next);
     setSidebarOpen(false);
     setWorkspaceOpen(false);
@@ -977,8 +1149,7 @@ export function App() {
           }
         }}
         onNewThread={(workspace) => {
-          if (workspace === undefined) setProjectPickerIntent("new-thread");
-          else void newThread(workspace);
+          openNewThreadDraft(workspace);
         }}
         onAddProject={() => setProjectPickerIntent("add-project")}
         newThreadDisabled={newThreadPending}
@@ -1022,22 +1193,6 @@ export function App() {
       />
 
       <main className="workspace">
-        {newThreadFailure === null ? null : (
-          <div className="new-thread-error-banner" role="alert">
-            <div>
-              <strong>New thread failed</strong>
-              <span>{newThreadFailure.message}</span>
-            </div>
-            <button
-              className="secondary-button"
-              type="button"
-              disabled={newThreadPending}
-              onClick={() => void newThread(newThreadFailure.workspace)}
-            >
-              Try again
-            </button>
-          </div>
-        )}
         {page === "settings" ? (
           <SettingsView
             archivedError={threadListErrors.archived}
@@ -1062,6 +1217,8 @@ export function App() {
             approvals={approvals}
             pluginSnapshot={pluginSnapshot}
             composerStates={composerStates}
+            configuredProjects={configuredProjects}
+            newThreadDraft={newThreadDraft}
             threadAttachments={threadAttachments}
             threadUsage={threadUsage}
             models={models}
@@ -1071,6 +1228,25 @@ export function App() {
             onDraftChange={(threadId, draft) =>
               updateComposer(threadId, (state) => editComposer(state, draft))
             }
+            onNewThreadDraftChange={(draft) =>
+              updateNewThreadDraft((current) => ({
+                ...current,
+                composer: editComposer(current.composer, draft),
+              }))
+            }
+            onNewThreadProjectChange={(workspace) => {
+              setModelUpdateError(null);
+              updateNewThreadDraft((current) => ({
+                workspace,
+                composer: {
+                  ...current.composer,
+                  submission:
+                    current.composer.submission?.status === "failed"
+                      ? null
+                      : current.composer.submission,
+                },
+              }));
+            }}
             onImportImages={async (threadId, files) => {
               const imports = await Promise.all(
                 files.map(async (file) => ({
@@ -1084,16 +1260,43 @@ export function App() {
                 addComposerImages(state, images),
               );
             }}
+            onImportNewThreadImages={async (files) => {
+              const imports = await Promise.all(
+                files.map(async (file) => ({
+                  name: file.name,
+                  mediaType: file.type,
+                  bytes: new Uint8Array(await file.arrayBuffer()),
+                })),
+              );
+              const images = await window.zenx.imageAttachments.import(imports);
+              updateNewThreadDraft((current) => ({
+                ...current,
+                composer: addComposerImages(current.composer, images),
+              }));
+            }}
             onPickImages={async (threadId) => {
               const images = await window.zenx.imageAttachments.pick();
               updateComposer(threadId, (state) =>
                 addComposerImages(state, images),
               );
             }}
+            onPickNewThreadImages={async () => {
+              const images = await window.zenx.imageAttachments.pick();
+              updateNewThreadDraft((current) => ({
+                ...current,
+                composer: addComposerImages(current.composer, images),
+              }));
+            }}
             onRemoveImage={(threadId, imageId) =>
               updateComposer(threadId, (state) =>
                 removeComposerImage(state, imageId),
               )
+            }
+            onRemoveNewThreadImage={(imageId) =>
+              updateNewThreadDraft((current) => ({
+                ...current,
+                composer: removeComposerImage(current.composer, imageId),
+              }))
             }
             onReadAttachment={(attachment) =>
               window.zenx.imageAttachments.read(attachment)
@@ -1115,8 +1318,7 @@ export function App() {
             hasLastUsedProject={lastUsedWorkspace !== null}
             onAddProject={() => setProjectPickerIntent("add-project")}
             onNewThread={() => {
-              if (lastUsedWorkspace !== null) void newThread(lastUsedWorkspace);
-              else setProjectPickerIntent("new-thread");
+              openNewThreadDraft();
             }}
             onOpenSidebar={() => setSidebarOpen(true)}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
@@ -1136,6 +1338,7 @@ export function App() {
               }));
             }}
             onSubmit={submitComposer}
+            onSubmitNewThread={submitNewThreadDraft}
             requestError={projectError ?? requestError}
             selectedSettings={selectedSettings}
             selectedSummary={selectedSummary}
@@ -1148,7 +1351,7 @@ export function App() {
             }
             threadDetail={threadDetail}
             threadError={threadError}
-            threadLoading={threadLoading || newThreadPending}
+            threadLoading={threadLoading}
             titleProjection={
               selectedSummary === null
                 ? undefined
@@ -1170,8 +1373,16 @@ export function App() {
           onCancel={() => setProjectPickerIntent(null)}
           onSelect={(workspace) => {
             if (projectPickerIntent === "new-thread") {
-              setProjectPickerIntent(null);
-              void newThread(workspace);
+              void window.zenx.settings
+                .addWorkspace(workspace)
+                .then(async () => {
+                  await loadProjects();
+                  setProjectPickerIntent(null);
+                  openNewThreadDraft(workspace);
+                })
+                .catch((error: unknown) =>
+                  setRequestError(describeError(error)),
+                );
               return;
             }
             void window.zenx.settings
@@ -1192,6 +1403,8 @@ function AgentSurface({
   approvals,
   pluginSnapshot,
   composerStates,
+  configuredProjects,
+  newThreadDraft,
   threadAttachments,
   threadUsage,
   models,
@@ -1201,9 +1414,14 @@ function AgentSurface({
   onChangeThreadLifecycle,
   onDraftChange,
   onImportImages,
+  onImportNewThreadImages,
   onPickImages,
+  onPickNewThreadImages,
   onReadAttachment,
   onRemoveImage,
+  onRemoveNewThreadImage,
+  onNewThreadDraftChange,
+  onNewThreadProjectChange,
   hasProjects,
   hasLastUsedProject,
   onAddProject,
@@ -1217,6 +1435,7 @@ function AgentSurface({
   onRespondToApproval,
   onRetryTitle,
   onSubmit,
+  onSubmitNewThread,
   requestError,
   selectedSettings,
   selectedSummary,
@@ -1233,6 +1452,8 @@ function AgentSurface({
   approvals: ApprovalCardState[];
   pluginSnapshot: ZenXPluginSnapshot | null;
   composerStates: Record<string, ComposerState>;
+  configuredProjects: ZenXProjectProjectionEntry[];
+  newThreadDraft: NewThreadDraft | null;
   threadAttachments: ZenXThreadAttachmentProjection;
   threadUsage: ModelUsageProjection | undefined;
   models: ModelSummary[];
@@ -1242,11 +1463,16 @@ function AgentSurface({
   onChangeThreadLifecycle(): Promise<void>;
   onDraftChange(threadId: string, draft: string): void;
   onImportImages(threadId: string, files: readonly File[]): Promise<void>;
+  onImportNewThreadImages(files: readonly File[]): Promise<void>;
   onPickImages(threadId: string): Promise<void>;
+  onPickNewThreadImages(): Promise<void>;
   onReadAttachment(
     attachment: import("../../../../../src/attachment.js").AttachmentRef,
   ): Promise<Uint8Array>;
   onRemoveImage(threadId: string, imageId: string): void;
+  onRemoveNewThreadImage(imageId: string): void;
+  onNewThreadDraftChange(draft: string): void;
+  onNewThreadProjectChange(workspace: string): void;
   hasProjects: boolean;
   hasLastUsedProject: boolean;
   onAddProject(): void;
@@ -1266,6 +1492,10 @@ function AgentSurface({
     intent: ComposerIntent,
     expectedTurnId: string | null,
   ): Promise<void>;
+  onSubmitNewThread(
+    intent: ComposerIntent,
+    expectedTurnId: string | null,
+  ): Promise<void>;
   requestError: string | null;
   selectedSettings: SelectedThreadSettings | null;
   selectedSummary: NativeThreadSummary | null;
@@ -1279,71 +1509,104 @@ function AgentSurface({
   threadLoading: boolean;
   titleProjection: ThreadTitleProjection | undefined;
 }) {
+  const draftSettings = defaultDraftSettings(models);
+  const draftProject =
+    newThreadDraft === null
+      ? undefined
+      : configuredProjects.find(
+          (project) => project.workspace === newThreadDraft.workspace,
+        );
+  const draftProjectLabel =
+    newThreadDraft?.workspace === null || newThreadDraft === null
+      ? null
+      : projectLabel(newThreadDraft.workspace);
+  const draftProjectError =
+    newThreadDraft?.workspace !== null &&
+    newThreadDraft !== null &&
+    draftProject === undefined
+      ? "This Project is no longer available. Choose another Project."
+      : null;
   return (
-    <section className="agent-surface">
-      <header className="workspace-header">
-        <div className="workspace-heading-row">
-          <button
-            className="icon-button mobile-menu"
-            type="button"
-            aria-label="Open sidebar"
-            onClick={onOpenSidebar}
-          >
-            <Icon name="tree" />
-          </button>
-          <div className="thread-heading">
-            {selectedSummary === null ? (
-              <strong>Start a conversation</strong>
-            ) : (
-              <ThreadTitleEditor
-                editable={!selectedSummary.archived}
-                onRename={onRename}
-                onRetry={onRetryTitle}
-                projection={titleProjection}
-                title={threadTitle(selectedSummary)}
+    <section
+      className={`agent-surface${newThreadDraft === null ? "" : " new-thread-draft-surface"}`}
+    >
+      {newThreadDraft !== null ? (
+        <button
+          className="icon-button mobile-menu new-thread-draft-mobile"
+          type="button"
+          aria-label="Open sidebar"
+          onClick={onOpenSidebar}
+        >
+          <Icon name="tree" />
+        </button>
+      ) : (
+        <header className="workspace-header">
+          <div className="workspace-heading-row">
+            <button
+              className="icon-button mobile-menu"
+              type="button"
+              aria-label="Open sidebar"
+              onClick={onOpenSidebar}
+            >
+              <Icon name="tree" />
+            </button>
+            <div className="thread-heading">
+              {selectedSummary === null ? (
+                <strong>Start a conversation</strong>
+              ) : (
+                <ThreadTitleEditor
+                  editable={!selectedSummary.archived}
+                  onRename={onRename}
+                  onRetry={onRetryTitle}
+                  projection={titleProjection}
+                  title={threadTitle(selectedSummary)}
+                />
+              )}
+              <span>
+                {selectedSummary === null
+                  ? "Select a Thread or create a new one"
+                  : selectedSummary.status === "systemError"
+                    ? "Unavailable journal"
+                    : selectedSummary.currentMetadata.cwd}
+              </span>
+            </div>
+          </div>
+          <div className="top-actions">
+            {selectedSummary === null ||
+            selectedSummary.status === "systemError" ||
+            selectedSummary.archived ? null : (
+              <ThreadLifecycleAction
+                archived={selectedSummary.archived}
+                busy={threadLifecycleBusy || threadArchiving}
+                error={threadLifecycleError}
+                hasActiveTurn={threadHasActiveTurn(
+                  selectedSummary,
+                  threadDetail,
+                )}
+                onChange={onChangeThreadLifecycle}
               />
             )}
-            <span>
-              {selectedSummary === null
-                ? "Select a Thread or create a new one"
-                : selectedSummary.status === "systemError"
-                  ? "Unavailable journal"
-                  : selectedSummary.currentMetadata.cwd}
-            </span>
+            <button
+              className="icon-button search-thread"
+              type="button"
+              aria-label="Thread search is not available in this build"
+              disabled
+            >
+              <Icon name="search" />
+            </button>
+            <button
+              className="icon-button"
+              type="button"
+              aria-label="Open workspace panel"
+              aria-haspopup="dialog"
+              disabled={threadDetail === null}
+              onClick={onOpenWorkspace}
+            >
+              <Icon name="panel-right" />
+            </button>
           </div>
-        </div>
-        <div className="top-actions">
-          {selectedSummary === null ||
-          selectedSummary.status === "systemError" ||
-          selectedSummary.archived ? null : (
-            <ThreadLifecycleAction
-              archived={selectedSummary.archived}
-              busy={threadLifecycleBusy || threadArchiving}
-              error={threadLifecycleError}
-              hasActiveTurn={threadHasActiveTurn(selectedSummary, threadDetail)}
-              onChange={onChangeThreadLifecycle}
-            />
-          )}
-          <button
-            className="icon-button search-thread"
-            type="button"
-            aria-label="Thread search is not available in this build"
-            disabled
-          >
-            <Icon name="search" />
-          </button>
-          <button
-            className="icon-button"
-            type="button"
-            aria-label="Open workspace panel"
-            aria-haspopup="dialog"
-            disabled={threadDetail === null}
-            onClick={onOpenWorkspace}
-          >
-            <Icon name="panel-right" />
-          </button>
-        </div>
-      </header>
+        </header>
+      )}
 
       {serverStatus.type === "error" || requestError !== null ? (
         <EmptyState
@@ -1383,6 +1646,59 @@ function AgentSurface({
           error
           title="Could not open conversation"
           detail={threadError}
+        />
+      ) : newThreadDraft !== null ? (
+        <ThreadView
+          approvals={[]}
+          composer={newThreadDraft.composer}
+          composerContext={
+            <NewThreadProjectSelector
+              disabled={
+                newThreadDraft.composer.submission?.status === "pending"
+              }
+              onChange={onNewThreadProjectChange}
+              projects={configuredProjects}
+              selectedWorkspace={newThreadDraft.workspace}
+            />
+          }
+          emptyContent={
+            <div className="thread-empty new-thread-draft-empty">
+              <div className="empty-glyph" aria-hidden="true">
+                <Icon name="compose" size={20} />
+              </div>
+              <h2>
+                {draftProjectLabel === null
+                  ? "What should we build?"
+                  : `What should we build in ${draftProjectLabel}?`}
+              </h2>
+            </div>
+          }
+          imageCapabilityError={imageCapabilityMessage(
+            providerProfiles,
+            draftSettings,
+          )}
+          imageCapabilityNotice={imageCapabilityNotice(
+            providerProfiles,
+            draftSettings,
+          )}
+          modelDisabled
+          modelError={
+            draftProjectError ?? modelUpdateError ?? modelCatalogError
+          }
+          models={models}
+          providerProfiles={providerProfiles}
+          permissionLabel={null}
+          selectedModel={draftSettings?.model}
+          selectedReasoningEffort={draftSettings?.reasoningEffort}
+          thread={null}
+          onDraftChange={onNewThreadDraftChange}
+          onImportImages={onImportNewThreadImages}
+          onPickImages={onPickNewThreadImages}
+          onReadAttachment={onReadAttachment}
+          onRemoveImage={onRemoveNewThreadImage}
+          onInterrupt={async () => undefined}
+          onRespondToApproval={onRespondToApproval}
+          onSubmit={onSubmitNewThread}
         />
       ) : selectedSummary === null || threadDetail === null ? (
         <EmptyState
@@ -1466,6 +1782,154 @@ function AgentSurface({
         </>
       )}
     </section>
+  );
+}
+
+function NewThreadProjectSelector({
+  disabled,
+  onChange,
+  projects,
+  selectedWorkspace,
+}: {
+  disabled: boolean;
+  onChange(workspace: string): void;
+  projects: readonly ZenXProjectProjectionEntry[];
+  selectedWorkspace: string | null;
+}) {
+  const [open, setOpen] = useState(selectedWorkspace === null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const selectedProject = projects.find(
+    (project) => project.workspace === selectedWorkspace,
+  );
+  const selectedLabel =
+    selectedWorkspace === null
+      ? "Choose a Project"
+      : selectedProject === undefined
+        ? `${projectLabel(selectedWorkspace)} unavailable`
+        : projectLabel(selectedProject.workspace);
+
+  const closeAndRestoreFocus = () => {
+    setOpen(false);
+    queueMicrotask(() => triggerRef.current?.focus());
+  };
+
+  useEffect(() => {
+    if (disabled && open) setOpen(false);
+  }, [disabled, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const focusSelected = () => {
+      const selected = menuRef.current?.querySelector<HTMLButtonElement>(
+        '[role="menuitemradio"][aria-checked="true"]',
+      );
+      (
+        selected ??
+        menuRef.current?.querySelector<HTMLButtonElement>(
+          '[role="menuitemradio"]',
+        )
+      )?.focus();
+    };
+    queueMicrotask(focusSelected);
+    const onPointerDown = (event: PointerEvent) => {
+      if (rootRef.current?.contains(event.target as Node)) return;
+      setOpen(false);
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      event.preventDefault();
+      closeAndRestoreFocus();
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div className="new-thread-project-context" ref={rootRef}>
+      <div
+        className="new-thread-project-current"
+        title={selectedWorkspace ?? undefined}
+      >
+        <Icon name="folder" size={13} />
+        <span>{selectedLabel}</span>
+      </div>
+      <button
+        ref={triggerRef}
+        className="new-thread-project-trigger"
+        type="button"
+        aria-controls={open ? "new-thread-project-menu" : undefined}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        disabled={disabled}
+        onClick={() => setOpen((value) => !value)}
+      >
+        Change Project
+        <Icon name="chevron-down" size={12} />
+      </button>
+      {open ? (
+        <div
+          ref={menuRef}
+          className="new-thread-project-menu"
+          id="new-thread-project-menu"
+          role="menu"
+          aria-label="Choose a Project"
+          onKeyDown={(event) => {
+            if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key))
+              return;
+            const options = Array.from(
+              event.currentTarget.querySelectorAll<HTMLButtonElement>(
+                '[role="menuitemradio"]',
+              ),
+            );
+            if (options.length === 0) return;
+            event.preventDefault();
+            const currentIndex = options.indexOf(
+              document.activeElement as HTMLButtonElement,
+            );
+            const nextIndex =
+              event.key === "Home"
+                ? 0
+                : event.key === "End"
+                  ? options.length - 1
+                  : currentIndex === -1
+                    ? event.key === "ArrowUp"
+                      ? options.length - 1
+                      : 0
+                    : event.key === "ArrowUp"
+                      ? (currentIndex - 1 + options.length) % options.length
+                      : (currentIndex + 1) % options.length;
+            options[nextIndex]?.focus();
+          }}
+        >
+          {projects.map((project) => {
+            const selected = project.workspace === selectedWorkspace;
+            return (
+              <button
+                key={project.key}
+                type="button"
+                role="menuitemradio"
+                aria-checked={selected}
+                title={project.workspace}
+                onClick={() => {
+                  onChange(project.workspace);
+                  closeAndRestoreFocus();
+                }}
+              >
+                <Icon name="folder" size={13} />
+                <span>{projectLabel(project.workspace)}</span>
+                {selected ? <Icon name="check" size={13} /> : null}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
   );
 }
 
@@ -1732,6 +2196,27 @@ function unavailableSelectionMessage(
   return provider === undefined
     ? `Provider profile “${settings.modelProvider}” was deleted. Choose a model before sending.`
     : `The configured model from “${provider.displayName}” is hidden or unavailable. Choose another model before sending.`;
+}
+
+function defaultDraftSettings(
+  models: readonly ModelSummary[],
+): SelectedThreadSettings | null {
+  const model = models.find(
+    (candidate) => candidate.isDefault && !candidate.hidden,
+  );
+  return model === undefined
+    ? null
+    : {
+        threadId: "",
+        model: model.id,
+        modelProvider: model.model,
+        reasoningEffort: model.defaultReasoningEffort,
+      };
+}
+
+function projectLabel(workspace: string): string {
+  const normalized = workspace.replace(/[\\/]+$/u, "");
+  return normalized.split(/[\\/]/u).filter(Boolean).at(-1) ?? workspace;
 }
 
 async function composerSubmissionInput(

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -112,7 +112,6 @@ export function Sidebar({
     (() => Promise<void>) | null
   >(null);
   const [projectsOpen, setProjectsOpen] = useState(true);
-  const [projectChooserOpen, setProjectChooserOpen] = useState(false);
   const lastUsedProject =
     projects.lastUsedWorkspace === null
       ? undefined
@@ -208,22 +207,13 @@ export function Sidebar({
             <button
               className="new-thread-action"
               type="button"
-              aria-expanded={
-                configuredProjects.length > 0 && lastUsedProject === undefined
-                  ? projectChooserOpen
-                  : undefined
-              }
               disabled={newThreadDisabled}
               onClick={() => {
                 if (configuredProjects.length === 0) {
                   onNewThread();
                   return;
                 }
-                if (lastUsedProject !== undefined) {
-                  onNewThread(lastUsedProject.workspace);
-                  return;
-                }
-                setProjectChooserOpen((value) => !value);
+                onNewThread(lastUsedProject?.workspace);
               }}
             >
               <Icon name="compose" size={14} />
@@ -236,27 +226,6 @@ export function Sidebar({
                   : projectLabelForSidebar(lastUsedProject.workspace)}
               </small>
             </button>
-            {configuredProjects.length > 0 &&
-            lastUsedProject === undefined &&
-            projectChooserOpen ? (
-              <div className="new-thread-project-chooser">
-                {configuredProjects.map((project) => (
-                  <button
-                    key={project.key}
-                    type="button"
-                    title={project.workspace}
-                    disabled={newThreadDisabled}
-                    onClick={() => {
-                      setProjectChooserOpen(false);
-                      onNewThread(project.workspace);
-                    }}
-                  >
-                    <Icon name="folder" size={13} />
-                    <span>{projectLabelForSidebar(project.workspace)}</span>
-                  </button>
-                ))}
-              </div>
-            ) : null}
           </div>
 
           <div className="sidebar-view-head">
@@ -963,7 +932,6 @@ function ProjectRows({
         >
           <Icon name="folder" size={14} />
           <span>{group.label}</span>
-          {group.isDefault ? <small>Default</small> : null}
         </button>
         {group.workspace === null || !group.configured ? null : (
           <div className="project-actions" ref={menuRef}>

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { AttachmentRef } from "../../../../../src/attachment.js";
 import type {
@@ -39,18 +39,20 @@ import {
 interface ThreadViewProps {
   approvals: readonly ApprovalCardState[];
   composer: ComposerState;
+  composerContext?: ReactNode;
   composerDisabled?: boolean;
+  emptyContent?: ReactNode;
   modelDisabled?: boolean;
   modelError?: string | null;
   imageCapabilityError?: string | null;
   imageCapabilityNotice?: string | null;
   models?: readonly ModelSummary[];
-  permissionLabel?: string;
+  permissionLabel?: string | null;
   providerProfiles?: readonly ZenXProviderProfile[];
   selectedModel?: string;
   selectedReasoningEffort?: string | null;
   switchingModel?: boolean;
-  thread: Thread;
+  thread: Thread | null;
   threadAttachments?: ZenXThreadAttachmentProjection;
   threadUsage?: ModelUsageProjection;
   wakeups?: readonly TriggerHistoryEntry[];
@@ -78,7 +80,9 @@ interface ThreadViewProps {
 export function ThreadView({
   approvals,
   composer,
+  composerContext = null,
   composerDisabled = false,
+  emptyContent = null,
   modelDisabled = false,
   modelError = null,
   imageCapabilityError = null,
@@ -121,7 +125,8 @@ export function ThreadView({
   const [atLive, setAtLive] = useState(true);
   const scrollRef = useRef<HTMLDivElement>(null);
   const shouldFollowRef = useRef(true);
-  const runningTurn = activeTurn(thread);
+  const runningTurn = thread === null ? null : activeTurn(thread);
+  const turns = thread?.turns ?? [];
   const pendingApprovals = approvals.filter(
     (approval) => approval.status === "pending",
   );
@@ -136,7 +141,7 @@ export function ThreadView({
       scroll.scrollTop = scroll.scrollHeight;
       setAtLive(true);
     }
-  }, [thread.turns, approvals]);
+  }, [thread?.turns, approvals]);
 
   const submit = (intent: ComposerIntent) => {
     if (composerDisabled || !hasDraft || submitting || blockedByImageCapability)
@@ -221,35 +226,35 @@ export function ThreadView({
               {usageLabel(threadUsage.thread, "Thread cache")}
             </div>
           )}
-          {thread.turns.length === 0 ? (
-            <div className="thread-empty">
-              <div className="empty-glyph" aria-hidden="true">
-                <Icon name="compose" size={20} />
-              </div>
-              <h2>Start a new thread</h2>
-              <p>
-                Describe the outcome you want. ZenX will use this Thread’s
-                workspace, model, and permission policy.
-              </p>
-            </div>
-          ) : (
-            thread.turns.map((turn, index) => (
-              <TurnBlock
-                index={index}
-                key={turn.id}
-                turn={turn}
-                usage={threadUsage?.turns[turn.id]}
-                wakeups={wakeups}
-                attachments={threadAttachments}
-                onOpenImage={(attachment, name, trigger) =>
-                  setPreview({ attachment, name, trigger })
-                }
-                onReadAttachment={onReadAttachment}
-                pluginSnapshot={pluginSnapshot}
-                pluginUiRegistry={pluginUiRegistry}
-              />
-            ))
-          )}
+          {turns.length === 0
+            ? (emptyContent ?? (
+                <div className="thread-empty">
+                  <div className="empty-glyph" aria-hidden="true">
+                    <Icon name="compose" size={20} />
+                  </div>
+                  <h2>Start a new thread</h2>
+                  <p>
+                    Describe the outcome you want. ZenX will use this Thread’s
+                    workspace, model, and permission policy.
+                  </p>
+                </div>
+              ))
+            : turns.map((turn, index) => (
+                <TurnBlock
+                  index={index}
+                  key={turn.id}
+                  turn={turn}
+                  usage={threadUsage?.turns[turn.id]}
+                  wakeups={wakeups}
+                  attachments={threadAttachments}
+                  onOpenImage={(attachment, name, trigger) =>
+                    setPreview({ attachment, name, trigger })
+                  }
+                  onReadAttachment={onReadAttachment}
+                  pluginSnapshot={pluginSnapshot}
+                  pluginUiRegistry={pluginUiRegistry}
+                />
+              ))}
         </div>
       </div>
 
@@ -271,6 +276,7 @@ export function ThreadView({
       )}
 
       <div className="bottom-zone">
+        {composerContext}
         {pendingApprovals.map((approval) => (
           <ApprovalBar
             approval={approval}
@@ -369,15 +375,17 @@ export function ThreadView({
                   switching={switchingModel}
                 />
               )}
-              <button
-                className="composer-tool permission-control"
-                type="button"
-                aria-label={`Permission policy: ${permissionLabel}`}
-                disabled
-              >
-                <Icon name="lock" size={14} />
-                <span>{permissionLabel}</span>
-              </button>
+              {permissionLabel === null ? null : (
+                <button
+                  className="composer-tool permission-control"
+                  type="button"
+                  aria-label={`Permission policy: ${permissionLabel}`}
+                  disabled
+                >
+                  <Icon name="lock" size={14} />
+                  <span>{permissionLabel}</span>
+                </button>
+              )}
             </div>
             <div className="composer-actions">
               {runningTurn !== null && hasDraft ? (

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -381,43 +381,6 @@ a:focus-visible {
   text-align: left;
   box-shadow: inset 0 1px var(--surface-highlight);
 }
-.new-thread-project-chooser {
-  position: absolute;
-  z-index: 12;
-  top: calc(100% + 4px);
-  right: 0;
-  left: 0;
-  display: grid;
-  gap: 3px;
-  padding: 5px;
-  border: 1px solid var(--border-control);
-  border-radius: 9px;
-  background: var(--surface-control);
-  box-shadow: 0 14px 32px var(--shadow-color);
-}
-.new-thread-project-chooser button {
-  min-width: 0;
-  min-height: 32px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 8px;
-  border: 0;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-2);
-  text-align: left;
-}
-.new-thread-project-chooser button:hover,
-.new-thread-project-chooser button:focus-visible {
-  background: var(--surface-3);
-  color: var(--text);
-}
-.new-thread-project-chooser span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 .new-thread-action:hover {
   border-color: var(--border-focus);
   background: var(--surface-control-hover);
@@ -984,39 +947,6 @@ a:focus-visible {
     ),
     var(--main);
 }
-.new-thread-error-banner {
-  position: absolute;
-  z-index: 20;
-  top: 72px;
-  right: 22px;
-  left: 22px;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 16px;
-  padding: 12px 14px;
-  border: 1px solid color-mix(in srgb, var(--danger) 52%, var(--border));
-  border-radius: 10px;
-  background: var(--surface-danger);
-  box-shadow: var(--shadow-medium);
-  color: var(--danger);
-}
-.new-thread-error-banner > div {
-  min-width: 0;
-  display: grid;
-  gap: 3px;
-}
-.new-thread-error-banner strong {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 11px;
-  font-weight: 600;
-}
-.new-thread-error-banner span {
-  overflow-wrap: anywhere;
-  font-size: 10px;
-}
 .agent-surface,
 .product-page {
   width: 100%;
@@ -1025,6 +955,16 @@ a:focus-visible {
   min-height: 0;
   display: grid;
   grid-template-rows: 60px minmax(0, 1fr);
+}
+.agent-surface.new-thread-draft-surface {
+  position: relative;
+  grid-template-rows: minmax(0, 1fr);
+}
+.new-thread-draft-mobile {
+  position: absolute;
+  z-index: 8;
+  top: 8px;
+  left: 8px;
 }
 .workspace-header,
 .page-header {
@@ -1560,6 +1500,89 @@ a:focus-visible {
   min-width: 0;
   padding: 0 max(18px, calc((100% - 840px) / 2)) 18px;
   background: linear-gradient(180deg, transparent, var(--main) 18%);
+}
+.new-thread-project-context {
+  position: relative;
+  width: 100%;
+  max-width: 840px;
+  min-height: 32px;
+  margin: 0 auto 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 8px;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.new-thread-project-current,
+.new-thread-project-trigger {
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+.new-thread-project-current span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.new-thread-project-trigger {
+  min-height: 32px;
+  flex: 0 0 auto;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-3);
+  font-size: 10px;
+}
+.new-thread-project-trigger:hover:not(:disabled),
+.new-thread-project-trigger:focus-visible,
+.new-thread-project-trigger[aria-expanded="true"] {
+  background: var(--surface-2);
+  color: var(--text);
+}
+.new-thread-project-menu {
+  position: absolute;
+  z-index: 40;
+  right: 8px;
+  bottom: calc(100% + 6px);
+  width: min(280px, calc(100vw - 32px));
+  max-height: min(360px, 45vh);
+  overflow-y: auto;
+  display: grid;
+  gap: 3px;
+  padding: 6px;
+  border: 1px solid var(--border-control);
+  border-radius: 12px;
+  background: var(--surface-control);
+  box-shadow: 0 18px 48px var(--shadow-color-strong);
+}
+.new-thread-project-menu button {
+  width: 100%;
+  min-width: 0;
+  min-height: 40px;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) 18px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 9px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-2);
+  text-align: left;
+}
+.new-thread-project-menu button:hover,
+.new-thread-project-menu button:focus-visible {
+  background: var(--surface-3);
+  color: var(--text);
+}
+.new-thread-project-menu button span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .approval-bar {
   width: 100%;
@@ -3961,11 +3984,6 @@ a:focus-visible {
   .product-page {
     width: 100%;
     height: 100%;
-  }
-  .new-thread-error-banner {
-    top: 68px;
-    right: 12px;
-    left: 12px;
   }
   .agent-surface,
   .product-page {

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -4285,3 +4285,23 @@ a:focus-visible {
     transition-duration: 0.01ms !important;
   }
 }
+/* Ordinary renderer failures stay visible without replacing the conversation. */
+.app-notice {
+  position: fixed;
+  z-index: 30;
+  top: 76px;
+  left: 50%;
+  display: flex;
+  max-width: min(640px, calc(100vw - 32px));
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: 10px;
+  background: var(--surface-raised);
+  transform: translateX(-50%);
+}
+
+.app-notice button {
+  color: var(--text-secondary);
+}

--- a/apps/zenx/src/renderer/src/thread-list.ts
+++ b/apps/zenx/src/renderer/src/thread-list.ts
@@ -69,26 +69,6 @@ export function lastUsedProjectWorkspace(
   );
 }
 
-export function projectThreadStartParams(workspace: string | null): {
-  cwd: string;
-} {
-  if (workspace === null)
-    throw new Error("Add a Project before creating a Thread");
-  return { cwd: workspace };
-}
-
-export async function startProjectThread<T>(
-  workspace: string,
-  configure: (workspace: string) => Promise<unknown>,
-  start: (params: { cwd: string }) => Promise<T>,
-  onStarted: (workspace: string) => unknown | Promise<unknown>,
-): Promise<T> {
-  await configure(workspace);
-  const result = await start(projectThreadStartParams(workspace));
-  await onStarted(workspace);
-  return result;
-}
-
 export function readSidebarMode(
   storage: Pick<SidebarStorage, "getItem">,
 ): SidebarMode {

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -140,7 +140,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
       await Promise.resolve();
     });
     await waitFor(() => turnStarts.length === 1);
-    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(addWorkspaceCalls, 1);
     assert.equal(markWorkspaceCalls, 1);
   } finally {
     await unmountApp(harness);
@@ -505,6 +505,97 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     );
     assert.equal(document.activeElement, trigger);
   } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("same-leaf Projects show their parent paths in the draft chooser", async () => {
+  const harness = await mountApp({
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
+      {
+        key: "/tmp/zen",
+        workspace: "/tmp/zen",
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  });
+  try {
+    await act(async () => exactButton("Choose project")?.click());
+    const menu = await waitFor(() =>
+      document.querySelector<HTMLElement>(
+        '[role="menu"][aria-label="Choose a Project"]',
+      ),
+    );
+    assert.match(menu.textContent ?? "", /zen — \/work/u);
+    assert.match(menu.textContent ?? "", /zen — \/tmp/u);
+    const tmp = Array.from(
+      menu.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+    ).find((button) => button.getAttribute("aria-label")?.includes("/tmp/zen"));
+    assert.ok(tmp);
+    await act(async () => tmp.click());
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen — \/tmp\?/u,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("first Turn starts before ancillary Project refresh completes", async () => {
+  const marked = deferred<ReturnType<typeof publicSettings>>();
+  let turnStarts = 0;
+  const harness = await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: false,
+          threadIds: [],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      markWorkspaceUsed: async () => marked.promise,
+      startProjectThread: async (workspace) => started(liveThread(), workspace),
+      request: async (method) => {
+        if (method === "turn/start") {
+          turnStarts += 1;
+          return {};
+        }
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+    },
+  );
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Start promptly");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await waitFor(() => turnStarts === 1);
+  } finally {
+    marked.resolve(publicSettings([]));
     await unmountApp(harness);
   }
 });

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -8,23 +8,67 @@ import { createRoot, type Root } from "react-dom/client";
 
 import type { NativeThreadSummary } from "../../../src/thread-summary.js";
 import type { AppServerHostStatus } from "../src/main/app-server-manager.js";
+import type { ZenXImageDraft } from "../src/main/image-attachments.js";
 import type { ZenXProjectProjectionSnapshot } from "../src/main/project-projection.js";
 import type { ModelSummary, Thread } from "../src/protocol-client/index.js";
 import { encodeModelKey } from "../../../src/protocol/codex/model-key.js";
 const { act, createElement } = React;
 Object.assign(globalThis, { React });
-const { App } = await import("../src/renderer/src/App.js");
+const {
+  App,
+  acquireDraftPromotionLease,
+  optimisticThreadSummary,
+  releaseDraftPromotionLease,
+} = await import("../src/renderer/src/App.js");
 
 interface AppHarness {
   dom: JSDOM;
   root: Root;
 }
 
+function oneProject(): ZenXProjectProjectionSnapshot {
+  return {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+}
+
+test("optimistic summary preserves Thread seconds, identity, and idle status", () => {
+  const value = optimisticThreadSummary(
+    started(liveThread(), "/work/zen"),
+    "preview",
+  );
+  assert.equal(value.createdAt, new Date(1_000).toISOString());
+  assert.equal(value.updatedAt, new Date(2_000).toISOString());
+  assert.equal(value.threadId, "thread-1");
+  assert.equal(value.status, "idle");
+  assert.equal(value.currentMetadata.cwd, "/work/zen");
+});
+
+test("draft promotion leases delete released mappings", () => {
+  const leases = new Map<string, number>();
+  const promotions = new Map([["draft-1", "thread-1"]]);
+  acquireDraftPromotionLease(leases, "draft-1");
+  releaseDraftPromotionLease(leases, promotions, "draft-1");
+  assert.equal(leases.size, 0);
+  assert.equal(promotions.size, 0);
+});
+
 test("New thread stays local, switches Project, and creates on first Send", async () => {
   const selectedStart = deferred<ReturnType<typeof started>>();
   let projectReads = 0;
   let addWorkspaceCalls = 0;
   let markWorkspaceCalls = 0;
+  const projectMutationOrder: string[] = [];
   const startedWorkspaces: string[] = [];
   const turnStarts: Array<{
     clientUserMessageId?: string;
@@ -54,6 +98,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
   const harness = await mountApp(projects, {
     addWorkspace: async () => {
       addWorkspaceCalls += 1;
+      projectMutationOrder.push("add");
     },
     markWorkspaceUsed: async () => {
       markWorkspaceCalls += 1;
@@ -76,6 +121,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
       throw new Error(`Unexpected protocol request: ${method}`);
     },
     startProjectThread: async (workspace) => {
+      projectMutationOrder.push("start");
       startedWorkspaces.push(workspace);
       const value = await selectedStart.promise;
       created = true;
@@ -131,6 +177,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
     await invokeButtonClick(send, 2);
     await waitFor(() => startedWorkspaces.length === 1);
     assert.deepEqual(startedWorkspaces, ["/work/documents"]);
+    assert.deepEqual(projectMutationOrder, ["add", "start"]);
     assert.equal(turnStarts.length, 0);
     assert.equal(
       document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
@@ -212,6 +259,59 @@ test("abandoning an untouched new-thread draft performs no Project mutation", as
     assert.equal(addWorkspaceCalls, 0);
     assert.equal(markWorkspaceCalls, 0);
     assert.equal(projectReads, readsBeforeDraft);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("pending draft image pick follows promotion and releases its lease", async () => {
+  const pick = deferred<ZenXImageDraft[]>();
+  const create = deferred<ReturnType<typeof started>>();
+  const harness = await mountApp(oneProject(), {
+    pickImages: async () => pick.promise,
+    startProjectThread: async () => create.promise,
+    request: async (method) => {
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await act(async () =>
+      document
+        .querySelector<HTMLButtonElement>('[aria-label="Add images"]')
+        ?.click(),
+    );
+    await setTextareaValue(composer, "Create with a late image");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await act(async () => create.resolve(started(liveThread(), "/work/zen")));
+    await waitFor(() => document.querySelector("#thread-composer"));
+    await act(async () =>
+      pick.resolve([
+        {
+          id: "late-image",
+          name: "late.png",
+          attachment: {
+            type: "attachment",
+            sha256: "a".repeat(64),
+            mediaType: "image/png",
+            byteLength: 4,
+            width: 1,
+            height: 1,
+          },
+        },
+      ]),
+    );
+    await waitFor(() =>
+      document.querySelector('[aria-label="Remove late.png"]'),
+    );
   } finally {
     await unmountApp(harness);
   }
@@ -400,6 +500,59 @@ test("turn failure retries on the created Thread with the stable message id", as
   }
 });
 
+test("late create rejection restores the latest draft and stable submission id", async () => {
+  const firstCreate = deferred<ReturnType<typeof started>>();
+  const ids: string[] = [];
+  let creates = 0;
+  const harness = await mountApp(oneProject(), {
+    startProjectThread: async (workspace) => {
+      creates += 1;
+      if (creates === 1) return firstCreate.promise;
+      return started(liveThread(), workspace);
+    },
+    request: async (method, params) => {
+      if (method === "turn/start") {
+        ids.push(
+          (params as { clientUserMessageId: string }).clientUserMessageId,
+        );
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Submitted first");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await setTextareaValue(composer, "Latest queued edit");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
+    );
+    await act(async () => firstCreate.reject(new Error("create rejected")));
+    await waitFor(() => exactButton("Restore draft"));
+    assert.match(document.body.textContent ?? "", /Settings/u);
+    await act(async () => exactButton("Restore draft")?.click());
+    const restored = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    assert.equal(restored.value, "Latest queued edit");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await waitFor(() => ids.length === 1);
+    assert.equal(creates, 2);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("a pending first Send finishes without stealing a newer navigation", async () => {
   const createResponse = deferred<ReturnType<typeof started>>();
   let created = false;
@@ -508,6 +661,21 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     assert.equal(starts, 0);
 
     await act(async () => {
+      menu.dispatchEvent(
+        new window.KeyboardEvent("keydown", { bubbles: true, key: "Tab" }),
+      );
+    });
+    assert.equal(
+      document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
+      null,
+    );
+    assert.notEqual(document.activeElement, trigger);
+    await act(async () => trigger.click());
+    await waitFor(
+      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+    );
+
+    await act(async () => {
       document.dispatchEvent(
         new window.KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
       );
@@ -517,6 +685,18 @@ test("New thread without a last-used Project opens an unselected draft menu", as
       document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
       null,
     );
+    assert.equal(document.activeElement, trigger);
+    await act(async () => trigger.click());
+    await waitFor(
+      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+    );
+    await act(async () => {
+      document
+        .querySelector<HTMLElement>(".new-thread-draft-empty")
+        ?.dispatchEvent(
+          new window.MouseEvent("pointerdown", { bubbles: true }),
+        );
+    });
     assert.equal(document.activeElement, trigger);
   } finally {
     await unmountApp(harness);
@@ -667,6 +847,52 @@ test("summary failure stays non-covering after real Thread promotion", async () 
       document.body.textContent ?? "",
       /ZenX could not load data/u,
     );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("title and mark-used failures are dismissible without covering the conversation", async () => {
+  let turnStarts = 0;
+  const harness = await mountApp(oneProject(), {
+    observeTitle: async () => {
+      throw new Error("title staging failed");
+    },
+    markWorkspaceUsed: async () => {
+      throw new Error("mark used failed");
+    },
+    startProjectThread: async (workspace) => started(liveThread(), workspace),
+    request: async (method) => {
+      if (method === "turn/start") {
+        turnStarts += 1;
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Ancillary failures are not fatal");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await waitFor(() => turnStarts === 1);
+    assert.ok(document.querySelector("#thread-composer"));
+    const notice = await waitFor(() =>
+      document.querySelector<HTMLElement>(".app-notice[role=alert]"),
+    );
+    assert.match(
+      notice.textContent ?? "",
+      /(title staging failed|mark used failed)/u,
+    );
+    await act(async () => exactButton("Dismiss")?.click());
+    assert.equal(document.querySelector(".app-notice"), null);
+    assert.ok(document.querySelector("#thread-composer"));
   } finally {
     await unmountApp(harness);
   }
@@ -910,6 +1136,36 @@ test("packaged startup clears a transient Project failure after the App Server b
       document.querySelector<HTMLButtonElement>(".settings-nav-row")?.title,
       "Local service error: host exited",
     );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("zero-Project picker cancel fences delayed and duplicate folder selection", async () => {
+  const add = deferred<void>();
+  let adds = 0;
+  const harness = await mountApp(
+    { projects: [], unavailableThreadIds: [], lastUsedWorkspace: null },
+    {
+      addWorkspace: async () => {
+        adds += 1;
+        return add.promise;
+      },
+    },
+  );
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    await waitFor(() => document.querySelector('[role="dialog"]'));
+    const addFolder = exactButton("Add folder");
+    assert.ok(addFolder);
+    await invokeButtonClick(addFolder, 2);
+    assert.equal(adds, 1);
+    await act(async () => exactButton("Cancel")?.click());
+    await act(async () => add.resolve());
+    assert.equal(document.querySelector("#thread-composer"), null);
+    assert.equal(document.querySelector('[role="dialog"]'), null);
   } finally {
     await unmountApp(harness);
   }
@@ -1647,6 +1903,7 @@ async function mountApp(
     ): Promise<ReturnType<typeof publicSettings>>;
     request?(method: string, params?: unknown): Promise<unknown>;
     observeTitle?(): Promise<undefined>;
+    pickImages?(): Promise<ZenXImageDraft[]>;
     threads?(archived: boolean): Promise<NativeThreadSummary[]>;
   } = {},
 ): Promise<AppHarness> {
@@ -1694,7 +1951,8 @@ async function mountApp(
         options.threads === undefined ? [] : await options.threads(archived),
     },
     imageAttachments: {
-      pick: async () => [],
+      pick: async () =>
+        options.pickImages === undefined ? [] : await options.pickImages(),
       import: async () => [],
       read: async () => new Uint8Array(),
       forThread: async () => ({}),

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -20,9 +20,23 @@ interface AppHarness {
   root: Root;
 }
 
-test("desktop Choose project opens the existing directory picker", async () => {
-  const harness = await mountApp({
+test("New thread stays local, switches Project, and creates on first Send", async () => {
+  const selectedStart = deferred<ReturnType<typeof started>>();
+  let projectReads = 0;
+  let addWorkspaceCalls = 0;
+  let markWorkspaceCalls = 0;
+  const startedWorkspaces: string[] = [];
+  const turnStarts: Array<{ clientUserMessageId?: string }> = [];
+  let created = false;
+  const projects: ZenXProjectProjectionSnapshot = {
     projects: [
+      {
+        key: "/work/documents",
+        workspace: "/work/documents",
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
       {
         key: "/work/zen",
         workspace: "/work/zen",
@@ -32,186 +46,112 @@ test("desktop Choose project opens the existing directory picker", async () => {
       },
     ],
     unavailableThreadIds: [],
-    lastUsedWorkspace: null,
-  });
-  try {
-    const chooseProject = await waitFor(() => exactButton("Choose project"));
-    await act(async () => chooseProject.click());
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    assert.match(
-      document.querySelector('[role="dialog"]')?.textContent ?? "",
-      /Add a project folder/u,
-    );
-  } finally {
-    await unmountApp(harness);
-  }
-});
-
-test("zero-Project New thread opens the existing directory picker", async () => {
-  const startedWorkspaces: string[] = [];
-  const harness = await mountApp(
-    {
-      projects: [],
-      unavailableThreadIds: [],
-      lastUsedWorkspace: null,
-    },
-    {
-      startProjectThread: async (workspace) => {
-        startedWorkspaces.push(workspace);
-        return started(liveThread(), workspace);
-      },
-    },
-  );
-  try {
-    const newThread = await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(".new-thread-action"),
-    );
-    assert.match(newThread.textContent ?? "", /Add project first/u);
-    await act(async () => newThread.click());
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    assert.match(
-      document.querySelector('[role="dialog"]')?.textContent ?? "",
-      /Add a project folder/u,
-    );
-    await act(async () => exactButton("Add folder")?.click());
-    await waitFor(() => startedWorkspaces.length === 1);
-    assert.deepEqual(startedWorkspaces, ["/"]);
-  } finally {
-    await unmountApp(harness);
-  }
-});
-
-test("Project quick-create keeps the clicked workspace authoritative and fences duplicate starts", async () => {
-  const selectedWorkspace = "/work/documents";
-  const startResponse = deferred<ReturnType<typeof started>>();
-  const scopedStarts: string[] = [];
-  const genericStarts: unknown[] = [];
-  const projects: ZenXProjectProjectionSnapshot = {
-    projects: [
-      {
-        key: "/work/documents",
-        workspace: selectedWorkspace,
-        configured: true,
-        isDefault: false,
-        threadIds: [],
-      },
-      {
-        key: "/work",
-        workspace: "/work",
-        configured: true,
-        isDefault: true,
-        threadIds: [],
-      },
-    ],
-    unavailableThreadIds: [],
-    lastUsedWorkspace: "/work",
+    lastUsedWorkspace: "/work/zen",
   };
   const harness = await mountApp(projects, {
-    startProjectThread: async (workspace) => {
-      scopedStarts.push(workspace);
-      return await startResponse.promise;
+    addWorkspace: async () => {
+      addWorkspaceCalls += 1;
+    },
+    markWorkspaceUsed: async () => {
+      markWorkspaceCalls += 1;
+      return publicSettings([]);
+    },
+    projectsGet: async () => {
+      projectReads += 1;
+      return projects;
     },
     request: async (method, params) => {
-      if (method === "thread/start") {
-        genericStarts.push(params);
-        return await startResponse.promise;
+      if (method === "turn/start") {
+        turnStarts.push(params as { clientUserMessageId?: string });
+        return {};
       }
       throw new Error(`Unexpected protocol request: ${method}`);
     },
-  });
-  try {
-    const createInDocuments = await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="New thread in documents"]',
-      ),
-    );
-    await act(async () => {
-      createInDocuments.click();
-      createInDocuments.click();
-      await Promise.resolve();
-    });
-
-    await waitFor(() => scopedStarts.length + genericStarts.length === 1);
-    assert.deepEqual(scopedStarts, [selectedWorkspace]);
-    assert.deepEqual(genericStarts, []);
-    assert.equal(createInDocuments.disabled, true);
-    assert.equal(
-      document.querySelector<HTMLButtonElement>(".new-thread-action")?.disabled,
-      true,
-    );
-
-    await act(async () => {
-      startResponse.resolve(started(liveThread(), selectedWorkspace));
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-  } finally {
-    await unmountApp(harness);
-  }
-});
-
-test("successful Project quick-create commits profile, summaries, and projection before settling", async () => {
-  const workspace = "/work/zen";
-  const profileCommit = deferred<ReturnType<typeof publicSettings>>();
-  let committed = false;
-  let starts = 0;
-  const emptyProjects: ZenXProjectProjectionSnapshot = {
-    projects: [
-      {
-        key: workspace,
-        workspace,
-        configured: true,
-        isDefault: true,
-        threadIds: [],
-      },
-    ],
-    unavailableThreadIds: [],
-    lastUsedWorkspace: workspace,
-  };
-  const populatedProjects: ZenXProjectProjectionSnapshot = {
-    ...emptyProjects,
-    projects: [{ ...emptyProjects.projects[0]!, threadIds: ["thread-1"] }],
-  };
-  const harness = await mountApp(emptyProjects, {
-    markWorkspaceUsed: async () => {
-      const result = await profileCommit.promise;
-      committed = true;
-      return result;
-    },
-    projectsGet: async () => (committed ? populatedProjects : emptyProjects),
-    startProjectThread: async () => {
-      starts += 1;
-      return started(liveThread(), workspace);
+    startProjectThread: async (workspace) => {
+      startedWorkspaces.push(workspace);
+      const value = await selectedStart.promise;
+      created = true;
+      return value;
     },
     threads: async (archived) =>
-      !archived && committed ? [summary(false)] : [],
+      !archived && created
+        ? [summary(false, "thread-1", "Thread one", "/work/documents")]
+        : [],
   });
   try {
-    const create = await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="New thread in zen"]',
-      ),
+    await waitFor(() => projectReads > 0);
+    const readsBeforeDraft = projectReads;
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
     );
-    await act(async () => create.click());
-    await waitFor(() => starts === 1);
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen\?/u,
+    );
+    assert.deepEqual(startedWorkspaces, []);
+    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(markWorkspaceCalls, 0);
+    assert.equal(projectReads, readsBeforeDraft);
+
+    await act(async () => exactButton("Change Project")?.click());
+    const documents = await waitFor(() =>
+      Array.from(
+        document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+      ).find((button) => button.textContent?.includes("documents")),
+    );
+    await act(async () => documents.click());
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in documents\?/u,
+    );
+    assert.deepEqual(startedWorkspaces, []);
+    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(markWorkspaceCalls, 0);
+    assert.equal(projectReads, readsBeforeDraft);
+
+    await setTextareaValue(composer, "Build the documents flow");
+    const send = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+    );
+    await act(async () => exactButton("Change Project")?.click());
+    await waitFor(() =>
+      document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
+    );
+    await invokeButtonClick(send, 2);
+    await waitFor(() => startedWorkspaces.length === 1);
+    assert.deepEqual(startedWorkspaces, ["/work/documents"]);
+    assert.equal(turnStarts.length, 0);
     assert.equal(
-      document.querySelector(".project-group .thread-row-shell"),
+      document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
       null,
+    );
+    assert.equal(exactButton("Change Project")?.disabled, true);
+    assert.doesNotMatch(
+      document.body.textContent ?? "",
+      /Loading conversation/u,
     );
 
     await act(async () => {
-      profileCommit.resolve(publicSettings([]));
+      selectedStart.resolve(started(liveThread(), "/work/documents"));
+      await Promise.resolve();
       await Promise.resolve();
     });
-    await waitFor(() =>
-      document.querySelector(".project-group .thread-row-shell"),
-    );
+    await waitFor(() => turnStarts.length === 1);
+    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(markWorkspaceCalls, 1);
   } finally {
     await unmountApp(harness);
   }
 });
 
-test("New thread failure stays visible on Settings and retries in place", async () => {
+test("abandoning an untouched new-thread draft performs no Project mutation", async () => {
+  let projectReads = 0;
+  let addWorkspaceCalls = 0;
+  let markWorkspaceCalls = 0;
+  let starts = 0;
   const projects: ZenXProjectProjectionSnapshot = {
     projects: [
       {
@@ -225,47 +165,46 @@ test("New thread failure stays visible on Settings and retries in place", async 
     unavailableThreadIds: [],
     lastUsedWorkspace: "/work/zen",
   };
-  let starts = 0;
-  const populatedProjects: ZenXProjectProjectionSnapshot = {
-    ...projects,
-    projects: [{ ...projects.projects[0]!, threadIds: ["thread-1"] }],
-  };
   const harness = await mountApp(projects, {
-    projectsGet: async () => (starts >= 2 ? populatedProjects : projects),
+    addWorkspace: async () => {
+      addWorkspaceCalls += 1;
+    },
+    markWorkspaceUsed: async () => {
+      markWorkspaceCalls += 1;
+      return publicSettings([]);
+    },
+    projectsGet: async () => {
+      projectReads += 1;
+      return projects;
+    },
     startProjectThread: async (workspace) => {
       starts += 1;
-      if (starts === 1) throw new Error("runtime offline");
       return started(liveThread(), workspace);
     },
-    threads: async (archived) =>
-      !archived && starts >= 2 ? [summary(false)] : [],
   });
   try {
+    await waitFor(() => projectReads > 0);
+    const readsBeforeDraft = projectReads;
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    await waitFor(() => document.getElementById("thread-composer"));
     await act(async () =>
       document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
     );
     await waitFor(() => /Settings/u.test(document.body.textContent ?? ""));
-    await act(async () =>
-      document
-        .querySelector<HTMLButtonElement>('[aria-label="New thread in zen"]')
-        ?.click(),
-    );
-
-    const retry = await waitFor(() => exactButton("Try again"));
-    assert.match(document.body.textContent ?? "", /New thread failed/u);
-    assert.match(document.body.textContent ?? "", /runtime offline/u);
-    assert.match(document.body.textContent ?? "", /Settings/u);
-
-    await act(async () => retry.click());
-    await waitFor(() => starts === 2);
-    await waitFor(() => /Thread one/u.test(document.body.textContent ?? ""));
+    assert.equal(document.getElementById("thread-composer"), null);
+    assert.equal(starts, 0);
+    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(markWorkspaceCalls, 0);
+    assert.equal(projectReads, readsBeforeDraft);
   } finally {
     await unmountApp(harness);
   }
 });
 
-test("Project quick-create releases its loading fence after selection epoch changes and failure", async () => {
-  const firstStart = deferred<ReturnType<typeof started>>();
+test("New thread replaces a pending Thread resume with the local draft", async () => {
+  const resumeResponse = deferred<ReturnType<typeof resumed>>();
   let starts = 0;
   const projects: ZenXProjectProjectionSnapshot = {
     projects: [
@@ -282,43 +221,440 @@ test("Project quick-create releases its loading fence after selection epoch chan
   };
   const harness = await mountApp(projects, {
     request: async (method) => {
-      if (method === "thread/resume") return resumed(liveThread());
+      if (method === "thread/resume") return await resumeResponse.promise;
       throw new Error(`Unexpected protocol request: ${method}`);
     },
     startProjectThread: async (workspace) => {
       starts += 1;
-      if (starts === 1) return await firstStart.promise;
       return started(liveThread(), workspace);
     },
     threads: async (archived) => (archived ? [] : [summary(false)]),
   });
   try {
-    const create = await waitFor(() =>
-      document.querySelector<HTMLButtonElement>(
-        '[aria-label="New thread in zen"]',
+    const row = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(".thread-row"),
+    );
+    await act(async () => row.click());
+    await waitFor(() =>
+      /Loading conversation/u.test(document.body.textContent ?? ""),
+    );
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    await waitFor(() => document.getElementById("thread-composer"));
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen\?/u,
+    );
+    assert.equal(starts, 0);
+
+    await act(async () => {
+      resumeResponse.resolve(resumed(liveThread()));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen\?/u,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("thread creation failure preserves the local draft for retry", async () => {
+  let starts = 0;
+  let created = false;
+  const turnStarts: unknown[] = [];
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  const harness = await mountApp(projects, {
+    request: async (method, params) => {
+      if (method === "turn/start") {
+        turnStarts.push(params);
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      if (starts === 1) throw new Error("runtime offline");
+      created = true;
+      return started(liveThread(), workspace);
+    },
+    threads: async (archived) => (!archived && created ? [summary(false)] : []),
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Retry this first message");
+    const send = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+    );
+    await invokeButtonClick(send);
+    await waitFor(() =>
+      /runtime offline/u.test(document.body.textContent ?? ""),
+    );
+    assert.equal(composer.value, "Retry this first message");
+    assert.equal(turnStarts.length, 0);
+
+    await invokeButtonClick(send);
+    await waitFor(() => turnStarts.length === 1);
+    assert.equal(starts, 2);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("turn failure retries on the created Thread with the stable message id", async () => {
+  let starts = 0;
+  let created = false;
+  const turnStarts: Array<{ clientUserMessageId?: string }> = [];
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  const harness = await mountApp(projects, {
+    request: async (method, params) => {
+      if (method === "turn/start") {
+        turnStarts.push(params as { clientUserMessageId?: string });
+        if (turnStarts.length === 1) throw new Error("turn rejected");
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      created = true;
+      return started(liveThread(), workspace);
+    },
+    threads: async (archived) => (!archived && created ? [summary(false)] : []),
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Keep one message identity");
+    const send = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+    );
+    await invokeButtonClick(send);
+    await waitFor(() => /turn rejected/u.test(document.body.textContent ?? ""));
+    assert.equal(starts, 1);
+    assert.equal(composer.value, "Keep one message identity");
+
+    await invokeButtonClick(
+      await waitFor(() =>
+        document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
       ),
     );
-    await act(async () => create.click());
-    await waitFor(() => starts === 1);
-    await act(async () =>
-      document.querySelector<HTMLButtonElement>(".thread-row")?.click(),
+    await waitFor(() => turnStarts.length === 2);
+    assert.equal(starts, 1);
+    assert.equal(
+      turnStarts[1]?.clientUserMessageId,
+      turnStarts[0]?.clientUserMessageId,
     );
-    await waitFor(() => /Thread one/u.test(document.body.textContent ?? ""));
-    await act(async () => {
-      firstStart.reject(new Error("first start failed"));
-      await Promise.resolve();
-      await Promise.resolve();
-    });
+  } finally {
+    await unmountApp(harness);
+  }
+});
 
-    const retryCreate = await waitFor(() => {
-      const button = document.querySelector<HTMLButtonElement>(
-        '[aria-label="New thread in zen"]',
-      );
-      return button !== null && !button.disabled ? button : null;
+test("a pending first Send finishes without stealing a newer navigation", async () => {
+  const createResponse = deferred<ReturnType<typeof started>>();
+  let created = false;
+  const turnStarts: unknown[] = [];
+  const projects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  const harness = await mountApp(projects, {
+    request: async (method, params) => {
+      if (method === "turn/start") {
+        turnStarts.push(params);
+        return {};
+      }
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+    startProjectThread: async () => {
+      const value = await createResponse.promise;
+      created = true;
+      return value;
+    },
+    threads: async (archived) => (!archived && created ? [summary(false)] : []),
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Finish in the background");
+    await invokeButtonClick(
+      await waitFor(() =>
+        document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
+      ),
+    );
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
+    );
+    await waitFor(() => /Settings/u.test(document.body.textContent ?? ""));
+
+    await act(async () => {
+      createResponse.resolve(started(liveThread(), "/work/zen"));
+      await Promise.resolve();
+      await Promise.resolve();
     });
-    assert.match(document.body.textContent ?? "", /first start failed/u);
-    await act(async () => retryCreate.click());
-    await waitFor(() => starts === 2);
+    await waitFor(() => turnStarts.length === 1);
+    assert.match(document.body.textContent ?? "", /Settings/u);
+    assert.equal(document.getElementById("thread-composer"), null);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("New thread without a last-used Project opens an unselected draft menu", async () => {
+  let starts = 0;
+  const harness = await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: true,
+          threadIds: [],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: null,
+    },
+    {
+      startProjectThread: async (workspace) => {
+        starts += 1;
+        return started(liveThread(), workspace);
+      },
+    },
+  );
+  try {
+    const chooseProject = await waitFor(() => exactButton("Choose project"));
+    await act(async () => chooseProject.click());
+    await waitFor(() => document.getElementById("thread-composer"));
+    const menu = await waitFor(() =>
+      document.querySelector<HTMLElement>(
+        '[role="menu"][aria-label="Choose a Project"]',
+      ),
+    );
+    const trigger = exactButton("Change Project");
+    assert.ok(trigger);
+    assert.equal(trigger.getAttribute("aria-haspopup"), "menu");
+    assert.equal(trigger.getAttribute("aria-expanded"), "true");
+    await waitFor(
+      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+    );
+    assert.match(menu.textContent ?? "", /zen/u);
+    assert.match(document.body.textContent ?? "", /What should we build\?/u);
+    assert.equal(document.querySelector('[role="dialog"]'), null);
+    assert.equal(starts, 0);
+
+    await act(async () => {
+      document.dispatchEvent(
+        new window.KeyboardEvent("keydown", { bubbles: true, key: "Escape" }),
+      );
+      await Promise.resolve();
+    });
+    assert.equal(
+      document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
+      null,
+    );
+    assert.equal(document.activeElement, trigger);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("a Project revision lets an open draft reselect after its Project disappears", async () => {
+  let starts = 0;
+  let addWorkspaceCalls = 0;
+  let markWorkspaceCalls = 0;
+  let statusListener: ((status: AppServerHostStatus) => void) | undefined;
+  let currentProjects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/work/zen",
+        workspace: "/work/zen",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+      {
+        key: "/work/docs",
+        workspace: "/work/docs",
+        configured: true,
+        isDefault: false,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: "/work/zen",
+  };
+  const harness = await mountApp(currentProjects, {
+    addWorkspace: async () => {
+      addWorkspaceCalls += 1;
+    },
+    markWorkspaceUsed: async () => {
+      markWorkspaceCalls += 1;
+      return publicSettings([]);
+    },
+    onStatus: (listener) => {
+      statusListener = listener;
+      return () => {
+        statusListener = undefined;
+      };
+    },
+    projectsGet: async () => currentProjects,
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      return started(liveThread(), workspace);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    await waitFor(() => document.getElementById("thread-composer"));
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen\?/u,
+    );
+
+    currentProjects = {
+      projects: [
+        {
+          key: "/work/docs",
+          workspace: "/work/docs",
+          configured: true,
+          isDefault: true,
+          threadIds: [],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/docs",
+    };
+    await act(async () => {
+      statusListener?.({ type: "ready", reconnected: false });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() =>
+      /zen unavailable/u.test(document.body.textContent ?? ""),
+    );
+    assert.match(
+      document.querySelector(".composer-error")?.textContent ?? "",
+      /no longer available/u,
+    );
+
+    await act(async () => exactButton("Change Project")?.click());
+    const docs = await waitFor(() =>
+      Array.from(
+        document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
+      ).find((button) => button.textContent?.includes("docs")),
+    );
+    assert.equal(docs.getAttribute("aria-checked"), "false");
+    await act(async () => docs.click());
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in docs\?/u,
+    );
+    assert.equal(starts, 0);
+    assert.equal(addWorkspaceCalls, 0);
+    assert.equal(markWorkspaceCalls, 0);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("zero-Project New thread adds a Project but still does not create a Thread", async () => {
+  const startedWorkspaces: string[] = [];
+  let added = false;
+  const emptyProjects: ZenXProjectProjectionSnapshot = {
+    projects: [],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  };
+  const addedProjects: ZenXProjectProjectionSnapshot = {
+    projects: [
+      {
+        key: "/",
+        workspace: "/",
+        configured: true,
+        isDefault: true,
+        threadIds: [],
+      },
+    ],
+    unavailableThreadIds: [],
+    lastUsedWorkspace: null,
+  };
+  const harness = await mountApp(emptyProjects, {
+    addWorkspace: async () => {
+      added = true;
+    },
+    projectsGet: async () => (added ? addedProjects : emptyProjects),
+    startProjectThread: async (workspace) => {
+      startedWorkspaces.push(workspace);
+      return started(liveThread(), workspace);
+    },
+  });
+  try {
+    const newThread = await waitFor(() =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action"),
+    );
+    assert.match(newThread.textContent ?? "", /Add project first/u);
+    await act(async () => newThread.click());
+    await waitFor(() => document.querySelector('[role="dialog"]'));
+    assert.match(
+      document.querySelector('[role="dialog"]')?.textContent ?? "",
+      /Add a project folder/u,
+    );
+    await act(async () => exactButton("Add folder")?.click());
+    await waitFor(() => document.getElementById("thread-composer"));
+    assert.deepEqual(startedWorkspaces, []);
   } finally {
     await unmountApp(harness);
   }
@@ -1129,6 +1465,7 @@ test("serializes cross-row Pin mutations against the latest confirmed order", as
 async function mountApp(
   projects: ZenXProjectProjectionSnapshot,
   options: {
+    addWorkspace?(workspace: string): Promise<void>;
     getStatus?(): Promise<AppServerHostStatus>;
     initialPinnedThreadIds?: string[];
     onStatus?(listener: (status: AppServerHostStatus) => void): () => void;
@@ -1228,7 +1565,10 @@ async function mountApp(
           ? currentSettings
           : await options.markWorkspaceUsed(workspace),
       onManualCodeRequested: () => () => undefined,
-      addWorkspace: async () => ({ profile: { onboardingComplete: true } }),
+      addWorkspace: async (workspace: string) => {
+        await options.addWorkspace?.(workspace);
+        return { profile: { onboardingComplete: true } };
+      },
       getDirectoryBrowser: async () => ({
         locations: [{ label: "Root", path: "/" }],
         initialPath: "/",
@@ -1339,13 +1679,14 @@ function summary(
   archived: boolean,
   threadId = "thread-1",
   name = "Thread one",
+  cwd = "/work/zen",
 ): NativeThreadSummary {
   return {
     threadId,
     currentMetadata: {
       model: "fake",
       provider: "fake",
-      cwd: "/work/zen",
+      cwd,
       sandbox: "danger-full-access",
       approvalPolicy: "never",
     },

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -26,7 +26,10 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
   let addWorkspaceCalls = 0;
   let markWorkspaceCalls = 0;
   const startedWorkspaces: string[] = [];
-  const turnStarts: Array<{ clientUserMessageId?: string }> = [];
+  const turnStarts: Array<{
+    clientUserMessageId?: string;
+    input?: Array<{ type: string; text?: string }>;
+  }> = [];
   let created = false;
   const projects: ZenXProjectProjectionSnapshot = {
     projects: [
@@ -62,7 +65,12 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
     },
     request: async (method, params) => {
       if (method === "turn/start") {
-        turnStarts.push(params as { clientUserMessageId?: string });
+        turnStarts.push(
+          params as {
+            clientUserMessageId?: string;
+            input?: Array<{ type: string; text?: string }>;
+          },
+        );
         return {};
       }
       throw new Error(`Unexpected protocol request: ${method}`);
@@ -133,6 +141,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
       document.body.textContent ?? "",
       /Loading conversation/u,
     );
+    await setTextareaValue(composer, "Second message stays queued");
 
     await act(async () => {
       selectedStart.resolve(started(liveThread(), "/work/documents"));
@@ -140,6 +149,11 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
       await Promise.resolve();
     });
     await waitFor(() => turnStarts.length === 1);
+    assert.equal(turnStarts[0]?.input?.[0]?.text, "Build the documents flow");
+    assert.equal(
+      document.querySelector<HTMLTextAreaElement>("#thread-composer")?.value,
+      "Second message stays queued",
+    );
     assert.equal(addWorkspaceCalls, 1);
     assert.equal(markWorkspaceCalls, 1);
   } finally {
@@ -596,6 +610,64 @@ test("first Turn starts before ancillary Project refresh completes", async () =>
     await waitFor(() => turnStarts === 1);
   } finally {
     marked.resolve(publicSettings([]));
+    await unmountApp(harness);
+  }
+});
+
+test("summary failure stays non-covering after real Thread promotion", async () => {
+  let created = false;
+  let turnStarts = 0;
+  const harness = await mountApp(
+    {
+      projects: [
+        {
+          key: "/work/zen",
+          workspace: "/work/zen",
+          configured: true,
+          isDefault: false,
+          threadIds: [],
+        },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      startProjectThread: async (workspace) => {
+        created = true;
+        return started(liveThread(), workspace);
+      },
+      threads: async () => {
+        if (created) throw new Error("summary unavailable");
+        return [];
+      },
+      request: async (method) => {
+        if (method === "turn/start") {
+          turnStarts += 1;
+          return {};
+        }
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+    },
+  );
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Keep the conversation visible");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await waitFor(() => turnStarts === 1);
+    assert.ok(document.querySelector("#thread-composer"));
+    assert.match(document.body.textContent ?? "", /summary unavailable/u);
+    assert.doesNotMatch(
+      document.body.textContent ?? "",
+      /ZenX could not load data/u,
+    );
+  } finally {
     await unmountApp(harness);
   }
 });

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -616,6 +616,110 @@ test("a pending first Send finishes without stealing a newer navigation", async 
   }
 });
 
+test("explicit newer draft discards stale recovery before unrelated errors", async () => {
+  const create = deferred<ReturnType<typeof started>>();
+  let starts = 0;
+  const harness = await mountApp(oneProject(), {
+    markWorkspaceUsed: async () => {
+      throw new Error("later metadata error");
+    },
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      if (starts === 1) return create.promise;
+      return started(liveThread(), workspace);
+    },
+    request: async (method) => {
+      if (method === "turn/start") return {};
+      throw new Error(`Unexpected protocol request: ${method}`);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    let composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Old recoverable draft");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
+    );
+    await act(async () => create.reject(new Error("old create failed")));
+    await waitFor(() => exactButton("Restore draft"));
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "New draft wins");
+    assert.equal(exactButton("Restore draft"), undefined);
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await waitFor(() =>
+      /later metadata error/u.test(document.body.textContent ?? ""),
+    );
+    assert.equal(exactButton("Restore draft"), undefined);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("selecting an existing Thread discards stale recovery", async () => {
+  const create = deferred<ReturnType<typeof started>>();
+  const existing = summary(false, "existing-thread", "Existing thread");
+  const harness = await mountApp(
+    {
+      projects: [
+        { ...oneProject().projects[0]!, threadIds: [existing.threadId] },
+      ],
+      unavailableThreadIds: [],
+      lastUsedWorkspace: "/work/zen",
+    },
+    {
+      threads: async (archived) => (archived ? [] : [existing]),
+      startProjectThread: async () => create.promise,
+      request: async (method) => {
+        if (method === "thread/resume") return resumed(liveThread());
+        throw new Error(`Unexpected protocol request: ${method}`);
+      },
+    },
+  );
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Recover me once");
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>('[aria-label="Send"]')?.click(),
+    );
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".settings-nav-row")?.click(),
+    );
+    await act(async () => create.reject(new Error("create failed")));
+    await waitFor(() => exactButton("Restore draft"));
+    await act(async () =>
+      document
+        .querySelector<HTMLButtonElement>(
+          '[data-thread-id="existing-thread"] > .thread-row',
+        )
+        ?.click(),
+    );
+    await waitFor(() => document.querySelector("#thread-composer"));
+    assert.equal(exactButton("Restore draft"), undefined);
+    assert.match(document.body.textContent ?? "", /Existing thread/u);
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("New thread without a last-used Project opens an unselected draft menu", async () => {
   let starts = 0;
   const harness = await mountApp(

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -791,7 +791,10 @@ test("packaged startup clears a transient Project failure after the App Server b
       await Promise.resolve();
     });
     await waitFor(() => projectCalls === 1);
-    assert.match(document.body.textContent ?? "", /ZenX could not load data/u);
+    assert.match(
+      document.body.textContent ?? "",
+      /Zen App Server is not ready/u,
+    );
     assert.doesNotMatch(
       document.body.textContent ?? "",
       /Zen App Server stopped/u,

--- a/apps/zenx/test/project-workspace-smoke.test.ts
+++ b/apps/zenx/test/project-workspace-smoke.test.ts
@@ -131,6 +131,7 @@ test("packaged Project acceptance opens each Project menu before its actions", a
       "More actions for project-b",
       "Remove from ZenX",
       "New thread in project-b",
+      "Send",
       "New thread in project-b",
       "Set as default",
       "More actions for project-a",
@@ -138,6 +139,14 @@ test("packaged Project acceptance opens each Project menu before its actions", a
       "More actions for project-b",
       "More actions for project-a",
     ]);
+    assert.ok(
+      expressions.some(
+        (expression) =>
+          expression.includes("HTMLTextAreaElement.prototype") &&
+          expression.includes("Packaged Project workspace acceptance"),
+      ),
+      "the packaged acceptance should enter a first message before waiting for the Thread",
+    );
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/projects-ui.test.ts
+++ b/apps/zenx/test/projects-ui.test.ts
@@ -77,5 +77,6 @@ test("configured Project exposes the recent and scoped New thread actions", asyn
   assert.match(html, /title="\/work\/zen">zen</u);
   assert.match(html, /aria-label="New thread in zen"/u);
   assert.match(html, /aria-label="More actions for zen"/u);
+  assert.doesNotMatch(html, />Default</u);
   assert.doesNotMatch(html, /aria-label="Remove zen from ZenX"/u);
 });

--- a/apps/zenx/test/thread-list.test.ts
+++ b/apps/zenx/test/thread-list.test.ts
@@ -8,9 +8,7 @@ import {
   deriveProjectGroups,
   moveSidebarProject,
   moveSidebarThread,
-  projectThreadStartParams,
   readSidebarMode,
-  startProjectThread,
   lastUsedProjectWorkspace,
   threadModelIdentity,
   threadPreview,
@@ -244,17 +242,13 @@ test("keeps a configured project visible when it has no threads", () => {
   );
 });
 
-test("blocks no-project Thread creation and binds creation after Add project", () => {
+test("resolves last-used Project only from an explicit configured projection", () => {
   const empty = {
     projects: [],
     unavailableThreadIds: [],
     lastUsedWorkspace: null,
   };
   assert.equal(lastUsedProjectWorkspace(empty), null);
-  assert.throws(
-    () => projectThreadStartParams(lastUsedProjectWorkspace(empty)),
-    /Add a Project/u,
-  );
   const configured = {
     projects: [
       {
@@ -268,10 +262,6 @@ test("blocks no-project Thread creation and binds creation after Add project", (
     unavailableThreadIds: [],
     lastUsedWorkspace: null,
   };
-  assert.deepEqual(
-    projectThreadStartParams(configured.projects[0]!.workspace),
-    { cwd: "/work/selected" },
-  );
   assert.equal(lastUsedProjectWorkspace(configured), null);
   assert.equal(
     lastUsedProjectWorkspace({
@@ -280,80 +270,6 @@ test("blocks no-project Thread creation and binds creation after Add project", (
     }),
     "/work/selected",
   );
-});
-
-test("records last-used only after Project Thread creation succeeds", async () => {
-  const remembered: string[] = [];
-  await assert.rejects(
-    startProjectThread(
-      "/work/failing",
-      async () => undefined,
-      async () => {
-        throw new Error("start failed");
-      },
-      (workspace) => remembered.push(workspace),
-    ),
-    /start failed/u,
-  );
-  assert.equal(remembered.length, 0);
-
-  const result = await startProjectThread(
-    "/work/created",
-    async () => undefined,
-    async (params) => ({ id: "thread-created", ...params }),
-    (workspace) => remembered.push(workspace),
-  );
-  assert.deepEqual(result, {
-    id: "thread-created",
-    cwd: "/work/created",
-  });
-  assert.deepEqual(remembered, ["/work/created"]);
-});
-
-test("configures a derived Project before starting its Thread", async () => {
-  const events: string[] = [];
-
-  await startProjectThread(
-    "/work/derived",
-    async (workspace) => {
-      events.push(`configure:${workspace}`);
-    },
-    async ({ cwd }) => {
-      events.push(`start:${cwd}`);
-      return { id: "thread-derived" };
-    },
-    (workspace) => events.push(`started:${workspace}`),
-  );
-
-  assert.deepEqual(events, [
-    "configure:/work/derived",
-    "start:/work/derived",
-    "started:/work/derived",
-  ]);
-});
-
-test("waits for the successful Project Thread post-start commit", async () => {
-  const commitEntered = deferred<void>();
-  const releaseCommit = deferred<void>();
-  let completed = false;
-
-  const pending = startProjectThread(
-    "/work/committed",
-    async () => undefined,
-    async () => ({ id: "thread-committed" }),
-    async () => {
-      commitEntered.resolve();
-      await releaseCommit.promise;
-    },
-  ).then(() => {
-    completed = true;
-  });
-  await commitEntered.promise;
-  assert.equal(completed, false);
-
-  releaseCommit.resolve();
-  await pending;
-  assert.equal(completed, true);
 });
 
 test("presents trigger wakeups without leaking raw system prompts", () => {
@@ -455,15 +371,4 @@ function project(key: string, threadIds: string[]) {
     isDefault: false,
     threadIds,
   };
-}
-
-function deferred<T>(): {
-  promise: Promise<T>;
-  resolve(value: T | PromiseLike<T>): void;
-} {
-  let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((onResolve) => {
-    resolve = onResolve;
-  });
-  return { promise, resolve };
 }


### PR DESCRIPTION
## Summary

- open New thread as a renderer-local draft with a Project chooser
- create the real Thread only on the first valid Send, then promote the same Composer without losing pending text or images
- keep creation and metadata failures explicit, recoverable, dismissible, and non-covering
- remove the visible DEFAULT Project badge while preserving default behavior
- document the lazy-create lifecycle without changing Core, runtime ownership, or the fixed Codex wire

## Validation

- 80/80 focused renderer/state tests
- `npm run typecheck --workspace @zen/zenx`
- `npm run format:check`
- `npm run lint`
- `git diff --check`

The branch is based directly on `main` so this remains independent from the three earlier UI PRs.