### PR TITLE
docs: propose multi-model tool evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ ZenX 插件开发合同与命令见 [packages/zenx-plugin-sdk/README.md](package
 - [ARCHITECTURE.md](ARCHITECTURE.md) — 不变量、核心概念、协议、adapter 边界
 - [LESSONS.md](LESSONS.md) — 非目标与 zen-legacy 的教训
 - [PRODUCTS.md](PRODUCTS.md) — 各接入端的定位与里程碑
+- [docs/tool-strategy.md](docs/tool-strategy.md) — 多模型工具策略与编辑评测提案
 - [SALVAGE.md](SALVAGE.md) — 从 zen-legacy 移植的清单
 - [src/protocol/codex/README.md](src/protocol/codex/README.md) — 固定协议版本与精确子集
 

--- a/docs/tool-eval-cases.json
+++ b/docs/tool-eval-cases.json
@@ -1,0 +1,101 @@
+{
+  "version": 1,
+  "profiles": ["shell_only", "generic_exact_replace", "vendor_native"],
+  "cases": [
+    {
+      "id": "unique-small-replacement",
+      "category": "local_edit",
+      "prompt": "Change the only development port from 3000 to 3100 and preserve all other bytes.",
+      "setup": {
+        "config.txt": "host=127.0.0.1\nport=3000\nmode=development\n"
+      },
+      "checks": [
+        "config.txt equals host=127.0.0.1\\nport=3100\\nmode=development\\n",
+        "no other path changed"
+      ]
+    },
+    {
+      "id": "repeated-text-disambiguation",
+      "category": "local_edit",
+      "prompt": "Change only the beta service timeout from 30 to 45.",
+      "setup": { "services.txt": "[alpha]\ntimeout=30\n[beta]\ntimeout=30\n" },
+      "checks": [
+        "alpha remains timeout=30",
+        "beta equals timeout=45",
+        "no other path changed"
+      ]
+    },
+    {
+      "id": "stale-after-observation",
+      "category": "failure_recovery",
+      "prompt": "Change the release channel from stable to preview without losing concurrent changes.",
+      "setup": { "release.txt": "channel=stable\nrevision=1\n" },
+      "mutationAfterFirstRead": {
+        "release.txt": "channel=stable\nrevision=2\n"
+      },
+      "checks": [
+        "release.txt equals channel=preview\\nrevision=2\\n",
+        "the concurrent revision change is preserved"
+      ]
+    },
+    {
+      "id": "crlf-bom-unicode",
+      "category": "encoding",
+      "prompt": "Change the quoted status from “draft” to “ready” while preserving BOM and CRLF line endings.",
+      "setup": { "status.txt": "\ufeffname=Zen\r\nstatus=“draft”\r\n" },
+      "checks": [
+        "status is “ready”",
+        "UTF-8 BOM is preserved",
+        "all line endings remain CRLF"
+      ]
+    },
+    {
+      "id": "multiple-edits-one-file",
+      "category": "local_edit",
+      "prompt": "Rename the declared color token from ocean to lake and update both uses in this file.",
+      "setup": {
+        "theme.css": ":root { --ocean: #06c; }\n.button { color: var(--ocean); }\n.link { color: var(--ocean); }\n"
+      },
+      "checks": [
+        "--lake is declared once",
+        "var(--lake) occurs twice",
+        "ocean does not occur"
+      ]
+    },
+    {
+      "id": "create-new-file",
+      "category": "whole_file",
+      "prompt": "Create NOTICE.txt containing exactly Zen followed by one newline.",
+      "setup": {},
+      "checks": ["NOTICE.txt equals Zen\\n", "no other path changed"]
+    },
+    {
+      "id": "multi-file-change",
+      "category": "multi_file",
+      "prompt": "Rename the public greeting from hello to welcome in both source and test.",
+      "setup": {
+        "src.txt": "export const greeting = 'hello';\n",
+        "test.txt": "expect(greeting).toBe('hello');\n"
+      },
+      "checks": [
+        "src.txt contains 'welcome'",
+        "test.txt contains 'welcome'",
+        "hello does not occur"
+      ]
+    },
+    {
+      "id": "recover-after-no-match",
+      "category": "failure_recovery",
+      "prompt": "After any failed edit, inspect the current file and change maxRetries from 4 to 5.",
+      "setup": {
+        "retry.json": "{\n  \"maxRetries\": 4,\n  \"backoffMs\": 100\n}\n"
+      },
+      "initialMisleadingContext": "The file was previously formatted as {\"maxRetries\":4}.",
+      "checks": [
+        "maxRetries equals 5",
+        "backoffMs equals 100",
+        "JSON remains valid"
+      ]
+    }
+  ]
+}

--- a/docs/tool-eval-cases.json
+++ b/docs/tool-eval-cases.json
@@ -1,6 +1,28 @@
 {
   "version": 1,
   "profiles": ["shell_only", "generic_exact_replace", "vendor_native"],
+  "phase1Models": [
+    {
+      "provider": "openai-subscription",
+      "modelId": "gpt-5.6-terra",
+      "applicableProfiles": [
+        "shell_only",
+        "generic_exact_replace",
+        "vendor_native"
+      ],
+      "nativeContract": "openai_apply_patch_v4a"
+    },
+    {
+      "provider": "deepseek",
+      "modelId": "deepseek-chat",
+      "applicableProfiles": ["shell_only", "generic_exact_replace"]
+    },
+    {
+      "provider": "kimi",
+      "modelId": "kimi-k2",
+      "applicableProfiles": ["shell_only", "generic_exact_replace"]
+    }
+  ],
   "cases": [
     {
       "id": "unique-small-replacement",

--- a/docs/tool-eval-cases.json
+++ b/docs/tool-eval-cases.json
@@ -5,12 +5,7 @@
     {
       "provider": "openai-subscription",
       "modelId": "gpt-5.6-terra",
-      "applicableProfiles": [
-        "shell_only",
-        "generic_exact_replace",
-        "vendor_native"
-      ],
-      "nativeContract": "openai_apply_patch_v4a"
+      "applicableProfiles": ["shell_only", "generic_exact_replace"]
     },
     {
       "provider": "deepseek",
@@ -21,6 +16,15 @@
       "provider": "kimi",
       "modelId": "kimi-k2",
       "applicableProfiles": ["shell_only", "generic_exact_replace"]
+    }
+  ],
+  "deferredNativeComparisons": [
+    {
+      "provider": "openai-subscription",
+      "modelId": "gpt-5.6-terra",
+      "profile": "vendor_native",
+      "nativeContract": "openai_apply_patch_v4a",
+      "blockedBy": "json_function_only_model_tool_boundary"
     }
   ],
   "cases": [

--- a/docs/tool-eval-result.example.json
+++ b/docs/tool-eval-result.example.json
@@ -4,8 +4,8 @@
   "caseId": "unique-small-replacement",
   "profile": "shell_only",
   "model": {
-    "provider": "example-provider",
-    "modelId": "example-model"
+    "provider": "openai-subscription",
+    "modelId": "gpt-5.6-terra"
   },
   "repetition": 1,
   "metrics": {

--- a/docs/tool-eval-result.example.json
+++ b/docs/tool-eval-result.example.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "runId": "example-only-not-an-eval-result",
+  "caseId": "unique-small-replacement",
+  "profile": "shell_only",
+  "model": {
+    "provider": "example-provider",
+    "modelId": "example-model"
+  },
+  "repetition": 1,
+  "metrics": {
+    "completed": true,
+    "firstEditAttemptSucceeded": null,
+    "unintendedChanges": 0,
+    "schemaValidCalls": 1,
+    "schemaInvalidCalls": 0,
+    "toolCalls": 1,
+    "modelTurns": 1,
+    "inputTokens": null,
+    "outputTokens": null,
+    "elapsedMs": 1
+  },
+  "failureCodes": [],
+  "notes": "Shape example only; these values are not evaluation evidence."
+}

--- a/docs/tool-eval-result.schema.json
+++ b/docs/tool-eval-result.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/albert-zen/zen/docs/tool-eval-result.schema.json",
+  "title": "Zen tool strategy evaluation result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "runId",
+    "caseId",
+    "profile",
+    "model",
+    "repetition",
+    "metrics",
+    "failureCodes"
+  ],
+  "allOf": [
+    {
+      "if": { "properties": { "profile": { "const": "vendor_native" } } },
+      "then": {
+        "properties": { "model": { "required": ["nativeContract"] } }
+      }
+    }
+  ],
+  "properties": {
+    "version": { "const": 1 },
+    "runId": { "type": "string", "minLength": 1 },
+    "caseId": { "type": "string", "minLength": 1 },
+    "profile": {
+      "enum": ["shell_only", "generic_exact_replace", "vendor_native"]
+    },
+    "model": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "modelId"],
+      "properties": {
+        "provider": { "type": "string", "minLength": 1 },
+        "modelId": { "type": "string", "minLength": 1 },
+        "nativeContract": { "type": "string", "minLength": 1 }
+      }
+    },
+    "repetition": { "type": "integer", "minimum": 1 },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "completed",
+        "firstEditAttemptSucceeded",
+        "unintendedChanges",
+        "schemaValidCalls",
+        "schemaInvalidCalls",
+        "toolCalls",
+        "modelTurns",
+        "inputTokens",
+        "outputTokens",
+        "elapsedMs"
+      ],
+      "properties": {
+        "completed": { "type": "boolean" },
+        "firstEditAttemptSucceeded": { "type": ["boolean", "null"] },
+        "unintendedChanges": { "type": "integer", "minimum": 0 },
+        "schemaValidCalls": { "type": "integer", "minimum": 0 },
+        "schemaInvalidCalls": { "type": "integer", "minimum": 0 },
+        "toolCalls": { "type": "integer", "minimum": 0 },
+        "modelTurns": { "type": "integer", "minimum": 1 },
+        "inputTokens": { "type": ["integer", "null"], "minimum": 0 },
+        "outputTokens": { "type": ["integer", "null"], "minimum": 0 },
+        "elapsedMs": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "failureCodes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/docs/tool-strategy.md
+++ b/docs/tool-strategy.md
@@ -1,0 +1,129 @@
+# Tool strategy and editing evaluation
+
+Status: proposal for review; no tool implementation is approved.
+
+## Product question
+
+Zen supports multiple model providers, so the question is not “how quickly can we add a
+string replacement helper?” The question is which model-visible editing contracts Zen
+should deliberately support, and whether the answer differs by model family.
+
+Three decisions must remain separate:
+
+1. a generic exact replacement/edit tool for small local changes;
+2. a whole-file create/overwrite tool;
+3. vendor-native profiles that reproduce a vendor's name, schema, grammar, and result
+   contract.
+
+A local replacement tool must not be named `write`. Across the surveyed tool-schema
+harnesses, `write` consistently means whole-file creation or replacement. `replace` or
+`edit` would describe a local replacement, but this proposal does not approve either
+name or any implementation.
+
+## Evidence rules
+
+The comparison uses three labels:
+
+- **Direct training evidence**: the vendor publicly says a model was trained or optimized
+  for an exact tool signature.
+- **Harness-source observation**: an official repository exposes a tool contract or model
+  routing choice. This says what that harness does, not how a model was trained.
+- **Inference**: a Zen design implication derived from those facts. It is not a vendor
+  guarantee.
+
+“No direct evidence found” means only that the reviewed official public material does not
+support the claim. It does not claim knowledge of private training data.
+
+## Official-source comparison
+
+| System                      | Observed editing surface                                                                                                                                                     | Evidence about training or adaptation                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Relevance to Zen                                                                                                                                      |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenAI Codex / Responses    | `apply_patch` is a named freeform tool using the V4A patch format; shell is a separate tool.                                                                                 | **Direct training evidence:** OpenAI says GPT-5.2 was post-trained for `apply_patch` and shell, and reports 35% fewer patch failures for the named freeform tool than a custom patch implementation. [Latest-model guide](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.2), [apply_patch contract](https://developers.openai.com/api/docs/guides/tools-apply-patch)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | **Inference:** copying only the name is insufficient. A Zen OpenAI-native profile would need the complete grammar and result contract.                |
+| Claude Code / Anthropic API | Claude Code exposes exact `Edit` separately from whole-file `Write`. The Anthropic API exposes a versioned command-union text editor.                                        | **Direct training evidence applies only to the API signatures:** Anthropic calls its Anthropic-defined `text_editor`, `bash`, and other client tools “trained-in” exact signatures. [Tool-use guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/how-tool-use-works), [text editor](https://platform.claude.com/docs/en/agents-and-tools/tool-use/text-editor-tool), [Claude Code tools](https://code.claude.com/docs/en/tools-reference)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | **Inference:** Claude Code's `Edit` name must not inherit the API editor's training claim. A native profile means a supported versioned API contract. |
+| DeepSeek Harness            | The first-party harness offers `edit` plus whole-file `write`, and a separate command-union string-replace editor.                                                           | **Harness-source observation; no direct training evidence found.** The harness is a developer preview and supports configurable native/PTC presentation. [README @ `0a53fb5`](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/README.md), [filesystem tools @ `0a53fb5`](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/fs/tool-fs/README.md), [editor @ `0a53fb5`](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/fs/tool-str-replace-editor/README.md), [tool presentation @ `0a53fb5`](https://github.com/deepseek-ai/deepseek-harness/blob/0a53fb55bea101816fa226bb964ae2bed71c343b/packages/core/tools/README.md)                                                                                                                                                                                                                                                                                                                    | **Inference:** schema presentation, execution, and stale-observation policy are separable choices.                                                    |
+| Kimi Code                   | `Edit` performs local exact replacement; `Write` creates, overwrites, or appends.                                                                                            | **Harness-source observation.** Kimi-K2 documents native function-call serialization, but the reviewed sources do not say Kimi Code's editing names or schemas were trained in. [Tools @ `616d510`](https://github.com/MoonshotAI/kimi-code/blob/616d51045dbb7c3949c05713d4a0273c74dd07fc/docs/en/reference/tools.md), [tool-call guidance @ `1b4022b`](https://github.com/MoonshotAI/Kimi-K2/blob/1b4022bbb7187cf4011a8bdf0b4cd10e2daa26c4/docs/tool_call_guidance.md)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | **Inference:** evaluate Kimi with the generic profile unless Zen results justify another profile.                                                     |
+| Gemini CLI                  | `replace` is separate from whole-file `write_file`. Its executor may progress from exact matching to flexible/fuzzy matching and a second-model correction path.             | **Harness-source observation; no direct training evidence found.** The official source defines schemas by model family. [Tools @ `0bd1d43`](https://github.com/google-gemini/gemini-cli/blob/0bd1d439751478771c45d3d0895a6a9760554bf4/docs/reference/tools.md), [Gemini 3 definitions @ `0bd1d43`](https://github.com/google-gemini/gemini-cli/blob/0bd1d439751478771c45d3d0895a6a9760554bf4/packages/core/src/tools/definitions/model-family-sets/gemini-3.ts), [matching @ `0bd1d43`](https://github.com/google-gemini/gemini-cli/blob/0bd1d439751478771c45d3d0895a6a9760554bf4/packages/core/src/tools/edit.ts#L300-L350), [self-correction @ `0bd1d43`](https://github.com/google-gemini/gemini-cli/blob/0bd1d439751478771c45d3d0895a6a9760554bf4/packages/core/src/tools/edit.ts#L544-L635)                                                                                                                                                                                                                                                                                                        | **Inference:** hidden fuzzy or LLM correction is a distinct product policy, not an implementation detail of an “exact” tool.                          |
+| pi                          | `edit` accepts multiple old/new edits for one file; `write` creates or overwrites a whole file. The executor normalizes some model output and text mismatches.               | **Harness-source observation; not vendor training evidence.** [Registry @ `853a80d`](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/tools/index.ts#L93-L170), [edit @ `853a80d`](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/tools/edit.ts#L34-L147), [matching @ `853a80d`](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/tools/edit-diff.ts#L201-L361), [write @ `853a80d`](https://github.com/earendil-works/pi/blob/853a80d26c90a14c1886f0ebb8ffaae133ca2185/packages/coding-agent/src/core/tools/write.ts#L187-L232)                                                                                                                                                                                                                                                                                                                                                                  | **Inference:** batching and normalization may reduce turns, but each enlarges the contract and needs Zen evidence.                                    |
+| Cline / OpenCode            | Cline provides a strict local `editor` and a separate patch tool. OpenCode provides `edit` plus whole-file `write`, while routing newer GPT models to `apply_patch`.         | **Harness-source observation; not vendor training evidence.** [Cline schema @ `48d6385`](https://github.com/cline/cline/blob/48d63852745460ff0fa3dfcc0457bbe2493841de/sdk/packages/core/src/extensions/tools/schemas.ts#L191-L244), [Cline executor @ `48d6385`](https://github.com/cline/cline/blob/48d63852745460ff0fa3dfcc0457bbe2493841de/sdk/packages/core/src/extensions/tools/executors/editor.ts#L141-L262), [Cline routing @ `48d6385`](https://github.com/cline/cline/blob/48d63852745460ff0fa3dfcc0457bbe2493841de/sdk/packages/core/src/extensions/tools/model-tool-routing.ts#L60-L75), [OpenCode edit @ `9f69463`](https://github.com/anomalyco/opencode/blob/9f69463f1d556af2b5b51d2efa1c04f5f544f911/packages/opencode/src/tool/edit.ts#L47-L215), [OpenCode write @ `9f69463`](https://github.com/anomalyco/opencode/blob/9f69463f1d556af2b5b51d2efa1c04f5f544f911/packages/opencode/src/tool/write.ts#L20-L104), [OpenCode routing @ `9f69463`](https://github.com/anomalyco/opencode/blob/9f69463f1d556af2b5b51d2efa1c04f5f544f911/packages/opencode/src/tool/registry.ts#L291-L303) | **Inference:** a generic editor and vendor-specific patch profile can coexist without sharing semantics.                                              |
+| Aider                       | Models emit SEARCH/REPLACE blocks or another configured edit format rather than JSON tool calls. Matching includes bounded tolerance, and edit format is selected per model. | **Harness-source observation; not vendor training evidence.** [SEARCH/REPLACE prompt @ `5dc9490`](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/aider/coders/editblock_prompts.py#L120-L158), [executor @ `5dc9490`](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/aider/coders/editblock_coder.py#L41-L187), [model settings @ `5dc9490`](https://github.com/Aider-AI/aider/blob/5dc9490bb35f9729ef2c95d00a19ccd30c26339c/aider/resources/model-settings.yml#L548-L655)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | **Inference:** per-model format selection is plausible, but Aider's assistant-output protocol is not a Zen wire/tool contract.                        |
+
+For editing-contract decisions, the direct signature/training evidence in this survey is
+limited to OpenAI's named `apply_patch` contract and Anthropic's versioned API editor.
+OpenAI also names shell in its post-training statement, and Anthropic names other API
+tools, but those facts do not establish another editing contract. The other rows are
+useful harness observations, not proof of model training.
+
+## Current conclusions
+
+- Do not introduce a local replacement tool named `write`.
+- Treat generic exact replacement/edit, whole-file writing, and vendor-native profiles as
+  independent product decisions.
+- Do not silently add fuzzy matching, secondary-model correction, or format adaptation to
+  a contract described as exact.
+- Do not claim native compatibility from a shared name. Compatibility includes the full
+  model-visible input and output contract.
+- No editing tool, schema, runtime behavior, protocol change, or provider routing is
+  approved by this document.
+
+## Small evaluation before implementation
+
+The evaluation compares tool surfaces, not executor engineering. It should use the current
+Zen runtime and representative configured models, with no persistent coordinator or new
+benchmark service.
+
+For each provider/model family that Zen intends to support, select one currently usable
+model and record the exact provider label and model id. Run at least three repetitions of
+each applicable case in [`tool-eval-cases.json`](tool-eval-cases.json), starting each run
+from an identical temporary fixture. Compare:
+
+1. `shell_only`: today's baseline;
+2. `generic_exact_replace`: a proposed exact-one local replacement contract, supplied only
+   in the evaluation harness;
+3. `vendor_native`: only where a complete supported native contract and direct evidence
+   exist—OpenAI `apply_patch` or an Anthropic versioned API text editor.
+
+The generic evaluation contract is intentionally narrow: `path`, `old_string`, and
+`new_string`; exactly one literal current-content match; zero or multiple matches fail
+without mutation. This is an eval hypothesis, not an approved Zen schema.
+
+The cases cover unique replacement, repeated text, stale observations, CRLF/BOM/Unicode,
+multiple edits in one file, file creation, multi-file changes, and correction after a
+failed edit. Whole-file creation is included to expose whether a separate writer is useful;
+it does not smuggle create semantics into the generic replacement profile.
+
+Record every run using [`tool-eval-result.schema.json`](tool-eval-result.schema.json); the
+companion [`tool-eval-result.example.json`](tool-eval-result.example.json) demonstrates the
+shape and is explicitly not evidence. The primary metrics are task completion,
+first-edit-attempt success, unintended changes, schema-valid model calls, tool calls, model
+turns, input/output tokens, elapsed time, and failure codes. Preserve raw canonical Item
+traces outside the repository when available; only reviewed aggregate results belong in
+this document.
+
+Validate the static cases and any result files before review:
+
+```sh
+npm run validate:tool-eval
+npm run validate:tool-eval -- path/to/result.json another-result.json
+```
+
+The command validates fixtures and result shape only. It does not run a model, choose a
+winner, or alter Zen.
+
+### Decision rule
+
+Do not select a profile from a single successful run. Compare per-model medians and inspect
+every unintended change or incomplete run. A candidate may proceed to a separate design
+and implementation review only when it improves completion or interaction cost without
+increasing unintended changes, and the benefit repeats across the intended model set.
+Vendor-native complexity requires a material advantage over the generic profile for that
+vendor. Whole-file `write` requires evidence from create/overwrite cases independently of
+local-edit performance.
+
+## Decisions requested from reviewers
+
+1. Approve or reject this small evaluation direction before any editing tool is designed.
+2. Confirm the representative provider/model families and exact model ids to test.
+3. Confirm whether vendor-native evaluation is limited initially to OpenAI and Anthropic,
+   the only surveyed systems with direct signature/training evidence.
+4. Confirm the repetition count and acceptance interpretation; the proposed minimum is
+   three runs per applicable model/profile/case, with zero tolerance for unintended edits.

--- a/docs/tool-strategy.md
+++ b/docs/tool-strategy.md
@@ -71,16 +71,35 @@ The evaluation compares tool surfaces, not executor engineering. It should use t
 Zen runtime and representative configured models, with no persistent coordinator or new
 benchmark service.
 
-For each provider/model family that Zen intends to support, select one currently usable
-model and record the exact provider label and model id. Run at least three repetitions of
-each applicable case in [`tool-eval-cases.json`](tool-eval-cases.json), starting each run
-from an identical temporary fixture. Compare:
+Phase 1 uses this exact, bounded matrix from
+[`tool-eval-cases.json`](tool-eval-cases.json):
+
+| Configured identity                   | Applicable profiles                                    | Basis                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openai-subscription / gpt-5.6-terra` | `shell_only`, `generic_exact_replace`, `vendor_native` | Zen's public base includes `gpt-5.6-terra` in the subscription preset. As reviewed on 2026-08-31, the official OpenAI model page lists Apply Patch as supported. This is **current feature support**, not evidence that GPT-5.6 Terra shares GPT-5.2's published post-training history. [Zen model preset @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/cli/src/model-presets.ts#L24-L40), [GPT-5.6 Terra model page](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |
+| `deepseek / deepseek-chat`            | `shell_only`, `generic_exact_replace`                  | Zen publicly exposes the DeepSeek OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a DeepSeek-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                      |
+| `kimi / kimi-k2`                      | `shell_only`, `generic_exact_replace`                  | Zen publicly exposes the Kimi OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a Kimi-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                              |
+
+The OpenAI native profile must reproduce the complete official `apply_patch` freeform V4A
+grammar and `apply_patch_call_output` result contract; a same-named custom patch helper is
+not applicable. Anthropic's versioned API editor remains a direct-evidence future
+comparison, but it is outside phase 1 because Zen currently has no native Anthropic
+provider path. This proposal does not approve an eval-only provider driver or a production
+Anthropic adapter.
+
+Before recording any result, an eval runner must verify that the exact configured
+`provider / modelId` identity is available. If it is unavailable, that run fails before
+result recording; the runner must not substitute an alias, newer model, or another
+provider. Changing the matrix requires a reviewed fixture and validator update.
+
+Run at least three repetitions of each applicable case, starting each run from an
+identical temporary fixture. Compare:
 
 1. `shell_only`: today's baseline;
 2. `generic_exact_replace`: a proposed exact-one local replacement contract, supplied only
    in the evaluation harness;
-3. `vendor_native`: only where a complete supported native contract and direct evidence
-   exist—OpenAI `apply_patch` or an Anthropic versioned API text editor.
+3. `vendor_native`: in phase 1, only the complete OpenAI `apply_patch` contract with
+   `openai-subscription / gpt-5.6-terra`, based on current model feature support.
 
 The generic evaluation contract is intentionally narrow: `path`, `old_string`, and
 `new_string`; exactly one literal current-content match; zero or multiple matches fail
@@ -121,9 +140,9 @@ local-edit performance.
 
 ## Decisions requested from reviewers
 
-1. Approve or reject this small evaluation direction before any editing tool is designed.
-2. Confirm the representative provider/model families and exact model ids to test.
-3. Confirm whether vendor-native evaluation is limited initially to OpenAI and Anthropic,
-   the only surveyed systems with direct signature/training evidence.
+1. Approve or reject the exact three-identity phase-1 matrix and its profile applicability.
+2. Approve or reject this small evaluation direction before any editing tool is designed.
+3. Confirm that a missing exact identity aborts that run before result recording and is
+   never replaced ad hoc.
 4. Confirm the repetition count and acceptance interpretation; the proposed minimum is
    three runs per applicable model/profile/case, with zero tolerance for unintended edits.

--- a/docs/tool-strategy.md
+++ b/docs/tool-strategy.md
@@ -74,18 +74,38 @@ benchmark service.
 Phase 1 uses this exact, bounded matrix from
 [`tool-eval-cases.json`](tool-eval-cases.json):
 
-| Configured identity                   | Applicable profiles                                    | Basis                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openai-subscription / gpt-5.6-terra` | `shell_only`, `generic_exact_replace`, `vendor_native` | Zen's public base includes `gpt-5.6-terra` in the subscription preset. As reviewed on 2026-08-31, the official OpenAI model page lists Apply Patch as supported. This is **current feature support**, not evidence that GPT-5.6 Terra shares GPT-5.2's published post-training history. [Zen model preset @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/cli/src/model-presets.ts#L24-L40), [GPT-5.6 Terra model page](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |
-| `deepseek / deepseek-chat`            | `shell_only`, `generic_exact_replace`                  | Zen publicly exposes the DeepSeek OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a DeepSeek-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                      |
-| `kimi / kimi-k2`                      | `shell_only`, `generic_exact_replace`                  | Zen publicly exposes the Kimi OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a Kimi-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                              |
+| Configured identity                   | Applicable profiles                   | Basis                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openai-subscription / gpt-5.6-terra` | `shell_only`, `generic_exact_replace` | Zen's public base includes `gpt-5.6-terra` in the subscription preset. As reviewed on 2026-08-31, the official OpenAI model page lists Apply Patch as supported. This is **current feature support**, not evidence that GPT-5.6 Terra shares GPT-5.2's published post-training history. [Zen model preset @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/cli/src/model-presets.ts#L24-L40), [GPT-5.6 Terra model page](https://developers.openai.com/api/docs/models/gpt-5.6-terra) |
+| `deepseek / deepseek-chat`            | `shell_only`, `generic_exact_replace` | Zen publicly exposes the DeepSeek OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a DeepSeek-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                      |
+| `kimi / kimi-k2`                      | `shell_only`, `generic_exact_replace` | Zen publicly exposes the Kimi OpenAI-compatible host preset. No direct native-signature training evidence was found, so phase 1 does not invent a Kimi-native profile. [Zen provider presets @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/apps/zenx/src/main/provider-presets.ts#L18-L22)                                                                                                                                                                                              |
 
-The OpenAI native profile must reproduce the complete official `apply_patch` freeform V4A
-grammar and `apply_patch_call_output` result contract; a same-named custom patch helper is
-not applicable. Anthropic's versioned API editor remains a direct-evidence future
-comparison, but it is outside phase 1 because Zen currently has no native Anthropic
-provider path. This proposal does not approve an eval-only provider driver or a production
-Anthropic adapter.
+Phase 1 is deliberately limited to profiles that the current Zen model/tool boundary can
+represent: the existing shell baseline and a narrow eval-only exact replacement JSON
+function. Current `ModelTool` has only a name, description, and JSON input schema, and the
+subscription adapter always projects it as Responses `type: "function"`.
+[Zen `ModelTool` @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/src/model.ts#L70-L74),
+[subscription tool mapping @ `6a81252`](https://github.com/albert-zen/zen/blob/6a812525cc277f865eb0ca8439ea4d2cfc1624db/src/model/openai-subscription.ts#L170-L184)
+
+### Deferred native comparison
+
+The fixture mechanically reserves one deferred comparison:
+`openai-subscription / gpt-5.6-terra`, profile `vendor_native`, contract
+`openai_apply_patch_v4a`, blocked by the current JSON-function-only model/tool boundary.
+That contract means the complete official `apply_patch` freeform V4A grammar and
+`apply_patch_call_output` result contract, not a same-named custom function. The current
+OpenAI model page supports the feature; the direct post-training claim cited earlier is
+for GPT-5.2 and must not be transferred to GPT-5.6 Terra.
+
+No `vendor_native` result may be recorded under the current fixture and validator. The
+result schema retains its shape only for the deferred plan. Unlocking it requires a
+separate reviewed fixture revision and one explicitly authorized path: either a disposable
+evaluation driver capable of the complete vendor contract, or a production model/provider
+interface change. This proposal chooses and approves neither path.
+
+Anthropic's versioned API editor remains a direct-evidence future comparison, but phase 1
+has no configured Anthropic identity or run because Zen has no native Anthropic provider
+path. Adding an eval-only Anthropic driver or production adapter is likewise not approved.
 
 Before recording any result, an eval runner must verify that the exact configured
 `provider / modelId` identity is available. If it is unavailable, that run fails before
@@ -98,8 +118,6 @@ identical temporary fixture. Compare:
 1. `shell_only`: today's baseline;
 2. `generic_exact_replace`: a proposed exact-one local replacement contract, supplied only
    in the evaluation harness;
-3. `vendor_native`: in phase 1, only the complete OpenAI `apply_patch` contract with
-   `openai-subscription / gpt-5.6-terra`, based on current model feature support.
 
 The generic evaluation contract is intentionally narrow: `path`, `old_string`, and
 `new_string`; exactly one literal current-content match; zero or multiple matches fail
@@ -134,15 +152,18 @@ Do not select a profile from a single successful run. Compare per-model medians 
 every unintended change or incomplete run. A candidate may proceed to a separate design
 and implementation review only when it improves completion or interaction cost without
 increasing unintended changes, and the benefit repeats across the intended model set.
-Vendor-native complexity requires a material advantage over the generic profile for that
-vendor. Whole-file `write` requires evidence from create/overwrite cases independently of
-local-edit performance.
+If a future native evaluation is separately authorized, vendor-native complexity will
+require a material advantage over the generic profile for that vendor. Whole-file `write`
+requires evidence from create/overwrite cases independently of local-edit performance.
 
 ## Decisions requested from reviewers
 
-1. Approve or reject the exact three-identity phase-1 matrix and its profile applicability.
-2. Approve or reject this small evaluation direction before any editing tool is designed.
+1. Approve or reject the exact three-identity phase-1 shell/generic matrix.
+2. Approve or reject this bounded Phase-1 evaluation plan before any editing tool is
+   designed.
 3. Confirm that a missing exact identity aborts that run before result recording and is
    never replaced ad hoc.
 4. Confirm the repetition count and acceptance interpretation; the proposed minimum is
    three runs per applicable model/profile/case, with zero tolerance for unintended edits.
+5. Decide later whether a native evaluation is warranted and, if so, separately authorize
+   either a disposable full-contract driver or a production interface change.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "npm run test:node && npm run test:imzen",
     "test:imzen": "uv run --project apps/imzen --extra dev pytest -q apps/imzen/tests",
     "test:node": "npm test --workspace @zenx/plugin-sdk && npm run build && node --test dist/test/*.test.js",
-    "typecheck": "npm run typecheck --workspace @zenx/plugin-sdk && tsc -p tsconfig.json --noEmit"
+    "typecheck": "npm run typecheck --workspace @zenx/plugin-sdk && tsc -p tsconfig.json --noEmit",
+    "validate:tool-eval": "node scripts/validate-tool-eval.mjs"
   },
   "engines": {
     "node": ">=22"

--- a/scripts/validate-tool-eval.mjs
+++ b/scripts/validate-tool-eval.mjs
@@ -5,6 +5,28 @@ const profiles = new Set([
   "generic_exact_replace",
   "vendor_native",
 ]);
+const expectedPhase1Models = [
+  {
+    provider: "openai-subscription",
+    modelId: "gpt-5.6-terra",
+    applicableProfiles: [
+      "shell_only",
+      "generic_exact_replace",
+      "vendor_native",
+    ],
+    nativeContract: "openai_apply_patch_v4a",
+  },
+  {
+    provider: "deepseek",
+    modelId: "deepseek-chat",
+    applicableProfiles: ["shell_only", "generic_exact_replace"],
+  },
+  {
+    provider: "kimi",
+    modelId: "kimi-k2",
+    applicableProfiles: ["shell_only", "generic_exact_replace"],
+  },
+];
 const requiredMetricNames = [
   "completed",
   "firstEditAttemptSucceeded",
@@ -38,6 +60,46 @@ assert(
   JSON.stringify(cases.profiles) === JSON.stringify([...profiles]),
   "tool eval profiles do not match the result schema",
 );
+assert(
+  JSON.stringify(cases.phase1Models) === JSON.stringify(expectedPhase1Models),
+  "phase-1 model matrix must match the reviewed exact identities and profiles",
+);
+const phase1ModelsByIdentity = new Map();
+for (const model of cases.phase1Models) {
+  assertOnlyKeys(
+    model,
+    new Set(["provider", "modelId", "applicableProfiles", "nativeContract"]),
+    "phase-1 model",
+  );
+  assert(
+    typeof model.provider === "string" && model.provider.length > 0,
+    "phase-1 provider is required",
+  );
+  assert(
+    typeof model.modelId === "string" && model.modelId.length > 0,
+    "phase-1 modelId is required",
+  );
+  const identity = `${model.provider}\u0000${model.modelId}`;
+  assert(
+    !phase1ModelsByIdentity.has(identity),
+    `duplicate phase-1 identity: ${model.provider} / ${model.modelId}`,
+  );
+  assert(
+    Array.isArray(model.applicableProfiles) &&
+      model.applicableProfiles.length > 0 &&
+      model.applicableProfiles.every((profile) => profiles.has(profile)) &&
+      new Set(model.applicableProfiles).size ===
+        model.applicableProfiles.length,
+    `${model.provider} / ${model.modelId}: invalid applicable profiles`,
+  );
+  assert(
+    model.applicableProfiles.includes("vendor_native") ===
+      (typeof model.nativeContract === "string" &&
+        model.nativeContract.length > 0),
+    `${model.provider} / ${model.modelId}: native contract and profile must agree`,
+  );
+  phase1ModelsByIdentity.set(identity, model);
+}
 assert(
   Array.isArray(cases.cases) && cases.cases.length >= 8,
   "expected at least 8 cases",
@@ -129,12 +191,22 @@ function validateResult(result, path) {
     typeof result.model.modelId === "string" && result.model.modelId.length > 0,
     `${path}: model.modelId is required`,
   );
+  const phase1Model = phase1ModelsByIdentity.get(
+    `${result.model.provider}\u0000${result.model.modelId}`,
+  );
+  assert(phase1Model, `${path}: model identity is not in the phase-1 matrix`);
+  assert(
+    phase1Model.applicableProfiles.includes(result.profile),
+    `${path}: profile is not applicable to this phase-1 model`,
+  );
   if (result.profile === "vendor_native") {
     assert(
-      typeof result.model.nativeContract === "string" &&
-        result.model.nativeContract.length > 0,
-      `${path}: vendor_native requires model.nativeContract`,
+      result.model.nativeContract === phase1Model.nativeContract,
+      `${path}: vendor_native requires the reviewed native contract`,
     );
+  }
+  if (Object.hasOwn(result, "notes")) {
+    assert(typeof result.notes === "string", `${path}: notes must be a string`);
   }
   assert(
     result.metrics && typeof result.metrics === "object",

--- a/scripts/validate-tool-eval.mjs
+++ b/scripts/validate-tool-eval.mjs
@@ -9,12 +9,7 @@ const expectedPhase1Models = [
   {
     provider: "openai-subscription",
     modelId: "gpt-5.6-terra",
-    applicableProfiles: [
-      "shell_only",
-      "generic_exact_replace",
-      "vendor_native",
-    ],
-    nativeContract: "openai_apply_patch_v4a",
+    applicableProfiles: ["shell_only", "generic_exact_replace"],
   },
   {
     provider: "deepseek",
@@ -25,6 +20,15 @@ const expectedPhase1Models = [
     provider: "kimi",
     modelId: "kimi-k2",
     applicableProfiles: ["shell_only", "generic_exact_replace"],
+  },
+];
+const expectedDeferredNativeComparisons = [
+  {
+    provider: "openai-subscription",
+    modelId: "gpt-5.6-terra",
+    profile: "vendor_native",
+    nativeContract: "openai_apply_patch_v4a",
+    blockedBy: "json_function_only_model_tool_boundary",
   },
 ];
 const requiredMetricNames = [
@@ -64,6 +68,11 @@ assert(
   JSON.stringify(cases.phase1Models) === JSON.stringify(expectedPhase1Models),
   "phase-1 model matrix must match the reviewed exact identities and profiles",
 );
+assert(
+  JSON.stringify(cases.deferredNativeComparisons) ===
+    JSON.stringify(expectedDeferredNativeComparisons),
+  "deferred native comparisons must match the reviewed blocked contract",
+);
 const phase1ModelsByIdentity = new Map();
 for (const model of cases.phase1Models) {
   assertOnlyKeys(
@@ -93,12 +102,30 @@ for (const model of cases.phase1Models) {
     `${model.provider} / ${model.modelId}: invalid applicable profiles`,
   );
   assert(
-    model.applicableProfiles.includes("vendor_native") ===
-      (typeof model.nativeContract === "string" &&
-        model.nativeContract.length > 0),
-    `${model.provider} / ${model.modelId}: native contract and profile must agree`,
+    !model.applicableProfiles.includes("vendor_native") &&
+      !Object.hasOwn(model, "nativeContract"),
+    `${model.provider} / ${model.modelId}: vendor-native is not runnable in phase 1`,
   );
   phase1ModelsByIdentity.set(identity, model);
+}
+for (const comparison of cases.deferredNativeComparisons) {
+  assertOnlyKeys(
+    comparison,
+    new Set(["provider", "modelId", "profile", "nativeContract", "blockedBy"]),
+    "deferred native comparison",
+  );
+  assert(
+    comparison.profile === "vendor_native" &&
+      comparison.nativeContract === "openai_apply_patch_v4a" &&
+      comparison.blockedBy === "json_function_only_model_tool_boundary",
+    "deferred native comparison must remain blocked on the full reviewed contract",
+  );
+  assert(
+    phase1ModelsByIdentity.has(
+      `${comparison.provider}\u0000${comparison.modelId}`,
+    ),
+    "deferred native comparison must reference a reviewed identity",
+  );
 }
 assert(
   Array.isArray(cases.cases) && cases.cases.length >= 8,

--- a/scripts/validate-tool-eval.mjs
+++ b/scripts/validate-tool-eval.mjs
@@ -1,0 +1,208 @@
+import { readFile } from "node:fs/promises";
+
+const profiles = new Set([
+  "shell_only",
+  "generic_exact_replace",
+  "vendor_native",
+]);
+const requiredMetricNames = [
+  "completed",
+  "firstEditAttemptSucceeded",
+  "unintendedChanges",
+  "schemaValidCalls",
+  "schemaInvalidCalls",
+  "toolCalls",
+  "modelTurns",
+  "inputTokens",
+  "outputTokens",
+  "elapsedMs",
+];
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function readJson(path) {
+  return JSON.parse(await readFile(path, "utf8"));
+}
+
+const cases = await readJson(
+  new URL("../docs/tool-eval-cases.json", import.meta.url),
+);
+const schema = await readJson(
+  new URL("../docs/tool-eval-result.schema.json", import.meta.url),
+);
+
+assert(cases.version === 1, "tool eval cases must use version 1");
+assert(
+  JSON.stringify(cases.profiles) === JSON.stringify([...profiles]),
+  "tool eval profiles do not match the result schema",
+);
+assert(
+  Array.isArray(cases.cases) && cases.cases.length >= 8,
+  "expected at least 8 cases",
+);
+
+const caseIds = new Set();
+for (const item of cases.cases) {
+  assert(
+    typeof item.id === "string" && item.id.length > 0,
+    "case id is required",
+  );
+  assert(!caseIds.has(item.id), `duplicate case id: ${item.id}`);
+  caseIds.add(item.id);
+  assert(
+    typeof item.prompt === "string" && item.prompt.length > 0,
+    `${item.id}: prompt is required`,
+  );
+  assert(
+    item.setup && typeof item.setup === "object",
+    `${item.id}: setup is required`,
+  );
+  assert(
+    Array.isArray(item.checks) && item.checks.length > 0,
+    `${item.id}: checks are required`,
+  );
+}
+
+assert(
+  schema.properties.profile.enum.every((profile) => profiles.has(profile)),
+  "schema profiles differ from cases",
+);
+for (const metric of requiredMetricNames) {
+  assert(
+    schema.properties.metrics.required.includes(metric),
+    `schema must require metric: ${metric}`,
+  );
+}
+
+function isNonNegativeInteger(value) {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function assertOnlyKeys(value, allowed, path) {
+  assert(
+    Object.keys(value).every((key) => allowed.has(key)),
+    `${path}: unknown field`,
+  );
+}
+
+function validateResult(result, path) {
+  const allowedTopLevel = new Set(schema.required.concat("notes"));
+  assert(
+    result && typeof result === "object" && !Array.isArray(result),
+    `${path}: result must be an object`,
+  );
+  assertOnlyKeys(result, allowedTopLevel, path);
+  for (const field of schema.required) {
+    assert(Object.hasOwn(result, field), `${path}: missing ${field}`);
+  }
+  assert(result.version === 1, `${path}: version must be 1`);
+  assert(
+    typeof result.runId === "string" && result.runId.length > 0,
+    `${path}: runId is required`,
+  );
+  assert(
+    caseIds.has(result.caseId),
+    `${path}: unknown caseId ${result.caseId}`,
+  );
+  assert(
+    profiles.has(result.profile),
+    `${path}: unknown profile ${result.profile}`,
+  );
+  assert(
+    Number.isInteger(result.repetition) && result.repetition >= 1,
+    `${path}: repetition must be positive`,
+  );
+  assert(
+    result.model &&
+      typeof result.model.provider === "string" &&
+      result.model.provider.length > 0,
+    `${path}: model.provider is required`,
+  );
+  assertOnlyKeys(
+    result.model,
+    new Set(["provider", "modelId", "nativeContract"]),
+    `${path}.model`,
+  );
+  assert(
+    typeof result.model.modelId === "string" && result.model.modelId.length > 0,
+    `${path}: model.modelId is required`,
+  );
+  if (result.profile === "vendor_native") {
+    assert(
+      typeof result.model.nativeContract === "string" &&
+        result.model.nativeContract.length > 0,
+      `${path}: vendor_native requires model.nativeContract`,
+    );
+  }
+  assert(
+    result.metrics && typeof result.metrics === "object",
+    `${path}: metrics are required`,
+  );
+  assertOnlyKeys(
+    result.metrics,
+    new Set(requiredMetricNames),
+    `${path}.metrics`,
+  );
+  for (const metric of requiredMetricNames) {
+    assert(
+      Object.hasOwn(result.metrics, metric),
+      `${path}: missing metric ${metric}`,
+    );
+  }
+  assert(
+    typeof result.metrics.completed === "boolean",
+    `${path}: completed must be boolean`,
+  );
+  assert(
+    [true, false, null].includes(result.metrics.firstEditAttemptSucceeded),
+    `${path}: invalid firstEditAttemptSucceeded`,
+  );
+  for (const metric of [
+    "unintendedChanges",
+    "schemaValidCalls",
+    "schemaInvalidCalls",
+    "toolCalls",
+    "elapsedMs",
+  ]) {
+    assert(
+      isNonNegativeInteger(result.metrics[metric]),
+      `${path}: ${metric} must be non-negative`,
+    );
+  }
+  for (const metric of ["inputTokens", "outputTokens"]) {
+    assert(
+      result.metrics[metric] === null ||
+        isNonNegativeInteger(result.metrics[metric]),
+      `${path}: ${metric} must be non-negative or null`,
+    );
+  }
+  assert(
+    Number.isInteger(result.metrics.modelTurns) &&
+      result.metrics.modelTurns >= 1,
+    `${path}: modelTurns must be positive`,
+  );
+  assert(
+    Array.isArray(result.failureCodes) &&
+      result.failureCodes.every(
+        (code) => typeof code === "string" && code.length > 0,
+      ),
+    `${path}: failureCodes must be strings`,
+  );
+  assert(
+    new Set(result.failureCodes).size === result.failureCodes.length,
+    `${path}: failureCodes must be unique`,
+  );
+}
+
+const resultPaths =
+  process.argv.length > 2
+    ? process.argv.slice(2)
+    : [new URL("../docs/tool-eval-result.example.json", import.meta.url)];
+
+for (const path of resultPaths) validateResult(await readJson(path), path);
+
+console.log(
+  `Validated ${cases.cases.length} tool-eval cases and ${resultPaths.length} result file(s).`,
+);


### PR DESCRIPTION
## Summary

This is a **design/eval proposal, no tool implementation**.

- Frames the product question as a deliberate multi-model tool strategy, not an immediate custom string-replace implementation.
- Compares OpenAI, Anthropic/Claude, DeepSeek, Kimi, Gemini CLI, pi, Cline/OpenCode, and Aider with public official sources and explicit evidence labels.
- Records the current conclusions: local replacement must not be named `write`; generic exact edit, whole-file write, and vendor-native profiles are separate decisions; no editing tool or routing change is approved.
- Adds eight static eval cases, a result schema/example, and a dependency-free validator.
- Pins the Phase-1 shell/generic matrix to `gpt-5.6-terra`, `deepseek-chat`, and `kimi-k2`.
- Records OpenAI freeform `apply_patch` and Anthropic's versioned editor as deferred native comparisons. The current fixture rejects native-profile results because Zen's current model boundary only represents JSON function tools.

## Scope boundaries

- No `replace`, `write`, or `apply_patch` implementation.
- No runtime, provider routing, model interface, protocol, canonical Item, or tool-schema change.
- No benchmark framework, CI expansion, permission system, or durable coordination state.

## Validation

- `npm run validate:tool-eval`
- explicit example-result validation
- negative validation for non-string `notes`
- negative validation that current-fixture `vendor_native` results are rejected
- `npm run check` (23 plugin SDK tests, 239 Node tests, 38 IMZen tests)
- `git diff --check`
- all cited links reachable; public-safety scan found no private paths, task/thread IDs, credentials, or private work state
- independent Review Round 3 passed exact head `ddb4619afcadabd968d2b2b035bba0dcf4175786`

## Decisions requested

1. Approve or reject the exact three-model Phase-1 shell/generic evaluation matrix.
2. Approve or reject running the bounded evaluation before designing an editing tool.
3. Confirm that unavailable exact model identities fail the run rather than being substituted ad hoc.
4. Confirm at least three repetitions per model/profile/case and zero tolerance for unintended edits.
5. Decide later whether a vendor-native comparison is warranted and, if so, separately authorize either a disposable full-contract eval driver or a production model/provider interface change.

This PR is intentionally draft and must not be merged as approval to implement a tool.
