### PR TITLE
feat(zenx): configure context compaction prompt

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -59,6 +59,8 @@
 - **ContextCompactionItem** — Zen 在完整 Turn 边界生成并追加的 provider-neutral
   context summary；它记录覆盖边界、稳定有序的保留 Item、冻结的 Provider selection、
   版本化算法与 token usage，使后续模型上下文和重启投影都只由 append-only ItemList 推导。
+- **ContextCompactionConfig** — Host-owned 压缩策略配置；当前只允许替换模型摘要指令，
+  省略时使用 Core 默认，配置本身不写入 Thread canonical ItemList。
 - **ModelUsageItem** — Provider 对一次稳定 model response 报告的 canonical 执行事实，
   保存包含 cached 部分的 total input、可选 cached input、output 与可选 reasoning output tokens。
 - **NativeThreadSummaryProjection** — ZAS 把 canonical journal 与
@@ -546,9 +548,11 @@ Provider `inputTokens`，若 compaction 已经使该样本代表旧上下文，�
 手动 context compaction 只在没有 active / incomplete Turn 时取最新
 `turn_completed` 作为覆盖边界；调用者不能指定任意 Item。Zen 以 admission 时
 Thread 当前生效的 `providerProfileId / modelId / reasoningEffort` 调用所选 Provider，
-使用版本化、provider-neutral 的 summary 指令且不使用 Provider opaque compaction
-或 cache。v1 确定性保留该最新完整 Turn 的全部 canonical Item；生成、abort、验证或
-journal append 失败都明确返回且不追加 compaction Item，不隐藏重试。
+默认使用版本化、provider-neutral 的 summary 指令且不使用 Provider opaque compaction
+或 cache。Host 可以配置替代的 summary 指令；该配置只影响未来 summary 生成，不写入
+Thread Item，也不改变已生成 compaction 的重放语义。v1 确定性保留该最新完整 Turn 的全部
+canonical Item；生成、abort、验证或 journal append 失败都明确返回且不追加 compaction
+Item，不隐藏重试。
 
 成功 Turn 使用 admission 时冻结的 Provider adapter、selection、catalog entry 与
 `contextWindow` 判断自动 compaction；只有 Provider 实际报告的有效 `inputTokens`

--- a/PRODUCTS.md
+++ b/PRODUCTS.md
@@ -118,6 +118,9 @@ child process、本地服务或远程服务。模型初始只看到 builtin tool
 取消会中断这条工具路径；模型、journal 与 Runtime 失败仍保留既有 Turn failure 语义。
 tool loop 默认不限轮数；ZenX General Settings 可选择一个正整数最大轮数，只有显式配置后
 Runtime 才以该上限终止持续请求工具的 Turn。
+ZenX host profile 也可以保存可选的 context compaction summary instruction；省略时使用
+Core 默认 prompt，配置只影响未来 compaction，不进入 Thread canonical state 或 CAS/ZAS
+wire。
 
 CLI 与 ZenX 现在通过同一个 Host composition 默认发布 `both` Tool Presentation；Host-owned
 配置可显式切换 `direct | code | both`，不进入 Item。`run_code` 使用 fresh、可取消的 Node

--- a/apps/cli/src/host.ts
+++ b/apps/cli/src/host.ts
@@ -12,6 +12,7 @@ import {
   RunCodeToolRuntime,
   type CodeRuntimeLimits,
 } from "../../../src/code-runtime.js";
+import type { ContextCompactionConfig } from "../../../src/context-compaction.js";
 import {
   JsonlThreadJournal,
   type ThreadJournal,
@@ -103,6 +104,8 @@ export interface ZenHostOptions {
   maxConcurrentToolBodies?: number;
   /** Product warning sink used when both degrades to direct. */
   onToolPresentationWarning?: (warning: string) => void;
+  /** Host-owned context compaction behavior; omitted fields use Core defaults. */
+  contextCompaction?: ContextCompactionConfig;
   attachments?: AttachmentStore;
   /** Host-local owner injection, primarily for composition and lifecycle tests. */
   toolOutputSpool?: ToolOutputSpool;
@@ -282,6 +285,9 @@ export function createHostedAppServer(
       sandbox: "danger-full-access",
       approvalPolicy: options.approvalPolicy,
     },
+    ...(options.contextCompaction === undefined
+      ? {}
+      : { contextCompaction: options.contextCompaction }),
   });
   let closeTransportPromise: Promise<void> | undefined;
   const closeProviderTransport = async () => {

--- a/apps/zenx/docs/ui-ux.md
+++ b/apps/zenx/docs/ui-ux.md
@@ -234,6 +234,8 @@ Composer 保持一个位置、几何和命中区域稳定的 primary action，�
 
 - Settings 是由左下导航进入的 routed page。Settings 顶部动作的最终合同仍为 **TBD**；“不提供 Done”以及“只在 dirty 时显示或强调 Apply & restart”是当前设计实验，不是 durable semantics。
 - Settings 明确管理 Archived Threads、Provider/Account 和 Plugins；General 可以承载其他 host-local preferences，但不能改变这些核心分区的所有权。
+- Context compaction prompt 是可选的 host-local preference；省略时使用 Core 默认。它只影响未来
+  compaction summary 生成，不重写历史 Thread，也不进入 canonical ItemList。
 - Settings → Models & providers 展示所有稳定 Provider profiles，并让用户以明确的
   `Provider display name · model ID` 选择全局 Default model 与 Title model；相同 model ID
   可以属于不同 profile，选择器不能把它们合并。Profile 内的结构化 ModelCatalog 使用可聚焦的

--- a/apps/zenx/src/main/host-config.ts
+++ b/apps/zenx/src/main/host-config.ts
@@ -73,6 +73,13 @@ export function resolveZenXHostConfig(
     models,
     approvalPolicy,
     toolPresentation,
+    ...(environment["ZENX_CONTEXT_COMPACTION_PROMPT"] === undefined
+      ? {}
+      : {
+          contextCompaction: {
+            summaryInstruction: environment["ZENX_CONTEXT_COMPACTION_PROMPT"],
+          },
+        }),
     provider,
     secretEnvironmentVariables,
   };

--- a/apps/zenx/src/main/host-profile.ts
+++ b/apps/zenx/src/main/host-profile.ts
@@ -11,6 +11,7 @@ import {
   type ModelCatalogEntry,
   type ModelCatalogEntryInput,
 } from "../../../../src/model-catalog.js";
+import type { ContextCompactionConfig } from "../../../../src/context-compaction.js";
 import type { ZenXHostConfig } from "./host-messages.js";
 import { resolveProjectPath } from "./project-projection.js";
 import type { ToolPresentation } from "../../../../src/tool-presentation.js";
@@ -58,6 +59,8 @@ export interface ZenXHostProfile {
   toolPresentation?: ToolPresentation;
   /** Omitted means tool rounds are unlimited. */
   maxToolRounds?: number;
+  /** Omitted means Core uses its default compaction prompt. */
+  contextCompaction?: ContextCompactionConfig;
   pinnedThreadIds: string[];
   sidebarOrder: ZenXSidebarOrder;
 }
@@ -72,6 +75,7 @@ export type ZenXSettingsUpdate = Pick<
   | "approvalPolicy"
   | "toolPresentation"
   | "maxToolRounds"
+  | "contextCompaction"
 >;
 
 export interface ZenXProviderEditOptions {
@@ -133,6 +137,7 @@ const MAX_PROVIDER_PROFILE_ID_LENGTH = 512;
 const MAX_MODEL_ID_LENGTH = 512;
 const MAX_PROVIDER_PROFILES = 128;
 const MAX_MODELS_PER_PROFILE = 1_024;
+const MAX_CONTEXT_COMPACTION_PROMPT_LENGTH = 32_768;
 
 export class ZenXHostProfileStore {
   readonly #filePath: string;
@@ -265,6 +270,9 @@ export function validateHostProfile(
   }
   const maxToolRounds = optionalMaximumToolRounds(value.maxToolRounds);
   const toolPresentation = validateToolPresentation(value.toolPresentation);
+  const contextCompaction = optionalContextCompactionConfig(
+    value.contextCompaction,
+  );
   const workspace =
     value.workspace === null
       ? null
@@ -296,6 +304,7 @@ export function validateHostProfile(
     approvalPolicy: value.approvalPolicy,
     toolPresentation,
     ...(maxToolRounds === undefined ? {} : { maxToolRounds }),
+    ...(contextCompaction === undefined ? {} : { contextCompaction }),
     pinnedThreadIds: normalizePinnedThreadIds(value.pinnedThreadIds),
     sidebarOrder: normalizeSidebarOrder(value.sidebarOrder),
   };
@@ -434,6 +443,9 @@ export function hostConfigFromProfile(
     ...(validated.maxToolRounds === undefined
       ? {}
       : { maxToolRounds: validated.maxToolRounds }),
+    ...(validated.contextCompaction === undefined
+      ? {}
+      : { contextCompaction: validated.contextCompaction }),
     providers: validated.providerProfiles.map((providerProfile) => ({
       ...providerRuntimeCatalog(providerProfile, validated.defaultModel),
       providerProfileId: providerProfile.providerProfileId,
@@ -896,6 +908,25 @@ function optionalMaximumToolRounds(value: unknown): number | undefined {
     throw new Error("ZenX maximum tool rounds must be a positive safe integer");
   }
   return value as number;
+}
+
+function optionalContextCompactionConfig(
+  value: unknown,
+): ContextCompactionConfig | undefined {
+  if (value === undefined) return undefined;
+  if (!isRecord(value)) {
+    throw new Error("ZenX context compaction config is invalid");
+  }
+  const instruction = value.summaryInstruction;
+  if (instruction === undefined) return undefined;
+  if (
+    typeof instruction !== "string" ||
+    instruction.trim().length === 0 ||
+    instruction.length > MAX_CONTEXT_COMPACTION_PROMPT_LENGTH
+  ) {
+    throw new Error("ZenX context compaction prompt is invalid");
+  }
+  return { summaryInstruction: instruction };
 }
 
 function nonEmpty(value: unknown, label: string): string {

--- a/apps/zenx/src/main/settings-service.ts
+++ b/apps/zenx/src/main/settings-service.ts
@@ -477,6 +477,7 @@ export class ZenXSettingsService {
             approvalPolicy: settings.approvalPolicy,
             toolPresentation: settings.toolPresentation ?? "both",
             maxToolRounds: settings.maxToolRounds,
+            contextCompaction: settings.contextCompaction,
           }),
           [],
         )

--- a/apps/zenx/test/host-config.test.ts
+++ b/apps/zenx/test/host-config.test.ts
@@ -45,6 +45,17 @@ test("validates the Host-owned tool presentation environment setting", () => {
   );
 });
 
+test("resolves the optional context compaction prompt from environment", () => {
+  const config = resolveZenXHostConfig({
+    ZENX_CONTEXT_COMPACTION_PROMPT: "Custom compact prompt.",
+  });
+
+  assert.equal(
+    config.contextCompaction?.summaryInstruction,
+    "Custom compact prompt.",
+  );
+});
+
 test("moves an OpenAI-compatible key into host config and blocks shell inheritance", () => {
   const environment: NodeJS.ProcessEnv = {
     ZENX_PROVIDER: "openai-compatible",

--- a/apps/zenx/test/host-profile.test.ts
+++ b/apps/zenx/test/host-profile.test.ts
@@ -156,6 +156,39 @@ test("validates and projects an opt-in maximum tool round setting", () => {
   }
 });
 
+test("validates and projects the optional context compaction prompt", () => {
+  const configured = validateHostProfile({
+    ...profile,
+    contextCompaction: {
+      summaryInstruction: "Custom summary prompt.",
+    },
+  });
+  const config = hostConfigFromProfile(configured, {
+    dataDirectory: path.join(os.tmpdir(), "data"),
+    subscriptionProfilePath: path.join(os.tmpdir(), "auth"),
+    fallbackWorkspace: path.join(os.tmpdir(), "fallback"),
+    apiKeys: { local: "secret" },
+  });
+
+  assert.deepEqual(configured.contextCompaction, {
+    summaryInstruction: "Custom summary prompt.",
+  });
+  assert.deepEqual(config.contextCompaction, configured.contextCompaction);
+  assert.equal(
+    validateHostProfile({ ...profile, contextCompaction: {} })
+      .contextCompaction,
+    undefined,
+  );
+  assert.throws(
+    () =>
+      validateHostProfile({
+        ...profile,
+        contextCompaction: { summaryInstruction: "" },
+      }),
+    /context compaction prompt/u,
+  );
+});
+
 test("migrates v1 deterministically, persists v3, and preserves adapter identity and preferences", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "zenx-profile-v1-"));
   const file = path.join(directory, "host-profile.json");

--- a/apps/zenx/test/settings-service.test.ts
+++ b/apps/zenx/test/settings-service.test.ts
@@ -482,6 +482,46 @@ test("persists the Host-owned tool presentation across restart", async () => {
   }
 });
 
+test("persists and clears the optional context compaction prompt", async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "zenx-context-compaction-settings-"),
+  );
+  try {
+    const service = settingsFor(directory, inactiveSubscription());
+    await service.initialize({});
+    const initial = (await service.publicSettings()).profile;
+    assert.equal(initial.contextCompaction, undefined);
+
+    await service.save({
+      ...initial,
+      contextCompaction: {
+        summaryInstruction: "Custom summary prompt.",
+      },
+    });
+    assert.deepEqual((await service.hostConfig()).contextCompaction, {
+      summaryInstruction: "Custom summary prompt.",
+    });
+
+    const restarted = settingsFor(directory, inactiveSubscription());
+    await restarted.initialize({});
+    const persisted = (await restarted.publicSettings()).profile;
+    assert.deepEqual(persisted.contextCompaction, {
+      summaryInstruction: "Custom summary prompt.",
+    });
+
+    const defaults = { ...persisted };
+    delete defaults.contextCompaction;
+    await restarted.save(defaults);
+    assert.equal(
+      (await restarted.publicSettings()).profile.contextCompaction,
+      undefined,
+    );
+    assert.equal((await restarted.hostConfig()).contextCompaction, undefined);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
 test("persists explicit foreground computer consent across restart and allows revocation", async () => {
   const directory = await mkdtemp(
     path.join(os.tmpdir(), "zenx-foreground-setting-"),

--- a/src/app-server.ts
+++ b/src/app-server.ts
@@ -9,9 +9,11 @@ import {
 } from "./attachment.js";
 import {
   CONTEXT_COMPACTION_ALGORITHM_VERSION,
-  CONTEXT_COMPACTION_SUMMARY_INSTRUCTION,
   latestCompaction,
   latestEligibleCompactionBoundary,
+  normalizeContextCompactionConfig,
+  type ContextCompactionConfig,
+  type ResolvedContextCompactionConfig,
 } from "./context-compaction.js";
 import type {
   AgentMessageItem,
@@ -188,6 +190,7 @@ export class ZenAppServer {
   readonly #threadMetadata: ThreadMetadataStore;
   readonly #threadSummaryProjection: ThreadSummaryProjection;
   readonly #defaults: AppServerDefaults;
+  readonly #contextCompaction: ResolvedContextCompactionConfig;
   readonly #id: () => string;
   readonly #now: () => string;
   readonly #threads = new Map<string, Thread>();
@@ -219,6 +222,7 @@ export class ZenAppServer {
     threadMetadata: ThreadMetadataStore;
     threadSummaryProjection?: ThreadSummaryProjection;
     defaults: AppServerDefaults;
+    contextCompaction?: ContextCompactionConfig;
     idFactory?: () => string;
     now?: () => string;
   }) {
@@ -233,6 +237,9 @@ export class ZenAppServer {
       ...options.defaults,
       cwd: path.resolve(options.defaults.cwd),
     };
+    this.#contextCompaction = normalizeContextCompactionConfig(
+      options.contextCompaction,
+    );
     this.#id = options.idFactory ?? randomUUID;
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#requireSelection(this.#defaults);
@@ -1087,6 +1094,7 @@ export class ZenAppServer {
       model: options.selection.selection.modelId,
       reasoningEffort: options.selection.selection.reasoningEffort,
       messages: sourceMessages,
+      summaryInstruction: this.#contextCompaction.summaryInstruction,
       signal: options.signal,
     });
     const item: ContextCompactionItem = {
@@ -1662,6 +1670,7 @@ async function generateContextCompactionSummary(options: {
   model: string;
   reasoningEffort: string | null;
   messages: ModelMessage[];
+  summaryInstruction: string;
   signal: AbortSignal;
 }): Promise<{
   text: string;
@@ -1672,7 +1681,7 @@ async function generateContextCompactionSummary(options: {
   let outputTokens = 0;
   const messages: ModelMessage[] = [
     ...options.messages,
-    { role: "user", text: CONTEXT_COMPACTION_SUMMARY_INSTRUCTION },
+    { role: "user", text: options.summaryInstruction },
   ];
   try {
     for await (const event of options.adapter.stream({

--- a/src/context-compaction.ts
+++ b/src/context-compaction.ts
@@ -14,10 +14,27 @@ Summarize the conversation context above for a provider-neutral agent continuati
 Preserve concrete user goals, decisions, constraints, unfinished work, exact identifiers,
 and tool outcomes that affect future work. Do not call tools. Return only the summary.`;
 
+export interface ContextCompactionConfig {
+  summaryInstruction?: string;
+}
+
+export interface ResolvedContextCompactionConfig {
+  summaryInstruction: string;
+}
+
 export interface CompactionBoundary {
   item: Extract<CanonicalItem, { type: "turn_completed" }>;
   index: number;
   retainedItemIds: string[];
+}
+
+export function normalizeContextCompactionConfig(
+  config: ContextCompactionConfig = {},
+): ResolvedContextCompactionConfig {
+  const summaryInstruction =
+    config.summaryInstruction ?? CONTEXT_COMPACTION_SUMMARY_INSTRUCTION;
+  requireNonEmpty(summaryInstruction, "summaryInstruction", true);
+  return { summaryInstruction };
 }
 
 export function latestCompaction(

--- a/test/context-compaction.test.ts
+++ b/test/context-compaction.test.ts
@@ -2,7 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { AppServerError, ZenAppServer } from "../src/app-server.js";
-import { validateContextCompactionItem } from "../src/context-compaction.js";
+import {
+  normalizeContextCompactionConfig,
+  validateContextCompactionItem,
+  type ContextCompactionConfig,
+} from "../src/context-compaction.js";
 import type {
   CanonicalItem,
   ContextCompactionItem,
@@ -130,6 +134,60 @@ test("manually compacts long history without changing the complete transcript", 
       "userMessage",
       "agentMessage",
     ],
+  );
+});
+
+test("uses the configured context compaction prompt exactly", async () => {
+  const prompt = "CUSTOM_COMPACTION_PROMPT\nKeep the active blockers first.";
+  const requests: ModelRequest[] = [];
+  const model: ModelAdapter = {
+    provider: "recording",
+    async *stream(request): AsyncIterable<ModelEvent> {
+      requests.push(cloneRequest(request));
+      const latest = request.messages.at(-1);
+      if (
+        latest?.role === "user" &&
+        "text" in latest &&
+        latest.text === prompt
+      ) {
+        yield { type: "text_delta", delta: "custom summary" };
+        return;
+      }
+      yield { type: "text_delta", delta: "answer" };
+    },
+  };
+  const server = createServer({
+    journal: new InMemoryThreadJournal(),
+    model,
+    contextCompaction: { summaryInstruction: prompt },
+  });
+  const thread = await server.startThread();
+  await (
+    await server.startTurn(thread.id, "one")
+  ).done;
+
+  await server.compactThread(thread.id);
+
+  const summaryRequest = requests.at(-1);
+  assert(summaryRequest !== undefined);
+  assert.deepEqual(summaryRequest.tools, []);
+  assert.deepEqual(summaryRequest.messages.at(-1), {
+    role: "user",
+    text: prompt,
+  });
+  assert.equal(
+    (await server.readThread(thread.id)).items.at(-1)?.type,
+    "context_compaction",
+  );
+});
+
+test("rejects an empty configured context compaction prompt", () => {
+  assert.throws(
+    () =>
+      normalizeContextCompactionConfig({
+        summaryInstruction: " \n\t ",
+      }),
+    /summaryInstruction/u,
   );
 });
 
@@ -1042,6 +1100,7 @@ function createServer(options: {
   model: ModelAdapter;
   modelCatalog?: ModelCatalog;
   runtime?: AgentRuntime;
+  contextCompaction?: ContextCompactionConfig;
 }): ZenAppServer {
   const modelCatalog =
     options.modelCatalog ??
@@ -1072,6 +1131,9 @@ function createServer(options: {
       sandbox: "danger-full-access",
       approvalPolicy: "never",
     },
+    ...(options.contextCompaction === undefined
+      ? {}
+      : { contextCompaction: options.contextCompaction }),
   });
 }
 


### PR DESCRIPTION

## Summary
- add host-owned ContextCompactionConfig with a configurable summaryInstruction and Core default fallback
- thread the config through createHostedAppServer, ZenX env config, host profile persistence, and settings saves
- keep the prompt config outside canonical Thread Items so existing compaction replay remains ItemList-derived

## Stacked On
- #168

## Validation
- npm run typecheck
- npm run build
- npm run lint
- npx prettier --check ARCHITECTURE.md PRODUCTS.md apps/zenx/docs/ui-ux.md src/context-compaction.ts src/app-server.ts apps/cli/src/host.ts apps/zenx/src/main/host-config.ts apps/zenx/src/main/host-profile.ts apps/zenx/src/main/settings-service.ts test/context-compaction.test.ts apps/zenx/test/host-config.test.ts apps/zenx/test/host-profile.test.ts apps/zenx/test/settings-service.test.ts
- node --test dist/test/context-compaction.test.js
- npm exec --workspace @zen/zenx -- tsx --test --test-name-pattern "context compaction prompt|optional context compaction prompt" test/host-config.test.ts test/host-profile.test.ts test/settings-service.test.ts

## Known Existing Verification Failures
- npm run check stops at repo-wide Prettier baseline; this run reported 338 pre-existing files
- npm test still has unrelated Windows/environment failures around Temp rename EPERM, missing printf, run_code child cleanup/timing, and shell scheduler expectations; the new context-compaction tests passed in the full run
