### PR TITLE
fix(zenx): keep attachment thumbnails stable across streaming re-renders

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -227,6 +227,7 @@ Composer 保持一个位置、几何和命中区域稳定的 primary action，�
   Unknown 不得冒充 unsupported。文字草稿的普通发送行为不受影响。
 - transcript 从 canonical `user_message` 的 `AttachmentRef` 投影图片；send 后与 resume 后使用同一渲染路径。
   缩略图可用鼠标或键盘打开应用内 modal preview；Escape、关闭按钮和 backdrop 可关闭，关闭后焦点返回触发缩略图。
+  附件 payload 读取按 `AttachmentRef` 身份（mediaType + sha256）在 renderer 会话内缓存 object URL：流式重渲染、projection 刷新与 disclosure 折叠重建都复用同一 URL，不重新读取、不闪回 loading 占位；读取失败不缓存，后续挂载重试。
 
 ### 4.6 Settings 与 onboarding
 

--- a/apps/zenx/src/renderer/src/App.tsx
+++ b/apps/zenx/src/renderer/src/App.tsx
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useId,
   useLayoutEffect,
@@ -7,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 
+import type { AttachmentRef } from "../../../../../src/attachment.js";
 import type { NativeThreadSummary } from "../../../../../src/thread-summary.js";
 import type { ModelUsageProjection } from "../../../../../src/model-usage.js";
 import type {
@@ -339,6 +341,13 @@ export function App() {
   const [threadUsage, setThreadUsage] = useState<
     ModelUsageProjection | undefined
   >();
+  // Stable identity so streaming re-renders of App do not restart every
+  // mounted attachment read; thumbnails cache payloads per attachment.
+  const readAttachment = useCallback(
+    (attachment: AttachmentRef) =>
+      window.zenx.imageAttachments.read(attachment),
+    [],
+  );
 
   const confirmPinnedThreadIds = (threadIds: readonly string[]) => {
     const confirmed = [...threadIds];
@@ -1865,9 +1874,7 @@ export function App() {
                 composer: removeComposerImage(current.composer, imageId),
               }))
             }
-            onReadAttachment={(attachment) =>
-              window.zenx.imageAttachments.read(attachment)
-            }
+            onReadAttachment={readAttachment}
             onInterrupt={async (turnId) => {
               if (threadDetail === null)
                 throw new Error("No thread is selected");

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1001,34 +1001,48 @@ function ImagePreview({
   );
 }
 
+// Object URLs are cached per attachment identity for the renderer session so
+// streaming re-renders and disclosure remounts reuse the same URL instead of
+// re-reading the payload and flashing the loading placeholder. Read failures
+// are not cached, so a later mount retries.
+const attachmentUrlCache = new Map<string, string>();
+
 function useAttachmentUrl(
   attachment: AttachmentRef,
   read: (attachment: AttachmentRef) => Promise<Uint8Array>,
 ): { url: string | null; error: string | null } {
+  const cacheKey = `${attachment.mediaType}:${attachment.sha256}`;
   const [state, setState] = useState<{
     url: string | null;
     error: string | null;
-  }>({ url: null, error: null });
+  }>(() => ({ url: attachmentUrlCache.get(cacheKey) ?? null, error: null }));
   useEffect(() => {
+    const cached = attachmentUrlCache.get(cacheKey);
+    if (cached !== undefined) {
+      setState((current) =>
+        current.url === cached && current.error === null
+          ? current
+          : { url: cached, error: null },
+      );
+      return;
+    }
     let active = true;
-    let objectUrl: string | null = null;
     setState({ url: null, error: null });
     void read(attachment)
       .then((bytes) => {
-        if (!active) return;
-        objectUrl = URL.createObjectURL(
+        const objectUrl = URL.createObjectURL(
           new Blob([bytes.slice().buffer], { type: attachment.mediaType }),
         );
-        setState({ url: objectUrl, error: null });
+        attachmentUrlCache.set(cacheKey, objectUrl);
+        if (active) setState({ url: objectUrl, error: null });
       })
       .catch((error: unknown) => {
         if (active) setState({ url: null, error: describeError(error) });
       });
     return () => {
       active = false;
-      if (objectUrl !== null) URL.revokeObjectURL(objectUrl);
     };
-  }, [attachment, read]);
+  }, [cacheKey, attachment, read]);
   return state;
 }
 

--- a/apps/zenx/test/image-composer-interaction.test.ts
+++ b/apps/zenx/test/image-composer-interaction.test.ts
@@ -213,6 +213,64 @@ test("Unknown image capability warns but keeps the try-send action available", a
   });
 });
 
+test("attachment thumbnails reuse cached payloads across streaming re-renders and remounts", async () => {
+  await withDom(async (dom, root) => {
+    const streaming: AttachmentRef = {
+      type: "attachment",
+      sha256: "f".repeat(64),
+      mediaType: "image/png",
+      byteLength: 4,
+      width: 1,
+      height: 1,
+    };
+    let reads = 0;
+    let createdUrls = 0;
+    Object.assign(dom.window.URL, {
+      createObjectURL: () => `blob:zenx-stream-${String((createdUrls += 1))}`,
+    });
+    const streamingView = (attachment: AttachmentRef) =>
+      root.render(
+        createElement(ThreadView, {
+          approvals: [],
+          composer: addComposerImages(emptyComposerState(), [
+            { id: "draft-1", name: "stream.png", attachment },
+          ]),
+          thread: emptyThread(),
+          onDraftChange: () => undefined,
+          onInterrupt: async () => undefined,
+          onReadAttachment: async () => {
+            reads += 1;
+            return new Uint8Array([1, 2, 3, 4]);
+          },
+          onRespondToApproval: async () => undefined,
+          onSubmit: async () => undefined,
+        }),
+      );
+    await act(async () => void streamingView(streaming));
+    await act(async () => Promise.resolve());
+    const firstSrc = required<HTMLImageElement>(".draft-image img").src;
+    assert.equal(reads, 1);
+    assert.equal(createdUrls, 1);
+
+    // A streaming re-render with fresh callback and attachment identities of
+    // the same attachment must not re-read, recreate the object URL, or drop
+    // back to the loading placeholder.
+    await act(async () => void streamingView({ ...streaming }));
+    await act(async () => Promise.resolve());
+    assert.equal(reads, 1);
+    assert.equal(createdUrls, 1);
+    assert.equal(required<HTMLImageElement>(".draft-image img").src, firstSrc);
+
+    // Unmount and remount (Turn disclosure collapse and reopen) also reuse
+    // the session cache instead of flashing the loading placeholder.
+    await act(async () => root.render(null));
+    await act(async () => void streamingView(streaming));
+    assert.equal(reads, 1);
+    assert.equal(createdUrls, 1);
+    assert.equal(required<HTMLImageElement>(".draft-image img").src, firstSrc);
+  });
+});
+
 async function withDom(
   run: (dom: JSDOM, root: ReturnType<typeof createRoot>) => Promise<void>,
 ) {


### PR DESCRIPTION
## 问题
模型 Turn 流式运行期间，transcript/Composer 中的图片持续闪烁。

## 根因
1. `App.tsx` 里 `onReadAttachment` 是内联箭头函数，每次流式重渲染都换 identity；
2. `useAttachmentUrl` 的 effect 依赖该 identity，且每次重跑都先 `setState({url:null})` 再重新 IPC 读取、重建 object URL —— 每个 delta 都闪一次 loading 占位；
3. Turn 完成折叠/展开时 user item 在 DOM 中换位重挂载，同样触发重读。

## 改动
- `App.tsx`：`readAttachment` 用 `useCallback` 固定 identity。
- `ThreadView.tsx`：object URL 按 attachment 身份（`mediaType:sha256`）做 renderer 会话级缓存；命中缓存直接复用，不重读、不闪占位；读取失败不缓存（后续挂载重试）。
- 新增回归测试：同一附件在“新回调 identity + 新 attachment 对象”的重渲染与卸载重挂中，读取次数与 object URL 数量保持 1，`<img src>` 不变。
- `ui-ux.md` 4.5 记录缓存合同。
Base：`origin/main`（450247f）。来自 2026-09-04 ZenX UI bug 清理会话；四个分支互相独立，`ui-ux.md` 4.5 与 `ThreadView.tsx`/`styles.css` 存在相邻行，后合入者按惯例 rebase 即可。

验证：`tsx --test` 相关测试文件全绿；`tsc -p tsconfig.web.json` + `tsc -p tsconfig.node.json` 干净；提交 blob 通过 `prettier --check`；全量 `npm run test` 与 origin/main 基线对比：仅同一组 Windows 环境性 flake（symlink EPERM / pnpm / 子进程 spawn / deadline 类），renderer 相关测试无失败。
