### PR TITLE
feat(zenx): show model context usage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,6 +68,9 @@
   原生 summary 映射为兼容的 Codex Thread DTO，不反向定义 Zen 产品模型。
 - **ZenXThreadSummaryAdapter** — ZenX Electron main 通过既有 host-local 进程边界查询
   ZAS 原生 summary，并以 typed IPC 暴露给产品层，不拥有 Thread 语义或新增 wire method。
+- **ZenXThreadUsageProjection** — ZenX Electron main 从 canonical `model_usage`、
+  当前模型目录 `contextWindow` 和可重放模型消息投影展示用 usage / context pressure，
+  不进入 CAS schema、Agent 上下文或自动压缩决策。
 - **ZenXImageAttachmentProjection** — ZenX Electron main 通过既有 host-local 边界从 canonical
   `user_message` 投影按 Item 顺序排列的 `AttachmentRef`，并以只接受这些引用的 typed preload IPC
   导入和读取 Attachment Store payload；renderer 只持有草稿引用与短时 object URL，不取得任意文件读取权。
@@ -536,6 +539,9 @@ telemetry。`inputTokens` 始终是包含 cached 部分的 total input，uncache
 重放旧的重复 response usage 时 projection 也按 journal 顺序取最后一份，避免重复计数。即使 usage
 之后 request 失败，已经报告的最后一份 usage 仍须先落盘。Turn/Thread cache hit rate 只对报告
 cached 数据的 response 做 token-weighted 归约：`sum(cachedInputTokens) / sum(inputTokens)`。
+ZenX 的上下文占比读模型不能使用 Thread 累计 input tokens；它用最新未被 compaction 覆盖的
+Provider `inputTokens`，若 compaction 已经使该样本代表旧上下文，则用当前 `compileModelMessages`
+的固定轻量估算并在展示中标记 estimated。该估算只用于 UI 参考，不参与自动 compaction。
 
 手动 context compaction 只在没有 active / incomplete Turn 时取最新
 `turn_completed` 作为覆盖边界；调用者不能指定任意 Item。Zen 以 admission 时

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -30,8 +30,10 @@ Interrupt & send；Provider/onboarding、安全 Markdown、Trigger / Watching / 
 ZenX 的产品读取模型来自 ZAS 原生 `ThreadSummary` 查询，并经 Electron main/preload
 typed IPC 暴露；当前 Codex-base Thread DTO 只属于 CAS adapter，不定义 ZenX 产品模型。
 ZenX 同样经 host-local typed projection 从 canonical `model_usage` Items 展示 Thread/Turn
-的 input/output token 与 token-weighted cache hit rate；cache 明细缺失时明确显示 Unknown，
-不为此增加 ZAS protocol method 或 notification，也不估算费率、货币或成本。
+的 input/output token 与 token-weighted cache hit rate，并把最新上下文 pressure
+对照当前模型目录的 `contextWindow` 展示占比；cache 或 window 缺失时明确显示 Unknown，
+压缩后只用标记为 estimated 的轻量估算恢复占比，不为此增加 ZAS protocol method 或 notification，
+也不估算费率、货币或成本。
 高保真 renderer 的当前 UI/UX 合同单独维护在 `apps/zenx/docs/ui-ux.md`，本文件不重复
 具体布局。Thread 的重命名、归档与取消归档全部通过既有 App Server 操作；Archive
 作为可逆的安全删除替代，不提供永久删除，也不在活动 Turn 期间暗改 Thread 设置。

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -152,9 +152,11 @@ New thread 可保留独立 row；它相对 Plugin spaces / Projects 的精确视
 - 如果完成后没有 Final Message，显示明确 fallback，不留下空 Turn。
 - Final Message 是完成结果，不能与中间 Agent Message 重复渲染。
 - Thread 顶部与每个 Turn metadata 使用一行弱化、紧凑的 usage 摘要展示 input/output tokens
-  与 cache hit rate。它只消费 Host 从 canonical ItemList 派生的 typed projection；当前产品
-  不需要为此新增 ZAS method 或 notification。cache rate 是仅对报告 cache 明细的 response 做 token-weighted
-  聚合；有 usage 但 Provider 未报告 cache 时显示 **Cache unknown**，不得显示 `0%`。
+  与 cache hit rate；Thread 顶部还展示当前模型上下文占比。它只消费 Host 从 canonical ItemList
+  和 host ModelCatalog 派生的 typed projection；当前产品不需要为此新增 ZAS method 或 notification。
+  cache rate 是仅对报告 cache 明细的 response 做 token-weighted 聚合；有 usage 但 Provider 未报告
+  cache 时显示 **Cache unknown**，不得显示 `0%`。context window 缺失时显示 Unknown；compaction
+  使最新 Provider usage 代表旧上下文后，可以用当前模型消息的轻量估算恢复占比，但必须标记 estimated。
 - usage 展示不包含费率、货币、成本、预算、图表或 pricing 配置；reasoning output tokens 即使
   Provider 报告也只属于 canonical usage 明细，不要求在当前紧凑摘要中展开。
 
@@ -359,8 +361,9 @@ ThreadView
 - [ ] Settings 使用左下 navigation row，并管理 Archived Threads、Provider/Account 和 Plugins；顶部 action contract 不作为本轮验收合同。
 - [ ] Tool details 位于 chat flow，approval 位于 Composer 上方，没有常驻 Activity rail。
 - [ ] Running Turn 始终展开；Completed Turn 默认只显示一次 Final Message并可展开历史。
-- [ ] Thread/Turn usage 从 canonical ItemList 的 host-local projection 派生；cache 缺失显示 Unknown，
-      已报告样本按 token-weighted rate 聚合，且不出现成本 UI。
+- [ ] Thread/Turn usage 从 canonical ItemList 的 host-local projection 派生；Thread 顶部 context
+      占比同时读取 host ModelCatalog 的 context window；cache/window 缺失显示 Unknown，已报告样本按
+      token-weighted rate 聚合，压缩后估算标记 estimated，且不出现成本 UI。
 - [ ] Agent Message 不嵌套在 Trace Group；连续 Thinking/Tool Items 保持顺序并被轻量聚合。
 - [ ] Composer 的 Steer、Stop、Interrupt & Send、Send 和 disabled 均语义明确；primary action 切换时几何稳定。
 - [ ] Composer primary action 的可见圆更小但图标和 hit target 不随之大幅缩小；底部 toolbar 更靠近容器底边。

--- a/apps/zenx/src/main/app-server-host.ts
+++ b/apps/zenx/src/main/app-server-host.ts
@@ -17,7 +17,11 @@ import {
 } from "./capability-tool-executor.js";
 import type { ZenXCapabilityGenerationSnapshot } from "./capabilities/types.js";
 import { projectThreadAttachments } from "./image-attachments.js";
-import { projectModelUsage } from "../../../../src/model-usage.js";
+import { compileModelMessages } from "../../../../src/model.js";
+import {
+  estimateModelMessageInputTokens,
+  projectModelUsage,
+} from "../../../../src/model-usage.js";
 import { ToolOutputSpool } from "../../../../src/tool-output-spool.js";
 
 let server: CodexWebSocketServer | undefined;
@@ -153,12 +157,29 @@ async function handleCommand(command: HostCommand): Promise<void> {
       return;
     }
     try {
+      const snapshot = await appServer.readThread(command.threadId);
+      const selection = {
+        providerProfileId: snapshot.providerProfileId,
+        modelId: snapshot.modelId,
+        reasoningEffort: snapshot.reasoningEffort,
+      };
+      const contextWindow =
+        appServer
+          .listModels()
+          .find(
+            (entry) =>
+              entry.providerProfileId === selection.providerProfileId &&
+              entry.model.id === selection.modelId,
+          )?.model.contextWindow ?? null;
       send({
         type: "thread-usage/result",
         requestId: command.requestId,
-        usage: projectModelUsage(
-          (await appServer.readThread(command.threadId)).items,
-        ),
+        usage: projectModelUsage(snapshot.items, {
+          contextWindow,
+          estimatedInputTokens: estimateModelMessageInputTokens(
+            compileModelMessages(snapshot.items, selection),
+          ),
+        }),
       });
     } catch (error) {
       send({

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -91,7 +91,7 @@ import {
   type SidebarMode,
 } from "./thread-list.js";
 import { applyThreadViewNotification } from "./thread-view-state.js";
-import { ThreadView, usageLabel } from "./ThreadView.js";
+import { ThreadView, contextUsageLabel, usageLabel } from "./ThreadView.js";
 import { ZenXBrand } from "./ZenXBrand.js";
 
 type ProductPage = string;
@@ -2018,7 +2018,7 @@ function ConversationTitleBar({
         {threadUsage === undefined ||
         threadUsage.thread.responseCount === 0 ? null : (
           <small className="thread-usage">
-            {usageLabel(threadUsage.thread, "Thread cache")}
+            {threadHeaderUsageLabel(threadUsage)}
           </small>
         )}
         <button
@@ -2034,6 +2034,12 @@ function ConversationTitleBar({
       </div>
     </div>
   );
+}
+
+function threadHeaderUsageLabel(threadUsage: ModelUsageProjection): string {
+  const context = contextUsageLabel(threadUsage.context);
+  const usage = usageLabel(threadUsage.thread, "Thread cache");
+  return context === null ? usage : `${context} · ${usage}`;
 }
 
 function PageTitleBar({

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { AttachmentRef } from "../../../../../src/attachment.js";
 import type {
+  ModelContextUsageProjection,
   ModelUsageAggregate,
   ModelUsageProjection,
 } from "../../../../../src/model-usage.js";
@@ -578,6 +579,26 @@ export function usageLabel(usage: ModelUsageAggregate, prefix: string): string {
       ? `${prefix} unknown`
       : `${prefix} ${String(Math.round(usage.cacheHitRate * 100))}%`;
   return `${cache} · ${formatTokenCount(usage.inputTokens)} in · ${formatTokenCount(usage.outputTokens)} out`;
+}
+
+export function contextUsageLabel(
+  context: ModelContextUsageProjection,
+): string | null {
+  if (context.inputTokens === null && context.contextWindow === null) {
+    return null;
+  }
+  if (context.inputTokens === null) {
+    const window = context.contextWindow;
+    return window === null
+      ? null
+      : `Context unknown · ${formatTokenCount(window)} max`;
+  }
+  const input = formatTokenCount(context.inputTokens);
+  const source = context.inputTokenSource === "estimated" ? " est." : "";
+  if (context.contextWindow === null || context.ratio === null) {
+    return `Context unknown · ${input} in${source}`;
+  }
+  return `Context ${String(Math.round(context.ratio * 100))}%${source} · ${input} / ${formatTokenCount(context.contextWindow)}`;
 }
 
 function formatTokenCount(value: number): string {

--- a/apps/zenx/test/app-live-projection.test.ts
+++ b/apps/zenx/test/app-live-projection.test.ts
@@ -86,11 +86,18 @@ test("resume commits canonical state before auxiliary reads and replays catch-up
       usage.resolve({
         thread: { responseCount: 1, inputTokens: 7, outputTokens: 3 },
         turns: {},
+        context: {
+          inputTokens: 7,
+          inputTokenSource: "provider",
+          contextWindow: 70,
+          ratio: 0.1,
+        },
       });
       await Promise.resolve();
       await Promise.resolve();
     });
     assert.match(document.body.textContent ?? "", /7 in/u);
+    assert.match(document.body.textContent ?? "", /Context 10% · 7 \/ 70/u);
   } finally {
     await harness.unmount();
   }
@@ -479,6 +486,12 @@ async function mountApp(options: MountOptions) {
           ? {
               thread: { responseCount: 0, inputTokens: 0, outputTokens: 0 },
               turns: {},
+              context: {
+                inputTokens: null,
+                inputTokenSource: null,
+                contextWindow: null,
+                ratio: null,
+              },
             }
           : await options.usage(threadId),
     },

--- a/apps/zenx/test/app-project-picker-interaction.test.ts
+++ b/apps/zenx/test/app-project-picker-interaction.test.ts
@@ -2009,6 +2009,12 @@ test("conversation header owns thread cache telemetry and only retains workspace
           cacheHitRate: undefined,
         },
         turns: {},
+        context: {
+          inputTokens: 200,
+          inputTokenSource: "provider",
+          contextWindow: 400,
+          ratio: 0.5,
+        },
       }),
       request: async (method) => {
         if (method === "thread/resume")
@@ -2043,7 +2049,7 @@ test("conversation header owns thread cache telemetry and only retains workspace
     assert.match(
       document.querySelector(".workspace-header .thread-usage")?.textContent ??
         "",
-      /Thread cache unknown · 200 in · 25 out/u,
+      /Context 50% · 200 \/ 400 · Thread cache unknown · 200 in · 25 out/u,
     );
     assert.equal(
       document.querySelector(".messages-inner > .thread-usage"),
@@ -2581,6 +2587,12 @@ async function mountApp(
           ? {
               thread: { responseCount: 0, inputTokens: 0, outputTokens: 0 },
               turns: {},
+              context: {
+                inputTokens: null,
+                inputTokenSource: null,
+                contextWindow: null,
+                ratio: null,
+              },
             }
           : await options.modelUsage(),
     },

--- a/apps/zenx/test/app-request-freshness.test.ts
+++ b/apps/zenx/test/app-request-freshness.test.ts
@@ -378,6 +378,12 @@ function projectedUsage(inputTokens: number): ModelUsageProjection {
       outputTokens: 1,
     },
     turns: {},
+    context: {
+      inputTokens: inputTokens === 0 ? null : inputTokens,
+      inputTokenSource: inputTokens === 0 ? null : "provider",
+      contextWindow: inputTokens === 0 ? null : 100,
+      ratio: inputTokens === 0 ? null : inputTokens / 100,
+    },
   };
 }
 

--- a/apps/zenx/test/host-messages.test.ts
+++ b/apps/zenx/test/host-messages.test.ts
@@ -207,6 +207,12 @@ test("validates exclusive canonical Thread usage projections", () => {
         cacheHitRate: 0.25,
       },
     },
+    context: {
+      inputTokens: 100,
+      inputTokenSource: "provider",
+      contextWindow: 400,
+      ratio: 0.25,
+    },
   };
   assert.equal(
     isHostEvent({
@@ -223,6 +229,12 @@ test("validates exclusive canonical Thread usage projections", () => {
       usage: {
         thread: { responseCount: 1, inputTokens: 10, outputTokens: 2 },
         turns: {},
+        context: {
+          inputTokens: 10,
+          inputTokenSource: "provider",
+          contextWindow: null,
+          ratio: null,
+        },
       },
     }),
     true,
@@ -241,6 +253,12 @@ test("validates exclusive canonical Thread usage projections", () => {
           cacheHitRate: 1,
         },
         turns: {},
+        context: {
+          inputTokens: 10,
+          inputTokenSource: "provider",
+          contextWindow: 10,
+          ratio: 1,
+        },
       },
     }),
     true,

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -253,6 +253,12 @@ test("Turn disclosure does not repeat cache telemetry from assistant actions", (
           cacheHitRate: 0.4,
         },
       },
+      context: {
+        inputTokens: 150,
+        inputTokenSource: "provider",
+        contextWindow: null,
+        ratio: null,
+      },
     },
   );
   const disclosure = html.match(
@@ -295,6 +301,12 @@ test("only the final assistant message exposes metadata and hover actions", asyn
             outputTokens: 17,
             cacheHitRate: 0.4,
           },
+        },
+        context: {
+          inputTokens: 150,
+          inputTokenSource: "provider",
+          contextWindow: null,
+          ratio: null,
         },
       },
     );
@@ -431,6 +443,12 @@ test("renders compact token-weighted cache usage for each Turn, not the message 
           inputTokens: 50,
           outputTokens: 8,
         },
+      },
+      context: {
+        inputTokens: 50,
+        inputTokenSource: "provider",
+        contextWindow: null,
+        ratio: null,
       },
     },
   );

--- a/src/model-usage.ts
+++ b/src/model-usage.ts
@@ -1,4 +1,5 @@
 import type { CanonicalItem, ModelUsageItem } from "./item.js";
+import type { ModelMessage } from "./model.js";
 
 export interface ModelUsageAggregate {
   responseCount: number;
@@ -13,15 +14,32 @@ export interface ModelUsageAggregate {
 export interface ModelUsageProjection {
   thread: ModelUsageAggregate;
   turns: Readonly<Record<string, ModelUsageAggregate>>;
+  context: ModelContextUsageProjection;
+}
+
+export interface ModelContextUsageProjection {
+  inputTokens: number | null;
+  inputTokenSource: "provider" | "estimated" | null;
+  contextWindow: number | null;
+  ratio: number | null;
 }
 
 export function projectModelUsage(
   items: readonly CanonicalItem[],
+  options: {
+    contextWindow?: number | null;
+    estimatedInputTokens?: number;
+  } = {},
 ): ModelUsageProjection {
   const latestByResponse = new Map<string, ModelUsageItem>();
-  for (const item of items) {
+  let latestUsage: { item: ModelUsageItem; index: number } | undefined;
+  let latestCompactionIndex = -1;
+  for (const [index, item] of items.entries()) {
     if (item.type === "model_usage") {
       latestByResponse.set(item.modelResponseId, item);
+      latestUsage = { item, index };
+    } else if (item.type === "context_compaction") {
+      latestCompactionIndex = index;
     }
   }
 
@@ -36,13 +54,35 @@ export function projectModelUsage(
     turns: Object.fromEntries(
       [...byTurn].map(([turnId, usages]) => [turnId, aggregate(usages)]),
     ),
+    context: contextProjection({
+      contextWindow: options.contextWindow ?? null,
+      ...(options.estimatedInputTokens === undefined
+        ? {}
+        : { estimatedInputTokens: options.estimatedInputTokens }),
+      latestCompactionIndex,
+      ...(latestUsage === undefined ? {} : { latestUsage }),
+    }),
   };
+}
+
+export function estimateModelMessageInputTokens(
+  messages: readonly ModelMessage[],
+): number {
+  return messages.reduce(
+    (total, message) => add(total, estimateModelMessage(message)),
+    0,
+  );
 }
 
 export function isModelUsageProjection(
   value: unknown,
 ): value is ModelUsageProjection {
-  if (!isRecord(value) || !isAggregate(value.thread) || !isRecord(value.turns))
+  if (
+    !isRecord(value) ||
+    !isAggregate(value.thread) ||
+    !isRecord(value.turns) ||
+    !isContextProjection(value.context)
+  )
     return false;
   return Object.values(value.turns).every(isAggregate);
 }
@@ -115,6 +155,92 @@ function aggregate(usages: readonly ModelUsageItem[]): ModelUsageAggregate {
       ? { cacheHitRate: cachedInputTokens / cacheEligibleInputTokens }
       : {}),
   };
+}
+
+function contextProjection(options: {
+  contextWindow: number | null;
+  estimatedInputTokens?: number;
+  latestCompactionIndex: number;
+  latestUsage?: { item: ModelUsageItem; index: number };
+}): ModelContextUsageProjection {
+  const canUseProviderUsage =
+    options.latestUsage !== undefined &&
+    options.latestUsage.index > options.latestCompactionIndex;
+  const estimatedInputTokens = options.estimatedInputTokens;
+  const providerInputTokens = canUseProviderUsage
+    ? options.latestUsage?.item.inputTokens
+    : undefined;
+  const inputTokens = providerInputTokens ?? estimatedInputTokens;
+  const source: ModelContextUsageProjection["inputTokenSource"] =
+    inputTokens === undefined
+      ? null
+      : canUseProviderUsage
+        ? "provider"
+        : "estimated";
+  const normalizedInput = inputTokens ?? null;
+  return {
+    inputTokens: normalizedInput,
+    inputTokenSource: source,
+    contextWindow: options.contextWindow,
+    ratio:
+      normalizedInput === null || options.contextWindow === null
+        ? null
+        : normalizedInput / options.contextWindow,
+  };
+}
+
+function isContextProjection(
+  value: unknown,
+): value is ModelContextUsageProjection {
+  if (!isRecord(value)) return false;
+  return (
+    (value.inputTokens === null || isCount(value.inputTokens)) &&
+    (value.inputTokenSource === null ||
+      value.inputTokenSource === "provider" ||
+      value.inputTokenSource === "estimated") &&
+    (value.contextWindow === null || isPositiveCount(value.contextWindow)) &&
+    (value.ratio === null ||
+      (typeof value.ratio === "number" &&
+        Number.isFinite(value.ratio) &&
+        value.ratio >= 0))
+  );
+}
+
+function isPositiveCount(value: unknown): value is number {
+  return isCount(value) && value > 0;
+}
+
+function estimateModelMessage(message: ModelMessage): number {
+  switch (message.role) {
+    case "assistant":
+      return estimateText((message.text ?? "") + toolCallsText(message));
+    case "reasoning":
+      return estimateText(
+        `${message.reasoningContent}\n${message.summary ?? ""}`,
+      );
+    case "tool":
+      return estimateText(`${message.callId}\n${message.text}`);
+    case "user":
+      return "content" in message
+        ? estimateText(
+            message.content
+              .map((part) =>
+                part.type === "text"
+                  ? part.text
+                  : `[image:${part.attachment.mediaType}:${part.attachment.byteLength}]`,
+              )
+              .join("\n"),
+          )
+        : estimateText(message.text);
+  }
+}
+
+function toolCallsText(message: ModelMessage): string {
+  return "toolCalls" in message ? JSON.stringify(message.toolCalls) : "";
+}
+
+function estimateText(text: string): number {
+  return Math.ceil(text.length / 4) + 4;
 }
 
 function add(left: number, right: number): number {

--- a/test/model-usage.test.ts
+++ b/test/model-usage.test.ts
@@ -58,6 +58,55 @@ test("keeps cache usage unknown when no response reports cache data", () => {
   assert.equal(projection.thread.cacheHitRate, undefined);
 });
 
+test("projects context pressure from provider usage and configured window", () => {
+  const projection = projectModelUsage(
+    [
+      metadata(),
+      usage("usage-a", "turn-a", "response-a", 90, undefined, 3),
+      usage("usage-b", "turn-a", "response-b", 120, undefined, 4),
+    ],
+    { contextWindow: 200 },
+  );
+
+  assert.deepEqual(projection.context, {
+    inputTokens: 120,
+    inputTokenSource: "provider",
+    contextWindow: 200,
+    ratio: 0.6,
+  });
+});
+
+test("uses estimated context pressure after compaction invalidates latest usage", () => {
+  const projection = projectModelUsage(
+    [
+      metadata(),
+      usage("usage-a", "turn-a", "response-a", 180, undefined, 3),
+      {
+        id: "compaction",
+        threadId: "thread",
+        createdAt: "2026-08-27T00:00:02.000Z",
+        type: "context_compaction",
+        coveredThroughItemId: "completed",
+        summary: "summary",
+        retainedItemIds: [],
+        providerProfileId: "provider",
+        modelId: "model",
+        reasoningEffort: "medium",
+        algorithmVersion: "zen.context-compaction.v1",
+        tokenUsage: { inputTokens: 180, outputTokens: 5 },
+      },
+    ],
+    { contextWindow: 200, estimatedInputTokens: 40 },
+  );
+
+  assert.deepEqual(projection.context, {
+    inputTokens: 40,
+    inputTokenSource: "estimated",
+    contextWindow: 200,
+    ratio: 0.2,
+  });
+});
+
 test("replays canonical model usage from the JSONL journal", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zen-usage-"));
   try {


### PR DESCRIPTION
## Summary
- add a context usage projection beside the existing canonical model usage aggregate
- derive ZenX header context pressure from the latest provider input tokens plus the selected model context window
- fall back to a marked lightweight estimate after compaction, and document the UI-only nature of that estimate

## Validation
- npm run typecheck
- npm run build
- npx prettier --check ARCHITECTURE.md PRODUCTS.md apps/zenx/docs/ui-ux.md apps/zenx/src/main/app-server-host.ts apps/zenx/src/renderer/src/App.tsx apps/zenx/src/renderer/src/ThreadView.tsx apps/zenx/test/app-live-projection.test.ts apps/zenx/test/app-project-picker-interaction.test.ts apps/zenx/test/app-request-freshness.test.ts apps/zenx/test/host-messages.test.ts apps/zenx/test/thread-view-component.test.ts src/model-usage.ts test/model-usage.test.ts
- node --test dist/test/model-usage.test.js
- npm exec --workspace @zen/zenx -- tsx --test test/host-messages.test.ts test/thread-view-component.test.ts test/app-live-projection.test.ts test/app-project-picker-interaction.test.ts test/app-request-freshness.test.ts

## Known Existing Verification Failures
- npm run check currently stops in repo-wide Prettier baseline with 357 pre-existing files reported
- npm test currently has unrelated Windows/environment failures around Temp rename EPERM, missing printf, run_code child timing, and shell scheduler expectations
