### PR TITLE
fix(zenx): float the Composer over a full-height transcript scroll area

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -212,6 +212,7 @@ Composer 保持一个位置、几何和命中区域稳定的 primary action，�
 - Approval bar 位于聊天流与 Composer 之间，不塞入 Trace Group 或 Composer toolbar。
 - 用户处于实时底部时，新 Item 自动跟随；用户向上阅读后，不改变滚动位置，并显示 **Back to live**。
 - Back to live 返回实时底部后才恢复自动跟随。流式 patch 不得丢失 disclosure、焦点或草稿。
+- Composer（含审批条与上下文行）是浮在满高 transcript 滚动区底部的 overlay：transcript 滚动条贯穿右侧从上到下，列表底部保留与 bottom zone 等高的虚拟留白，Back to live 悬浮在 bottom zone 正上方并随其高度上移。所有可滚动表面使用统一的细滚动条。这是布局与视觉校准，不改变 live following 的交互合同。
 - Tool completion 与 Final Message / Turn completion 的到达顺序可能不同；UI 等到可展示终态后再切换完成态投影。
 
 ### 4.5 图片草稿与预览

--- a/apps/zenx/src/renderer/src/ThreadView.tsx
+++ b/apps/zenx/src/renderer/src/ThreadView.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import type { AttachmentRef } from "../../../../../src/attachment.js";
 import type {
@@ -126,6 +133,8 @@ export function ThreadView({
   const [atLive, setAtLive] = useState(true);
   const scrollRef = useRef<HTMLDivElement>(null);
   const shouldFollowRef = useRef(true);
+  const viewRef = useRef<HTMLDivElement>(null);
+  const bottomZoneRef = useRef<HTMLDivElement>(null);
   const runningTurn = thread === null ? null : activeTurn(thread);
   const turns = thread?.turns ?? [];
   const pendingApprovals = approvals.filter(
@@ -143,6 +152,32 @@ export function ThreadView({
       setAtLive(true);
     }
   }, [thread?.turns, approvals]);
+
+  // The Composer overlays the bottom of the full-height transcript scroll
+  // area. Publish its live height so the list reserves matching virtual
+  // space and Back to live can float just above it; growth keeps a live
+  // view pinned to the bottom.
+  useLayoutEffect(() => {
+    const view = viewRef.current;
+    const zone = bottomZoneRef.current;
+    if (view === null || zone === null) return;
+    const publish = () => {
+      const height = `${Math.round(zone.getBoundingClientRect().height)}px`;
+      if (view.style.getPropertyValue("--bottom-zone-height") === height)
+        return;
+      view.style.setProperty("--bottom-zone-height", height);
+      const scroll = scrollRef.current;
+      if (shouldFollowRef.current && scroll !== null)
+        scroll.scrollTop = scroll.scrollHeight;
+    };
+    publish();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(publish);
+    observer.observe(zone);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   const submit = (intent: ComposerIntent) => {
     if (composerDisabled || !hasDraft || submitting || blockedByImageCapability)
@@ -182,6 +217,7 @@ export function ThreadView({
   return (
     <div
       className={`thread-view${draggingImages ? " image-dragging" : ""}`}
+      ref={viewRef}
       onDragEnter={(event) => {
         if (composerDisabled || submitting) return;
         if (hasImageFiles(event.dataTransfer.files)) setDraggingImages(true);
@@ -267,7 +303,7 @@ export function ThreadView({
         </button>
       )}
 
-      <div className="bottom-zone">
+      <div className="bottom-zone" ref={bottomZoneRef}>
         {composerContext}
         {pendingApprovals.map((approval) => (
           <ApprovalBar

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -12,6 +12,13 @@
   font-synthesis: none;
 }
 
+/* One thin, track-less scrollbar vocabulary for every scrollable surface so
+   no platform default sits thick or opaque on top of the app surfaces. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-control) transparent;
+}
+
 .plugin-page-scroll {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
@@ -1322,18 +1329,20 @@ a:focus-visible {
   position: relative;
   min-width: 0;
   min-height: 0;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  display: block;
   overflow: hidden;
 }
 .messages {
+  position: absolute;
+  inset: 0;
   min-width: 0;
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior: contain;
   scrollbar-width: thin;
-  scrollbar-color: var(--color-border-control) transparent;
-  padding: 28px max(24px, calc((100% - 820px) / 2)) 38px;
+  scrollbar-color: var(--border-control) transparent;
+  padding: 28px max(24px, calc((100% - 820px) / 2))
+    calc(38px + var(--bottom-zone-height, 0px));
 }
 .messages-inner {
   width: 100%;
@@ -1778,7 +1787,7 @@ a:focus-visible {
 .back-live {
   position: absolute;
   left: 50%;
-  bottom: 150px;
+  bottom: calc(var(--bottom-zone-height, 0px) + 12px);
   z-index: 5;
   min-height: 36px;
   display: inline-flex;
@@ -1795,7 +1804,10 @@ a:focus-visible {
 }
 
 .bottom-zone {
-  position: relative;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 4;
   min-width: 0;
   padding: 0 max(18px, calc((100% - 840px) / 2)) 18px;
@@ -2063,6 +2075,8 @@ a:focus-visible {
   display: block;
   resize: none;
   overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-control) transparent;
   padding: 15px 16px 6px;
   border: 0;
   outline: 0;
@@ -4783,7 +4797,7 @@ a:focus-visible {
     flex-basis: 100%;
   }
   .messages {
-    padding: 20px 14px 28px;
+    padding: 20px 14px calc(28px + var(--bottom-zone-height, 0px));
   }
   .messages-inner {
     gap: 20px;
@@ -4846,9 +4860,6 @@ a:focus-visible {
   }
   .permission-control span {
     display: none;
-  }
-  .back-live {
-    bottom: 132px;
   }
   .page-scroll {
     padding: 20px 14px 34px;

--- a/apps/zenx/test/image-composer-interaction.test.ts
+++ b/apps/zenx/test/image-composer-interaction.test.ts
@@ -213,6 +213,47 @@ test("Unknown image capability warns but keeps the try-send action available", a
   });
 });
 
+test("the Composer overlay publishes its live bottom-zone height", async () => {
+  await withDom(async (_dom, root) => {
+    let notify: (() => void) | null = null;
+    class FakeResizeObserver {
+      constructor(callback: () => void) {
+        notify = callback;
+      }
+      observe(): void {}
+      disconnect(): void {}
+    }
+    Object.assign(globalThis, { ResizeObserver: FakeResizeObserver });
+    try {
+      await act(async () =>
+        root.render(
+          createElement(ThreadView, {
+            approvals: [],
+            composer: emptyComposerState(),
+            thread: emptyThread(),
+            onDraftChange: () => undefined,
+            onInterrupt: async () => undefined,
+            onRespondToApproval: async () => undefined,
+            onSubmit: async () => undefined,
+          }),
+        ),
+      );
+      const view = required<HTMLElement>(".thread-view");
+      assert.equal(view.style.getPropertyValue("--bottom-zone-height"), "0px");
+      required<HTMLElement>(".bottom-zone").getBoundingClientRect = () =>
+        ({ height: 216 }) as DOMRect;
+      assert.ok(notify !== null);
+      await act(async () => notify?.());
+      assert.equal(
+        view.style.getPropertyValue("--bottom-zone-height"),
+        "216px",
+      );
+    } finally {
+      Reflect.deleteProperty(globalThis, "ResizeObserver");
+    }
+  });
+});
+
 async function withDom(
   run: (dom: JSDOM, root: ReturnType<typeof createRoot>) => Promise<void>,
 ) {

--- a/apps/zenx/test/theme-source-policy.test.ts
+++ b/apps/zenx/test/theme-source-policy.test.ts
@@ -11,7 +11,13 @@ const themePath = path.join(rendererRoot, "theme.css");
 const rawColor = /#[0-9a-f]{3,8}\b|\b(?:rgb|rgba|hsl|hsla)\(/giu;
 const definition = /(--[a-z0-9_-]+)\s*:/giu;
 const consumption = /var\((--[a-z0-9_-]+)/giu;
-const dynamicProductTokens = new Set(["--zenx-brand-asset"]);
+// Component-owned runtime seams published by their owning component: the
+// brand asset is set by ZenXBrand, and --bottom-zone-height is published by
+// ThreadView for the Composer overlay layout.
+const dynamicProductTokens = new Set([
+  "--zenx-brand-asset",
+  "--bottom-zone-height",
+]);
 
 test("renderer product styles keep raw colors in the single theme source", async () => {
   const files = await rendererProductFiles(rendererRoot);


### PR DESCRIPTION
## 问题
1. “Back to live”按钮用写死的 `bottom: 150px/132px` 锚定；Composer 被文本/附件撑高后按钮停在原地，视觉上落在 Composer 中间。
2. transcript 滚动条只覆盖 Composer 之上的区域（grid 行布局），右缘看起来“短一截”；Composer textarea 滚动条是未设样式的平台默认（粗、带箭头）；各滚动面样式不统一。

## 改动（按用户确认的方向：Composer 作为浮层）
- `.thread-view` 改为定位容器：`.messages` absolute 铺满全高（滚动条贯穿从上到下），`.bottom-zone`（审批条+Composer）absolute 浮在底部。
- `ThreadView` 用 `ResizeObserver` 把 bottom-zone 实时高度发布为 `--bottom-zone-height`；列表底部 padding 预留等高虚拟留白；`Back to live` 锚定 `calc(var(--bottom-zone-height) + 12px)`，随 Composer 高度自然上移；删除两处魔法数字。
- bottom-zone 增高时若处于 live 底部则保持贴底。
- 滚动条统一：全局 `*` 规则 `scrollbar-width: thin` + token 化 `scrollbar-color`；textarea 与 messages 显式对齐（并修正 `--color-border-control` → 共享别名 `--border-control`）。
- `theme-source-policy`：`--bottom-zone-height` 注册为组件持有的 dynamic seam。
- `ui-ux.md` 4.4 记录布局校准，live following 交互合同不变。
- 新增测试：bottom-zone 高度发布与更新（fake ResizeObserver）。
Base：`origin/main`（450247f）。来自 2026-09-04 ZenX UI bug 清理会话；四个分支互相独立，`ui-ux.md` 4.5 与 `ThreadView.tsx`/`styles.css` 存在相邻行，后合入者按惯例 rebase 即可。

验证：`tsx --test` 相关测试文件全绿；`tsc -p tsconfig.web.json` + `tsc -p tsconfig.node.json` 干净；提交 blob 通过 `prettier --check`；全量 `npm run test` 与 origin/main 基线对比：仅同一组 Windows 环境性 flake（symlink EPERM / pnpm / 子进程 spawn / deadline 类），renderer 相关测试无失败。
