### PR TITLE
[codex] Show message actions only on final replies

### DIFF
--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -531,6 +531,7 @@ function TurnBlock({
           {!complete && projection.finalItem !== null ? (
             <AgentMessage
               item={projection.finalItem}
+              showActions={false}
               turn={turn}
               usage={usage}
             />
@@ -539,7 +540,12 @@ function TurnBlock({
       ) : null}
       {complete && projection.finalItem !== null ? (
         <div className="turn-final">
-          <AgentMessage item={projection.finalItem} turn={turn} usage={usage} />
+          <AgentMessage
+            item={projection.finalItem}
+            showActions
+            turn={turn}
+            usage={usage}
+          />
         </div>
       ) : projection.terminalFallback === null ? null : (
         <div className="turn-terminal" role="status">
@@ -580,7 +586,12 @@ function DisplayNode({
   pluginUiRegistry: PluginUiRegistry | null;
 }) {
   return node.kind === "agent" ? (
-    <AgentMessage item={node.item} turn={turn} usage={usage} />
+    <AgentMessage
+      item={node.item}
+      showActions={false}
+      turn={turn}
+      usage={usage}
+    />
   ) : (
     <TraceSequence
       node={node}
@@ -999,10 +1010,12 @@ function hasImageFiles(files: FileList): boolean {
 
 function AgentMessage({
   item,
+  showActions,
   turn,
   usage,
 }: {
   item: Extract<ThreadItem, { type: "agentMessage" }>;
+  showActions: boolean;
   turn: Turn;
   usage?: ModelUsageAggregate;
 }) {
@@ -1010,13 +1023,15 @@ function AgentMessage({
     <article className="agent-copy">
       <Markdown text={item.text} />
       {item.text.length === 0 ? <span className="stream-cursor" /> : null}
-      <MessageActions
-        className="assistant-message-actions"
-        copyLabel="Copy assistant message"
-        text={item.text}
-        turn={turn}
-        usage={usage}
-      />
+      {showActions ? (
+        <MessageActions
+          className="assistant-message-actions"
+          copyLabel="Copy assistant message"
+          text={item.text}
+          turn={turn}
+          usage={usage}
+        />
+      ) : null}
     </article>
   );
 }

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -143,6 +143,55 @@ test("Turn disclosure does not repeat cache telemetry from assistant actions", (
   assert.doesNotMatch(html, /class="turn-usage"/u);
 });
 
+test("only the final assistant message exposes metadata and hover actions", async () => {
+  await withDom(async (root) => {
+    await renderInteractive(
+      root,
+      turnWithItems(
+        "completed",
+        [
+          user("request"),
+          agent("Intermediate update"),
+          reasoning("Checked the result"),
+          agent("Final answer"),
+        ],
+        1_000,
+      ),
+      {
+        thread: {
+          responseCount: 1,
+          inputTokens: 150,
+          cachedInputTokens: 40,
+          outputTokens: 17,
+          cacheHitRate: 0.4,
+        },
+        turns: {
+          "turn-1": {
+            responseCount: 1,
+            inputTokens: 150,
+            cachedInputTokens: 40,
+            outputTokens: 17,
+            cacheHitRate: 0.4,
+          },
+        },
+      },
+    );
+    await act(async () => requiredButton(".turn-toggle").click());
+
+    const messages = document.querySelectorAll(".agent-copy");
+    assert.equal(messages.length, 2);
+    assert.match(messages[0]?.textContent ?? "", /Intermediate update/u);
+    assert.equal(messages[0]?.querySelector(".message-actions"), null);
+    assert.match(messages[1]?.textContent ?? "", /Final answer/u);
+    assert.ok(messages[1]?.querySelector(".assistant-message-actions"));
+    assert.equal(
+      document.querySelectorAll(".assistant-message-actions .message-cache")
+        .length,
+      1,
+    );
+  });
+});
+
 test("running Turns do not invent a completion timestamp in message controls", () => {
   const html = renderTurns([
     turnWithItems("inProgress", [user("Still running"), agent("Partial")]),
@@ -730,13 +779,18 @@ async function openReasoningRow(
   return requiredElement<HTMLElement>(".trace-singleton");
 }
 
-async function renderInteractive(root: Root, value: Turn): Promise<void> {
+async function renderInteractive(
+  root: Root,
+  value: Turn,
+  threadUsage?: ModelUsageProjection,
+): Promise<void> {
   await act(async () =>
     root.render(
       createElement(ThreadView, {
         approvals: [],
         composer: emptyComposerState(),
         thread: thread([value]),
+        threadUsage,
         onDraftChange: () => undefined,
         onInterrupt: noop,
         onRespondToApproval: noop,


### PR DESCRIPTION
## What changed

- render assistant message metadata and copy actions only for the final reply in a Turn
- leave intermediate assistant updates without the hidden action row, removing its reserved spacing and hover affordance
- add a regression test that expands a completed Turn and verifies the intermediate and final message behavior separately

## Why

All assistant messages shared the same `AgentMessage` rendering path, so intermediate updates also mounted the hidden action row. Its minimum height reserved visible whitespace, and hovering the message revealed timestamp, cache telemetry, and copy controls that should belong only to the final reply.

## Impact

Expanded Turn history is more compact and intermediate agent updates no longer expose final-response metadata or copy controls. Final replies retain the existing timestamp, cache summary, and copy action.

## Validation

- `./node_modules/.bin/tsx --test apps/zenx/test/thread-view-component.test.ts` (28/28 passed)
- `npm run typecheck --workspace @zen/zenx`
- `git diff --check`
