### PR TITLE
feat(zenx): add central draft Project switcher

### DIFF
--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -165,6 +165,7 @@ export function App() {
     unavailableThreadIds: [],
     lastUsedWorkspace: null,
   });
+  const [projectListLoaded, setProjectListLoaded] = useState(false);
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [threadDetail, setThreadDetail] = useState<Thread | null>(null);
   const [threadLoading, setThreadLoading] = useState(false);
@@ -341,6 +342,7 @@ export function App() {
         projectsRef.current = snapshot;
         setProjects(snapshot);
         setProjectError(null);
+        setProjectListLoaded(true);
       }
     } catch (error) {
       if (projectLoadEpoch.current === epoch)
@@ -679,13 +681,8 @@ export function App() {
     (project) => project.configured,
   );
 
-  const openNewThreadDraft = (workspace?: string) => {
+  const showNewThreadDraft = (workspace: string | null) => {
     discardRecoverableDraft();
-    if (workspace === undefined && configuredProjects.length === 0) {
-      openProjectPicker("new-thread");
-      return;
-    }
-    const selectedWorkspace = workspace ?? lastUsedWorkspace;
     selectionEpoch.current += 1;
     threadUsageLoadEpoch.current += 1;
     selectedThreadIdRef.current = null;
@@ -702,11 +699,42 @@ export function App() {
     setModelUpdateError(null);
     confirmNewThreadDraft({
       id: crypto.randomUUID(),
-      workspace: selectedWorkspace,
+      workspace,
       composer: emptyComposerState(),
     });
     void loadComposerCatalog();
   };
+
+  const openNewThreadDraft = (workspace?: string) => {
+    if (workspace === undefined && configuredProjects.length === 0) {
+      openProjectPicker("new-thread");
+      return;
+    }
+    showNewThreadDraft(workspace ?? lastUsedWorkspace);
+  };
+
+  useEffect(() => {
+    if (
+      !projectListLoaded ||
+      serverStatus.type !== "ready" ||
+      page !== "agent" ||
+      selectedThreadIdRef.current !== null ||
+      newThreadDraftRef.current !== null
+    )
+      return;
+    showNewThreadDraft(
+      lastUsedWorkspace ??
+        configuredProjects.find((project) => project.isDefault)?.workspace ??
+        configuredProjects[0]?.workspace ??
+        null,
+    );
+  }, [
+    configuredProjects,
+    lastUsedWorkspace,
+    page,
+    projectListLoaded,
+    serverStatus.type,
+  ]);
 
   const updateNewThreadDraft = (
     update: (draft: NewThreadDraft) => NewThreadDraft,
@@ -1552,14 +1580,6 @@ export function App() {
             onModelChange={(model) => void changeModel(model)}
             onReasoningChange={(effort) => void changeReasoning(effort)}
             onChangeThreadLifecycle={changeThreadLifecycle}
-            hasProjects={projects.projects.some(
-              (project) => project.configured,
-            )}
-            hasLastUsedProject={lastUsedWorkspace !== null}
-            onAddProject={() => openProjectPicker("add-project")}
-            onNewThread={() => {
-              openNewThreadDraft();
-            }}
             onOpenSidebar={() => setSidebarOpen(true)}
             onOpenWorkspace={() => setWorkspaceOpen(true)}
             onRename={async (title) => {
@@ -1692,13 +1712,9 @@ function AgentSurface({
   onNewThreadDraftChange,
   onNewThreadProjectChange,
   onAddNewThreadProject,
-  hasProjects,
-  hasLastUsedProject,
-  onAddProject,
   onInterrupt,
   onModelChange,
   onReasoningChange,
-  onNewThread,
   onOpenSidebar,
   onOpenWorkspace,
   onRename,
@@ -1743,13 +1759,9 @@ function AgentSurface({
   onNewThreadDraftChange(draft: string): void;
   onNewThreadProjectChange(workspace: string): void;
   onAddNewThreadProject(): void;
-  hasProjects: boolean;
-  hasLastUsedProject: boolean;
-  onAddProject(): void;
   onInterrupt(turnId: string): Promise<void>;
   onModelChange(model: string): void;
   onReasoningChange(effort: string): void;
-  onNewThread(): void;
   onOpenSidebar(): void;
   onOpenWorkspace(): void;
   onRename(title: string): Promise<void>;
@@ -1795,7 +1807,7 @@ function AgentSurface({
     <section
       className={`agent-surface${newThreadDraft === null ? "" : " new-thread-draft-surface"}`}
     >
-      {newThreadDraft !== null ? (
+      {newThreadDraft !== null || selectedSummary === null ? (
         <button
           className="icon-button mobile-menu new-thread-draft-mobile"
           type="button"
@@ -1918,9 +1930,6 @@ function AgentSurface({
           }
           emptyContent={
             <div className="thread-empty new-thread-draft-empty">
-              <div className="empty-glyph" aria-hidden="true">
-                <Icon name="compose" size={20} />
-              </div>
               <div
                 className="new-thread-draft-heading"
                 role="heading"
@@ -1967,25 +1976,7 @@ function AgentSurface({
           onRespondToApproval={onRespondToApproval}
           onSubmit={onSubmitNewThread}
         />
-      ) : selectedSummary === null || threadDetail === null ? (
-        <EmptyState
-          title={hasProjects ? "No thread selected" : "Add your first project"}
-          detail={
-            hasProjects
-              ? "Choose New thread to start working in the selected Project."
-              : "Choose a folder before ZenX creates a Thread. Your files stay where they are."
-          }
-          action={hasProjects ? onNewThread : onAddProject}
-          actionLabel={
-            hasProjects
-              ? hasLastUsedProject
-                ? "New thread"
-                : "Choose project"
-              : "Add project"
-          }
-          actionIcon={hasProjects ? "compose" : "folder"}
-        />
-      ) : (
+      ) : selectedSummary === null || threadDetail === null ? null : (
         <>
           <ThreadView
             approvals={approvals.filter(
@@ -2067,6 +2058,11 @@ function NewThreadProjectSelector({
 }) {
   const [open, setOpen] = useState(selectedWorkspace === null);
   const [query, setQuery] = useState("");
+  const [popoverLayout, setPopoverLayout] = useState<{
+    placement: "above" | "below";
+    maxHeight: number;
+    offsetX: number;
+  }>({ placement: "above", maxHeight: 360, offsetX: 0 });
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -2102,9 +2098,78 @@ function NewThreadProjectSelector({
     triggerRef.current?.focus();
   }, [open]);
 
+  useLayoutEffect(() => {
+    if (!open) return;
+    const updatePopoverLayout = () => {
+      const trigger = triggerRef.current;
+      if (trigger === null) return;
+      const rect = trigger.getBoundingClientRect();
+      const clippingRect = trigger
+        .closest<HTMLElement>(".messages")
+        ?.getBoundingClientRect();
+      const viewportMargin = 16;
+      const triggerGap = 12;
+      const preferredHeight = 360;
+      const preferredWidth = 286;
+      const comfortableHeight = 240;
+      const topLimit = Math.max(
+        viewportMargin,
+        (clippingRect?.top ?? 0) + viewportMargin,
+      );
+      const bottomLimit = Math.min(
+        window.innerHeight - viewportMargin,
+        (clippingRect?.bottom ?? window.innerHeight) - viewportMargin,
+      );
+      const availableAbove = Math.max(0, rect.top - topLimit - triggerGap);
+      const availableBelow = Math.max(
+        0,
+        bottomLimit - rect.bottom - triggerGap,
+      );
+      const placement =
+        availableAbove >= Math.min(preferredHeight, comfortableHeight) ||
+        availableAbove >= availableBelow
+          ? "above"
+          : "below";
+      const available = placement === "above" ? availableAbove : availableBelow;
+      const popoverWidth = Math.min(
+        preferredWidth,
+        Math.max(0, window.innerWidth - viewportMargin * 2),
+      );
+      const triggerCenter = rect.left + rect.width / 2;
+      const halfPopoverWidth = popoverWidth / 2;
+      const clampedCenter = Math.min(
+        window.innerWidth - viewportMargin - halfPopoverWidth,
+        Math.max(viewportMargin + halfPopoverWidth, triggerCenter),
+      );
+      const next = {
+        placement,
+        maxHeight: Math.floor(Math.min(preferredHeight, available)),
+        offsetX: Math.round(clampedCenter - triggerCenter),
+      } as const;
+      setPopoverLayout((current) =>
+        current.placement === next.placement &&
+        current.maxHeight === next.maxHeight &&
+        current.offsetX === next.offsetX
+          ? current
+          : next,
+      );
+    };
+    updatePopoverLayout();
+    window.addEventListener("resize", updatePopoverLayout);
+    window.addEventListener("scroll", updatePopoverLayout, true);
+    return () => {
+      window.removeEventListener("resize", updatePopoverLayout);
+      window.removeEventListener("scroll", updatePopoverLayout, true);
+    };
+  }, [open]);
+
   useEffect(() => {
     if (disabled && open) closeMenu(false);
   }, [disabled, open]);
+
+  useEffect(() => {
+    if (selectedWorkspace === null && !disabled) setOpen(true);
+  }, [disabled, selectedWorkspace]);
 
   useEffect(() => {
     if (!open) return;
@@ -2161,11 +2226,20 @@ function NewThreadProjectSelector({
       {open ? (
         <div
           className="new-thread-project-popover"
+          data-placement={popoverLayout.placement}
           id={popoverId}
           role="dialog"
           aria-label="Switch Project"
-          onKeyDown={(event) => {
-            if (event.key === "Tab") {
+          style={{
+            maxHeight: `${popoverLayout.maxHeight}px`,
+            transform: `translateX(calc(-50% + ${popoverLayout.offsetX}px))`,
+          }}
+          onBlur={(event) => {
+            const nextFocus = event.relatedTarget;
+            if (
+              !(nextFocus instanceof Node) ||
+              !event.currentTarget.contains(nextFocus)
+            ) {
               closeMenu(false);
             }
           }}
@@ -2247,11 +2321,12 @@ function NewThreadProjectSelector({
             {filteredProjects.length === 0 ? (
               <p className="new-thread-project-empty">No projects found</p>
             ) : null}
+          </div>
+          <div className="new-thread-project-actions">
             <div className="new-thread-project-separator" role="separator" />
             <button
               className="new-thread-project-add"
               type="button"
-              role="menuitem"
               onClick={() => {
                 closeMenu(false);
                 onAddProject();

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { ModelUsageProjection } from "../../../../../src/model-usage.js";
@@ -359,7 +359,24 @@ export function App() {
       await loadProjects();
       if (projectPickerOperationEpoch.current !== epoch) return;
       closeProjectPicker();
-      if (intent === "new-thread") openNewThreadDraft(workspace);
+      if (intent === "new-thread") {
+        const draft = newThreadDraftRef.current;
+        if (draft === null) openNewThreadDraft(workspace);
+        else {
+          setModelUpdateError(null);
+          confirmNewThreadDraft({
+            ...draft,
+            workspace,
+            composer: {
+              ...draft.composer,
+              submission:
+                draft.composer.submission?.status === "failed"
+                  ? null
+                  : draft.composer.submission,
+            },
+          });
+        }
+      }
     } catch (error) {
       if (projectPickerOperationEpoch.current === epoch)
         setRequestError(describeError(error));
@@ -1456,6 +1473,7 @@ export function App() {
                 },
               }));
             }}
+            onAddNewThreadProject={() => openProjectPicker("new-thread")}
             onImportImages={async (threadId, files) => {
               const imports = await Promise.all(
                 files.map(async (file) => ({
@@ -1673,6 +1691,7 @@ function AgentSurface({
   onRemoveNewThreadImage,
   onNewThreadDraftChange,
   onNewThreadProjectChange,
+  onAddNewThreadProject,
   hasProjects,
   hasLastUsedProject,
   onAddProject,
@@ -1723,6 +1742,7 @@ function AgentSurface({
   onRemoveNewThreadImage(imageId: string): void;
   onNewThreadDraftChange(draft: string): void;
   onNewThreadProjectChange(workspace: string): void;
+  onAddNewThreadProject(): void;
   hasProjects: boolean;
   hasLastUsedProject: boolean;
   onAddProject(): void;
@@ -1765,12 +1785,6 @@ function AgentSurface({
       : configuredProjects.find(
           (project) => project.workspace === newThreadDraft.workspace,
         );
-  const draftProjectLabel =
-    newThreadDraft?.workspace === null || newThreadDraft === null
-      ? null
-      : draftProject === undefined
-        ? projectLabel(newThreadDraft.workspace)
-        : projectDisplayLabel(draftProject.workspace, configuredProjects);
   const draftProjectError =
     newThreadDraft?.workspace !== null &&
     newThreadDraft !== null &&
@@ -1897,11 +1911,7 @@ function AgentSurface({
           approvals={[]}
           composer={newThreadDraft.composer}
           composerContext={
-            <NewThreadProjectSelector
-              disabled={
-                newThreadDraft.composer.submission?.status === "pending"
-              }
-              onChange={onNewThreadProjectChange}
+            <NewThreadProjectContext
               projects={configuredProjects}
               selectedWorkspace={newThreadDraft.workspace}
             />
@@ -1911,11 +1921,23 @@ function AgentSurface({
               <div className="empty-glyph" aria-hidden="true">
                 <Icon name="compose" size={20} />
               </div>
-              <h2>
-                {draftProjectLabel === null
-                  ? "What should we build?"
-                  : `What should we build in ${draftProjectLabel}?`}
-              </h2>
+              <div
+                className="new-thread-draft-heading"
+                role="heading"
+                aria-level={2}
+              >
+                What should we build in{" "}
+                <NewThreadProjectSelector
+                  disabled={
+                    newThreadDraft.composer.submission?.status === "pending"
+                  }
+                  onAddProject={onAddNewThreadProject}
+                  onChange={onNewThreadProjectChange}
+                  projects={configuredProjects}
+                  selectedWorkspace={newThreadDraft.workspace}
+                />
+                ?
+              </div>
             </div>
           }
           imageCapabilityError={imageCapabilityMessage(
@@ -2032,20 +2054,25 @@ function AgentSurface({
 
 function NewThreadProjectSelector({
   disabled,
+  onAddProject,
   onChange,
   projects,
   selectedWorkspace,
 }: {
   disabled: boolean;
+  onAddProject(): void;
   onChange(workspace: string): void;
   projects: readonly ZenXProjectProjectionEntry[];
   selectedWorkspace: string | null;
 }) {
   const [open, setOpen] = useState(selectedWorkspace === null);
+  const [query, setQuery] = useState("");
   const rootRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const restoreFocusRef = useRef(false);
+  const popoverId = useId();
   const selectedProject = projects.find(
     (project) => project.workspace === selectedWorkspace,
   );
@@ -2055,10 +2082,18 @@ function NewThreadProjectSelector({
       : selectedProject === undefined
         ? `${projectLabel(selectedWorkspace)} unavailable`
         : projectDisplayLabel(selectedProject.workspace, projects);
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const filteredProjects = projects.filter((project) => {
+    if (normalizedQuery.length === 0) return true;
+    return `${projectDisplayLabel(project.workspace, projects)} ${project.workspace}`
+      .toLocaleLowerCase()
+      .includes(normalizedQuery);
+  });
 
   const closeMenu = (restoreFocus: boolean) => {
     restoreFocusRef.current = restoreFocus;
     setOpen(false);
+    setQuery("");
   };
 
   useLayoutEffect(() => {
@@ -2073,22 +2108,13 @@ function NewThreadProjectSelector({
 
   useEffect(() => {
     if (!open) return;
-    const focusSelected = () => {
-      const selected = menuRef.current?.querySelector<HTMLButtonElement>(
-        '[role="menuitemradio"][aria-checked="true"]',
-      );
-      (
-        selected ??
-        menuRef.current?.querySelector<HTMLButtonElement>(
-          '[role="menuitemradio"]',
-        )
-      )?.focus();
-    };
-    queueMicrotask(focusSelected);
+    queueMicrotask(() => searchRef.current?.focus());
     const onPointerDown = (event: PointerEvent) => {
       if (rootRef.current?.contains(event.target as Node)) return;
-      const focusWasInMenu = menuRef.current?.contains(document.activeElement);
-      closeMenu(Boolean(focusWasInMenu && !isFocusableTarget(event.target)));
+      const focusWasInPopover = rootRef.current?.contains(
+        document.activeElement,
+      );
+      closeMenu(Boolean(focusWasInPopover && !isFocusableTarget(event.target)));
     };
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
@@ -2103,27 +2129,25 @@ function NewThreadProjectSelector({
     };
   }, [open]);
 
+  const focusProject = (direction: "first" | "selected") => {
+    const selected = menuRef.current?.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"][aria-checked="true"]',
+    );
+    const first = menuRef.current?.querySelector<HTMLButtonElement>(
+      '[role="menuitemradio"]',
+    );
+    (direction === "selected" ? (selected ?? first) : first)?.focus();
+  };
+
   return (
-    <div className="new-thread-project-context" ref={rootRef}>
-      <div
-        className="new-thread-project-current"
-        aria-label={
-          selectedWorkspace === null
-            ? "No Project selected"
-            : `Selected Project: ${selectedWorkspace}`
-        }
-        title={selectedWorkspace ?? undefined}
-      >
-        <Icon name="folder" size={13} />
-        <span>{selectedLabel}</span>
-      </div>
+    <div className="new-thread-project-switcher" ref={rootRef}>
       <button
         ref={triggerRef}
         className="new-thread-project-trigger"
         type="button"
-        aria-controls={open ? "new-thread-project-menu" : undefined}
+        aria-controls={open ? popoverId : undefined}
         aria-expanded={open}
-        aria-haspopup="menu"
+        aria-haspopup="dialog"
         aria-label={
           selectedWorkspace === null
             ? "Choose a Project"
@@ -2132,71 +2156,145 @@ function NewThreadProjectSelector({
         disabled={disabled}
         onClick={() => (open ? closeMenu(false) : setOpen(true))}
       >
-        Change Project
-        <Icon name="chevron-down" size={12} />
+        {selectedLabel}
       </button>
       {open ? (
         <div
-          ref={menuRef}
-          className="new-thread-project-menu"
-          id="new-thread-project-menu"
-          role="menu"
-          aria-label="Choose a Project"
+          className="new-thread-project-popover"
+          id={popoverId}
+          role="dialog"
+          aria-label="Switch Project"
           onKeyDown={(event) => {
             if (event.key === "Tab") {
               closeMenu(false);
-              return;
             }
-            if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key))
-              return;
-            const options = Array.from(
-              event.currentTarget.querySelectorAll<HTMLButtonElement>(
-                '[role="menuitemradio"]',
-              ),
-            );
-            if (options.length === 0) return;
-            event.preventDefault();
-            const currentIndex = options.indexOf(
-              document.activeElement as HTMLButtonElement,
-            );
-            const nextIndex =
-              event.key === "Home"
-                ? 0
-                : event.key === "End"
-                  ? options.length - 1
-                  : currentIndex === -1
-                    ? event.key === "ArrowUp"
-                      ? options.length - 1
-                      : 0
-                    : event.key === "ArrowUp"
-                      ? (currentIndex - 1 + options.length) % options.length
-                      : (currentIndex + 1) % options.length;
-            options[nextIndex]?.focus();
           }}
         >
-          {projects.map((project) => {
-            const selected = project.workspace === selectedWorkspace;
-            return (
-              <button
-                key={project.key}
-                type="button"
-                role="menuitemradio"
-                aria-checked={selected}
-                aria-label={`${selected ? "Selected Project" : "Select Project"}: ${project.workspace}`}
-                title={project.workspace}
-                onClick={() => {
-                  onChange(project.workspace);
-                  closeMenu(true);
-                }}
-              >
-                <Icon name="folder" size={13} />
-                <span>{projectDisplayLabel(project.workspace, projects)}</span>
-                {selected ? <Icon name="check" size={13} /> : null}
-              </button>
-            );
-          })}
+          <label className="new-thread-project-search">
+            <Icon name="search" size={13} />
+            <span className="sr-only">Search projects</span>
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              placeholder="Search projects"
+              aria-label="Search projects"
+              onChange={(event) => setQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key !== "ArrowDown" && event.key !== "ArrowUp")
+                  return;
+                event.preventDefault();
+                focusProject(event.key === "ArrowUp" ? "selected" : "first");
+              }}
+            />
+          </label>
+          <div
+            ref={menuRef}
+            className="new-thread-project-menu"
+            role="menu"
+            aria-label="Choose a Project"
+            onKeyDown={(event) => {
+              if (!["ArrowDown", "ArrowUp", "Home", "End"].includes(event.key))
+                return;
+              const options = Array.from(
+                event.currentTarget.querySelectorAll<HTMLButtonElement>(
+                  '[role="menuitemradio"]',
+                ),
+              );
+              if (options.length === 0) return;
+              event.preventDefault();
+              const currentIndex = options.indexOf(
+                document.activeElement as HTMLButtonElement,
+              );
+              const nextIndex =
+                event.key === "Home"
+                  ? 0
+                  : event.key === "End"
+                    ? options.length - 1
+                    : currentIndex === -1
+                      ? event.key === "ArrowUp"
+                        ? options.length - 1
+                        : 0
+                      : event.key === "ArrowUp"
+                        ? (currentIndex - 1 + options.length) % options.length
+                        : (currentIndex + 1) % options.length;
+              options[nextIndex]?.focus();
+            }}
+          >
+            {filteredProjects.map((project) => {
+              const selected = project.workspace === selectedWorkspace;
+              return (
+                <button
+                  key={project.key}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={selected}
+                  aria-label={`${selected ? "Selected Project" : "Select Project"}: ${project.workspace}`}
+                  title={project.workspace}
+                  onClick={() => {
+                    onChange(project.workspace);
+                    closeMenu(true);
+                  }}
+                >
+                  <Icon name="folder" size={13} />
+                  <span>
+                    {projectDisplayLabel(project.workspace, projects)}
+                  </span>
+                  {selected ? <Icon name="check" size={13} /> : null}
+                </button>
+              );
+            })}
+            {filteredProjects.length === 0 ? (
+              <p className="new-thread-project-empty">No projects found</p>
+            ) : null}
+            <div className="new-thread-project-separator" role="separator" />
+            <button
+              className="new-thread-project-add"
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                closeMenu(false);
+                onAddProject();
+              }}
+            >
+              <Icon name="folder-plus" size={13} />
+              <span>Add project</span>
+            </button>
+          </div>
         </div>
       ) : null}
+    </div>
+  );
+}
+
+function NewThreadProjectContext({
+  projects,
+  selectedWorkspace,
+}: {
+  projects: readonly ZenXProjectProjectionEntry[];
+  selectedWorkspace: string | null;
+}) {
+  const selectedProject = projects.find(
+    (project) => project.workspace === selectedWorkspace,
+  );
+  const selectedLabel =
+    selectedWorkspace === null
+      ? "Choose a Project"
+      : selectedProject === undefined
+        ? `${projectLabel(selectedWorkspace)} unavailable`
+        : projectDisplayLabel(selectedProject.workspace, projects);
+  return (
+    <div
+      className="new-thread-project-context"
+      aria-label={
+        selectedWorkspace === null
+          ? "No Project selected"
+          : `Selected Project: ${selectedWorkspace}`
+      }
+      title={selectedWorkspace ?? undefined}
+    >
+      <Icon name="folder" size={13} />
+      <span>{selectedLabel}</span>
     </div>
   );
 }

--- a/apps/zenx/src/renderer/src/Sidebar.tsx
+++ b/apps/zenx/src/renderer/src/Sidebar.tsx
@@ -17,6 +17,7 @@ import type { AppServerHostStatus } from "../../main/app-server-manager.js";
 import { Icon } from "./icons.js";
 import type { LoadedPluginContribution } from "./plugin-contributions.js";
 import { ProviderLogo } from "./ProviderLogo.js";
+import { ZenXBrand } from "./ZenXBrand.js";
 import {
   deriveInboxSections,
   deriveProjectGroups,
@@ -175,6 +176,9 @@ export function Sidebar({
         aria-label="Projects and threads"
         aria-hidden={collapsed && !open ? true : undefined}
       >
+        <div className="sidebar-platform-brand">
+          <ZenXBrand />
+        </div>
         <header className="sidebar-header">
           <PluginSpaces
             contributions={pluginContributions}

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1216,6 +1216,7 @@ a:focus-visible {
   min-height: 360px;
 }
 .thread-empty h2,
+.new-thread-draft-heading,
 .empty-canvas h2 {
   margin: 2px 0 0;
   font-size: 18px;
@@ -1571,67 +1572,105 @@ a:focus-visible {
   background: linear-gradient(180deg, transparent, var(--main) 18%);
 }
 .new-thread-project-context {
-  position: relative;
   width: 100%;
   max-width: 840px;
   min-height: 32px;
   margin: 0 auto 6px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
+  justify-content: flex-start;
+  gap: 7px;
   padding: 0 8px;
   color: var(--text-3);
   font-size: 10px;
 }
-.new-thread-project-current,
-.new-thread-project-trigger {
+.new-thread-project-context span {
   min-width: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-}
-.new-thread-project-current span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.new-thread-project-switcher {
+  position: relative;
+  display: inline-block;
+}
 .new-thread-project-trigger {
-  min-height: 32px;
-  flex: 0 0 auto;
-  padding: 0 8px;
+  min-height: 0;
+  padding: 0 1px 1px;
   border: 0;
-  border-radius: 8px;
+  border-bottom: 1px solid currentColor;
+  border-radius: 0;
   background: transparent;
-  color: var(--text-3);
-  font-size: 10px;
+  color: var(--text-2);
+  font: inherit;
+  font-weight: inherit;
 }
 .new-thread-project-trigger:hover:not(:disabled),
 .new-thread-project-trigger:focus-visible,
 .new-thread-project-trigger[aria-expanded="true"] {
-  background: var(--surface-2);
-  color: var(--text);
+  color: var(--text-accent);
 }
-.new-thread-project-menu {
+.new-thread-project-trigger:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 4px;
+  border-radius: 3px;
+}
+.new-thread-project-popover {
   position: absolute;
   z-index: 40;
-  right: 8px;
-  bottom: calc(100% + 6px);
-  width: min(280px, calc(100vw - 32px));
+  left: 50%;
+  bottom: calc(100% + 12px);
+  width: min(286px, calc(100vw - 32px));
   max-height: min(360px, 45vh);
-  overflow-y: auto;
   display: grid;
-  gap: 3px;
+  gap: 5px;
   padding: 6px;
+  transform: translateX(-50%);
   border: 1px solid var(--border-control);
   border-radius: 12px;
   background: var(--surface-control);
   box-shadow: 0 18px 48px var(--shadow-color-strong);
+  text-align: left;
+}
+.new-thread-project-search {
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--text-3);
+}
+.new-thread-project-search:focus-within {
+  border-color: var(--border-strong);
+  background: var(--surface-2);
+  color: var(--text-2);
+}
+.new-thread-project-search input {
+  min-width: 0;
+  flex: 1;
+  padding: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+}
+.new-thread-project-search input::placeholder {
+  color: var(--text-3);
+}
+.new-thread-project-menu {
+  max-height: min(300px, 38vh);
+  overflow-y: auto;
+  display: grid;
+  gap: 2px;
 }
 .new-thread-project-menu button {
   width: 100%;
   min-width: 0;
-  min-height: 40px;
+  min-height: 34px;
   display: grid;
   grid-template-columns: 18px minmax(0, 1fr) 18px;
   align-items: center;
@@ -1648,10 +1687,28 @@ a:focus-visible {
   background: var(--surface-3);
   color: var(--text);
 }
+.new-thread-project-menu button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .new-thread-project-menu button span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.new-thread-project-empty {
+  margin: 8px;
+  color: var(--text-3);
+  font-size: 11px;
+  text-align: center;
+}
+.new-thread-project-separator {
+  height: 1px;
+  margin: 3px 4px;
+  background: var(--border);
+}
+.new-thread-project-add {
+  grid-template-columns: 18px minmax(0, 1fr) 18px;
 }
 .approval-bar {
   width: 100%;

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -263,9 +263,10 @@ a:focus-visible {
   border-radius: 8px;
 }
 :root[data-platform="darwin"] .window-titlebar-brand {
+  justify-content: flex-end;
   padding-left: 84px;
 }
-:root[data-platform="darwin"] .window-titlebar-brand .brand-wordmark {
+:root[data-platform="darwin"] .window-titlebar-brand > .brand {
   display: none;
 }
 :root[data-platform="darwin"] .app-shell.sidebar-collapsed {
@@ -291,6 +292,19 @@ a:focus-visible {
   pointer-events: none;
   opacity: 0;
   transform: translateX(-12px);
+}
+.sidebar-platform-brand {
+  display: none;
+}
+:root[data-platform="darwin"] .sidebar-platform-brand {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  border-bottom: 1px solid var(--border-soft);
+}
+:root[data-platform="darwin"] .sidebar-platform-brand .brand {
+  display: flex;
 }
 .sidebar-header {
   padding: 8px 12px 12px;
@@ -1200,6 +1214,12 @@ a:focus-visible {
   display: grid;
   gap: 24px;
 }
+.new-thread-draft-surface .messages {
+  display: grid;
+}
+.new-thread-draft-surface .messages-inner {
+  min-height: 100%;
+}
 .thread-empty,
 .empty-canvas,
 .page-loading {
@@ -1214,6 +1234,9 @@ a:focus-visible {
 }
 .thread-empty {
   min-height: 360px;
+}
+.new-thread-draft-empty {
+  min-height: 0;
 }
 .thread-empty h2,
 .new-thread-draft-heading,
@@ -1621,16 +1644,21 @@ a:focus-visible {
   left: 50%;
   bottom: calc(100% + 12px);
   width: min(286px, calc(100vw - 32px));
-  max-height: min(360px, 45vh);
   display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
   gap: 5px;
   padding: 6px;
+  overflow: hidden;
   transform: translateX(-50%);
   border: 1px solid var(--border-control);
   border-radius: 12px;
   background: var(--surface-control);
   box-shadow: 0 18px 48px var(--shadow-color-strong);
   text-align: left;
+}
+.new-thread-project-popover[data-placement="below"] {
+  top: calc(100% + 12px);
+  bottom: auto;
 }
 .new-thread-project-search {
   min-height: 34px;
@@ -1662,12 +1690,15 @@ a:focus-visible {
   color: var(--text-3);
 }
 .new-thread-project-menu {
-  max-height: min(300px, 38vh);
+  min-height: 0;
   overflow-y: auto;
   display: grid;
   gap: 2px;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
-.new-thread-project-menu button {
+.new-thread-project-menu button,
+.new-thread-project-actions button {
   width: 100%;
   min-width: 0;
   min-height: 34px;
@@ -1683,15 +1714,19 @@ a:focus-visible {
   text-align: left;
 }
 .new-thread-project-menu button:hover,
-.new-thread-project-menu button:focus-visible {
+.new-thread-project-menu button:focus-visible,
+.new-thread-project-actions button:hover,
+.new-thread-project-actions button:focus-visible {
   background: var(--surface-3);
   color: var(--text);
 }
-.new-thread-project-menu button:focus-visible {
+.new-thread-project-menu button:focus-visible,
+.new-thread-project-actions button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.new-thread-project-menu button span {
+.new-thread-project-menu button span,
+.new-thread-project-actions button span {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1706,6 +1741,10 @@ a:focus-visible {
   height: 1px;
   margin: 3px 4px;
   background: var(--border);
+}
+.new-thread-project-actions {
+  display: grid;
+  gap: 2px;
 }
 .new-thread-project-add {
   grid-template-columns: 18px minmax(0, 1fr) 18px;

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -127,6 +127,34 @@ test("desktop title bar collapses and restores the Sidebar", async () => {
   }
 });
 
+test("startup opens a local welcome draft without creating a Thread", async () => {
+  let starts = 0;
+  const harness = await mountApp(oneProject(), {
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      return started(liveThread(), workspace);
+    },
+  });
+  try {
+    const heading = await waitFor(() =>
+      document.querySelector<HTMLElement>(".new-thread-draft-heading"),
+    );
+    assert.match(heading.textContent ?? "", /What should we build in zen\?/u);
+    assert.equal(
+      document.querySelector(".new-thread-draft-empty .empty-glyph"),
+      null,
+    );
+    assert.ok(document.getElementById("thread-composer"));
+    assert.equal(starts, 0);
+    assert.doesNotMatch(
+      document.body.textContent ?? "",
+      /Start a conversation|No thread selected/u,
+    );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
 test("optimistic summary preserves Thread seconds, identity, and idle status", () => {
   const value = optimisticThreadSummary(
     started(liveThread(), "/work/zen"),
@@ -829,8 +857,12 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     },
   );
   try {
-    const chooseProject = await waitFor(() => exactButton("Choose project"));
-    await act(async () => chooseProject.click());
+    await waitFor(() =>
+      document.querySelector<HTMLElement>(".new-thread-draft-heading"),
+    );
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
     await waitFor(() => document.getElementById("thread-composer"));
     const menu = await waitFor(() =>
       document.querySelector<HTMLElement>(
@@ -857,9 +889,29 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     );
     assert.equal(starts, 0);
 
+    const addProject = exactButton("Add project");
+    assert.ok(addProject);
     await act(async () => {
-      menu.dispatchEvent(
-        new window.KeyboardEvent("keydown", { bubbles: true, key: "Tab" }),
+      search.dispatchEvent(
+        new window.FocusEvent("focusout", {
+          bubbles: true,
+          relatedTarget: addProject,
+        }),
+      );
+    });
+    assert.ok(
+      document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
+    );
+    const nextOutsideControl =
+      document.querySelector<HTMLButtonElement>(".new-thread-action");
+    assert.ok(nextOutsideControl);
+    await act(async () => {
+      addProject.focus();
+      addProject.dispatchEvent(
+        new window.FocusEvent("focusout", {
+          bubbles: true,
+          relatedTarget: nextOutsideControl,
+        }),
       );
     });
     assert.equal(
@@ -922,7 +974,8 @@ test("same-leaf Projects show their parent paths in the draft chooser", async ()
     lastUsedWorkspace: null,
   });
   try {
-    await act(async () => exactButton("Choose project")?.click());
+    const trigger = await waitFor(() => projectSwitcher());
+    await act(async () => trigger.click());
     const menu = await waitFor(() =>
       document.querySelector<HTMLElement>(
         '[role="menu"][aria-label="Choose a Project"]',
@@ -959,6 +1012,97 @@ test("same-leaf Projects show their parent paths in the draft chooser", async ()
       /What should we build in zen — \/tmp\?/u,
     );
   } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("draft Project chooser stays within the viewport and only scrolls its results", async () => {
+  const harness = await mountApp(oneProject());
+  const originalInnerHeight = Object.getOwnPropertyDescriptor(
+    window,
+    "innerHeight",
+  );
+  const originalInnerWidth = Object.getOwnPropertyDescriptor(
+    window,
+    "innerWidth",
+  );
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const trigger = await waitFor(() => projectSwitcher());
+    let triggerTop = 40;
+    let triggerBottom = 60;
+    const messages = document.querySelector<HTMLElement>(".messages");
+    assert.ok(messages);
+    messages.getBoundingClientRect = () =>
+      ({
+        top: 24,
+        bottom: 396,
+        left: 0,
+        right: 320,
+        width: 320,
+        height: 372,
+        x: 0,
+        y: 24,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    trigger.getBoundingClientRect = () =>
+      ({
+        top: triggerTop,
+        bottom: triggerBottom,
+        left: 400,
+        right: 500,
+        width: 100,
+        height: triggerBottom - triggerTop,
+        x: 400,
+        y: triggerTop,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 420,
+    });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 320,
+    });
+
+    await act(async () => trigger.click());
+    let popover = await waitFor(() =>
+      document.querySelector<HTMLElement>(".new-thread-project-popover"),
+    );
+    assert.equal(popover.dataset.placement, "below");
+    assert.equal(popover.style.maxHeight, "308px");
+    assert.equal(popover.style.transform, "translateX(calc(-50% + -289px))");
+    const results = popover.querySelector(".new-thread-project-menu");
+    const actions = popover.querySelector(".new-thread-project-actions");
+    assert.ok(results);
+    assert.ok(actions);
+    assert.equal(results.querySelector(".new-thread-project-add"), null);
+    assert.ok(actions.querySelector(".new-thread-project-add"));
+
+    triggerTop = 350;
+    triggerBottom = 370;
+    await act(async () => window.dispatchEvent(new window.Event("resize")));
+    popover = await waitFor(() => {
+      const candidate = document.querySelector<HTMLElement>(
+        ".new-thread-project-popover",
+      );
+      return candidate?.dataset.placement === "above" ? candidate : undefined;
+    });
+    assert.equal(popover.style.maxHeight, "298px");
+  } finally {
+    if (originalInnerHeight === undefined) {
+      Reflect.deleteProperty(window, "innerHeight");
+    } else {
+      Object.defineProperty(window, "innerHeight", originalInnerHeight);
+    }
+    if (originalInnerWidth === undefined) {
+      Reflect.deleteProperty(window, "innerWidth");
+    } else {
+      Object.defineProperty(window, "innerWidth", originalInnerWidth);
+    }
     await unmountApp(harness);
   }
 });
@@ -1392,7 +1536,14 @@ test("packaged startup clears a transient Project failure after the App Server b
       document.querySelector<HTMLButtonElement>(".settings-nav-row")?.title,
       "Local service ready",
     );
-    assert.match(document.body.textContent ?? "", /No thread selected/u);
+    await waitFor(() =>
+      document.querySelector<HTMLElement>(".new-thread-draft-heading"),
+    );
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in zen\?/u,
+    );
+    assert.doesNotMatch(document.body.textContent ?? "", /No thread selected/u);
 
     await act(async () => {
       statusListener?.({ type: "error", message: "host exited" });
@@ -1424,15 +1575,14 @@ test("zero-Project picker cancel fences delayed and duplicate folder selection",
     await act(async () =>
       document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
     );
-    await waitFor(() => document.querySelector('[role="dialog"]'));
-    const addFolder = exactButton("Add folder");
-    assert.ok(addFolder);
+    await waitFor(() => document.querySelector(".directory-picker-dialog"));
+    const addFolder = await waitFor(() => exactButton("Add folder"));
     await invokeButtonClick(addFolder, 2);
     assert.equal(adds, 1);
     await act(async () => exactButton("Cancel")?.click());
     await act(async () => add.resolve());
-    assert.equal(document.querySelector("#thread-composer"), null);
-    assert.equal(document.querySelector('[role="dialog"]'), null);
+    assert.ok(document.querySelector("#thread-composer"));
+    assert.equal(document.querySelector(".directory-picker-dialog"), null);
   } finally {
     await unmountApp(harness);
   }

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -42,6 +42,13 @@ function oneProject(): ZenXProjectProjectionSnapshot {
   };
 }
 
+function projectSwitcher(): HTMLButtonElement | undefined {
+  return (
+    document.querySelector<HTMLButtonElement>(".new-thread-project-trigger") ??
+    undefined
+  );
+}
+
 test("desktop title bar collapses and restores the Sidebar", async () => {
   const harness = await mountApp({
     projects: [],
@@ -228,7 +235,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
     assert.equal(markWorkspaceCalls, 0);
     assert.equal(projectReads, readsBeforeDraft);
 
-    await act(async () => exactButton("Change Project")?.click());
+    await act(async () => projectSwitcher()?.click());
     const documents = await waitFor(() =>
       Array.from(
         document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
@@ -248,7 +255,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
     const send = await waitFor(() =>
       document.querySelector<HTMLButtonElement>('[aria-label="Send"]'),
     );
-    await act(async () => exactButton("Change Project")?.click());
+    await act(async () => projectSwitcher()?.click());
     await waitFor(() =>
       document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
     );
@@ -261,7 +268,7 @@ test("New thread stays local, switches Project, and creates on first Send", asyn
       document.querySelector('[role="menu"][aria-label="Choose a Project"]'),
       null,
     );
-    assert.equal(exactButton("Change Project")?.disabled, true);
+    assert.equal(projectSwitcher()?.disabled, true);
     assert.doesNotMatch(
       document.body.textContent ?? "",
       /Loading conversation/u,
@@ -830,16 +837,24 @@ test("New thread without a last-used Project opens an unselected draft menu", as
         '[role="menu"][aria-label="Choose a Project"]',
       ),
     );
-    const trigger = exactButton("Change Project");
+    const trigger = projectSwitcher();
     assert.ok(trigger);
-    assert.equal(trigger.getAttribute("aria-haspopup"), "menu");
+    assert.equal(trigger.getAttribute("aria-haspopup"), "dialog");
     assert.equal(trigger.getAttribute("aria-expanded"), "true");
-    await waitFor(
-      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+    const search = await waitFor(() =>
+      document.querySelector<HTMLInputElement>(
+        'input[aria-label="Search projects"]',
+      ),
     );
+    await waitFor(() => document.activeElement === search);
     assert.match(menu.textContent ?? "", /zen/u);
-    assert.match(document.body.textContent ?? "", /What should we build\?/u);
-    assert.equal(document.querySelector('[role="dialog"]'), null);
+    assert.match(
+      document.body.textContent ?? "",
+      /What should we build in Choose a Project/u,
+    );
+    assert.ok(
+      document.querySelector('[role="dialog"][aria-label="Switch Project"]'),
+    );
     assert.equal(starts, 0);
 
     await act(async () => {
@@ -854,7 +869,7 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     assert.notEqual(document.activeElement, trigger);
     await act(async () => trigger.click());
     await waitFor(
-      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+      () => document.activeElement?.getAttribute("type") === "search",
     );
 
     await act(async () => {
@@ -870,7 +885,7 @@ test("New thread without a last-used Project opens an unselected draft menu", as
     assert.equal(document.activeElement, trigger);
     await act(async () => trigger.click());
     await waitFor(
-      () => document.activeElement?.getAttribute("role") === "menuitemradio",
+      () => document.activeElement?.getAttribute("type") === "search",
     );
     await act(async () => {
       document
@@ -915,6 +930,25 @@ test("same-leaf Projects show their parent paths in the draft chooser", async ()
     );
     assert.match(menu.textContent ?? "", /zen — \/work/u);
     assert.match(menu.textContent ?? "", /zen — \/tmp/u);
+    const search = document.querySelector<HTMLInputElement>(
+      'input[aria-label="Search projects"]',
+    );
+    assert.ok(search);
+    await setInputValue(search, "/tmp");
+    await waitFor(
+      () => menu.querySelectorAll('[role="menuitemradio"]').length === 1,
+    );
+    assert.doesNotMatch(menu.textContent ?? "", /zen — \/work/u);
+    assert.match(menu.textContent ?? "", /zen — \/tmp/u);
+    await act(async () => {
+      search.dispatchEvent(
+        new window.KeyboardEvent("keydown", {
+          bubbles: true,
+          key: "ArrowDown",
+        }),
+      );
+    });
+    assert.equal(document.activeElement?.getAttribute("role"), "menuitemradio");
     const tmp = Array.from(
       menu.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
     ).find((button) => button.getAttribute("aria-label")?.includes("/tmp/zen"));
@@ -924,6 +958,57 @@ test("same-leaf Projects show their parent paths in the draft chooser", async ()
       document.body.textContent ?? "",
       /What should we build in zen — \/tmp\?/u,
     );
+  } finally {
+    await unmountApp(harness);
+  }
+});
+
+test("adding a Project from the central switcher preserves the local draft", async () => {
+  let currentProjects = oneProject();
+  let addWorkspaceCalls = 0;
+  let starts = 0;
+  const harness = await mountApp(currentProjects, {
+    addWorkspace: async (workspace) => {
+      addWorkspaceCalls += 1;
+      currentProjects = {
+        projects: [
+          ...currentProjects.projects,
+          {
+            key: workspace,
+            workspace,
+            configured: true,
+            isDefault: false,
+            threadIds: [],
+          },
+        ],
+        unavailableThreadIds: [],
+        lastUsedWorkspace: workspace,
+      };
+    },
+    projectsGet: async () => currentProjects,
+    startProjectThread: async (workspace) => {
+      starts += 1;
+      return started(liveThread(), workspace);
+    },
+  });
+  try {
+    await act(async () =>
+      document.querySelector<HTMLButtonElement>(".new-thread-action")?.click(),
+    );
+    const composer = await waitFor(() =>
+      document.querySelector<HTMLTextAreaElement>("#thread-composer"),
+    );
+    await setTextareaValue(composer, "Keep this draft");
+    await act(async () => projectSwitcher()?.click());
+    const addProject = await waitFor(() => exactButton("Add project"));
+    await act(async () => addProject.click());
+    const addFolder = await waitFor(() => exactButton("Add folder"));
+    await waitFor(() => addFolder.disabled === false);
+    await act(async () => addFolder.click());
+    await waitFor(() => projectSwitcher()?.textContent?.trim() === "/");
+    assert.equal(composer.value, "Keep this draft");
+    assert.equal(addWorkspaceCalls, 1);
+    assert.equal(starts, 0);
   } finally {
     await unmountApp(harness);
   }
@@ -1161,7 +1246,7 @@ test("a Project revision lets an open draft reselect after its Project disappear
       /no longer available/u,
     );
 
-    await act(async () => exactButton("Change Project")?.click());
+    await act(async () => projectSwitcher()?.click());
     const docs = await waitFor(() =>
       Array.from(
         document.querySelectorAll<HTMLButtonElement>('[role="menuitemradio"]'),
@@ -2102,6 +2187,10 @@ async function mountApp(
     window: dom.window,
     IS_REACT_ACT_ENVIRONMENT: true,
   });
+  Object.defineProperties(dom.window.HTMLInputElement.prototype, {
+    attachEvent: { value: () => undefined },
+    detachEvent: { value: () => undefined },
+  });
   let currentSettings = publicSettings(options.initialPinnedThreadIds ?? []);
   const zenx = {
     platform: "darwin",
@@ -2505,6 +2594,18 @@ async function setTextareaValue(
   const props = reactProps<{
     onChange?(event: { target: { value: string } }): void;
   }>(textarea);
+  const onChange = props?.onChange;
+  assert.ok(onChange);
+  await act(async () => {
+    onChange({ target: { value } });
+    await Promise.resolve();
+  });
+}
+
+async function setInputValue(input: HTMLInputElement, value: string) {
+  const props = reactProps<{
+    onChange?(event: { target: { value: string } }): void;
+  }>(input);
   const onChange = props?.onChange;
   assert.ok(onChange);
   await act(async () => {

--- a/apps/zenx/test/window-titlebar.test.ts
+++ b/apps/zenx/test/window-titlebar.test.ts
@@ -4,7 +4,7 @@ import test from "node:test";
 
 const rendererRoot = new URL("../src/renderer/src/", import.meta.url);
 
-test("integrated title bar orders ZenX branding, Inbox, and Sidebar controls", async () => {
+test("integrated title bar keeps controls while macOS moves ZenX branding into the Sidebar", async () => {
   const [app, sidebar, styles, main] = await Promise.all([
     readFile(new URL("App.tsx", rendererRoot), "utf8"),
     readFile(new URL("Sidebar.tsx", rendererRoot), "utf8"),
@@ -22,7 +22,8 @@ test("integrated title bar orders ZenX branding, Inbox, and Sidebar controls", a
     /sidebarCollapsed \? "Expand sidebar" : "Collapse sidebar"/u,
   );
   assert.match(sidebar, /id="primary-sidebar"/u);
-  assert.doesNotMatch(sidebar, /<ZenXBrand/u);
+  assert.match(sidebar, /className="sidebar-platform-brand"/u);
+  assert.match(sidebar, /<ZenXBrand \/>/u);
   assert.doesNotMatch(sidebar, /className="icon-button inbox-button"/u);
   assert.match(styles, /-webkit-app-region: drag;/u);
   assert.match(
@@ -32,6 +33,14 @@ test("integrated title bar orders ZenX branding, Inbox, and Sidebar controls", a
   assert.match(
     styles,
     /\.app-shell\.sidebar-collapsed\s*\{[^}]*--sidebar-track: 0px;/su,
+  );
+  assert.match(
+    styles,
+    /:root\[data-platform="darwin"\] \.window-titlebar-brand > \.brand\s*\{[^}]*display: none;/su,
+  );
+  assert.match(
+    styles,
+    /:root\[data-platform="darwin"\] \.sidebar-platform-brand\s*\{[^}]*display: flex;/su,
   );
   assert.match(main, /titleBarStyle: "hidden"/u);
   assert.match(main, /titleBarOverlay:/u);

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,55 +1,55 @@
-# ZenX central Project switcher design QA
+# ZenX welcome draft and Project switcher design QA
 
-**Source visual truth**
+## Source visual truth
 
-- `/var/folders/kn/qprvl_8n6vn88tcp8tv_h2ph0000gn/T/codex-clipboard-9682f21f-cbaf-4bef-8726-5a7507b8be04.png`
-- 1638 × 1037 pixels, dark macOS desktop state, New chat draft with the central Project menu open.
+- `/var/folders/kn/qprvl_8n6vn88tcp8tv_h2ph0000gn/T/codex-clipboard-0995f127-24d2-4d6c-80f0-3341ad7dbe63.png`
+  - 2560 × 1640 pixels. User-marked packaged ZenX welcome state: remove or replace the generic compose glyph, lower the welcome content, and verify horizontal centering.
+- `/var/folders/kn/qprvl_8n6vn88tcp8tv_h2ph0000gn/T/codex-clipboard-36207038-e6bb-4761-96aa-bc6a043d7f46.png`
+  - 830 × 598 pixels. Codex reference for a fixed search row, scrollable Project results, fixed bottom actions, and viewport containment.
 
-**Implementation evidence**
+## Implementation evidence
 
-- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-packaged-start.png`
-- 1199 × 768 pixels, dark macOS desktop state, packaged ZenX startup screen.
-- Packaged app: `/private/tmp/ZenX-ui7.app` from branch `codex/zenx-draft-project-switcher`.
+- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-final-welcome.png`
+  - 1199 × 768 pixels. Final packaged ZenX welcome state.
+- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-final-project-menu.png`
+  - 1199 × 768 pixels. Final packaged ZenX Project menu state.
+- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-welcome-comparison.png`
+  - 2398 × 802 pixels. The 2560 × 1640 user screenshot normalized to the 1199 × 768 implementation size and placed beside the final packaged capture.
+- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-project-menu-comparison.png`
+  - 1040 × 424 pixels. Focused Codex-menu reference and final packaged ZenX menu in one comparison image.
+- Packaged app: `/tmp/zenx-ui7-final-h4o1d9/ZenX.app`.
 
-**Viewport and normalization**
+## Viewport and state
 
-- The source and implementation have different window dimensions and do not show the same interaction state.
-- No density normalization or side-by-side fidelity judgment was performed because the packaged implementation could not be advanced to the open-menu state through the available desktop-control channel.
+- Final Electron CSS viewport: 1280 × 820; macOS dark mode.
+- Computer Use screenshots are 1199 × 768 pixels for that window. The user's 2560 × 1640 screenshot has the same aspect ratio and was downsampled to the implementation screenshot size for the welcome comparison.
+- The Project menu was opened in the packaged app. Runtime geometry confirms the scroll clipping region is `top=44, bottom=638`, while the menu is `top=60.25, bottom=313.25`; it remains fully inside the visible messages region with a 16px top inset.
 
-**State and interaction evidence**
+## Findings and fidelity surfaces
 
-- Component tests exercise the central trigger, automatic search focus, text filtering, Arrow-key transfer into the result list, selected-state semantics, Escape/Tab/outside dismissal, Project switching, and Add Project draft preservation.
-- The packaged application starts successfully from the short path and reaches `Local service ready` with the real Project list.
-- Computer Use could read and capture the window, but its native action channel closed on both semantic and coordinate clicks before New thread could be opened. No message was sent and no Thread was created during QA.
+- Fonts and typography: ZenX keeps its established system typography and hierarchy. The central prompt remains one concise heading with the Project name as its only interactive emphasis.
+- Spacing and layout rhythm: the generic compose glyph is removed. The heading now fills and centers within the available message region, moving it visibly down from the user-marked state. Its geometric center matches the right-side workspace center; the earlier apparent horizontal drift came from the Sidebar's visual weight and the glyph above the heading.
+- Colors and visual tokens: all changed surfaces reuse existing ZenX border, surface, text, focus, and shadow tokens.
+- Image and asset fidelity: the welcome state no longer adds a redundant icon or substitute asset. The existing production ZenX brand remains in the macOS Sidebar brand row.
+- Copy and content: Project names, search, selected state, and `Add project` match ZenX product semantics. The Codex reference's projectless action is intentionally omitted because ZenX still requires a Project for first Send.
+- Interaction and containment: search and bottom actions remain fixed while only Project results scroll. The menu is clamped against the actual `.messages` clipping region, not only the browser viewport, so the search row no longer disappears behind the titlebar.
 
-**Full-view comparison evidence**
+## Comparison history
 
-- Blocked: the source is the open central Project menu while the captured implementation is the pre-draft startup screen. Treating these as a visual comparison would be misleading.
+- Pass 1 found the Project list could exceed the visible region and the macOS brand occupied the traffic-light row.
+- Pass 2 fixed internal Project scrolling, viewport placement, and the macOS-only second-row brand, but packaged evidence exposed that the menu could still cross the workspace's own clipping boundary.
+- Pass 3 fixed placement against the `.messages` clipping rectangle. Packaged geometry and the final menu screenshot confirm the complete search row, scrollable results, and fixed action are visible.
+- Pass 4 addressed the user's welcome-state polish: removed the generic compose glyph and centered the heading through the available message region. The normalized before/after comparison confirms the content moved down and remains horizontally centered.
 
-**Focused region comparison evidence**
+## Verification evidence
 
-- Blocked for the same reason; there is no implementation capture of the central prompt/menu region.
+- Project/titlebar UI tests: 37/37 passed.
+- ZenX typecheck, repository format check, lint, and `git diff --check`: passed.
+- Portable packaging passed with provider manifest digest `f4c4c70eee9be26166d804534126569e0dde22b18ac9d6e855b2d3eeabb8f0dd`.
+- Packaged startup reached `Local service ready`; welcome and open-menu states were captured from the final package.
 
-**Findings**
+## Follow-up polish
 
-- [P1] Missing rendered open-menu comparison evidence.
-  Location: New-thread empty state, central Project switcher.
-  Evidence: source shows the open searchable menu; available implementation capture does not.
-  Impact: typography, popup anchoring, spacing, and overflow cannot be signed off visually from the actual packaged screen.
-  Fix: open New thread in the packaged app, click the underlined Project name, capture the window at the same state, and compare the central region against the source.
+- No P0/P1/P2 visual findings remain. Additional spacing or typography changes would be subjective iteration rather than fidelity blockers.
 
-**Comparison history**
-
-- Pass 1: blocked before comparison because the Computer Use click channel closed; no visual findings were inferred from code or separate-state screenshots.
-
-**Implementation checklist**
-
-- Capture the packaged open-menu state.
-- Compare full view and a focused central-menu crop against the source.
-- Fix any P0/P1/P2 typography, anchoring, spacing, color, icon, copy, focus, or overflow mismatch and repeat the capture.
-
-**Follow-up polish**
-
-- None recorded until the required same-state comparison is available.
-
-**final result: blocked**
+**final result: passed**

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,55 @@
+# ZenX central Project switcher design QA
+
+**Source visual truth**
+
+- `/var/folders/kn/qprvl_8n6vn88tcp8tv_h2ph0000gn/T/codex-clipboard-9682f21f-cbaf-4bef-8726-5a7507b8be04.png`
+- 1638 × 1037 pixels, dark macOS desktop state, New chat draft with the central Project menu open.
+
+**Implementation evidence**
+
+- `/Users/xbjt/work/agent-data/projects/zen/evidence/zenx-ui7-packaged-start.png`
+- 1199 × 768 pixels, dark macOS desktop state, packaged ZenX startup screen.
+- Packaged app: `/private/tmp/ZenX-ui7.app` from branch `codex/zenx-draft-project-switcher`.
+
+**Viewport and normalization**
+
+- The source and implementation have different window dimensions and do not show the same interaction state.
+- No density normalization or side-by-side fidelity judgment was performed because the packaged implementation could not be advanced to the open-menu state through the available desktop-control channel.
+
+**State and interaction evidence**
+
+- Component tests exercise the central trigger, automatic search focus, text filtering, Arrow-key transfer into the result list, selected-state semantics, Escape/Tab/outside dismissal, Project switching, and Add Project draft preservation.
+- The packaged application starts successfully from the short path and reaches `Local service ready` with the real Project list.
+- Computer Use could read and capture the window, but its native action channel closed on both semantic and coordinate clicks before New thread could be opened. No message was sent and no Thread was created during QA.
+
+**Full-view comparison evidence**
+
+- Blocked: the source is the open central Project menu while the captured implementation is the pre-draft startup screen. Treating these as a visual comparison would be misleading.
+
+**Focused region comparison evidence**
+
+- Blocked for the same reason; there is no implementation capture of the central prompt/menu region.
+
+**Findings**
+
+- [P1] Missing rendered open-menu comparison evidence.
+  Location: New-thread empty state, central Project switcher.
+  Evidence: source shows the open searchable menu; available implementation capture does not.
+  Impact: typography, popup anchoring, spacing, and overflow cannot be signed off visually from the actual packaged screen.
+  Fix: open New thread in the packaged app, click the underlined Project name, capture the window at the same state, and compare the central region against the source.
+
+**Comparison history**
+
+- Pass 1: blocked before comparison because the Computer Use click channel closed; no visual findings were inferred from code or separate-state screenshots.
+
+**Implementation checklist**
+
+- Capture the packaged open-menu state.
+- Compare full view and a focused central-menu crop against the source.
+- Fix any P0/P1/P2 typography, anchoring, spacing, color, icon, copy, focus, or overflow mismatch and repeat the capture.
+
+**Follow-up polish**
+
+- None recorded until the required same-state comparison is available.
+
+**final result: blocked**


### PR DESCRIPTION
## Summary
- make the Project name in the local New thread prompt the visible switcher
- add searchable configured-Project selection with keyboard/focus handling and Add project
- preserve Composer text and zero-Thread semantics when switching or adding a Project

## Verification
- `node --import tsx --test apps/zenx/test/app-project-picker-interaction.test.ts` (34 passed)
- `NODE_OPTIONS=--max-old-space-size=768 npm run typecheck --workspace @zen/zenx`
- `npm run format:check`
- `npm run lint`
- `git diff --check`
- packaged macOS app reaches Local service ready from `/private/tmp/ZenX-ui7.app`

## Visual QA
`design-qa.md` records a blocked same-state screenshot comparison because Computer Use could capture the packaged Electron window but its native click channel closed before opening the Project menu. The interaction itself is covered by focused renderer tests.