### PR TITLE
fix(zenx): render transcript attachments as standalone thumbnails

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -227,6 +227,7 @@ Composer 保持一个位置、几何和命中区域稳定的 primary action，�
   Unknown 不得冒充 unsupported。文字草稿的普通发送行为不受影响。
 - transcript 从 canonical `user_message` 的 `AttachmentRef` 投影图片；send 后与 resume 后使用同一渲染路径。
   缩略图可用鼠标或键盘打开应用内 modal preview；Escape、关闭按钮和 backdrop 可关闭，关闭后焦点返回触发缩略图。
+  Transcript 附件渲染为文字气泡上方的独立紧凑缩略图行（右对齐、可换行），不被包进气泡边框内；只有存在文字时才渲染文字气泡。这是视觉校准，不改变 `AttachmentRef` 权威与投影路径。
 
 ### 4.6 Settings 与 onboarding
 

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -838,22 +838,24 @@ function UserMessage({
   const text = item.content.map((content) => content.text).join("\n");
   return (
     <article className="user-row">
-      <div className="user-bubble">
-        {attachments.length === 0 ? null : (
-          <div className="message-images" aria-label="Attached images">
-            {attachments.map((attachment, index) => (
-              <AttachmentImage
-                attachment={attachment}
-                key={`${attachment.sha256}-${String(index)}`}
-                name={`Attached image ${String(index + 1)}`}
-                onOpen={onOpenImage}
-                onReadAttachment={onReadAttachment}
-              />
-            ))}
-          </div>
-        )}
-        {text.length === 0 ? null : <Markdown text={text} />}
-      </div>
+      {attachments.length === 0 ? null : (
+        <div className="message-images" aria-label="Attached images">
+          {attachments.map((attachment, index) => (
+            <AttachmentImage
+              attachment={attachment}
+              key={`${attachment.sha256}-${String(index)}`}
+              name={`Attached image ${String(index + 1)}`}
+              onOpen={onOpenImage}
+              onReadAttachment={onReadAttachment}
+            />
+          ))}
+        </div>
+      )}
+      {text.length === 0 ? null : (
+        <div className="user-bubble">
+          <Markdown text={text} />
+        </div>
+      )}
       <MessageActions
         className="user-message-actions"
         copyLabel="Copy user message"

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -1439,13 +1439,12 @@ a:focus-visible {
   box-shadow: inset 0 1px var(--color-surface-wash);
 }
 .message-images {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(96px, 220px));
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 6px;
-  margin-bottom: 9px;
-}
-.message-images:last-child {
-  margin-bottom: 0;
+  max-width: 700px;
+  margin-bottom: 6px;
 }
 .image-thumbnail {
   width: 100%;
@@ -1474,6 +1473,7 @@ a:focus-visible {
   object-fit: cover;
 }
 .message-images .image-thumbnail {
+  width: 120px;
   aspect-ratio: 4 / 3;
 }
 .image-placeholder {
@@ -4830,8 +4830,8 @@ a:focus-visible {
   .image-preview {
     border-radius: 12px;
   }
-  .message-images {
-    grid-template-columns: repeat(2, minmax(80px, 1fr));
+  .message-images .image-thumbnail {
+    width: 96px;
   }
   .composer-rail {
     gap: 6px;

--- a/apps/zenx/test/thread-view-component.test.ts
+++ b/apps/zenx/test/thread-view-component.test.ts
@@ -839,6 +839,13 @@ test("resumed user messages expose canonical attachments with accessible preview
   assert.match(html, /aria-label="Attached images"/u);
   assert.match(html, /aria-label="Preview Attached image 1"/u);
   assert.doesNotMatch(html, /base64|\/tmp\//u);
+  // An image-only transcript message renders standalone thumbnails and no
+  // text bubble; attachments are never wrapped inside the bubble itself.
+  assert.doesNotMatch(html, /class="user-bubble"/u);
+  assert.ok(
+    html.indexOf('aria-label="Attached images"') <
+      html.indexOf('aria-label="Preview Attached image 1"'),
+  );
 });
 
 test("images precede text in Composer and transcript, including image-only messages", () => {
@@ -875,6 +882,10 @@ test("images precede text in Composer and transcript, including image-only messa
   );
   assert.ok(
     transcriptHtml.indexOf('class="message-images"') <
+      transcriptHtml.indexOf('class="user-bubble"'),
+  );
+  assert.ok(
+    transcriptHtml.indexOf('class="user-bubble"') <
       transcriptHtml.indexOf("line one"),
   );
   assert.ok(
@@ -889,13 +900,8 @@ test("images precede text in Composer and transcript, including image-only messa
     { "user-1": [first] },
   );
   assert.match(imageOnlyHtml, /class="message-images"/u);
-  const userBubbleStart = imageOnlyHtml.indexOf('class="user-bubble"');
-  const userBubbleEnd = imageOnlyHtml.indexOf("</article>", userBubbleStart);
-  assert.ok(userBubbleStart >= 0 && userBubbleEnd > userBubbleStart);
-  assert.doesNotMatch(
-    imageOnlyHtml.slice(userBubbleStart, userBubbleEnd),
-    /markdown-body|<p>/u,
-  );
+  // Without text there is no empty bubble behind the standalone thumbnails.
+  assert.doesNotMatch(imageOnlyHtml, /class="user-bubble"/u);
 });
 
 function render(


### PR DESCRIPTION
## 问题
发送带图片的消息后，transcript 把缩略图和文字一起包进同一个气泡容器（整块大圆角边框），与 Codex 的呈现不一致。

## 改动
- `UserMessage`：附件缩略图移出 `user-bubble`，成为文字气泡上方的独立紧凑缩略图行（右对齐、可换行）；无文字时不再渲染空气泡。
- CSS：`.message-images` 改为 flex 右对齐，缩略图稳定占位 120px（窄屏 96px），4/3 比例不变。
- `ui-ux.md` 4.5 记录该视觉校准（不改变 `AttachmentRef` 权威与投影路径）。
- 更新两个 attachment 结构测试断言。
Base：`origin/main`（450247f）。来自 2026-09-04 ZenX UI bug 清理会话；四个分支互相独立，`ui-ux.md` 4.5 与 `ThreadView.tsx`/`styles.css` 存在相邻行，后合入者按惯例 rebase 即可。

验证：`tsx --test` 相关测试文件全绿；`tsc -p tsconfig.web.json` + `tsc -p tsconfig.node.json` 干净；提交 blob 通过 `prettier --check`；全量 `npm run test` 与 origin/main 基线对比：仅同一组 Windows 环境性 flake（symlink EPERM / pnpm / 子进程 spawn / deadline 类），renderer 相关测试无失败。
