### PR TITLE
fix(zenx): shrink draft image remove badge to Codex scale

### DIFF
--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -222,6 +222,7 @@ Composer 保持一个位置、几何和命中区域稳定的 primary action，�
   不以 base64 或源文件路径为权威。导入或读取失败在 Composer 附近明确显示并保留现有草稿。
 - 每张待发送图片显示紧凑、有稳定占位尺寸和 accessible name 的缩略图；删除一张不得清除文字或其他图片。
   picker、paste、drop 与 thumbnail 更新不得改变既有 Enter / Shift+Enter、组合 Model / Reasoning menu 或 primary action 语义。
+  删除控件是贴在缩略图右上角的小圆形 badge（约 18px 可见圆、22px hit target），不覆盖缩略图主体，也不沿用大号圆形按钮样式。
 - 已选模型明确不支持 image 时，Send / Interrupt & Send 在进入 Provider 前阻断并保留完整草稿。
   Unknown 必须显示为 Unknown，并提供“尝试发送”以及 Settings 中显式 probe / 手动配置的恢复入口；
   Unknown 不得冒充 unsupported。文字草稿的普通发送行为不受影响。

--- a/apps/zenx/src/renderer/src/styles.css
+++ b/apps/zenx/src/renderer/src/styles.css
@@ -2079,7 +2079,7 @@ a:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  padding: 0 14px 8px;
+  padding: 6px 14px 8px;
   overflow: hidden;
 }
 .draft-image {
@@ -2094,30 +2094,31 @@ a:focus-visible {
 }
 .remove-draft-image {
   position: absolute;
-  top: -5px;
-  right: -5px;
-  width: 44px;
-  height: 44px;
+  top: -6px;
+  right: -6px;
+  width: 22px;
+  height: 22px;
   display: grid;
   place-items: center;
   padding: 0;
   border: 0;
   border-radius: 50%;
   background: transparent;
-  color: var(--text-2);
+  color: var(--text);
   cursor: pointer;
 }
 .remove-draft-image::before {
   content: "";
   position: absolute;
-  inset: 8px;
-  border: 1px solid var(--border-strong);
+  inset: 2px;
   border-radius: 50%;
   background: var(--surface-overlay);
   box-shadow: var(--shadow-low);
 }
 .remove-draft-image svg {
   position: relative;
+  width: 10px;
+  height: 10px;
 }
 .thread-view.image-dragging::after {
   content: "Drop images to attach";


### PR DESCRIPTION
## 问题
Composer 草稿缩略图的删除按钮是 44px 大圆（可见圆约 28px），压在缩略图右上角显得笨重，与 Codex 的克制小 badge 不一致。

## 改动（纯 CSS）
- 删除按钮：22px hit target、18px 可见圆、10px 图标、去描边保留投影，贴合缩略图角部；颜色用 `--text` 保证对比。
- `.composer-images` 增加 6px 顶部 padding，避免角部 badge 被容器 `overflow: hidden` 裁切。
- `ui-ux.md` 4.5 记录该视觉规格。
Base：`origin/main`（450247f）。来自 2026-09-04 ZenX UI bug 清理会话；四个分支互相独立，`ui-ux.md` 4.5 与 `ThreadView.tsx`/`styles.css` 存在相邻行，后合入者按惯例 rebase 即可。

验证：`tsx --test` 相关测试文件全绿；`tsc -p tsconfig.web.json` + `tsc -p tsconfig.node.json` 干净；提交 blob 通过 `prettier --check`；全量 `npm run test` 与 origin/main 基线对比：仅同一组 Windows 环境性 flake（symlink EPERM / pnpm / 子进程 spawn / deadline 类），renderer 相关测试无失败。
