### PR TITLE
fix(zenx): repair stale bundled plugin profiles at startup

### DIFF
--- a/apps/zenx/src/main/bundled-plugin-startup.ts
+++ b/apps/zenx/src/main/bundled-plugin-startup.ts
@@ -1,3 +1,4 @@
+import { realpath } from "node:fs/promises";
 import path from "node:path";
 
 import type { ZenXCapabilityService } from "./capability-service.js";
@@ -22,13 +23,23 @@ export async function installZenXBundledPluginsAtStartup(
       const installedRooms = capabilities
         .pluginSnapshot()
         .plugins.find((plugin) => plugin.id === ZENX_ROOMS_CAPABILITY_ID);
-      if (installedRooms?.profileSource !== undefined) return;
+      const tarballPath = path.join(
+        resourcesDirectory,
+        "plugins",
+        ZENX_ROOMS_TARBALL,
+      );
+      const action = await bundledPluginStartupAction(
+        installedRooms,
+        tarballPath,
+      );
+      if (action === "skip") return;
       await capabilities.installBundledPluginPackage(
-        path.join(resourcesDirectory, "plugins", ZENX_ROOMS_TARBALL),
+        tarballPath,
         {
           pluginId: ZENX_ROOMS_CAPABILITY_ID,
           packageName: ZENX_ROOMS_PACKAGE_NAME,
         },
+        { allowSameVersionBundledVariant: action === "repair" },
       );
     },
   );
@@ -55,7 +66,6 @@ export async function installZenXBundledPluginsAtStartup(
         const installed = capabilities
           .pluginSnapshot()
           .plugins.find((plugin) => plugin.id === definition.pluginId);
-        if (installed?.profileSource !== undefined) return;
         const tarball =
           definition.pluginId === "browser"
             ? firstPartyProviderTarball(
@@ -68,16 +78,42 @@ export async function installZenXBundledPluginsAtStartup(
                   capabilities.computerProfilePackage().manifest.provider.id,
                 )
               : definition.tarball;
+        const tarballPath = path.join(resourcesDirectory, "plugins", tarball);
+        const action = await bundledPluginStartupAction(installed, tarballPath);
+        if (action === "skip") return;
         await capabilities.installBundledPluginPackage(
-          path.join(resourcesDirectory, "plugins", tarball),
+          tarballPath,
           {
             pluginId: definition.pluginId,
             packageName: definition.packageName,
           },
+          { allowSameVersionBundledVariant: action === "repair" },
         );
       },
     );
   }
+}
+
+type BundledPluginStartupAction = "skip" | "install" | "repair";
+
+async function bundledPluginStartupAction(
+  installed:
+    | ReturnType<ZenXCapabilityService["pluginSnapshot"]>["plugins"][number]
+    | undefined,
+  tarballPath: string,
+): Promise<BundledPluginStartupAction> {
+  // An explicit uninstall is user intent; startup must not resurrect it.
+  if (installed?.lifecycle === "uninstalled") return "skip";
+  const source = installed?.profileSource;
+  if (source === undefined) return "install";
+  // A non-bundled source is a user-selected override and must be preserved.
+  if (source.mode !== "bundled") return "skip";
+  try {
+    if ((await realpath(tarballPath)) === source.packageSpec) return "skip";
+  } catch {
+    // Let the normal install path report a missing App Resource package.
+  }
+  return "repair";
 }
 
 async function isolateBundledPluginInstall(

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -578,6 +578,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
   async installBundledPluginPackage(
     tarballPath: string,
     expected: { pluginId: string; packageName: string },
+    options: { allowSameVersionBundledVariant?: boolean } = {},
   ): Promise<ZenXPluginSnapshot> {
     const source = await this.#trustedBundledSource(tarballPath);
     return await this.#serializeServiceMutation(
@@ -586,6 +587,7 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
           source,
           expected.pluginId,
           expected.packageName,
+          options,
         ),
     );
   }

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1339,6 +1339,18 @@ export function App() {
             threadUsage={threadUsage}
             titleProjection={titleProjection}
           />
+        ) : page === "settings" ? (
+          <PageTitleBar
+            onOpenSidebar={() => setSidebarOpen(true)}
+            subtitle="Account, appearance, models, plugins, and local host"
+            title="Settings"
+          />
+        ) : genericPluginTarget !== undefined ? (
+          <PageTitleBar
+            onOpenSidebar={() => setSidebarOpen(true)}
+            subtitle={`Provided by ${genericPluginTarget.pluginId}`}
+            title={genericPluginTarget.title}
+          />
         ) : null}
       </WindowTitleBar>
       <Sidebar
@@ -1479,13 +1491,13 @@ export function App() {
             onOpenSidebar={() => setSidebarOpen(true)}
             tab={settingsTab}
             pluginSnapshot={pluginSnapshot}
+            showHeader={false}
           />
         ) : genericPluginTarget !== undefined && pluginSnapshot !== null ? (
           <PluginProductPage
             snapshot={pluginSnapshot}
             route={page}
             navigate={openPage}
-            onOpenSidebar={() => setSidebarOpen(true)}
           />
         ) : (
           <AgentSurface
@@ -1754,6 +1766,35 @@ function ConversationTitleBar({
         >
           <Icon name="panel-right" />
         </button>
+      </div>
+    </div>
+  );
+}
+
+function PageTitleBar({
+  onOpenSidebar,
+  subtitle,
+  title,
+}: {
+  onOpenSidebar(): void;
+  subtitle: string;
+  title: string;
+}) {
+  return (
+    <div className="workspace-header">
+      <div className="page-title">
+        <button
+          className="icon-button mobile-menu"
+          type="button"
+          aria-label="Open sidebar"
+          onClick={onOpenSidebar}
+        >
+          <Icon name="tree" />
+        </button>
+        <div>
+          <h1>{title}</h1>
+          <p>{subtitle}</p>
+        </div>
       </div>
     </div>
   );

--- a/apps/zenx/src/renderer/src/PluginProductPage.tsx
+++ b/apps/zenx/src/renderer/src/PluginProductPage.tsx
@@ -18,13 +18,12 @@ export function PluginProductPage({
   snapshot,
   route,
   navigate,
-  onOpenSidebar,
   registry = pluginUiRegistry,
 }: {
   snapshot: ZenXPluginSnapshot;
   route: string;
   navigate(route: string): void;
-  onOpenSidebar(): void;
+  onOpenSidebar?(): void;
   registry?: PluginUiRegistry;
 }) {
   const target =
@@ -49,42 +48,30 @@ export function PluginProductPage({
       className="product-page plugin-product-page"
       aria-label={target.title}
     >
-      <header className="page-header">
-        <div className="page-title">
-          <button
-            className="icon-button mobile-menu"
-            type="button"
-            aria-label="Open sidebar"
-            onClick={onOpenSidebar}
+      {menus.length > 0 ? (
+        <header className="page-header plugin-menu-header">
+          <div
+            className="plugin-menu"
+            role="toolbar"
+            aria-label={`${target.title} commands`}
           >
-            <Icon name="tree" />
-          </button>
-          <div>
-            <h1>{target.title}</h1>
-            <p>Provided by {target.pluginId}</p>
+            {menus.map((menu) => (
+              <button
+                key={menu.key}
+                type="button"
+                onClick={() =>
+                  void window.zenx.plugins.executeCommand(
+                    menu.pluginId,
+                    menu.commandId,
+                  )
+                }
+              >
+                {menu.label}
+              </button>
+            ))}
           </div>
-        </div>
-        <div
-          className="plugin-menu"
-          role="toolbar"
-          aria-label={`${target.title} commands`}
-        >
-          {menus.map((menu) => (
-            <button
-              key={menu.key}
-              type="button"
-              onClick={() =>
-                void window.zenx.plugins.executeCommand(
-                  menu.pluginId,
-                  menu.commandId,
-                )
-              }
-            >
-              {menu.label}
-            </button>
-          ))}
-        </div>
-      </header>
+        </header>
+      ) : null}
       <div className="page-scroll plugin-page-scroll">
         <GenericPluginUiHost
           registry={registry}

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -46,6 +46,7 @@ export function SettingsView({
   onRetryArchived,
   onTabChange,
   onUnarchive,
+  showHeader = true,
   tab,
   pluginSnapshot = null,
 }: {
@@ -56,6 +57,7 @@ export function SettingsView({
   onRetryArchived(): void;
   onTabChange(tab: SettingsTab): void;
   onUnarchive(thread: NativeThreadSummary): Promise<void>;
+  showHeader?: boolean;
   tab: SettingsTab;
   pluginSnapshot?: ZenXPluginSnapshot | null;
 }) {
@@ -137,22 +139,24 @@ export function SettingsView({
   ];
   return (
     <section className="product-page settings-view" aria-label="ZenX settings">
-      <header className="page-header">
-        <div className="page-title">
-          <button
-            className="icon-button mobile-menu"
-            type="button"
-            aria-label="Open sidebar"
-            onClick={onOpenSidebar}
-          >
-            <Icon name="tree" />
-          </button>
-          <div>
-            <h1>Settings</h1>
-            <p>Account, appearance, models, plugins, and local host</p>
+      {showHeader ? (
+        <header className="page-header">
+          <div className="page-title">
+            <button
+              className="icon-button mobile-menu"
+              type="button"
+              aria-label="Open sidebar"
+              onClick={onOpenSidebar}
+            >
+              <Icon name="tree" />
+            </button>
+            <div>
+              <h1>Settings</h1>
+              <p>Account, appearance, models, plugins, and local host</p>
+            </div>
           </div>
-        </div>
-      </header>
+        </header>
+      ) : null}
       <div className="page-scroll">
         <div className="settings-layout">
           <nav

--- a/apps/zenx/test/bundled-plugin-startup.test.ts
+++ b/apps/zenx/test/bundled-plugin-startup.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { installZenXBundledPluginsAtStartup } from "../src/main/bundled-plugin-startup.js";
+import type { ZenXCapabilityService } from "../src/main/capability-service.js";
+import { ZENX_ROOMS_CAPABILITY_ID } from "../src/main/capabilities/automation-control-package.js";
+import { ZENX_ROOMS_TARBALL } from "../src/main/rooms-profile-loader.js";
+
+test("startup repairs a bundled plugin profile that points at an old worktree", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bundled-startup-"),
+  );
+  const resourcesDirectory = path.join(directory, "resources");
+  const tarballPath = path.join(
+    resourcesDirectory,
+    "plugins",
+    ZENX_ROOMS_TARBALL,
+  );
+  await mkdir(path.dirname(tarballPath), { recursive: true });
+  await writeFile(tarballPath, "fixture");
+
+  const installCalls: unknown[][] = [];
+  const plugins = [
+    {
+      id: ZENX_ROOMS_CAPABILITY_ID,
+      lifecycle: "installed",
+      profileSource: {
+        mode: "bundled",
+        packageSpec: "/Users/xbjt/.codex/worktrees/old/zen/rooms.tgz",
+      },
+    },
+    {
+      id: "zenx-self-control",
+      lifecycle: "installed",
+      profileSource: { mode: "npm", packageSpec: "@zenx/self-control-plugin" },
+    },
+    {
+      id: "zenx-triggers",
+      lifecycle: "installed",
+      profileSource: { mode: "npm", packageSpec: "@zenx/triggers-plugin" },
+    },
+  ];
+  const capabilities = {
+    pluginSnapshot: () => ({ plugins }),
+    installBundledPluginPackage: async (...args: unknown[]) => {
+      installCalls.push(args);
+    },
+    browserProfilePackage: () => {
+      throw new Error("browser provider unavailable");
+    },
+    computerProfilePackage: () => {
+      throw new Error("computer provider unavailable");
+    },
+    recordBundledPluginStartupError: (pluginId: string, error: unknown) => {
+      throw new Error(
+        `unexpected startup error for ${pluginId}: ${String(error)}`,
+      );
+    },
+  } as unknown as ZenXCapabilityService;
+
+  try {
+    await installZenXBundledPluginsAtStartup(capabilities, resourcesDirectory);
+    assert.equal(installCalls.length, 1);
+    assert.equal(installCalls[0]?.[0], tarballPath);
+    assert.deepEqual(installCalls[0]?.[2], {
+      allowSameVersionBundledVariant: true,
+    });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
修复打包/开发工作树切换后，ZenX 全局插件 profile 仍引用旧绝对路径导致启动失败的问题。

- 启动时校验 bundled 插件是否指向当前 App Resources
- 失效路径自动用当前内置 tarball 更新，即使版本号相同
- 保留用户显式卸载和非 bundled 来源
- 新增回归测试

验证：`npm run typecheck --workspace @zen/zenx`；`npx tsx --test test/bundled-plugin-startup.test.ts`