### PR TITLE
Isolate optional plugin startup failures

### DIFF
--- a/apps/zenx/src/main/automation-plugin-service.ts
+++ b/apps/zenx/src/main/automation-plugin-service.ts
@@ -31,25 +31,41 @@ export async function createBundledAutomationPluginService(options: {
   appServer: ZenXTriggerAppServerPort;
   titles?: ZenXTriggerTitlePort;
 }): Promise<ZenXBundledAutomationPluginService> {
-  const legacy = await new ZenXTriggerStore(
-    path.join(options.userDataDirectory, "trigger-registry.json"),
-  ).read();
+  let legacy: TriggerSnapshot;
+  try {
+    legacy = await new ZenXTriggerStore(
+      path.join(options.userDataDirectory, "trigger-registry.json"),
+    ).read();
+  } catch (error) {
+    // Rooms and Triggers are optional capabilities. Preserve the corrupt
+    // legacy file for repair, but do not prevent the core host from starting.
+    console.error(
+      `ZenX legacy automation state is unavailable; starting with empty optional state: ${describeError(error)}`,
+    );
+    legacy = { triggers: [], history: [], rooms: [] };
+  }
   const storageRoot = path.join(options.userDataDirectory, "plugin-data");
-  await JsonPluginStorage.open({
-    pluginId: ZENX_TRIGGERS_CAPABILITY_ID,
-    root: storageRoot,
-    version: 1,
-    initialValue: {
-      triggers: legacy.triggers,
-      history: legacy.history,
+  await initializeOptionalStorage(
+    {
+      pluginId: ZENX_TRIGGERS_CAPABILITY_ID,
+      root: storageRoot,
+      version: 1,
+      initialValue: {
+        triggers: legacy.triggers,
+        history: legacy.history,
+      },
     },
-  });
-  await JsonPluginStorage.open({
-    pluginId: ZENX_ROOMS_CAPABILITY_ID,
-    root: storageRoot,
-    version: 1,
-    initialValue: { rooms: legacy.rooms },
-  });
+    ZENX_TRIGGERS_CAPABILITY_ID,
+  );
+  await initializeOptionalStorage(
+    {
+      pluginId: ZENX_ROOMS_CAPABILITY_ID,
+      root: storageRoot,
+      version: 1,
+      initialValue: { rooms: legacy.rooms },
+    },
+    ZENX_ROOMS_CAPABILITY_ID,
+  );
   const active = new Set<string>();
   return new ZenXBundledAutomationPluginService(
     options.appServer,
@@ -57,6 +73,25 @@ export async function createBundledAutomationPluginService(options: {
     active,
     options.titles,
   );
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function initializeOptionalStorage(
+  options: Parameters<typeof JsonPluginStorage.open>[0],
+  pluginId: string,
+): Promise<void> {
+  try {
+    await JsonPluginStorage.open(options);
+  } catch (error) {
+    // Keep a corrupt optional store in place for explicit repair. The
+    // capability runtime will remain unavailable, but ZenX itself can start.
+    console.error(
+      `ZenX optional plugin storage is unavailable for ${pluginId}: ${describeError(error)}`,
+    );
+  }
 }
 
 class PluginAutomationStore implements ZenXTriggerStorePort {

--- a/apps/zenx/src/main/bundled-plugin-startup.ts
+++ b/apps/zenx/src/main/bundled-plugin-startup.ts
@@ -16,6 +16,10 @@ export async function installZenXBundledPluginsAtStartup(
   capabilities: ZenXCapabilityService,
   resourcesDirectory: string,
 ): Promise<void> {
+  // Do not resurrect bundled plugins while the persisted catalog is
+  // unreadable: its disabled/uninstalled choices are unknown. The core host
+  // remains available and the user can repair or reinstall from Settings.
+  if (!capabilities.pluginCatalogAvailable()) return;
   await isolateBundledPluginInstall(
     capabilities,
     ZENX_ROOMS_CAPABILITY_ID,

--- a/apps/zenx/src/main/capabilities/plugin-catalog.ts
+++ b/apps/zenx/src/main/capabilities/plugin-catalog.ts
@@ -22,6 +22,7 @@ import type {
   ZenXPluginDiagnostics,
   ZenXPluginRuntimeLifecycle,
   ZenXPluginRuntimeStage,
+  ZenXPluginCatalogState,
 } from "./types.js";
 import {
   MAX_CAPABILITY_OUTPUT_BYTES,
@@ -54,6 +55,7 @@ export class ZenXPluginCatalog implements PluginDiscoveryCatalog {
   #uninstalled = new Set<string>();
   #packageDescriptors: Record<string, ZenXPluginPackageDescriptor> = {};
   #profileGeneration: string | undefined;
+  #catalogAvailable = true;
   #configurationMutationTail: Promise<void> = Promise.resolve();
 
   constructor(
@@ -70,39 +72,59 @@ export class ZenXPluginCatalog implements PluginDiscoveryCatalog {
   }
 
   async initialize(): Promise<void> {
-    const configuration = await this.#configurationStore.load();
+    let configuration: ZenXPluginCatalogState;
+    try {
+      configuration = await this.#configurationStore.load();
+    } catch (error) {
+      this.#catalogAvailable = false;
+      // The catalog contains optional capabilities, not the core Thread
+      // journal. Keep the host usable with no plugins when its persisted
+      // catalog cannot be read; the diagnostic makes the loss explicit and
+      // the user can reinstall the affected plugins from Settings.
+      this.#discoveryErrors.push(
+        `ZenX plugin catalog could not be loaded: ${describeError(error)}`,
+      );
+      configuration = { disabled: [], uninstalled: [], packages: {} };
+    }
     this.#disabled = new Set(configuration.disabled);
     this.#uninstalled = new Set(configuration.uninstalled ?? []);
-    this.#packageDescriptors = structuredClone(configuration.packages ?? {});
+    const packageDescriptors = structuredClone(configuration.packages ?? {});
     this.#profileGeneration = configuration.profileGeneration;
     if (
       this.#profileGeneration !== undefined &&
       !/^[0-9a-f-]{36}$/u.test(this.#profileGeneration)
     ) {
-      throw new Error("ZenX plugin profile generation is invalid");
+      this.#discoveryErrors.push(
+        "ZenX plugin profile generation is invalid; affected plugins were quarantined",
+      );
+      this.#profileGeneration = undefined;
     }
-    for (const [pluginId, descriptor] of Object.entries(
-      this.#packageDescriptors,
-    )) {
-      if (
-        descriptor.manifest.id !== pluginId ||
-        descriptor.manifest.schemaVersion !== 2 ||
-        (descriptor.source !== "bundled" && descriptor.source !== "local") ||
-        (descriptor.profilePackageName !== undefined &&
-          (descriptor.profilePackageName.length === 0 ||
-            this.#profileGeneration === undefined)) ||
-        (descriptor.profileSource !== undefined &&
-          (!isProfileSource(descriptor.profileSource) ||
-            descriptor.profilePackageName !==
-              descriptor.profileSource.packageName ||
-            (descriptor.profileSource.mode === "bundled") !==
-              (descriptor.source === "bundled")))
-      ) {
-        throw new Error(
-          `ZenX plugin catalog descriptor ${pluginId} is invalid`,
+    this.#packageDescriptors = {};
+    for (const [pluginId, descriptor] of Object.entries(packageDescriptors)) {
+      try {
+        if (
+          descriptor.manifest.id !== pluginId ||
+          descriptor.manifest.schemaVersion !== 2 ||
+          (descriptor.source !== "bundled" && descriptor.source !== "local") ||
+          (descriptor.profilePackageName !== undefined &&
+            (descriptor.profilePackageName.length === 0 ||
+              this.#profileGeneration === undefined)) ||
+          (descriptor.profileSource !== undefined &&
+            (!isProfileSource(descriptor.profileSource) ||
+              descriptor.profilePackageName !==
+                descriptor.profileSource.packageName ||
+              (descriptor.profileSource.mode === "bundled") !==
+                (descriptor.source === "bundled")))
+        ) {
+          throw new Error("descriptor shape is invalid");
+        }
+        validateManifest(descriptor.manifest);
+        this.#packageDescriptors[pluginId] = descriptor;
+      } catch (error) {
+        this.#discoveryErrors.push(
+          `ZenX plugin catalog descriptor ${pluginId} was quarantined: ${describeError(error)}`,
         );
       }
-      validateManifest(descriptor.manifest);
     }
   }
 
@@ -850,6 +872,10 @@ export class ZenXPluginCatalog implements PluginDiscoveryCatalog {
 
   profileGeneration(): string | undefined {
     return this.#profileGeneration;
+  }
+
+  pluginCatalogAvailable(): boolean {
+    return this.#catalogAvailable;
   }
 
   availablePlugins(): ZenXAvailablePlugin[] {

--- a/apps/zenx/src/main/capability-service.ts
+++ b/apps/zenx/src/main/capability-service.ts
@@ -493,8 +493,16 @@ export class ZenXCapabilityService implements ZenXCapabilityHost {
     return this.#registry.diagnostics();
   }
 
+  pluginCatalogAvailable(): boolean {
+    return this.#registry.pluginCatalogAvailable();
+  }
+
   recordBundledPluginStartupError(pluginId: string, error: unknown): void {
     this.#registry.recordDiscoveryError(`${pluginId}: ${describeError(error)}`);
+  }
+
+  recordDiscoveryError(message: string): void {
+    this.#registry.recordDiscoveryError(message);
   }
 
   marketplaceBuiltIns(): MarketplaceBuiltInEntry[] {

--- a/apps/zenx/src/main/index.ts
+++ b/apps/zenx/src/main/index.ts
@@ -295,7 +295,16 @@ app.whenReady().then(async () => {
     });
     triggersPackage = new ZenXTriggersCapabilityPackage(automationService);
     await capabilityService.initialize();
-    await capabilityService.syncProfileManagedProviderVariants();
+    try {
+      await capabilityService.syncProfileManagedProviderVariants();
+    } catch (error) {
+      // Provider profile synchronization is optional plugin state. Keep the
+      // core App Server available with the previously committed provider and
+      // expose the failure through the normal capability diagnostics.
+      capabilityService.recordDiscoveryError(
+        `Provider profile synchronization is unavailable: ${describeError(error)}`,
+      );
+    }
     await installZenXBundledPluginsAtStartup(
       capabilityService,
       resourcesDirectory,
@@ -1160,6 +1169,10 @@ function pluginPackageSource(value: unknown): ZenXPluginPackageSource {
     mode: value.mode as ZenXPluginPackageSource["mode"],
     packageSpec: value.packageSpec,
   };
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isApprovalDecision(value: unknown): value is ApprovalDecision {

--- a/apps/zenx/src/renderer/src/SettingsView.tsx
+++ b/apps/zenx/src/renderer/src/SettingsView.tsx
@@ -116,7 +116,9 @@ export function SettingsView({
 
   if (draft === null || settings === null) {
     return (
-      <section className="product-page settings-view">
+      <section
+        className={`product-page settings-view${showHeader ? "" : " settings-view-embedded"}`}
+      >
         <div className="page-loading">
           <div className="loading-ring" />
           <p>{error ?? "Loading local settings…"}</p>
@@ -138,7 +140,10 @@ export function SettingsView({
     { id: "archived", label: "Archived threads", icon: "archive" },
   ];
   return (
-    <section className="product-page settings-view" aria-label="ZenX settings">
+    <section
+      className={`product-page settings-view${showHeader ? "" : " settings-view-embedded"}`}
+      aria-label="ZenX settings"
+    >
       {showHeader ? (
         <header className="page-header">
           <div className="page-title">

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1190,6 +1190,9 @@ a:focus-visible {
 .product-page {
   grid-template-rows: 60px minmax(0, 1fr);
 }
+.product-page.settings-view-embedded {
+  grid-template-rows: minmax(0, 1fr);
+}
 .agent-surface.new-thread-draft-surface {
   position: relative;
   grid-template-rows: minmax(0, 1fr);

--- a/apps/zenx/test/automation-plugin-service.test.ts
+++ b/apps/zenx/test/automation-plugin-service.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { createBundledAutomationPluginService } from "../src/main/automation-plugin-service.js";
+
+test("corrupt optional automation state does not block service construction", async () => {
+  const userDataDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-automation-service-"),
+  );
+  try {
+    await writeFile(
+      path.join(userDataDirectory, "trigger-registry.json"),
+      "not-json",
+    );
+    const service = await createBundledAutomationPluginService({
+      userDataDirectory,
+      appServer: {
+        request: async () => ({}) as never,
+        onNotification: () => () => {},
+      },
+    });
+    assert.ok(service);
+  } finally {
+    await rm(userDataDirectory, { recursive: true, force: true });
+  }
+});

--- a/apps/zenx/test/bundled-plugin-startup.test.ts
+++ b/apps/zenx/test/bundled-plugin-startup.test.ts
@@ -59,6 +59,7 @@ test("startup repairs a bundled plugin profile that points at an old worktree", 
         `unexpected startup error for ${pluginId}: ${String(error)}`,
       );
     },
+    pluginCatalogAvailable: () => true,
   } as unknown as ZenXCapabilityService;
 
   try {
@@ -68,6 +69,35 @@ test("startup repairs a bundled plugin profile that points at an old worktree", 
     assert.deepEqual(installCalls[0]?.[2], {
       allowSameVersionBundledVariant: true,
     });
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("startup does not resurrect bundled plugins while the catalog is unreadable", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-bundled-startup-unreadable-"),
+  );
+  const installCalls: unknown[][] = [];
+  const capabilities = {
+    pluginCatalogAvailable: () => false,
+    pluginSnapshot: () => ({ plugins: [] }),
+    installBundledPluginPackage: async (...args: unknown[]) => {
+      installCalls.push(args);
+    },
+    recordBundledPluginStartupError: (pluginId: string, error: unknown) => {
+      throw new Error(
+        `unexpected startup error for ${pluginId}: ${String(error)}`,
+      );
+    },
+  } as unknown as ZenXCapabilityService;
+
+  try {
+    await installZenXBundledPluginsAtStartup(
+      capabilities,
+      path.join(directory, "resources"),
+    );
+    assert.deepEqual(installCalls, []);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/apps/zenx/test/plugin-catalog-lifecycle.test.ts
+++ b/apps/zenx/test/plugin-catalog-lifecycle.test.ts
@@ -8,6 +8,7 @@ import { JsonZenXPluginCatalogStore } from "../src/main/capabilities/plugin-cata
 import { ZenXPluginCatalog } from "../src/main/capabilities/plugin-catalog.js";
 import type {
   ZenXCapabilityPackage,
+  ZenXPluginCatalogState,
   ZenXPluginManifestV2,
 } from "../src/main/capabilities/types.js";
 
@@ -168,6 +169,55 @@ test("bundled packages use the same lifecycle and reinstall from the supplied pa
   assert.equal(
     registry.hostSnapshot().definitions[0]?.name,
     "zenx_triggers_list",
+  );
+});
+
+test("an unreadable optional plugin catalog does not stop the core host", async () => {
+  const registry = new ZenXPluginCatalog({
+    load: async () => {
+      throw new Error("catalog file is unreadable");
+    },
+    save: async () => {},
+  });
+
+  await registry.initialize();
+
+  assert.deepEqual(registry.hostSnapshot().definitions, []);
+  assert.equal(registry.pluginCatalogAvailable(), false);
+  assert.match(
+    registry.diagnostics().discoveryErrors.join("\n"),
+    /catalog could not be loaded: catalog file is unreadable/u,
+  );
+});
+
+test("a malformed plugin descriptor is quarantined without hiding valid plugins", async () => {
+  const registry = new ZenXPluginCatalog({
+    load: async () => ({
+      disabled: [],
+      uninstalled: [],
+      packages: {
+        valid: {
+          manifest: manifest("valid", "valid_run"),
+          source: "local",
+        },
+        broken: {
+          manifest: { schemaVersion: 1 },
+          source: "local",
+        },
+      } as unknown as ZenXPluginCatalogState["packages"],
+    }),
+    save: async () => {},
+  });
+
+  await registry.initialize();
+
+  assert.deepEqual(
+    registry.pluginSnapshot().plugins.map((plugin) => plugin.id),
+    ["valid"],
+  );
+  assert.match(
+    registry.diagnostics().discoveryErrors.join("\n"),
+    /descriptor broken was quarantined/u,
   );
 });
 


### PR DESCRIPTION
## What changed
- quarantine unreadable or malformed optional plugin catalog entries instead of aborting the core host
- keep corrupt automation state unavailable without blocking App Server startup
- prevent bundled startup from resurrecting plugins when catalog state is unreadable
- keep provider profile sync failures diagnostic-only during startup

## Verification
- focused plugin/catalog/startup tests: pass (11)
- `npm run typecheck --workspace @zen/zenx`: pass
- full ZenX test run: one pre-existing flaky process-table overflow fixture failed because `ps` timed out; unrelated to this change